### PR TITLE
test(ui): extract shared ensurePlansMode helper, fix health.spec race

### DIFF
--- a/ui/e2e/health.spec.ts
+++ b/ui/e2e/health.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForHydration } from './helpers/hydration';
+import { ensurePlansMode } from './helpers/leftPanelMode';
 import { connectionStatus } from './helpers/selectors';
 
 test.describe('@t0 @smoke health check', () => {
@@ -28,15 +29,12 @@ test.describe('@t0 @smoke health check', () => {
 		await waitForHydration(page);
 		// LeftPanel auto-switches to Feed mode when loops exist (c50c87f).
 		// Under mock stack, earlier @t0 specs create plans that spawn loops, so
-		// this test routinely lands on Feed. Click Plans and wait for the
-		// aria-checked flip before asserting on Plans-mode UI — otherwise the
-		// getByTitle('New Plan') query hits a stale DOM where PlansList isn't
-		// mounted yet.
-		const plansRadio = page.getByRole('radio', { name: 'Plans' });
-		if ((await plansRadio.getAttribute('aria-checked')) !== 'true') {
-			await plansRadio.click();
-			await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
-		}
+		// this test routinely lands on Feed. ensurePlansMode clicks Plans
+		// unconditionally (locks manualOverride=true) and awaits the Filter
+		// plans radiogroup — without that handshake the auto-switch $effect
+		// races us and the New Plan button query times out against a DOM
+		// where PlansList isn't mounted.
+		await ensurePlansMode(page);
 		await page.getByTitle('New Plan').click();
 		await expect(page).toHaveURL('/plans/new');
 		await expect(page.getByLabel('What do you want to build?')).toBeVisible();

--- a/ui/e2e/helpers/leftPanelMode.ts
+++ b/ui/e2e/helpers/leftPanelMode.ts
@@ -1,0 +1,22 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Ensure LeftPanel is in Plans mode and stays in Plans mode for the rest of
+ * the test. Click is unconditional because we need `manualOverride=true` in
+ * `LeftPanel.svelte` — a one-shot `aria-checked` read can miss the auto-switch
+ * `$effect` that fires when `activityStore.loopLastSeen` picks up SSE updates
+ * from earlier specs' loops. Wait on the "Filter plans" radiogroup so callers
+ * know `PlansList` (not `ActivityFeed`) is actually mounted before reaching for
+ * filter chips, plan list items, or the New Plan button.
+ *
+ * Use this in any spec that interacts with Plans-mode UI in the left panel.
+ * History: extracted from `plan-list.spec.ts` after PR #9 fixed the race
+ * there; PR follow-up after `health.spec.ts` was caught hitting the same
+ * pattern in a cold lifecycle triage run.
+ */
+export async function ensurePlansMode(page: Page): Promise<void> {
+	const plansRadio = page.getByRole('radio', { name: 'Plans' });
+	await plansRadio.click();
+	await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
+	await expect(page.getByRole('radiogroup', { name: 'Filter plans' })).toBeVisible();
+}

--- a/ui/e2e/plan-list.spec.ts
+++ b/ui/e2e/plan-list.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { waitForHydration } from './helpers/hydration';
 import { createPlan, deletePlan } from './helpers/api';
+import { ensurePlansMode } from './helpers/leftPanelMode';
 import {
 	filterChip,
 	planListItem,
@@ -8,20 +9,6 @@ import {
 	plansModeRadio,
 	feedModeRadio
 } from './helpers/selectors';
-
-/**
- * Ensure Plans mode is active and stays active. Click is unconditional because
- * we need manualOverride=true in LeftPanel — a one-shot aria-checked read can
- * miss the auto-switch effect that fires when activityStore picks up SSE
- * replays from prior tests' loops. Wait on the "Filter plans" radiogroup so
- * we know PlansList (not ActivityFeed) is actually mounted before proceeding.
- */
-async function ensurePlansMode(page: import('@playwright/test').Page) {
-	const plansRadio = page.getByRole('radio', { name: 'Plans' });
-	await plansRadio.click();
-	await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
-	await expect(page.getByRole('radiogroup', { name: 'Filter plans' })).toBeVisible();
-}
 
 test.describe('@t0 plan-list', () => {
 	let createdSlugs: string[] = [];


### PR DESCRIPTION
## Summary

- Triage of `task e2e:ui:test:mock` from a cold stack (3 runs, 2026-05-17) found one deterministic race: `@t0 @smoke health.spec.ts > navigates to new plan form` still used the one-shot `aria-checked` pattern that PR #9 already replaced in `plan-list.spec.ts`. Single t0 failure cascaded to 13 `did-not-run` (suite is `@smoke`-gated).
- Extracted PR #9's robust pattern into `ui/e2e/helpers/leftPanelMode.ts` so future spec authors don't re-roll the one-shot. Both health.spec.ts and plan-list.spec.ts now import it.
- Also closed the `[[t1-execution-complete-lifecycle-flake-2026-05-16]]` memory entry: that "worktree race" was Docker VM disk pressure (semembed couldn't load its model). With `docker builder prune -af` the lifecycle is **121/121 in <1 min**.

## Changes

- **`ui/e2e/helpers/leftPanelMode.ts`** (new) — exports `ensurePlansMode(page)` with the robust pattern: click unconditionally to lock `manualOverride=true`, await the "Filter plans" radiogroup so callers know `PlansList` (not `ActivityFeed`) is mounted.
- **`ui/e2e/health.spec.ts`** — replace the one-shot `aria-checked` read with `ensurePlansMode(page)`.
- **`ui/e2e/plan-list.spec.ts`** — drop the local copy of the helper; import from the new shared module.

## Test plan

- [x] `cd ui && npx tsc --noEmit -p tsconfig.json` — clean
- [x] Cold `task e2e:ui:test:mock` after the change — **121 passed, 5 skipped, 0 failed, 0 did-not-run** (46.5 s)
- [x] Triage baseline before the change — 1/3 cold runs failed on health.spec → 13 cascade did-not-run

## Other issues found

- `task e2e:check-ports:ui` cleans up under compose project `semspec-ui-e2e`, but stacks come up under project `ui` — cleanup silently fails to find containers, leaving stale ports between runs. Worth a one-line taskfile fix.
- The `[[t1-execution-complete-lifecycle-flake-2026-05-16]]` finding from yesterday turned out to be Docker VM disk pressure (52 GB images + 24 GB build cache full → semembed model fetch failed). Ops lesson recorded in memory: check `docker system df` first when e2e does weird IO-shaped things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)