### PR TITLE
fix(ui): unblock @t1 by stabilizing LeftPanel mode in plan-list

### DIFF
--- a/ui/e2e/plan-list.spec.ts
+++ b/ui/e2e/plan-list.spec.ts
@@ -9,12 +9,18 @@ import {
 	feedModeRadio
 } from './helpers/selectors';
 
-/** Ensure Plans mode is active (may auto-switch to Feed when loops exist). */
+/**
+ * Ensure Plans mode is active and stays active. Click is unconditional because
+ * we need manualOverride=true in LeftPanel — a one-shot aria-checked read can
+ * miss the auto-switch effect that fires when activityStore picks up SSE
+ * replays from prior tests' loops. Wait on the "Filter plans" radiogroup so
+ * we know PlansList (not ActivityFeed) is actually mounted before proceeding.
+ */
 async function ensurePlansMode(page: import('@playwright/test').Page) {
 	const plansRadio = page.getByRole('radio', { name: 'Plans' });
-	if ((await plansRadio.getAttribute('aria-checked')) === 'false') {
-		await plansRadio.click();
-	}
+	await plansRadio.click();
+	await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
+	await expect(page.getByRole('radiogroup', { name: 'Filter plans' })).toBeVisible();
 }
 
 test.describe('@t0 plan-list', () => {

--- a/ui/src/lib/components/shell/LeftPanel.svelte
+++ b/ui/src/lib/components/shell/LeftPanel.svelte
@@ -19,15 +19,15 @@
 	let mode = $state<PanelMode>('plans');
 	let manualOverride = $state(false);
 
-	// Auto-switch: feed when there's activity from any source — active loops,
-	// plan-scoped feed events, OR global loop ticks. The global branch matters
-	// on /board where no plan is selected and feedStore never populates
-	// (ActivityFeed renders activityStore in that case — see scope="global").
+	// Auto-switch: feed when there's LIVE activity — active loops or
+	// plan-scoped feed events. Use activityStore.loopLastSeen (live, evicted on
+	// loop_deleted) instead of activityStore.recent.length (sliding window that
+	// retains completed loops, fires Feed mode on SSE replay of stale history).
 	$effect(() => {
 		const hasActivity =
 			activeLoopCount > 0 ||
 			feedStore.events.length > 0 ||
-			activityStore.recent.length > 0;
+			activityStore.loopLastSeen.size > 0;
 		if (hasActivity && !manualOverride) {
 			mode = 'feed';
 		} else if (!hasActivity) {


### PR DESCRIPTION
## Summary

- Two narrow fixes that unblock the full `task e2e:ui:test:mock` lifecycle for the first time since 7b228e4: t0 is fully green and t1 (plan-journey + plan-rejection-journey) runs cleanly under it.
- LeftPanel auto-switch no longer fires on stale SSE replay — only on LIVE activity (active loops + plan-scoped feed events).
- `ensurePlansMode` test helper is now actually idempotent and waits for PlansList content before returning.

## Root cause

`@t0 plan-list > plan item links to detail page` was the one t0 failure cascading through the entire t1 project (which `dependencies: ['t0']`). Symptom looked like a slug-mismatch, but the snapshot showed `panel-left` rendering the Activity Feed at click time, not PlansList. Tracing back: SSE replay of completed loops from prior tests filled `activityStore.recent` on every fresh page, the `LeftPanel` `$effect` flipped `mode = 'feed'` between `ensurePlansMode`'s one-shot `aria-checked` read and the next `.click()`, and the test then searched for the plan link inside an Activity Feed that didn't contain it.

## Changes

- `ui/src/lib/components/shell/LeftPanel.svelte` — replace `activityStore.recent.length > 0` with `activityStore.loopLastSeen.size > 0` in the auto-switch trigger. `loopLastSeen` evicts on `loop_deleted`, so it reflects live loops; `recent.length` is a sliding window that retains completed loops and triggers Feed mode on stale replay.
- `ui/e2e/plan-list.spec.ts` — `ensurePlansMode` now clicks Plans unconditionally (locks `manualOverride=true` even when mode appears 'plans') and waits for the `Filter plans` radiogroup so callers can trust PlansList is mounted.

## Test plan

- [x] `cd ui && USE_MOCK_LLM=true E2E_FIXTURE=hello-world-py npx playwright test --project t0 --workers=1` — 108 passed, 5 pre-existing skips, 0 failed
- [x] `cd ui && USE_MOCK_LLM=true E2E_FIXTURE=hello-world-py npx playwright test --project t1 --workers=1` — 108 t0 (deps) + 13 t1 all passed, 47s total
- [x] Verified the specific previously-flaky test (`@t0 plan-list > plan item links to detail page`) goes from 1.5m timeout → ~330ms pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)