### PR TITLE
test(ui): @t1 plan-journey asserts artifacts reach UI

### DIFF
--- a/configs/e2e-mock-ui.json
+++ b/configs/e2e-mock-ui.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.2.0",
   "persona_preset": "bmad",
   "platform": {
     "org": "semspec",

--- a/test/e2e/fixtures/mock-responses/hello-world/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/hello-world/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Task completed successfully\"}"
+        "arguments": "{\"summary\": \"Task completed successfully\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/hello-world/mock-recovery-agent.json
+++ b/test/e2e/fixtures/mock-responses/hello-world/mock-recovery-agent.json
@@ -1,0 +1,14 @@
+{
+  "content": "Recovery decision: refine the developer prompt and let TDD retry once.",
+  "tool_calls": [
+    {
+      "id": "call_recovery_refine",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"action\":\"refine_prompt\",\"diagnosis\":\"Developer loop stopped short of submitting files_modified. Refining the prompt to require the explicit file list in submit_work so the next TDD cycle terminates cleanly.\",\"refined_prompt\":\"On submit_work, always include files_modified with the actual files you wrote (e.g. api/app.py, api/test_goodbye.py). Empty arrays or missing fields will be rejected by the developer-terminal validator.\",\"recovery_succeeded\":true}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/ui/e2e/plan-journey.spec.ts
+++ b/ui/e2e/plan-journey.spec.ts
@@ -123,6 +123,41 @@ test.describe('@t1 @happy-path plan-journey', () => {
 		expect(plan.stage).toBe('ready_for_execution');
 	});
 
+	test('artifacts view renders backend-written markdown at ready_for_execution', async ({ page }) => {
+		// Closes the loop on PR #4: workflow-documents writes
+		// .semspec/plans/{slug}/{plan,architecture,requirements,scenarios}.md
+		// at every milestone; plan-manager serves them via /artifacts; the
+		// viewer fetches + renders them inline. Unit + smoke tests already
+		// cover the rendering pipeline against stubs — this one proves the
+		// real file → API → DOM path.
+		await page.goto(`/plans/${slug}`);
+		await waitForHydration(page);
+
+		// Switch to the Artifacts view mode.
+		await page.getByRole('button', { name: 'Artifacts' }).click();
+
+		const view = page.getByTestId('phase-artifacts');
+		await expect(view).toBeVisible();
+
+		// plan.md is non-skippable — RenderPlan always emits content, so it
+		// must appear regardless of which other phases ran. The TOC chip
+		// proves the list endpoint returned it; the section proves the
+		// content endpoint + renderer worked end-to-end.
+		await expect(page.getByTestId('toc-plan')).toBeVisible({ timeout: 15000 });
+		const planSection = page.locator('section#artifact-plan');
+		await expect(planSection).toBeVisible();
+		await expect(planSection.locator('.markdown-body')).not.toBeEmpty();
+
+		// Hello-world fixture exercises the architecture + requirement +
+		// scenario generators, so those artifacts should also be present
+		// by ready_for_execution. Asserting them here catches a regression
+		// in the workflow-documents milestone watcher.
+		for (const name of ['architecture', 'requirements', 'scenarios']) {
+			await expect(page.getByTestId(`toc-${name}`)).toBeVisible();
+			await expect(page.locator(`section#artifact-${name} .markdown-body`)).not.toBeEmpty();
+		}
+	});
+
 	test('editing is available at ready_for_execution', async ({ page }) => {
 		// After round 2 approval, the plan is at ready_for_execution — a human
 		// decision point. Editing should be enabled here so users can review

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -24,6 +24,17 @@ const dockerComposeCommand = useMockLLM
 	? 'docker compose -f docker-compose.e2e.yml -f docker-compose.e2e-mock.yml up --wait'
 	: 'docker compose -f docker-compose.e2e.yml up --wait';
 
+// Mock-LLM journeys are scripted against hello-world-py — the planner /
+// reviewer / coder fixtures all reference api/app.py + ui/app.js. The base
+// compose defaults semspec workspace to go-project, the mock overlay
+// defaults sandbox to hello-world-py; without an explicit override they
+// drift apart and planner scope.include validation fails on the first
+// dispatch. Pin both to hello-world-py here so operators don't have to
+// remember the env var.
+const mockEnv: Record<string, string> = useMockLLM
+	? { E2E_FIXTURE: process.env.E2E_FIXTURE ?? 'hello-world-py' }
+	: {};
+
 const T1_SPECS = ['e2e/plan-journey.spec.ts', 'e2e/plan-rejection-journey.spec.ts'];
 const T2_SPECS = [
 	'e2e/plan-lifecycle-llm.spec.ts',
@@ -75,6 +86,7 @@ export default defineConfig({
 		timeout: 120 * 1000,
 		stdout: 'pipe',
 		stderr: 'pipe',
+		env: mockEnv,
 	},
 	timeout,
 	expect: {


### PR DESCRIPTION
## Summary
- Extends the @t1 hello-world mock-LLM journey spec with one new test that switches to the Artifacts view at `ready_for_execution` and asserts plan/architecture/requirements/scenarios markdown reaches the DOM. Closes the loop on PR #4 — the unit + smoke tiers cover the renderer against stubs; this proves the real file → `/artifacts` endpoint → renderer path.
- Bumps `configs/e2e-mock-ui.json` version `1.0.3 → 1.2.0`. semstreams `config.Manager` compares file-vs-KV versions on boot; production `semspec.json` is at `1.1.0`, so an older mock config loses to a stale KV `model_registry` from any prior production-config boot reusing the NATS volume. Bumping above production keeps the file authoritative on mock startup.
- Three e2e infra fixes that unblock the journey through structural validation (was blocked at the developer terminal, then again at recovery dispatch):
  - **`mock-coder.json` fallback** now ships `files_modified` so the developer-terminal validator (added Apr 21 in `6e3c1a0`) doesn't reject the repeating fallback after numbered fixtures are consumed.
  - **`hello-world/mock-recovery-agent.json`** added — fixture existed for `task-dispatcher/` and `hello-world-iteration-exhaustion/` but not `hello-world/`, so any TDD-budget exhaustion 404'd at mock-llm. Returns `action=refine_prompt recovery_succeeded=true` so cascade can complete.
  - **`E2E_FIXTURE=hello-world-py`** wired into Playwright's `webServer.env` when `USE_MOCK_LLM=true`, so semspec and sandbox mount the same fixture without operator intervention.

## Why the version bump matters
Diagnosed end-to-end: on a reused NATS volume the e2e-mock stack was dispatching to `model=claude-opus` and falling through to `api.openai.com` (401), because `syncFromKV` re-applied the stale production registry. The "versions equal/older → sync from KV" branch in `semstreams/config/manager.go` is the active behavior. Bumping the mock version above production makes the file win deterministically. Operationally `docker compose down -v` also clears it, but that's brittle as a CI invariant.

## Test plan
- [x] `npx playwright test e2e/plan-journey.spec.ts --project=t1 --no-deps --workers=1` — the new artifact-assertion test passes in 363ms (test #6 of 11).
- 8/11 t1 cases green through this PR; `execution reaches complete` (and the two downstream tests it gates) still red due to two **deeper** issues that this PR's fixes _unmasked_ — filed as #6 and #7, not in scope for this branch.

## Follow-ups filed
- **#6 — Sandbox pytest missing despite pip-install.** Structural validation runs `python3 -m pytest` but the matching `pip install --break-system-packages` doesn't reach the same site-packages. Most likely a `pip` vs `python3 -m pip` interpreter split in `docker/sandbox.Dockerfile`'s ubuntu base.
- **#7 — cascade entity ID 9 parts instead of 6.** Recovery cascade builds entity IDs by concatenating dotted plan-decision IDs into the instance segment; graph-ingest rejects them. Needs `HashInstanceID` + triple companions per the entity-id convention.

Both were masked by the fixture drifts this PR fixes — they only surface once the developer loop produces valid output and the recovery agent actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)