### PR TITLE
fix(structural-validator): empty trigger means always run

### DIFF
--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -87,7 +87,14 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 
 	var results []payloads.CheckResult
 	for _, check := range checklist.Checks {
-		if !runAll && !matchesAny(check.Trigger, trigger.FilesModified) {
+		// Empty Trigger means "always run" — a checklist author who wanted
+		// the check to never run would simply delete it. matchesAny returns
+		// false on empty patterns (it's a pure pattern matcher), so the
+		// len-guard is what gives empty Trigger the always-run semantic
+		// fixture authors expect. Caught PR #8 (issue #6 ring 2):
+		// hello-world-py pip-install had trigger:[] and was silently
+		// skipped on every dispatch, so pytest ran against an empty venv.
+		if !runAll && len(check.Trigger) > 0 && !matchesAny(check.Trigger, trigger.FilesModified) {
 			continue
 		}
 

--- a/processor/structural-validator/executor_test.go
+++ b/processor/structural-validator/executor_test.go
@@ -520,6 +520,55 @@ func TestRunAllChecks_WithFilesModified(t *testing.T) {
 	}
 }
 
+// TestRunAllChecks_EmptyTrigger verifies that a check with no Trigger
+// patterns always runs, even when FilesModified is non-empty. Empty trigger
+// reads as "always run" — the alternative ("never matches") makes the
+// checklist authoring footgun caught in PR #8 (hello-world-py pip-install
+// silently skipped). Required-by-design test for the executor contract.
+func TestRunAllChecks_EmptyTrigger(t *testing.T) {
+	dir := t.TempDir()
+	writeChecklist(t, dir, workflow.Checklist{
+		Version: "1",
+		Checks: []workflow.Check{
+			{
+				Name:     "always",
+				Command:  trueCmd(),
+				Trigger:  nil, // empty trigger → always run
+				Category: workflow.CheckCategoryLint,
+				Required: true,
+				Timeout:  "5s",
+			},
+			{
+				Name:     "go-only",
+				Command:  falseCmd(), // would fail if run
+				Trigger:  []string{"*.go"},
+				Category: workflow.CheckCategoryCompile,
+				Required: true,
+				Timeout:  "5s",
+			},
+		},
+	})
+
+	exec := newTestExecutor(dir)
+	result, err := exec.Execute(context.Background(), &payloads.ValidationRequest{
+		Slug:          "empty-trigger",
+		FilesModified: []string{"README.md"}, // matches no patterns
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ChecksRun != 1 {
+		t.Errorf("expected 1 check to run (the always-run one), got %d", result.ChecksRun)
+	}
+	if !result.Passed {
+		t.Error("expected Passed=true — only the passing always-run check ran")
+	}
+	if len(result.CheckResults) > 0 && result.CheckResults[0].Name != "always" {
+		t.Errorf("expected the 'always' check to run, got %q", result.CheckResults[0].Name)
+	}
+}
+
 // TestSplitCommand exercises the command tokeniser directly.
 func TestSplitCommand(t *testing.T) {
 	tests := []struct {

--- a/test/e2e/fixtures/hello-world-py/.semspec/checklist.json
+++ b/test/e2e/fixtures/hello-world-py/.semspec/checklist.json
@@ -5,13 +5,11 @@
     {
       "name": "pip-install",
       "command": "cd api && python3 -m pip install --break-system-packages -q -r requirements.txt",
-      "trigger": [
-        "*.py"
-      ],
+      "trigger": [],
       "category": "setup",
       "required": true,
       "timeout": "120s",
-      "description": "Install Python project dependencies — must run whenever pytest does because pytest depends on the installed packages. structural-validator skips checks with empty trigger when FilesModified is non-empty (matchesAny returns false on []).",
+      "description": "Install Python project dependencies. Empty trigger means always run — pytest's runtime depends on these packages regardless of which files changed.",
       "working_dir": "."
     },
     {

--- a/workflow/project_config.go
+++ b/workflow/project_config.go
@@ -188,7 +188,11 @@ type Check struct {
 	Command string `json:"command"`
 
 	// Trigger is a list of glob patterns — the check runs only when a
-	// modified file matches at least one pattern.
+	// modified file matches at least one pattern. An empty Trigger
+	// (nil or []) means "always run", regardless of which files changed —
+	// use this for setup/install steps whose runtime is independent of the
+	// modified set. Authors who want a check to never run should omit it,
+	// not give it an empty Trigger.
 	Trigger []string `json:"trigger"`
 
 	// Category classifies the check type.


### PR DESCRIPTION
## Summary

- structural-validator's Execute loop silently skipped any checklist entry with `trigger: []` when `FilesModified` was non-empty — `matchesAny([], files)` returns false because the outer loop over patterns doesn't execute. That contradicts the only reasonable reading of an empty trigger ("setup/install step whose runtime is independent of the modified set").
- Direct continuation of PR #8 ring 2: the hello-world-py pip-install workaround (`trigger: ["*.py"]`) is no longer needed; reverted.
- Documents the empty-Trigger semantic on the Check struct so future fixture authors don't re-trip the same pattern.

## Changes

- **`processor/structural-validator/executor.go`** — guard the skip with `len(check.Trigger) > 0`. Empty Trigger is now first-class "always run". `matchesAny` keeps its pure-pattern-matcher semantics; the always-run intent lives in the caller.
- **`processor/structural-validator/executor_test.go`** — `TestRunAllChecks_EmptyTrigger`: one always-run check + one `*.go` check, `FilesModified=["README.md"]`. Asserts only the always-run check runs.
- **`test/e2e/fixtures/hello-world-py/.semspec/checklist.json`** — revert pip-install's trigger back to `[]` with a cleaner description. The workaround comment was specific to the executor bug that no longer exists.
- **`workflow/project_config.go`** — godoc on the `Check.Trigger` field calls out the empty-list semantic explicitly.

## Test plan

- [x] `go test ./processor/structural-validator/ ./workflow/` — green
- [x] `go build ./...` — clean
- [x] `cd ui && USE_MOCK_LLM=true E2E_FIXTURE=hello-world-py npx playwright test plan-journey.spec.ts --project t1 --no-deps --workers=1` — 11/11 pass (6.1s on `execution reaches complete`)

## Other issues found

- The full `task e2e:ui:test:mock` lifecycle (t0+t1) flakes at `@t1 plan-journey > execution reaches complete` on plain main (no changes from this branch), failing with a pytest collection error `from app import app` that does NOT reproduce when pytest is run manually inside the sandbox container against the same worktree. Pre-existing — PR #9 was claimed-green on the full lifecycle but only the warm-stack `--project t1 --workers=1` path was actually verified. Worth its own triage; not caused by this commit and not reproducible in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)