### PR TITLE
feat(plan-manager,ui): inline phase-artifact viewer

### DIFF
--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -487,6 +487,17 @@ func (c *Component) handlePlansWithSlug(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// Route phase-artifact endpoints (e.g. /artifacts, /artifacts/{name}).
+	if endpoint == "artifacts" || strings.HasPrefix(endpoint, "artifacts/") {
+		_, name := extractSlugArtifactName(r.URL.Path)
+		if name == "" {
+			requireMethod(w, r, http.MethodGet, func() { c.handlePlanArtifactsList(w, r, slug) })
+		} else {
+			requireMethod(w, r, http.MethodGet, func() { c.handlePlanArtifactContent(w, r, slug, name) })
+		}
+		return
+	}
+
 	// Route collection and action endpoints.
 	switch endpoint {
 	case "":

--- a/processor/plan-manager/http_artifacts.go
+++ b/processor/plan-manager/http_artifacts.go
@@ -2,10 +2,159 @@ package planmanager
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/c360studio/semspec/workflow"
 )
+
+// PhaseArtifact describes one of the per-phase markdown deliverables
+// written by the workflow-documents output component.
+type PhaseArtifact struct {
+	// Name is the stable identifier (no extension): "architecture",
+	// "requirements", "scenarios", "qa-summary", "run-summary", "plan".
+	Name string `json:"name"`
+	// Filename is the on-disk file name including extension.
+	Filename string `json:"filename"`
+	// Size is the file size in bytes.
+	Size int64 `json:"size"`
+	// ModifiedAt is the file mtime in RFC3339 format.
+	ModifiedAt string `json:"modified_at"`
+}
+
+// PhaseArtifactsResponse is the body of GET /plans/{slug}/artifacts.
+type PhaseArtifactsResponse struct {
+	Slug      string          `json:"slug"`
+	Artifacts []PhaseArtifact `json:"artifacts"`
+}
+
+// phaseArtifactAllowList enumerates the BMAD/OpenSpec markdown files that
+// workflow-documents writes under .semspec/plans/{slug}/. The map values
+// are the stable identifiers used in the API and as in-page anchor IDs.
+// Order is preserved by phaseArtifactOrder so the list endpoint returns
+// artifacts in the same sequence the rendering pipeline produces them.
+var phaseArtifactAllowList = map[string]string{
+	"plan":         "plan.md",
+	"architecture": "architecture.md",
+	"requirements": "requirements.md",
+	"scenarios":    "scenarios.md",
+	"qa-summary":   "qa-summary.md",
+	"run-summary":  "run-summary.md",
+}
+
+// phaseArtifactOrder defines the rendering order — same sequence the
+// workflow-documents component writes them.
+var phaseArtifactOrder = []string{
+	"plan",
+	"architecture",
+	"requirements",
+	"scenarios",
+	"qa-summary",
+	"run-summary",
+}
+
+// extractSlugArtifactName parses paths like
+// /plan-manager/plans/{slug}/artifacts and
+// /plan-manager/plans/{slug}/artifacts/{name}. Returns (slug, name) with
+// name="" when the request targets the collection endpoint.
+func extractSlugArtifactName(path string) (slug, name string) {
+	idx := strings.Index(path, "/plans/")
+	if idx == -1 {
+		return "", ""
+	}
+	remainder := path[idx+len("/plans/"):]
+	parts := strings.Split(strings.TrimSuffix(remainder, "/"), "/")
+	if len(parts) < 2 || parts[1] != "artifacts" {
+		return "", ""
+	}
+	slug = parts[0]
+	if len(parts) >= 3 {
+		name = parts[2]
+	}
+	return slug, name
+}
+
+// planArtifactsDir resolves the absolute path to .semspec/plans/{slug}/.
+// Slug is assumed to have passed workflow.ValidateSlug at the routing layer.
+func (c *Component) planArtifactsDir(slug string) string {
+	return filepath.Join(c.resolveRepoRoot(), ".semspec", "plans", slug)
+}
+
+// handlePlanArtifactsList handles GET /plan-manager/plans/{slug}/artifacts.
+// Returns the list of phase artifacts that currently exist on disk for
+// the plan, in canonical phase order. Empty list (200) is the response
+// shape when none have been written yet — the caller distinguishes
+// "no artifacts yet" from "plan does not exist" via the prior GET on
+// the plan itself.
+func (c *Component) handlePlanArtifactsList(w http.ResponseWriter, _ *http.Request, slug string) {
+	dir := c.planArtifactsDir(slug)
+
+	artifacts := make([]PhaseArtifact, 0, len(phaseArtifactOrder))
+	for _, name := range phaseArtifactOrder {
+		filename := phaseArtifactAllowList[name]
+		path := filepath.Join(dir, filename)
+		info, err := os.Stat(path)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			c.logger.Warn("Failed to stat phase artifact",
+				"slug", slug, "filename", filename, "error", err)
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		artifacts = append(artifacts, PhaseArtifact{
+			Name:       name,
+			Filename:   filename,
+			Size:       info.Size(),
+			ModifiedAt: info.ModTime().UTC().Format(time.RFC3339),
+		})
+	}
+
+	resp := PhaseArtifactsResponse{Slug: slug, Artifacts: artifacts}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		c.logger.Warn("Failed to encode artifacts response", "slug", slug, "error", err)
+	}
+}
+
+// handlePlanArtifactContent handles GET /plan-manager/plans/{slug}/artifacts/{name}.
+// Returns the raw markdown content for the named artifact. Name is
+// restricted to the phaseArtifactAllowList — anything else 404s without
+// touching the filesystem.
+func (c *Component) handlePlanArtifactContent(w http.ResponseWriter, _ *http.Request, slug, name string) {
+	filename, ok := phaseArtifactAllowList[name]
+	if !ok {
+		writeJSONError(w, "Unknown artifact", http.StatusNotFound)
+		return
+	}
+
+	path := filepath.Join(c.planArtifactsDir(slug), filename)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			writeJSONError(w, "Artifact not found", http.StatusNotFound)
+			return
+		}
+		c.logger.Error("Failed to read phase artifact",
+			"slug", slug, "name", name, "error", err)
+		writeJSONError(w, "Failed to read artifact", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	if _, err := w.Write(content); err != nil {
+		c.logger.Warn("Failed to write artifact body", "slug", slug, "name", name, "error", err)
+	}
+}
 
 // handleExportSpecs handles POST /plans/{slug}/export-specs.
 // Generates per-requirement spec Markdown files in .semspec/specs/.

--- a/processor/plan-manager/http_artifacts_test.go
+++ b/processor/plan-manager/http_artifacts_test.go
@@ -1,0 +1,210 @@
+package planmanager
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractSlugArtifactName(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantSlug string
+		wantName string
+	}{
+		{
+			name:     "collection endpoint",
+			path:     "/plan-manager/plans/feature-a/artifacts",
+			wantSlug: "feature-a",
+			wantName: "",
+		},
+		{
+			name:     "collection endpoint trailing slash",
+			path:     "/plan-manager/plans/feature-a/artifacts/",
+			wantSlug: "feature-a",
+			wantName: "",
+		},
+		{
+			name:     "named artifact",
+			path:     "/plan-manager/plans/feature-a/artifacts/architecture",
+			wantSlug: "feature-a",
+			wantName: "architecture",
+		},
+		{
+			name:     "named artifact with dash",
+			path:     "/plan-manager/plans/feature-a/artifacts/qa-summary",
+			wantSlug: "feature-a",
+			wantName: "qa-summary",
+		},
+		{
+			name:     "not artifacts endpoint",
+			path:     "/plan-manager/plans/feature-a/reviews",
+			wantSlug: "",
+			wantName: "",
+		},
+		{
+			name:     "missing slug",
+			path:     "/plan-manager/plans/",
+			wantSlug: "",
+			wantName: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			slug, name := extractSlugArtifactName(tc.path)
+			if slug != tc.wantSlug || name != tc.wantName {
+				t.Errorf("extractSlugArtifactName(%q) = (%q, %q), want (%q, %q)",
+					tc.path, slug, name, tc.wantSlug, tc.wantName)
+			}
+		})
+	}
+}
+
+// newArtifactsTestComponent builds a Component rooted at a temp directory
+// with .semspec/plans/{slug}/ pre-populated with the given markdown files.
+// Returns the component and the absolute slug directory.
+func newArtifactsTestComponent(t *testing.T, slug string, files map[string]string) (*Component, string) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	t.Setenv("SEMSPEC_REPO_PATH", repoRoot)
+
+	slugDir := filepath.Join(repoRoot, ".semspec", "plans", slug)
+	if err := os.MkdirAll(slugDir, 0o755); err != nil {
+		t.Fatalf("mkdir slug dir: %v", err)
+	}
+	for filename, content := range files {
+		path := filepath.Join(slugDir, filename)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", filename, err)
+		}
+	}
+
+	return &Component{logger: slog.Default()}, slugDir
+}
+
+func TestHandlePlanArtifactsList_ReturnsExisting(t *testing.T) {
+	c, _ := newArtifactsTestComponent(t, "feature-a", map[string]string{
+		"plan.md":         "# Plan\n",
+		"architecture.md": "# Architecture\n",
+		"requirements.md": "# Requirements\n",
+		// scenarios, qa-summary, run-summary intentionally missing.
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/plan-manager/plans/feature-a/artifacts", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePlanArtifactsList(w, req, "feature-a")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp PhaseArtifactsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Slug != "feature-a" {
+		t.Errorf("Slug = %q, want %q", resp.Slug, "feature-a")
+	}
+	if len(resp.Artifacts) != 3 {
+		t.Fatalf("Artifacts len = %d, want 3; got %+v", len(resp.Artifacts), resp.Artifacts)
+	}
+
+	// Canonical phase order: plan, architecture, requirements
+	wantNames := []string{"plan", "architecture", "requirements"}
+	for i, want := range wantNames {
+		if resp.Artifacts[i].Name != want {
+			t.Errorf("Artifacts[%d].Name = %q, want %q", i, resp.Artifacts[i].Name, want)
+		}
+		if resp.Artifacts[i].Filename != want+".md" {
+			t.Errorf("Artifacts[%d].Filename = %q, want %q", i, resp.Artifacts[i].Filename, want+".md")
+		}
+		if resp.Artifacts[i].Size == 0 {
+			t.Errorf("Artifacts[%d].Size = 0, want > 0", i)
+		}
+		if resp.Artifacts[i].ModifiedAt == "" {
+			t.Errorf("Artifacts[%d].ModifiedAt empty", i)
+		}
+	}
+}
+
+func TestHandlePlanArtifactsList_EmptyWhenNoFiles(t *testing.T) {
+	c, _ := newArtifactsTestComponent(t, "feature-empty", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/plan-manager/plans/feature-empty/artifacts", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePlanArtifactsList(w, req, "feature-empty")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp PhaseArtifactsResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Artifacts) != 0 {
+		t.Errorf("Artifacts len = %d, want 0; got %+v", len(resp.Artifacts), resp.Artifacts)
+	}
+}
+
+func TestHandlePlanArtifactContent_ReturnsMarkdown(t *testing.T) {
+	body := "# Architecture\n\nSome content.\n"
+	c, _ := newArtifactsTestComponent(t, "feature-a", map[string]string{
+		"architecture.md": body,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/plan-manager/plans/feature-a/artifacts/architecture", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePlanArtifactContent(w, req, "feature-a", "architecture")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/markdown") {
+		t.Errorf("Content-Type = %q, want text/markdown prefix", got)
+	}
+	if w.Body.String() != body {
+		t.Errorf("body = %q, want %q", w.Body.String(), body)
+	}
+}
+
+func TestHandlePlanArtifactContent_UnknownName(t *testing.T) {
+	c, _ := newArtifactsTestComponent(t, "feature-a", map[string]string{
+		"architecture.md": "# Architecture\n",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/plan-manager/plans/feature-a/artifacts/not-a-thing", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePlanArtifactContent(w, req, "feature-a", "not-a-thing")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestHandlePlanArtifactContent_NotWritten(t *testing.T) {
+	// Plan exists but qa-summary.md hasn't been emitted yet (pre-QA phase).
+	c, _ := newArtifactsTestComponent(t, "feature-a", map[string]string{
+		"architecture.md": "# Architecture\n",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/plan-manager/plans/feature-a/artifacts/qa-summary", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePlanArtifactContent(w, req, "feature-a", "qa-summary")
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}

--- a/ui/e2e/helpers/truth.ts
+++ b/ui/e2e/helpers/truth.ts
@@ -370,6 +370,80 @@ export async function stubRequirementFileDiff(
 }
 
 // ---------------------------------------------------------------------------
+// Phase-artifacts view — stubs for /plans/{slug}/artifacts list + content
+// endpoints backing PhaseArtifactsView. The list stub fulfils the JSON index;
+// the content stub serves text/markdown bodies keyed by artifact name.
+// Unstubbed names 404 so the loader's null-body branch is exercised.
+// ---------------------------------------------------------------------------
+
+export interface PhaseArtifactFixture {
+	name: string;
+	filename?: string;
+	size?: number;
+	modified_at?: string;
+}
+
+function materializeArtifact(input: PhaseArtifactFixture): Record<string, unknown> {
+	return {
+		name: input.name,
+		filename: input.filename ?? `${input.name}.md`,
+		size: input.size ?? 1,
+		modified_at: input.modified_at ?? new Date().toISOString()
+	};
+}
+
+export async function stubPhaseArtifacts(
+	page: Page,
+	slug: string,
+	artifacts: PhaseArtifactFixture[]
+): Promise<void> {
+	await page.route(`**/plan-manager/plans/${slug}/artifacts`, async (route) => {
+		if (route.request().method() !== 'GET') {
+			await route.fallback();
+			return;
+		}
+		await fulfillJSON(route, {
+			slug,
+			artifacts: artifacts.map(materializeArtifact)
+		});
+	});
+}
+
+/**
+ * Stub per-artifact markdown content. `contents` is a map from artifact
+ * name (e.g. "architecture") to the raw markdown body. Names not in the
+ * map fall through to a 404 — matches backend behaviour for not-yet-
+ * written artifacts and exercises the loader's null-body branch.
+ */
+export async function stubPhaseArtifactContent(
+	page: Page,
+	slug: string,
+	contents: Record<string, string>
+): Promise<void> {
+	await page.route(
+		new RegExp(`/plan-manager/plans/${slug}/artifacts/[^/?]+(\\?.*)?$`),
+		async (route) => {
+			if (route.request().method() !== 'GET') {
+				await route.fallback();
+				return;
+			}
+			const url = new URL(route.request().url());
+			const name = decodeURIComponent(url.pathname.split('/').pop() ?? '');
+			const body = contents[name];
+			if (body === undefined) {
+				await route.fulfill({ status: 404, contentType: 'application/json', body: '{}' });
+				return;
+			}
+			await route.fulfill({
+				status: 200,
+				contentType: 'text/markdown; charset=utf-8',
+				body
+			});
+		}
+	);
+}
+
+// ---------------------------------------------------------------------------
 // Board-scenario bundle — most /board truth-tests need the same four stubs
 // with identical no-op content. One call; specs can still add overrides.
 // ---------------------------------------------------------------------------

--- a/ui/e2e/phase-artifacts.spec.ts
+++ b/ui/e2e/phase-artifacts.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * @t0 @smoke truth-tests for PhaseArtifactsView (PR #4).
+ *
+ * Backend writes per-phase markdown to .semspec/plans/{slug}/{plan,architecture,
+ * requirements,scenarios,qa-summary,run-summary}.md. The viewer fetches the
+ * list, concurrent-fetches each body, renders inline with `marked`, sanitizes
+ * with DOMPurify, and DOM-rewrites heading anchors + ./X.md cross-links.
+ *
+ * Unit tests cover the pure renderer end-to-end (artifactRenderer.test.ts).
+ * These specs pin the integration: API shape → DOM, TOC click → in-page nav,
+ * empty + error states. Stubs only — no LLM, no docker filesystem seeding.
+ */
+
+import { test, expect } from '@playwright/test';
+import { waitForHydration } from './helpers/hydration';
+import { stubPhaseArtifactContent, stubPhaseArtifacts } from './helpers/truth';
+
+const slug = 'artifacts-fixture';
+
+test.describe('@t0 @smoke phase-artifacts view', () => {
+	test('empty list renders the "not written yet" state', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, []);
+		await stubPhaseArtifactContent(page, slug, {});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		const container = page.getByTestId('phase-artifacts');
+		await expect(container).toBeVisible();
+		await expect(container).toContainText('No phase artifacts written yet');
+	});
+
+	test('TOC chips render in canonical order and each artifact has a section', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, [
+			{ name: 'plan' },
+			{ name: 'architecture' },
+			{ name: 'requirements' }
+		]);
+		await stubPhaseArtifactContent(page, slug, {
+			plan: '# Plan\n\nBody.\n',
+			architecture: '# Architecture\n\n## Technology choices\n\nBody.\n',
+			requirements: '# Requirements\n\nBody.\n'
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		// One chip per artifact, with the human label.
+		const chipLabels = await page.locator('.toc-chip').allTextContents();
+		expect(chipLabels.map((s) => s.trim())).toEqual([
+			'Plan',
+			'Architecture',
+			'Requirements'
+		]);
+
+		// Each artifact lands in its own labelled section with the canonical id.
+		await expect(page.locator('section#artifact-plan')).toBeVisible();
+		await expect(page.locator('section#artifact-architecture')).toBeVisible();
+		await expect(page.locator('section#artifact-requirements')).toBeVisible();
+	});
+
+	test('GFM tables render through marked + sanitization', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, [{ name: 'architecture' }]);
+		await stubPhaseArtifactContent(page, slug, {
+			architecture:
+				'# Architecture\n\n' +
+				'| Category | Choice |\n|---|---|\n| Lang | Go |\n| Db | sqlite |\n'
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		const table = page.locator('section#artifact-architecture table');
+		await expect(table).toBeVisible();
+		await expect(table.locator('th').nth(0)).toHaveText('Category');
+		await expect(table.locator('td').filter({ hasText: 'Go' })).toBeVisible();
+	});
+
+	test('headings carry deterministic anchor ids', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, [{ name: 'architecture' }]);
+		await stubPhaseArtifactContent(page, slug, {
+			architecture: '# Architecture\n\n## Technology choices\n\nBody.\n'
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		// renderArtifact emits ${artifact}--${slug} ids on every heading inside.
+		await expect(
+			page.locator('section#artifact-architecture h2#architecture--technology-choices')
+		).toBeVisible();
+	});
+
+	test('cross-artifact links are rewritten to in-page anchors', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, [
+			{ name: 'run-summary' },
+			{ name: 'architecture' }
+		]);
+		await stubPhaseArtifactContent(page, slug, {
+			'run-summary':
+				'# Run summary\n\nSee [architecture](./architecture.md) for details.\n',
+			architecture: '# Architecture\n\nBody.\n'
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		const link = page.locator('section#artifact-run-summary a', { hasText: 'architecture' });
+		await expect(link).toHaveAttribute('href', '#artifact-architecture');
+	});
+
+	test('clicking a TOC chip jumps to the matching section', async ({ page }) => {
+		await stubPhaseArtifacts(page, slug, [
+			{ name: 'plan' },
+			{ name: 'architecture' },
+			{ name: 'requirements' }
+		]);
+		// Pad bodies so scroll position actually changes between sections.
+		const filler = '\n\n' + 'Lorem ipsum dolor sit amet.\n\n'.repeat(40);
+		await stubPhaseArtifactContent(page, slug, {
+			plan: '# Plan' + filler,
+			architecture: '# Architecture' + filler,
+			requirements: '# Requirements' + filler
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		const requirementsSection = page.locator('section#artifact-requirements');
+		await page.getByTestId('toc-requirements').click();
+
+		// scrollIntoView with smooth behavior isn't instant — wait for the
+		// section to actually enter the viewport rather than asserting on
+		// scrollY which is brittle across viewport sizes.
+		await expect(requirementsSection).toBeInViewport();
+	});
+
+	test('list endpoint failure surfaces an error banner', async ({ page }) => {
+		await page.route(`**/plan-manager/plans/${slug}/artifacts`, (route) => {
+			route.fulfill({
+				status: 500,
+				contentType: 'application/json',
+				body: JSON.stringify({ message: 'planner unavailable' })
+			});
+		});
+
+		await page.goto(`/e2e-test/phase-artifacts?slug=${slug}`);
+		await waitForHydration(page);
+
+		const banner = page.locator('[role="alert"]');
+		await expect(banner).toBeVisible();
+		await expect(banner).toContainText('planner unavailable');
+	});
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,10 +8,13 @@
       "name": "semspec-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
+        "dompurify": "^3.4.3",
         "graphology": "^0.26.0",
         "graphology-layout-forceatlas2": "^0.10.1",
         "graphology-types": "^0.24.8",
         "lucide-svelte": "^0.469.0",
+        "marked": "^14.1.4",
         "sigma": "^3.0.2"
       },
       "devDependencies": {
@@ -20,6 +23,7 @@
         "@sveltejs/kit": "^2.15.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@vitest/ui": "^4.0.18",
+        "jsdom": "^29.1.1",
         "openapi-typescript": "^7.4.4",
         "svelte": "^5.19.0",
         "svelte-check": "^4.1.4",
@@ -27,6 +31,57 @@
         "vite": "^6.0.7",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -51,6 +106,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -493,6 +701,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1219,6 +1445,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1230,6 +1465,12 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -1439,6 +1680,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1515,6 +1766,34 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1533,6 +1812,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1548,6 +1834,28 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1775,6 +2083,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1825,6 +2146,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1864,6 +2192,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1887,6 +2256,16 @@
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-svelte": {
       "version": "0.469.0",
       "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.469.0.tgz",
@@ -1904,6 +2283,25 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "5.1.6",
@@ -2012,6 +2410,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-parse": {
@@ -2134,6 +2545,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2235,6 +2656,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -2376,6 +2810,13 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -2420,6 +2861,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -2428,6 +2889,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-fest": {
@@ -2455,6 +2942,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -2630,6 +3127,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2646,6 +3191,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
     "@sveltejs/kit": "^2.15.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@vitest/ui": "^4.0.18",
+    "jsdom": "^29.1.1",
     "openapi-typescript": "^7.4.4",
     "svelte": "^5.19.0",
     "svelte-check": "^4.1.4",
@@ -34,10 +35,13 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.4.3",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",
     "graphology-types": "^0.24.8",
     "lucide-svelte": "^0.469.0",
+    "marked": "^14.1.4",
     "sigma": "^3.0.2"
   }
 }

--- a/ui/src/lib/api/artifacts.ts
+++ b/ui/src/lib/api/artifacts.ts
@@ -1,0 +1,78 @@
+import { request } from './client';
+
+/**
+ * Phase artifact descriptor. Mirrors
+ * `processor/plan-manager/http_artifacts.go:PhaseArtifact`.
+ */
+export interface PhaseArtifact {
+	/** Stable identifier without extension: "architecture", "plan", etc. */
+	name: PhaseArtifactName;
+	/** On-disk filename including the .md extension. */
+	filename: string;
+	/** File size in bytes. */
+	size: number;
+	/** RFC3339 mtime. */
+	modified_at: string;
+}
+
+export interface PhaseArtifactsResponse {
+	slug: string;
+	artifacts: PhaseArtifact[];
+}
+
+/**
+ * Canonical phase-artifact identifiers. Matches the backend allowList in
+ * `http_artifacts.go:phaseArtifactAllowList`. Listed in rendering order.
+ */
+export const PHASE_ARTIFACT_NAMES = [
+	'plan',
+	'architecture',
+	'requirements',
+	'scenarios',
+	'qa-summary',
+	'run-summary'
+] as const;
+
+export type PhaseArtifactName = (typeof PHASE_ARTIFACT_NAMES)[number];
+
+const PHASE_ARTIFACT_LABELS: Record<PhaseArtifactName, string> = {
+	plan: 'Plan',
+	architecture: 'Architecture',
+	requirements: 'Requirements',
+	scenarios: 'Scenarios',
+	'qa-summary': 'QA Summary',
+	'run-summary': 'Run Summary'
+};
+
+export function phaseArtifactLabel(name: PhaseArtifactName): string {
+	return PHASE_ARTIFACT_LABELS[name];
+}
+
+export async function fetchPhaseArtifacts(slug: string): Promise<PhaseArtifactsResponse> {
+	return request<PhaseArtifactsResponse>(
+		`/plan-manager/plans/${encodeURIComponent(slug)}/artifacts`
+	);
+}
+
+/**
+ * Fetch the raw markdown body of one phase artifact. Returns null when the
+ * artifact has not been written yet (404); other errors throw so the caller
+ * can surface them. Markdown bypasses the standard JSON `request` helper
+ * because the endpoint sends `text/markdown`.
+ */
+export async function fetchPhaseArtifactContent(
+	slug: string,
+	name: PhaseArtifactName
+): Promise<string | null> {
+	const response = await fetch(
+		`/plan-manager/plans/${encodeURIComponent(slug)}/artifacts/${encodeURIComponent(name)}`,
+		{ headers: { Accept: 'text/markdown' } }
+	);
+	if (response.status === 404) {
+		return null;
+	}
+	if (!response.ok) {
+		throw new Error(`Failed to load ${name}: ${response.status} ${response.statusText}`);
+	}
+	return response.text();
+}

--- a/ui/src/lib/components/plan/PhaseArtifactsView.svelte
+++ b/ui/src/lib/components/plan/PhaseArtifactsView.svelte
@@ -1,0 +1,329 @@
+<script lang="ts">
+	import {
+		fetchPhaseArtifactContent,
+		fetchPhaseArtifacts,
+		phaseArtifactLabel,
+		type PhaseArtifact,
+		type PhaseArtifactName
+	} from '$lib/api/artifacts';
+	import { artifactSectionId, renderArtifact } from './artifactRenderer';
+
+	interface Props {
+		slug: string;
+	}
+
+	let { slug }: Props = $props();
+
+	let artifacts = $state<PhaseArtifact[]>([]);
+	let contents = $state<Record<string, string>>({});
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	// Artifact contents arrive in parallel after the list. The renderer needs
+	// the markdown to produce HTML + headings; cache the rendered form keyed
+	// by name so subsequent reactive reads don't reparse.
+	let rendered = $derived.by(() => {
+		const out: Record<string, ReturnType<typeof renderArtifact>> = {};
+		for (const a of artifacts) {
+			const md = contents[a.name];
+			if (md !== undefined) {
+				out[a.name] = renderArtifact(a.name, md);
+			}
+		}
+		return out;
+	});
+
+	// Whenever the slug changes, refetch from scratch. `cancelled` guards
+	// against late responses from the previous slug overwriting the new
+	// view's state — a real risk with parallel content fetches.
+	$effect(() => {
+		const currentSlug = slug;
+		let cancelled = false;
+		loading = true;
+		error = null;
+		artifacts = [];
+		contents = {};
+
+		(async () => {
+			try {
+				const list = await fetchPhaseArtifacts(currentSlug);
+				if (cancelled) return;
+				artifacts = list.artifacts;
+				const results = await Promise.all(
+					list.artifacts.map(async (a) => {
+						const body = await fetchPhaseArtifactContent(currentSlug, a.name);
+						return [a.name, body] as const;
+					})
+				);
+				if (cancelled) return;
+				const next: Record<string, string> = {};
+				for (const [name, body] of results) {
+					if (body !== null) next[name] = body;
+				}
+				contents = next;
+			} catch (e) {
+				if (!cancelled) {
+					error = e instanceof Error ? e.message : 'Failed to load artifacts';
+				}
+			} finally {
+				if (!cancelled) loading = false;
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	function scrollToArtifact(name: PhaseArtifactName) {
+		const id = artifactSectionId(name);
+		const el = document.getElementById(id);
+		if (el) {
+			el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
+	}
+</script>
+
+<div class="artifacts" data-testid="phase-artifacts">
+	{#if loading}
+		<div class="artifacts-loading">Loading artifacts&hellip;</div>
+	{:else if error}
+		<div class="artifacts-error" role="alert">{error}</div>
+	{:else if artifacts.length === 0}
+		<div class="artifacts-empty">
+			<p>No phase artifacts written yet. They appear here as the plan progresses
+				through architecture, requirements, scenarios, and QA.</p>
+		</div>
+	{:else}
+		<nav class="artifacts-toc" aria-label="Artifact sections">
+			{#each artifacts as a (a.name)}
+				<button
+					type="button"
+					class="toc-chip"
+					onclick={() => scrollToArtifact(a.name)}
+					data-testid="toc-{a.name}"
+				>
+					{phaseArtifactLabel(a.name)}
+				</button>
+			{/each}
+		</nav>
+
+		{#each artifacts as a (a.name)}
+			{@const r = rendered[a.name]}
+			{@const sectionId = artifactSectionId(a.name)}
+			{@const titleId = `${sectionId}-title`}
+			<section
+				class="artifact-section"
+				id={sectionId}
+				aria-labelledby={titleId}
+				data-testid="artifact-{a.name}"
+			>
+				<header class="artifact-header">
+					<h2 id={titleId} class="artifact-title">{phaseArtifactLabel(a.name)}</h2>
+					<span class="artifact-filename">{a.filename}</span>
+				</header>
+				{#if r}
+					<div class="artifact-body markdown-body">
+						{@html r.html}
+					</div>
+				{:else}
+					<div class="artifact-body-loading">Loading&hellip;</div>
+				{/if}
+			</section>
+		{/each}
+	{/if}
+</div>
+
+<style>
+	.artifacts {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+		padding: var(--space-2) 0;
+	}
+
+	.artifacts-loading,
+	.artifacts-error,
+	.artifacts-empty {
+		padding: var(--space-8) var(--space-4);
+		color: var(--color-text-muted);
+		font-size: var(--font-size-sm);
+		text-align: center;
+	}
+
+	.artifacts-error {
+		color: var(--color-error);
+	}
+
+	.artifacts-toc {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+		padding: var(--space-2);
+		background: var(--color-bg-secondary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+	}
+
+	.toc-chip {
+		padding: var(--space-1) var(--space-2);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-medium);
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-secondary);
+		cursor: pointer;
+		transition: background var(--transition-fast);
+	}
+
+	.toc-chip:hover {
+		background: var(--color-bg-elevated);
+		color: var(--color-text-primary);
+	}
+
+	.artifact-section {
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+		scroll-margin-top: var(--space-12);
+	}
+
+	.artifact-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-4);
+		background: var(--color-bg-tertiary);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.artifact-title {
+		font-size: var(--font-size-md);
+		font-weight: var(--font-weight-semibold);
+		color: var(--color-text-primary);
+		margin: 0;
+	}
+
+	.artifact-filename {
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+		font-family: var(--font-mono, monospace);
+	}
+
+	.artifact-body {
+		padding: var(--space-4);
+		color: var(--color-text-primary);
+		font-size: var(--font-size-sm);
+		line-height: 1.6;
+	}
+
+	.artifact-body-loading {
+		padding: var(--space-4);
+		color: var(--color-text-muted);
+		font-size: var(--font-size-sm);
+	}
+
+	/* Markdown body styles — scoped via :global because @html content
+	   bypasses Svelte's CSS scoping. Keep selectors anchored at
+	   .markdown-body so we never bleed onto the rest of the app. */
+	:global(.markdown-body h1),
+	:global(.markdown-body h2),
+	:global(.markdown-body h3),
+	:global(.markdown-body h4),
+	:global(.markdown-body h5),
+	:global(.markdown-body h6) {
+		margin: var(--space-4) 0 var(--space-2);
+		color: var(--color-text-primary);
+		font-weight: var(--font-weight-semibold);
+		scroll-margin-top: var(--space-12);
+	}
+
+	:global(.markdown-body h1) {
+		font-size: var(--font-size-lg);
+	}
+	:global(.markdown-body h2) {
+		font-size: var(--font-size-md);
+	}
+	:global(.markdown-body h3) {
+		font-size: var(--font-size-sm);
+		text-transform: uppercase;
+		letter-spacing: 0.02em;
+		color: var(--color-text-secondary);
+	}
+
+	:global(.markdown-body p) {
+		margin: var(--space-2) 0;
+	}
+
+	:global(.markdown-body ul),
+	:global(.markdown-body ol) {
+		margin: var(--space-2) 0;
+		padding-left: var(--space-6);
+	}
+
+	:global(.markdown-body li) {
+		margin: var(--space-1) 0;
+	}
+
+	:global(.markdown-body code) {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.92em;
+		padding: 1px 4px;
+		background: var(--color-bg-tertiary);
+		border-radius: var(--radius-sm);
+	}
+
+	:global(.markdown-body pre) {
+		padding: var(--space-3);
+		background: var(--color-bg-tertiary);
+		border-radius: var(--radius-md);
+		overflow-x: auto;
+	}
+
+	:global(.markdown-body pre code) {
+		padding: 0;
+		background: none;
+	}
+
+	:global(.markdown-body table) {
+		border-collapse: collapse;
+		margin: var(--space-2) 0;
+		font-size: var(--font-size-xs);
+		width: 100%;
+	}
+
+	:global(.markdown-body th),
+	:global(.markdown-body td) {
+		border: 1px solid var(--color-border);
+		padding: var(--space-1) var(--space-2);
+		text-align: left;
+		vertical-align: top;
+	}
+
+	:global(.markdown-body th) {
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-secondary);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	:global(.markdown-body a) {
+		color: var(--color-accent);
+		text-decoration: none;
+	}
+
+	:global(.markdown-body a:hover) {
+		text-decoration: underline;
+	}
+
+	:global(.markdown-body blockquote) {
+		margin: var(--space-2) 0;
+		padding-left: var(--space-3);
+		border-left: 3px solid var(--color-border);
+		color: var(--color-text-secondary);
+	}
+</style>

--- a/ui/src/lib/components/plan/artifactRenderer.test.ts
+++ b/ui/src/lib/components/plan/artifactRenderer.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import {
+	artifactSectionId,
+	headingId,
+	renderArtifact,
+	rewriteCrossLink
+} from './artifactRenderer';
+
+describe('artifactSectionId', () => {
+	it('prefixes the artifact name with "artifact-"', () => {
+		expect(artifactSectionId('architecture')).toBe('artifact-architecture');
+		expect(artifactSectionId('qa-summary')).toBe('artifact-qa-summary');
+	});
+});
+
+describe('headingId', () => {
+	it('slugifies text and prefixes with the artifact name', () => {
+		expect(headingId('architecture', 'Technology choices')).toBe(
+			'architecture--technology-choices'
+		);
+	});
+
+	it('strips punctuation and collapses whitespace', () => {
+		expect(headingId('scenarios', 'REQ-001: User login!  ')).toBe(
+			'scenarios--req-001-user-login'
+		);
+	});
+
+	it('falls back to "section" for headings that slug away to empty', () => {
+		expect(headingId('plan', '!!!')).toBe('plan--section');
+	});
+});
+
+describe('rewriteCrossLink', () => {
+	it('rewrites ./X.md to the section anchor', () => {
+		expect(rewriteCrossLink('./architecture.md')).toBe('#artifact-architecture');
+		expect(rewriteCrossLink('./qa-summary.md')).toBe('#artifact-qa-summary');
+	});
+
+	it('accepts bare X.md without ./', () => {
+		expect(rewriteCrossLink('requirements.md')).toBe('#artifact-requirements');
+	});
+
+	it('forwards an in-file fragment verbatim, prefixed by the artifact', () => {
+		expect(rewriteCrossLink('./scenarios.md#requirement-overview')).toBe(
+			'#scenarios--requirement-overview'
+		);
+	});
+
+	it('does not re-slugify a fragment that already contains punctuation', () => {
+		// Authors emit fragments that match `${artifact}--${slug}` ids; the
+		// rewriter must concatenate, not re-slugify, so the round trip is
+		// stable for fragments that survive the first slugifier pass
+		// differently from a re-run.
+		expect(rewriteCrossLink('./requirements.md#REQ-001')).toBe(
+			'#requirements--REQ-001'
+		);
+	});
+
+	it('returns null for unknown artifact names', () => {
+		expect(rewriteCrossLink('./glossary.md')).toBeNull();
+	});
+
+	it('returns null for external links', () => {
+		expect(rewriteCrossLink('https://example.com/x.md')).toBeNull();
+		expect(rewriteCrossLink('mailto:nobody@example.com')).toBeNull();
+		expect(rewriteCrossLink('//cdn.example.com/x.md')).toBeNull();
+	});
+
+	it('returns null for non-markdown files (plan.json etc.)', () => {
+		expect(rewriteCrossLink('./plan.json')).toBeNull();
+	});
+});
+
+describe('renderArtifact', () => {
+	it('renders headings with deterministic ids', () => {
+		const md = '# Architecture: Auth\n\n## Technology choices\n\nBody.\n';
+		const out = renderArtifact('architecture', md);
+		expect(out.html).toContain('id="architecture--architecture-auth"');
+		expect(out.html).toContain('id="architecture--technology-choices"');
+		expect(out.headings).toEqual([
+			{ id: 'architecture--architecture-auth', text: 'Architecture: Auth', level: 1 },
+			{ id: 'architecture--technology-choices', text: 'Technology choices', level: 2 }
+		]);
+	});
+
+	it('renders GFM tables', () => {
+		const md = '| a | b |\n|---|---|\n| 1 | 2 |\n';
+		const out = renderArtifact('architecture', md);
+		expect(out.html).toContain('<table>');
+		expect(out.html).toContain('<th>a</th>');
+		expect(out.html).toContain('<td>1</td>');
+	});
+
+	it('rewrites cross-artifact links inline', () => {
+		const md = 'See [`scenarios.md`](./scenarios.md) for the BDD list.\n';
+		const out = renderArtifact('run-summary', md);
+		expect(out.html).toContain('href="#artifact-scenarios"');
+		expect(out.html).not.toContain('./scenarios.md');
+	});
+
+	it('leaves unknown links alone', () => {
+		const md = '[external](https://example.com)\n';
+		const out = renderArtifact('plan', md);
+		expect(out.html).toContain('href="https://example.com"');
+	});
+
+	it('deduplicates colliding heading ids inside the same artifact', () => {
+		const md = '## Overview\n\nFirst.\n\n## Overview\n\nSecond.\n';
+		const out = renderArtifact('plan', md);
+		expect(out.headings.map((h) => h.id)).toEqual([
+			'plan--overview',
+			'plan--overview-2'
+		]);
+	});
+
+	it('keeps every duplicate unique across three or more collisions', () => {
+		const md = '## Overview\n\nA.\n\n## Overview\n\nB.\n\n## Overview\n\nC.\n';
+		const out = renderArtifact('plan', md);
+		const ids = out.headings.map((h) => h.id);
+		expect(ids).toEqual(['plan--overview', 'plan--overview-2', 'plan--overview-3']);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it('strips dangerous inline HTML before injecting into the document', () => {
+		const md = '# Title\n\n<img src=x onerror="alert(1)">\n';
+		const out = renderArtifact('plan', md);
+		expect(out.html).not.toContain('onerror');
+	});
+});

--- a/ui/src/lib/components/plan/artifactRenderer.ts
+++ b/ui/src/lib/components/plan/artifactRenderer.ts
@@ -1,0 +1,141 @@
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+import {
+	PHASE_ARTIFACT_NAMES,
+	type PhaseArtifactName
+} from '$lib/api/artifacts';
+
+/** TOC entry exposed for the section navigation strip. */
+export interface ArtifactHeading {
+	id: string;
+	text: string;
+	/** 1-6, matching h1-h6. */
+	level: number;
+}
+
+export interface RenderedArtifact {
+	html: string;
+	headings: ArtifactHeading[];
+}
+
+const PHASE_ARTIFACT_SET = new Set<string>(PHASE_ARTIFACT_NAMES);
+
+/**
+ * Stable in-page id for the wrapper section of an artifact. Keep in sync
+ * with the prefix used by `headingId` and the cross-link rewriter so
+ * navigation lands on the section header, not a heading inside it.
+ */
+export function artifactSectionId(name: PhaseArtifactName): string {
+	return `artifact-${name}`;
+}
+
+/**
+ * Compute a deterministic anchor id from heading text plus the owning
+ * artifact name. The artifact prefix prevents collisions when two
+ * artifacts contain identical headings (e.g. both have "Overview"),
+ * which would otherwise cause a TOC link to jump to the wrong section.
+ */
+export function headingId(artifact: PhaseArtifactName, text: string): string {
+	const slug = text
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+	return `${artifact}--${slug || 'section'}`;
+}
+
+/**
+ * Rewrite a relative artifact link so it navigates inside the viewer.
+ * Returns null when the href is not a recognised cross-artifact link
+ * (caller should leave the original href alone). Accepts both
+ * `./architecture.md` and bare `architecture.md` forms, and preserves a
+ * trailing `#fragment` if present.
+ *
+ * The fragment is treated as an already-slugged anchor id (matching the
+ * `${artifact}--${slug}` shape `renderArtifact` emits), not as free
+ * heading text. Cross-artifact links in the Go renderer use ids that
+ * came from the same slug function, so concatenating directly avoids
+ * the double-slugification edge case where uppercase or punctuation in
+ * the fragment would survive differently on the second pass.
+ */
+export function rewriteCrossLink(href: string): string | null {
+	if (!href) return null;
+	// External links (http(s), mailto, protocol-relative) are out of scope.
+	if (/^[a-z]+:/i.test(href) || href.startsWith('//')) return null;
+
+	const trimmed = href.startsWith('./') ? href.slice(2) : href;
+	const hashIdx = trimmed.indexOf('#');
+	const base = hashIdx === -1 ? trimmed : trimmed.slice(0, hashIdx);
+	const frag = hashIdx === -1 ? '' : trimmed.slice(hashIdx + 1);
+
+	if (!base.endsWith('.md')) return null;
+	const name = base.slice(0, -3) as PhaseArtifactName;
+	if (!PHASE_ARTIFACT_SET.has(name)) return null;
+
+	if (frag) {
+		return `#${name}--${frag}`;
+	}
+	return `#${artifactSectionId(name)}`;
+}
+
+/**
+ * Render one artifact's markdown body to HTML, adding heading anchors
+ * and rewriting cross-artifact links. The HTML is sanitized with
+ * DOMPurify before any DOM walk because plan title/goal/context fields
+ * flow into the source markdown without HTML escaping — sanitization
+ * neutralises a stored-XSS path through user-supplied plan fields.
+ */
+export function renderArtifact(
+	artifact: PhaseArtifactName,
+	markdown: string
+): RenderedArtifact {
+	const rawHtml = marked.parse(markdown, {
+		gfm: true,
+		breaks: false,
+		async: false
+	}) as string;
+
+	const safeHtml = DOMPurify.sanitize(rawHtml);
+
+	// DOMParser is available in the browser and in jsdom-backed tests.
+	const doc = new DOMParser().parseFromString(`<div>${safeHtml}</div>`, 'text/html');
+	const root = doc.body.firstElementChild as HTMLElement | null;
+	if (!root) {
+		return { html: safeHtml, headings: [] };
+	}
+
+	const headings: ArtifactHeading[] = [];
+	// Counter is keyed on the *base* id so collisions track all variants
+	// against one canonical slug — without that, the third "Overview"
+	// heading would lookup an empty counter and re-emit the dedup'd id of
+	// the second one, producing duplicate DOM ids.
+	const seen = new Map<string, number>();
+	const headingNodes = root.querySelectorAll('h1, h2, h3, h4, h5, h6');
+	headingNodes.forEach((node) => {
+		const text = (node.textContent ?? '').trim();
+		if (!text) return;
+		const baseId = headingId(artifact, text);
+		const count = seen.get(baseId) ?? 0;
+		const id = count === 0 ? baseId : `${baseId}-${count + 1}`;
+		seen.set(baseId, count + 1);
+		node.setAttribute('id', id);
+		headings.push({
+			id,
+			text,
+			level: Number(node.tagName.slice(1))
+		});
+	});
+
+	root.querySelectorAll('a[href]').forEach((node) => {
+		const href = node.getAttribute('href') ?? '';
+		const rewritten = rewriteCrossLink(href);
+		if (rewritten) {
+			node.setAttribute('href', rewritten);
+			// Cross-artifact navigation stays in-page; suppress target overrides.
+			node.removeAttribute('target');
+		}
+	});
+
+	return { html: root.innerHTML, headings };
+}

--- a/ui/src/routes/e2e-test/phase-artifacts/+page.svelte
+++ b/ui/src/routes/e2e-test/phase-artifacts/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	/**
+	 * Playwright harness for PhaseArtifactsView. Renders the component in
+	 * isolation against stubbed /plan-manager/plans/{slug}/artifacts endpoints
+	 * so smoke tests can assert TOC + anchor + cross-link behavior without
+	 * touching the live LLM pipeline. Not linked from navigation.
+	 */
+	import PhaseArtifactsView from '$lib/components/plan/PhaseArtifactsView.svelte';
+	import type { PageData } from './$types';
+
+	interface Props {
+		data: PageData;
+	}
+
+	let { data }: Props = $props();
+</script>
+
+<div class="harness" data-testid="phase-artifacts-harness">
+	<PhaseArtifactsView slug={data.slug} />
+</div>
+
+<style>
+	.harness {
+		height: 100vh;
+		width: 100vw;
+		overflow-y: auto;
+		padding: 16px;
+	}
+</style>

--- a/ui/src/routes/e2e-test/phase-artifacts/+page.ts
+++ b/ui/src/routes/e2e-test/phase-artifacts/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types';
+
+/**
+ * SSR disabled so Playwright page.route stubs intercept every artifacts
+ * fetch from PhaseArtifactsView. Mirrors the /plan-workspace pattern.
+ */
+export const ssr = false;
+
+export const load: PageLoad = async ({ url }) => {
+	return { slug: url.searchParams.get('slug') ?? '' };
+};

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -7,6 +7,7 @@
 	import PlanDetail from '$lib/components/plan/PlanDetail.svelte';
 	import RequirementPanel from '$lib/components/plan/RequirementPanel.svelte';
 	import ActionBar from '$lib/components/plan/ActionBar.svelte';
+	import PhaseArtifactsView from '$lib/components/plan/PhaseArtifactsView.svelte';
 	import { AgentPipelineView } from '$lib/components/pipeline';
 	import ExecutionTimeline from '$lib/components/trajectory/ExecutionTimeline.svelte';
 	import { ReviewDashboard } from '$lib/components/review';
@@ -45,7 +46,7 @@
 	// ---------------------------------------------------------------------------
 	// View mode — toggle between Doc, Graph, and Files
 	// ---------------------------------------------------------------------------
-	type ViewMode = 'doc' | 'graph' | 'files';
+	type ViewMode = 'doc' | 'artifacts' | 'graph' | 'files';
 	let viewMode = $state<ViewMode>('doc');
 
 	// Build a plan-scoped graph adapter that loads the plan's entity neighborhood
@@ -309,6 +310,15 @@
 				</button>
 				<button
 					class="toggle-btn"
+					class:active={viewMode === 'artifacts'}
+					aria-pressed={viewMode === 'artifacts'}
+					onclick={() => setViewMode('artifacts')}
+				>
+					<Icon name="book-open" size={14} />
+					<span>Artifacts</span>
+				</button>
+				<button
+					class="toggle-btn"
 					class:active={viewMode === 'graph'}
 					aria-pressed={viewMode === 'graph'}
 					onclick={() => setViewMode('graph')}
@@ -387,6 +397,10 @@
 	{:else if viewMode === 'files'}
 		<div class="files-content">
 			<PlanWorkspace slug={plan.slug} />
+		</div>
+	{:else if viewMode === 'artifacts'}
+		<div class="artifacts-content">
+			<PhaseArtifactsView slug={plan.slug} />
 		</div>
 	{:else}
 		<div class="plan-content">
@@ -759,6 +773,13 @@
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
+	}
+
+	/* Artifacts mode content — scrolls vertically so the sticky TOC can pin. */
+	.artifacts-content {
+		flex: 1;
+		overflow-y: auto;
+		padding: 0 var(--space-2);
 	}
 
 	@media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- New backend endpoints serve the per-phase BMAD/OpenSpec markdown files written by `workflow-documents`: `GET /plan-manager/plans/{slug}/artifacts` (list) and `GET .../artifacts/{name}` (raw `text/markdown`). Names restricted to the known whitelist; missing files 404.
- New frontend view mode "Artifacts" alongside Doc/Graph/Files. `PhaseArtifactsView.svelte` fetches the list and concurrent-fetches each body, renders with `marked` (GFM tables), sanitizes with `DOMPurify`, and DOM-walks to inject `${artifact}--${slug}` heading anchors + rewrite `./X.md(#frag)?` cross-links to in-page anchors.
- Pure renderer in `artifactRenderer.ts` is fully unit-tested under jsdom (18 tests covering anchors, GFM tables, cross-link rewriting, 3+ collision dedup, and XSS-strip via DOMPurify).

## Review history
`svelte-reviewer` flagged CHANGES_REQUESTED on the first cut; required fixes shipped before this PR opened:
- Heading-dedup counter now keys on the canonical base id (third+ collisions stay unique).
- Cross-link fragments forwarded verbatim with `${name}--` prefix — no double-slugification.
- Each `<section>` now carries `aria-labelledby` to its title heading.
- DOMPurify sanitization closes a stored-XSS path through user-supplied plan title/goal flowing into source markdown.

## Test plan
- [x] `go test ./processor/plan-manager/` — 6 new artifact tests green
- [x] `npx vitest run` — 195/195 green (18 are new renderer tests)
- [x] `npm run check` — 0 errors, only pre-existing autofocus warnings in `settings/+page.svelte`
- [ ] Manual: open a plan that has progressed past architecture; switch to Artifacts; confirm TOC chips smooth-scroll, cross-links navigate in-page, GFM tables render, and the sticky TOC stays readable.
- [ ] Manual: regress Doc / Graph / Files toggles still work — Artifacts is additive.

## Deferred follow-ups (from `svelte-reviewer`, non-blocking)
- IntersectionObserver to set `aria-current="location"` on the active TOC chip.
- Verify sticky-TOC contrast against `--color-bg-secondary` in the live theme (probably wants a `box-shadow` on scroll entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)