### PR TITLE
Post-take-30 plumbing follow-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,20 @@
 # SANDBOX_UID=1000
 # SANDBOX_GID=1000
 
+# Docker socket group inside the sandbox (DooD for Testcontainers).
+# The sandbox mounts /var/run/docker.sock and joins this supplementary group
+# so the sandbox user can talk to the host docker daemon. Default 0 fits the
+# Mac Docker Desktop path (socket reported as root:root inside the container);
+# Linux rootful docker hosts typically need 999 (root:docker on the host).
+#
+#   Mac (Docker Desktop):     DOCKER_GID=0     (default, can leave unset)
+#   Linux rootful:            DOCKER_GID=999   (or `stat -c '%g' /var/run/docker.sock`)
+#   Linux rootless:           DOCKER_GID=$(id -g)  (socket is owned by your user)
+#
+# If integration QA fails with `permission denied while trying to connect to
+# the Docker daemon socket`, this is the knob to turn.
+# DOCKER_GID=0
+
 # ─── GitHub Packages (sandbox dependency resolution) ──────────────────
 
 # When the dev's build.gradle / pom.xml resolves dependencies from

--- a/output/workflow-documents/qa_summary_renderer.go
+++ b/output/workflow-documents/qa_summary_renderer.go
@@ -9,21 +9,15 @@ import (
 )
 
 // RenderQASummary produces a markdown view of the plan's QA phase
-// outcome — the executor result (QARun) plus any plan-decisions the
-// qa-reviewer raised. Returns "" when the plan has no QA state yet
-// (pre-reviewing_qa) and no PlanDecisions.
-//
-// Note: the qa-reviewer's prose verdict (summary, dimensions) is not
-// currently persisted on Plan — only the structured QARun and emitted
-// PlanDecisions are. A future Plan.QAVerdictSummary string field would
-// let this renderer surface the full reviewer narrative. Until then,
-// the document covers what is persisted: did tests pass, what failed,
-// what change proposals were raised.
+// outcome — the qa-reviewer's prose verdict (when persisted), the
+// executor result (QARun), and any plan-decisions the qa-reviewer raised.
+// Returns "" when the plan has no QA state at all (pre-verdict, no QARun,
+// no PlanDecisions, no QAVerdictSummary).
 func RenderQASummary(plan *workflow.Plan) string {
 	if plan == nil {
 		return ""
 	}
-	if plan.QARun == nil && len(plan.PlanDecisions) == 0 {
+	if plan.QARun == nil && plan.QAVerdictSummary == nil && len(plan.PlanDecisions) == 0 {
 		return ""
 	}
 	var b strings.Builder
@@ -33,13 +27,56 @@ func RenderQASummary(plan *workflow.Plan) string {
 		title = plan.Slug
 	}
 	b.WriteString(fmt.Sprintf("# QA Summary: %s\n\n", title))
-	b.WriteString(fmt.Sprintf("*Generated from the QA phase's executor result and any plan-decisions the qa-reviewer raised. QA level for this plan: `%s`.*\n\n",
+	b.WriteString(fmt.Sprintf("*Generated from the qa-reviewer verdict, the QA phase's executor result, and any plan-decisions the qa-reviewer raised. QA level for this plan: `%s`.*\n\n",
 		plan.EffectiveQALevel()))
 
+	renderQAVerdictSummary(&b, plan.QAVerdictSummary)
 	renderQARun(&b, plan.QARun)
 	renderQAPlanDecisions(&b, plan.PlanDecisions)
 
 	return b.String()
+}
+
+// renderQAVerdictSummary renders the qa-reviewer's prose verdict (overall
+// summary + per-dimension paragraphs). Each dimension is rendered only when
+// non-empty so we surface what the reviewer actually assessed at the plan's
+// QA level rather than showing empty headings for dimensions that don't
+// apply (e.g. flake_judgment is integration-tier and up).
+func renderQAVerdictSummary(b *strings.Builder, v *workflow.QAVerdictSummary) {
+	if v == nil {
+		return
+	}
+	b.WriteString("## Reviewer verdict\n\n")
+	b.WriteString(fmt.Sprintf("- **Verdict:** `%s`\n", v.Verdict))
+	b.WriteString(fmt.Sprintf("- **Level assessed:** `%s`\n", v.Level))
+	if !v.RecordedAt.IsZero() {
+		b.WriteString(fmt.Sprintf("- **Recorded at:** %s\n", v.RecordedAt.UTC().Format(time.RFC3339)))
+	}
+	b.WriteString("\n")
+	if v.Summary != "" {
+		b.WriteString(fmt.Sprintf("%s\n\n", v.Summary))
+	}
+
+	dims := []struct {
+		label, body string
+	}{
+		{"Requirement fulfillment", v.Dimensions.RequirementFulfillment},
+		{"Coverage", v.Dimensions.Coverage},
+		{"Assertion quality", v.Dimensions.AssertionQuality},
+		{"Regression surface", v.Dimensions.RegressionSurface},
+		{"Flake judgment", v.Dimensions.FlakeJudgment},
+	}
+	headerWritten := false
+	for _, d := range dims {
+		if strings.TrimSpace(d.body) == "" {
+			continue
+		}
+		if !headerWritten {
+			b.WriteString("### Dimensions\n\n")
+			headerWritten = true
+		}
+		b.WriteString(fmt.Sprintf("**%s.** %s\n\n", d.label, d.body))
+	}
 }
 
 func renderQARun(b *strings.Builder, run *workflow.QARun) {

--- a/output/workflow-documents/qa_summary_renderer_test.go
+++ b/output/workflow-documents/qa_summary_renderer_test.go
@@ -101,6 +101,100 @@ func TestRenderQASummary_WithPlanDecisions(t *testing.T) {
 	}
 }
 
+func TestRenderQASummary_WithVerdictSummary(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:    "with-verdict",
+		Title:   "Verdict carrier",
+		QALevel: workflow.QALevelIntegration,
+		QAVerdictSummary: &workflow.QAVerdictSummary{
+			Verdict:    workflow.QAVerdictApproved,
+			Level:      workflow.QALevelIntegration,
+			Summary:    "Plan satisfies the change request and tests cover the new surface.",
+			RecordedAt: time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC),
+			Dimensions: workflow.QAVerdictDimensions{
+				RequirementFulfillment: "All four requirements implemented.",
+				Coverage:               "Unit + integration cover the new surface.",
+				AssertionQuality:       "Assertions check semantic outcomes.",
+				RegressionSurface:      "No untouched code paths broken.",
+				// FlakeJudgment intentionally empty.
+			},
+		},
+	}
+	md := RenderQASummary(plan)
+	checks := []struct {
+		needle string
+		want   bool
+	}{
+		{"## Reviewer verdict", true},
+		{"**Verdict:** `approved`", true},
+		{"**Level assessed:** `integration`", true},
+		{"2026-05-16T12:00:00Z", true},
+		{"Plan satisfies the change request", true},
+		{"### Dimensions", true},
+		{"**Requirement fulfillment.**", true},
+		{"All four requirements implemented.", true},
+		{"**Coverage.**", true},
+		{"**Assertion quality.**", true},
+		{"**Regression surface.**", true},
+		{"**Flake judgment.**", false}, // empty body → header suppressed
+	}
+	for _, c := range checks {
+		got := strings.Contains(md, c.needle)
+		if got != c.want {
+			t.Errorf("contains(%q) = %v, want %v\ngot markdown:\n%s", c.needle, got, c.want, md)
+		}
+	}
+}
+
+func TestRenderQASummary_VerdictSummaryOnlyNoExecutor(t *testing.T) {
+	// Plan with only a verdict — no executor run, no plan-decisions.
+	// Represents the synthesis-level path where qa-reviewer produces a
+	// verdict directly without an executor. Renderer must still produce
+	// output (not return "" as it would have pre-Plan.QAVerdictSummary).
+	plan := &workflow.Plan{
+		Slug:    "verdict-only",
+		QALevel: workflow.QALevelSynthesis,
+		QAVerdictSummary: &workflow.QAVerdictSummary{
+			Verdict: workflow.QAVerdictApproved,
+			Level:   workflow.QALevelSynthesis,
+			Summary: "Synthesis review: change is coherent.",
+			Dimensions: workflow.QAVerdictDimensions{
+				RequirementFulfillment: "Change matches the requested behavior.",
+			},
+		},
+	}
+	md := RenderQASummary(plan)
+	if md == "" {
+		t.Fatal("expected non-empty render with QAVerdictSummary only")
+	}
+	if !strings.Contains(md, "## Reviewer verdict") {
+		t.Error("should render reviewer verdict section")
+	}
+	if !strings.Contains(md, "Synthesis review: change is coherent.") {
+		t.Error("should include verdict summary text")
+	}
+	if !strings.Contains(md, "### Dimensions") {
+		t.Error("dimensions header should appear when at least one dimension body is set")
+	}
+}
+
+func TestRenderQASummary_VerdictSummaryAllDimensionsEmpty(t *testing.T) {
+	// Confirms the dimensions header is suppressed when no dimension body
+	// is set (avoids empty "### Dimensions" headings).
+	plan := &workflow.Plan{
+		Slug: "empty-dims",
+		QAVerdictSummary: &workflow.QAVerdictSummary{
+			Verdict: workflow.QAVerdictApproved,
+			Level:   workflow.QALevelSynthesis,
+			Summary: "no dimensions assessed",
+		},
+	}
+	md := RenderQASummary(plan)
+	if strings.Contains(md, "### Dimensions") {
+		t.Errorf("expected no Dimensions header when all dimension bodies empty, got:\n%s", md)
+	}
+}
+
 func TestRenderQASummary_SynthesisLevelNoExecutor(t *testing.T) {
 	plan := &workflow.Plan{
 		Slug:    "synth",

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -903,6 +903,21 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 		return MutationResponse{Success: false, Error: fmt.Sprintf("plan must be in reviewing_rollup or reviewing_qa, got %s", current)}
 	}
 
+	// Persist the prose verdict before the status transition so it survives
+	// both the happy-path save below AND the assemble-fail save inside the
+	// approved branch. Without this placement, a plan-level merge conflict
+	// on QA-approved leaves operators with LastError but no reviewer
+	// narrative to explain WHY the verdict was approved in the first place
+	// — exactly the context needed to triage a "QA approved but stuck"
+	// state.
+	plan.QAVerdictSummary = &workflow.QAVerdictSummary{
+		Verdict:    req.Verdict,
+		Level:      req.Level,
+		Summary:    req.Summary,
+		Dimensions: req.Dimensions,
+		RecordedAt: time.Now().UTC(),
+	}
+
 	switch req.Verdict {
 	case workflow.QAVerdictApproved:
 		target := workflow.StatusComplete
@@ -968,19 +983,6 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 		c.logger.Warn("QA verdict — plan rejected",
 			"slug", req.Slug, "verdict", req.Verdict, "level", req.Level,
 			"plan_decision_ids", req.PlanDecisionIDs, "summary", req.Summary)
-	}
-
-	// Persist the prose verdict alongside the status transition so the
-	// qa-summary.md renderer can surface the reviewer's narrative.
-	// Pre-this-field, only QARun (executor result) + PlanDecisions (proposals)
-	// were persisted; the prose summary + dimension paragraphs lived only
-	// on the in-flight event.
-	plan.QAVerdictSummary = &workflow.QAVerdictSummary{
-		Verdict:    req.Verdict,
-		Level:      req.Level,
-		Summary:    req.Summary,
-		Dimensions: req.Dimensions,
-		RecordedAt: time.Now().UTC(),
 	}
 
 	if err := ps.save(ctx, plan); err != nil {

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -970,6 +970,19 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 			"plan_decision_ids", req.PlanDecisionIDs, "summary", req.Summary)
 	}
 
+	// Persist the prose verdict alongside the status transition so the
+	// qa-summary.md renderer can surface the reviewer's narrative.
+	// Pre-this-field, only QARun (executor result) + PlanDecisions (proposals)
+	// were persisted; the prose summary + dimension paragraphs lived only
+	// on the in-flight event.
+	plan.QAVerdictSummary = &workflow.QAVerdictSummary{
+		Verdict:    req.Verdict,
+		Level:      req.Level,
+		Summary:    req.Summary,
+		Dimensions: req.Dimensions,
+		RecordedAt: time.Now().UTC(),
+	}
+
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save plan after QA verdict", "slug", req.Slug, "error", err)
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}

--- a/processor/plan-manager/qa_verdict_test.go
+++ b/processor/plan-manager/qa_verdict_test.go
@@ -3,16 +3,20 @@ package planmanager
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
+	"net/http"
 	"testing"
 
+	"github.com/c360studio/semspec/tools/sandbox"
 	"github.com/c360studio/semspec/workflow"
 )
 
 // TestHandleQAVerdictMutation_PersistsVerdictSummary covers the needs_changes
-// path because (a) it doesn't depend on the sandbox required by the approved
-// branch's assembleRequirementBranches step and (b) the persistence logic
-// runs identically in both branches — the summary is set after the verdict
-// switch and before ps.save.
+// path. The persistence logic runs identically in all verdict branches —
+// QAVerdictSummary is assigned before the verdict switch so the approved+
+// merge-fail path (which has its own save) and the approved+happy path
+// both pick it up. See TestHandleQAVerdictMutation_PersistsSummaryOnMergeFail
+// for the merge-fail variant.
 func TestHandleQAVerdictMutation_PersistsVerdictSummary(t *testing.T) {
 	ctx := context.Background()
 	c := setupTestComponent(t)
@@ -66,5 +70,89 @@ func TestHandleQAVerdictMutation_PersistsVerdictSummary(t *testing.T) {
 	}
 	if stored.QAVerdictSummary.RecordedAt.IsZero() {
 		t.Error("RecordedAt should be set by plan-manager (zero indicates field not populated)")
+	}
+}
+
+// TestHandleQAVerdictMutation_PersistsSummaryOnMergeFail covers the
+// approved-verdict-but-plan-level-merge-conflict path. The reviewer's
+// prose narrative MUST survive this failure mode — operators triaging a
+// "QA approved but stuck" state need to know WHY the reviewer approved,
+// not just that a merge failed afterward. Before the QAVerdictSummary
+// assignment was moved above the verdict switch, this case dropped the
+// summary because the merge-fail branch has its own ps.save that ran
+// before the post-switch summary write.
+func TestHandleQAVerdictMutation_PersistsSummaryOnMergeFail(t *testing.T) {
+	ctx := context.Background()
+
+	stub := newStubMergeBranchesServer(t, http.StatusInternalServerError, map[string]any{
+		"status": "error",
+		"error":  "merge conflict in pkg/math/sub.go",
+	})
+
+	// We need a Component with both an in-memory plan store and a sandbox
+	// pointing at the conflict-returning stub. setupTestComponent wires the
+	// store; newTestComponentWithSandbox wires the sandbox. Compose by
+	// hand here — neither helper covers both.
+	ps, err := newPlanStore(ctx, nil, nil, slog.Default())
+	if err != nil {
+		t.Fatalf("newPlanStore: %v", err)
+	}
+	c := &Component{
+		name:    "plan-manager",
+		logger:  slog.Default(),
+		plans:   ps,
+		sandbox: sandbox.NewClient(stub.server.URL),
+	}
+
+	slug := "merge-fail-persists-summary"
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID(slug),
+		Slug:   slug,
+		Title:  slug,
+		Status: workflow.StatusReviewingQA,
+		Requirements: []workflow.Requirement{
+			{ID: "r1", Title: "R1"},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictApproved,
+		Summary: "Tests cover all requirements; ready for assembly.",
+		Dimensions: workflow.QAVerdictDimensions{
+			RequirementFulfillment: "All requirements implemented.",
+			Coverage:               "Unit + integration cover the new surface.",
+		},
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if resp.Success {
+		t.Fatal("mutation should have failed on merge conflict")
+	}
+
+	stored, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing from store after failed mutation")
+	}
+	if stored.QAVerdictSummary == nil {
+		t.Fatal("Plan.QAVerdictSummary must survive merge-fail save path " +
+			"(operators need the reviewer narrative to triage stuck plans)")
+	}
+	if stored.QAVerdictSummary.Verdict != workflow.QAVerdictApproved {
+		t.Errorf("Verdict = %q, want approved", stored.QAVerdictSummary.Verdict)
+	}
+	if stored.QAVerdictSummary.Summary != "Tests cover all requirements; ready for assembly." {
+		t.Errorf("Summary = %q, want full summary", stored.QAVerdictSummary.Summary)
+	}
+	if stored.LastError == "" {
+		t.Error("LastError should record the merge failure for operator visibility")
 	}
 }

--- a/processor/plan-manager/qa_verdict_test.go
+++ b/processor/plan-manager/qa_verdict_test.go
@@ -1,0 +1,70 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestHandleQAVerdictMutation_PersistsVerdictSummary covers the needs_changes
+// path because (a) it doesn't depend on the sandbox required by the approved
+// branch's assembleRequirementBranches step and (b) the persistence logic
+// runs identically in both branches — the summary is set after the verdict
+// switch and before ps.save.
+func TestHandleQAVerdictMutation_PersistsVerdictSummary(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+
+	slug := "verdict-persist"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingQA
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictNeedsChanges,
+		Summary: "Integration tier surfaced a coverage gap.",
+		Dimensions: workflow.QAVerdictDimensions{
+			RequirementFulfillment: "All four requirements implemented.",
+			Coverage:               "Missing assertions for the 5xx path.",
+		},
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+
+	stored, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing from store after mutation")
+	}
+	if stored.QAVerdictSummary == nil {
+		t.Fatal("Plan.QAVerdictSummary was not persisted")
+	}
+	if stored.QAVerdictSummary.Verdict != workflow.QAVerdictNeedsChanges {
+		t.Errorf("Verdict = %q, want needs_changes", stored.QAVerdictSummary.Verdict)
+	}
+	if stored.QAVerdictSummary.Level != workflow.QALevelIntegration {
+		t.Errorf("Level = %q, want integration", stored.QAVerdictSummary.Level)
+	}
+	if stored.QAVerdictSummary.Summary != "Integration tier surfaced a coverage gap." {
+		t.Errorf("Summary = %q, want full summary", stored.QAVerdictSummary.Summary)
+	}
+	if stored.QAVerdictSummary.Dimensions.Coverage != "Missing assertions for the 5xx path." {
+		t.Errorf("Dimensions.Coverage = %q, want full coverage text",
+			stored.QAVerdictSummary.Dimensions.Coverage)
+	}
+	if stored.QAVerdictSummary.RecordedAt.IsZero() {
+		t.Error("RecordedAt should be set by plan-manager (zero indicates field not populated)")
+	}
+}

--- a/processor/project-manager/http.go
+++ b/processor/project-manager/http.go
@@ -814,26 +814,47 @@ func (c *Component) handleConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Apply updates to a copy.
+	// Apply updates to a copy. Track whether any field actually changed so
+	// we can skip the save (and the UpdatedAt reseat that goes with it) on
+	// a true no-op PATCH. Without this, committed e2e fixture project.json
+	// files drift on every PATCH whose payload happens to match the
+	// current state (qa-cycle e2e scenario re-asserts qa_level=integration
+	// against a fixture that already has it).
 	updated := *pc
-	if req.Name != nil {
+	changed := false
+	if req.Name != nil && *req.Name != pc.Name {
 		updated.Name = *req.Name
+		changed = true
 	}
-	if req.Description != nil {
+	if req.Description != nil && *req.Description != pc.Description {
 		updated.Description = *req.Description
+		changed = true
 	}
-	if req.Org != nil {
+	if req.Org != nil && *req.Org != pc.Org {
 		updated.Org = *req.Org
+		changed = true
 	}
-	if req.Platform != nil {
+	if req.Platform != nil && *req.Platform != pc.Platform {
 		updated.Platform = *req.Platform
+		changed = true
 	}
-	if req.QALevel != nil {
+	if req.QALevel != nil && workflow.QALevel(*req.QALevel) != pc.QALevel {
 		updated.QALevel = workflow.QALevel(*req.QALevel)
+		changed = true
 	}
-	if req.QATestCommand != nil {
+	if req.QATestCommand != nil && *req.QATestCommand != pc.QATestCommand {
 		updated.QATestCommand = *req.QATestCommand
+		changed = true
 	}
+
+	if !changed {
+		// No-op PATCH — return the current config without touching the
+		// file (would otherwise reseat UpdatedAt and dirty the working
+		// tree for committed e2e fixture configs).
+		writeJSON(w, http.StatusOK, updated)
+		return
+	}
+
 	updated.UpdatedAt = time.Now()
 
 	if err := c.saveConfigThrough(r.Context(), s, &updated); err != nil {

--- a/processor/project-manager/http_config_test.go
+++ b/processor/project-manager/http_config_test.go
@@ -1,0 +1,125 @@
+package projectmanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// seedProjectConfig writes a project.json into the component's repo root and
+// loads it into the store cache. Returns the cached config for assertions.
+func seedProjectConfig(t *testing.T, c *Component, pc *workflow.ProjectConfig) {
+	t.Helper()
+	semspecDir := filepath.Join(c.repoPath, ".semspec")
+	if err := c.ensureInitDirs(semspecDir); err != nil {
+		t.Fatalf("ensureInitDirs: %v", err)
+	}
+	if err := writeJSONFile(filepath.Join(semspecDir, workflow.ProjectConfigFile), pc); err != nil {
+		t.Fatalf("write project.json: %v", err)
+	}
+	c.store.populateFromFiles()
+}
+
+// TestHandleConfig_NoopPatchPreservesTimestamp verifies that a PATCH whose
+// payload matches the current config does not reseat UpdatedAt or rewrite
+// the file. Without this guard, every qa-cycle e2e run dirties the
+// committed e2e workspace project.json with a fresh timestamp.
+func TestHandleConfig_NoopPatchPreservesTimestamp(t *testing.T) {
+	c, repoRoot := setupTestComponent(t)
+	srv := registerHandlers(c)
+	defer srv.Close()
+
+	originalTS := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedProjectConfig(t, c, &workflow.ProjectConfig{
+		Name:          "test",
+		Version:       "1.0.0",
+		InitializedAt: originalTS,
+		UpdatedAt:     originalTS,
+		QALevel:       workflow.QALevelIntegration,
+		QATestCommand: "./gradlew test",
+	})
+
+	// PATCH with the SAME qa_level and qa_test_command — should be a no-op.
+	qaLevel := string(workflow.QALevelIntegration)
+	qaCmd := "./gradlew test"
+	body, err := json.Marshal(map[string]*string{
+		"qa_level":        &qaLevel,
+		"qa_test_command": &qaCmd,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/project/config", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var afterFile workflow.ProjectConfig
+	readJSONFile(t, filepath.Join(repoRoot, ".semspec", workflow.ProjectConfigFile), &afterFile)
+	if !afterFile.UpdatedAt.Equal(originalTS) {
+		t.Errorf("UpdatedAt = %v, want unchanged %v (no-op PATCH reseated timestamp)",
+			afterFile.UpdatedAt, originalTS)
+	}
+}
+
+// TestHandleConfig_RealChangePatchUpdatesTimestamp verifies the guard
+// doesn't suppress timestamp updates for actual mutations.
+func TestHandleConfig_RealChangePatchUpdatesTimestamp(t *testing.T) {
+	c, repoRoot := setupTestComponent(t)
+	srv := registerHandlers(c)
+	defer srv.Close()
+
+	originalTS := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedProjectConfig(t, c, &workflow.ProjectConfig{
+		Name:          "test",
+		Version:       "1.0.0",
+		InitializedAt: originalTS,
+		UpdatedAt:     originalTS,
+		QALevel:       workflow.QALevelSynthesis,
+	})
+
+	qaLevel := string(workflow.QALevelIntegration)
+	body, err := json.Marshal(map[string]*string{"qa_level": &qaLevel})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/project/config", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var afterFile workflow.ProjectConfig
+	readJSONFile(t, filepath.Join(repoRoot, ".semspec", workflow.ProjectConfigFile), &afterFile)
+	if afterFile.QALevel != workflow.QALevelIntegration {
+		t.Errorf("QALevel = %q, want integration", afterFile.QALevel)
+	}
+	if !afterFile.UpdatedAt.After(originalTS) {
+		t.Errorf("UpdatedAt = %v, want after %v (real-change PATCH should reseat)",
+			afterFile.UpdatedAt, originalTS)
+	}
+}

--- a/processor/project-manager/http_config_test.go
+++ b/processor/project-manager/http_config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -74,6 +75,112 @@ func TestHandleConfig_NoopPatchPreservesTimestamp(t *testing.T) {
 	if !afterFile.UpdatedAt.Equal(originalTS) {
 		t.Errorf("UpdatedAt = %v, want unchanged %v (no-op PATCH reseated timestamp)",
 			afterFile.UpdatedAt, originalTS)
+	}
+}
+
+// TestHandleConfig_NoopOrgPatchWithExistingPlansSucceeds verifies the
+// prefixChanging guard does not falsely trigger when req.Org matches the
+// current value, even when plans already exist. Both guards (prefixChanging
+// at the top of handleConfig and the per-field change detector below it)
+// use the same "*req.X != pc.X" comparison; this test pins that they stay
+// in sync. Without the per-field guard, this PATCH would 200 + reseat
+// UpdatedAt; without the prefixChanging guard's same-value tolerance, it
+// would 409 even though nothing actually changes.
+func TestHandleConfig_NoopOrgPatchWithExistingPlansSucceeds(t *testing.T) {
+	c, repoRoot := setupTestComponent(t)
+	srv := registerHandlers(c)
+	defer srv.Close()
+
+	originalTS := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	seedProjectConfig(t, c, &workflow.ProjectConfig{
+		Name:          "test",
+		Org:           "acme",
+		Platform:      "prod",
+		Version:       "1.0.0",
+		InitializedAt: originalTS,
+		UpdatedAt:     originalTS,
+	})
+
+	// Simulate an existing plan: prefixChanging guard reads
+	// .semspec/projects/default/plans/ to decide whether org/platform
+	// changes are allowed. A non-empty dir triggers 409 on real changes.
+	plansDir := filepath.Join(repoRoot, ".semspec", "projects", "default", "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatalf("mkdir plans: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plansDir, "plan-1.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed plan file: %v", err)
+	}
+
+	// PATCH with the SAME org — must NOT trigger the prefixChanging 409.
+	org := "acme"
+	body, err := json.Marshal(map[string]*string{"org": &org})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/project/config", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no-op PATCH on existing-plan project should succeed)", resp.StatusCode)
+	}
+
+	// Timestamp must also be preserved — no-op detection runs after the
+	// prefixChanging guard, both keyed off the same comparison shape.
+	var afterFile workflow.ProjectConfig
+	readJSONFile(t, filepath.Join(repoRoot, ".semspec", workflow.ProjectConfigFile), &afterFile)
+	if !afterFile.UpdatedAt.Equal(originalTS) {
+		t.Errorf("UpdatedAt = %v, want unchanged %v", afterFile.UpdatedAt, originalTS)
+	}
+}
+
+// TestHandleConfig_RealOrgPatchWithExistingPlansRejects pins the
+// prefixChanging guard's intended behavior so a future refactor doesn't
+// accidentally relax it. Pair with the no-op test above.
+func TestHandleConfig_RealOrgPatchWithExistingPlansRejects(t *testing.T) {
+	c, repoRoot := setupTestComponent(t)
+	srv := registerHandlers(c)
+	defer srv.Close()
+
+	seedProjectConfig(t, c, &workflow.ProjectConfig{
+		Name:     "test",
+		Org:      "acme",
+		Platform: "prod",
+		Version:  "1.0.0",
+	})
+
+	plansDir := filepath.Join(repoRoot, ".semspec", "projects", "default", "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatalf("mkdir plans: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plansDir, "plan-1.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("seed plan file: %v", err)
+	}
+
+	newOrg := "newcorp"
+	body, err := json.Marshal(map[string]*string{"org": &newOrg})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPatch, srv.URL+"/api/project/config", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (real org change with existing plans must reject)", resp.StatusCode)
 	}
 }
 

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -593,6 +593,16 @@ type Plan struct {
 	// yet reached reviewing_qa.
 	QARun *QARun `json:"qa_run,omitempty"`
 
+	// QAVerdictSummary captures the qa-reviewer's prose verdict (summary +
+	// per-dimension paragraphs) at the moment plan-manager consumed the
+	// QAVerdictEvent. The structured QARun captures executor results;
+	// QAVerdictSummary captures the human-readable judgment so the
+	// qa-summary.md renderer can carry the full reviewer narrative.
+	//
+	// Nil for plans that never reached a QA verdict and plans that
+	// completed before this field landed.
+	QAVerdictSummary *QAVerdictSummary `json:"qa_verdict_summary,omitempty"`
+
 	// AssembledBranch is the git branch onto which plan-manager merged every
 	// completed requirement branch at plan-complete time (invariant B1 of
 	// docs/audit/task-11-worktree-invariants.md). Empty on plans that
@@ -632,6 +642,21 @@ type QARun struct {
 	RunnerError string          `json:"runner_error,omitempty"`
 	TraceID     string          `json:"trace_id,omitempty"`
 	CompletedAt time.Time       `json:"completed_at"`
+}
+
+// QAVerdictSummary is the persisted, human-readable form of the qa-reviewer's
+// verdict. Mirrors the verdict fields off QAVerdictEvent so the renderer can
+// read them straight off the plan without joining the in-flight event back in.
+//
+// RecordedAt is set by plan-manager when it consumes the verdict event, not
+// by qa-reviewer — it marks when the verdict landed on the plan, distinct
+// from QARun.CompletedAt (which marks when the executor finished).
+type QAVerdictSummary struct {
+	Verdict    QAVerdict           `json:"verdict"`
+	Level      QALevel             `json:"level"`
+	Summary    string              `json:"summary,omitempty"`
+	Dimensions QAVerdictDimensions `json:"dimensions,omitempty"`
+	RecordedAt time.Time           `json:"recorded_at"`
 }
 
 // EffectiveQALevel returns the plan's QA level, defaulting to synthesis when


### PR DESCRIPTION
## Summary

Bundled set of small follow-ups captured during the 2026-05-16 session after take-30 (the first verified-real 9/9 hybrid/hard run, merged in #2). All plumbing-level — no behavior change to the take-30 hot path. go-reviewer ran on the first commit; the second commit addresses the two HIGH-priority items it raised.

## What's in here

**1. `Plan.QAVerdictSummary` persistence** (`workflow/`, `processor/plan-manager/`, `output/workflow-documents/`)
- New `workflow.QAVerdictSummary {Verdict, Level, Summary, Dimensions, RecordedAt}` mirrored off `QAVerdictEvent` (same pattern as `QARun` ↔ `QACompletedEvent`)
- Persisted in `handleQAVerdictMutation` BEFORE the verdict switch, so the reviewer's prose narrative survives all three reachable outcomes including the approved+merge-conflict path (its own early-return save needs to pick the field up)
- `RenderQASummary` now renders the prose + per-dimension paragraphs; Dimensions header suppressed when all bodies empty

**2. `PATCH /project-manager/config` idempotency** (`processor/project-manager/`)
- Per-field equality check before mutating; no-op PATCH returns 200 without touching disk or reseating `UpdatedAt`
- Pre-fix, qa-cycle e2e runs that re-asserted `qa_level=integration` on a fixture that already had it dirtied the committed `test/e2e/workspace/.semspec/project.json` every run. Init itself is already idempotent at file granularity — the handoff's "init reseats timestamps" was misattribution; PATCH was the actual driver
- Tests cover: no-op preserves UpdatedAt; real-change reseats it; no-op org PATCH with existing plans succeeds (prefixChanging guard interaction); real org change with existing plans rejects with 409

**3. `DOCKER_GID` per-platform docs** (`.env.example`)
- Documents Mac (0), Linux rootful (999 or `stat -c '%g' /var/run/docker.sock`), Linux rootless (`$(id -g)`)
- Includes the failure-symptom hook ("permission denied while trying to connect to the Docker daemon socket")

Two follow-ups verified as no-action-needed:
- **Validator over-strictness sweep** — `cf4d14b` shipped the complete set of architect-validator relaxations; remaining "required" checks are correctly strict (downstream consumers depend on non-empty values)
- **Post-hoc vs native markdown parity** — native renderers from `8403c8d` are at parity with (and richer than) the post-hoc Python that produced `docs/sponsor-packages/take-30/run-narrative/`. Differences are stylistic; native adds mermaid graph, scenario-count links, orphan section, API-surface truncation cap

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on touched packages
- [x] `go test ./workflow/... ./processor/plan-manager/... ./processor/project-manager/... ./output/workflow-documents/...` — all pass including 3 new tests on the renderer, 2 new tests on the mutation handler (happy + merge-fail), 4 new tests on the PATCH handler (no-op preserves timestamp; real-change reseats; prefixChanging tolerance on same-value; prefixChanging rejection on real change)
- [x] go-reviewer pass on `3a14860`; both HIGH findings addressed in `3219431` before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)