### PR TITLE
refactor(e2e): cp fixture into named volume; stop polluting parent repo

### DIFF
--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -926,6 +926,19 @@ tasks:
           git -C "$fixture" for-each-ref --format='%(refname:short)' refs/heads | grep -vE '^main$' | while read -r b; do
             git -C "$fixture" branch -D -q "$b" 2>/dev/null || true
           done
+          # Restore parent-tracked .semspec/ files from the parent semspec
+          # repo's HEAD. The fixture's own `git reset --hard ROOT` above
+          # restores the fixture-git's view of .semspec/ (osh-driver-meshtastic
+          # committed .semspec/project.json + standards.json to its own nested
+          # git at root), which silently REVERTS any newer parent-tracked
+          # override (e.g. aa7ec51 chore(fixtures): qa_level=integration was
+          # added in the parent but the fixture's root commit predated it).
+          # Restoring from parent HEAD makes the parent repo's view of
+          # .semspec/ authoritative. The fixture-git's index entry then reads
+          # as "modified" from fixture's POV but we don't care; the
+          # cp-into-volume init container snapshots the working tree, not
+          # the fixture's git index.
+          git checkout -q HEAD -- "$fixture/.semspec/" 2>/dev/null || true
         done
         echo "[OK] Fixtures reset"
 

--- a/ui/docker-compose.e2e-epic.yml
+++ b/ui/docker-compose.e2e-epic.yml
@@ -33,19 +33,23 @@ volumes:
     driver: local
 
 services:
-  # Workspace semsource: swap to Java project fixture.
+  # Workspace semsource: keep the LLM-overlay semsource definition but ensure
+  # it watches the same workspace-snapshot volume the rest of the stack uses.
+  # The task wrapper sets E2E_FIXTURE=osh-driver-meshtastic for `hard` tier,
+  # which feeds the base workspace-init container — no hardcoded fixture
+  # path needed here.
   semsource:
     volumes:
       - ../docker/semsource.json:/etc/semsource/semsource.json:ro
-      - ../test/e2e/fixtures/osh-driver-meshtastic:/workspace:ro
+      - workspace-snapshot:/workspace:ro
 
-  # Sandbox: swap to Java project fixture.
-  # /sources is the read-only view of the shared semsource-clones volume —
-  # agent bash reads upstream files (pom.xml etc.) for ground-truth coords
-  # instead of fabricating them.
+  # Sandbox: also adds the read-only view of the shared semsource-clones
+  # volume at /sources/, where the 3 external semsources clone osh-core /
+  # ogc-cs / meshtastic upstream. Agent bash reads upstream files there
+  # for ground-truth coords instead of fabricating them.
   sandbox:
     volumes:
-      - ../test/e2e/fixtures/osh-driver-meshtastic:/workspace
+      - workspace-snapshot:/workspace
       - semsource-clones:/sources:ro
 
   # External semsources are CHAINED on healthy = "seeding done" — chain

--- a/ui/docker-compose.e2e-llm.yml
+++ b/ui/docker-compose.e2e-llm.yml
@@ -14,6 +14,8 @@ services:
   semsource:
     image: ghcr.io/c360studio/semsource:latest
     depends_on:
+      workspace-init:
+        condition: service_completed_successfully
       nats:
         condition: service_healthy
       semspec:
@@ -24,14 +26,15 @@ services:
     volumes:
       - ../docker/semsource.json:/etc/semsource/semsource.json:ro
       - ../docker/semsource.gitconfig:/root/.gitconfig:ro
-      # Honor E2E_FIXTURE so @hard tier (osh-driver-meshtastic) gets the
-      # right workspace mount on the bare LLM stack. Without this, every
-      # run lands go-project regardless of tier — caught take-18
-      # 2026-05-13 where @hard WITH_EPIC=0 silently mounted go-project
-      # and the dev hit iter=80 reconciling "Meshtastic Java" brief with
-      # a Go workspace. Epic overlay overrides this for WITH_EPIC=1; this
-      # default keeps the bare overlay consistent with base e2e.yml.
-      - ../test/e2e/fixtures/${E2E_FIXTURE:-go-project}:/workspace:ro
+      # Mount the same workspace-snapshot semspec + sandbox see. semsource
+      # runs watch-mode AST/docs indexers, so it must observe agent writes
+      # to keep the federated graph consistent with what the agent actually
+      # built. :ro is safe — semsource never writes to /workspace.
+      # Historical: previously bind-mounted the fixture directly; the
+      # E2E_FIXTURE-vs-default mismatch (caught take-18 2026-05-13) is now
+      # impossible because workspace-init in the base resolves the fixture
+      # once for the entire stack.
+      - workspace-snapshot:/workspace:ro
     command: ["run", "--config", "/etc/semsource/semsource.json", "--log-level", "${LOG_LEVEL:-info}"]
     healthcheck:
       test: ["CMD", "semsource", "version"]
@@ -72,12 +75,14 @@ services:
       # GitHub identity.
       GITHUB_ACTOR: ${GITHUB_ACTOR:-USERNAME}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+    depends_on:
+      workspace-init:
+        condition: service_completed_successfully
     volumes:
-      # Mirrors the semsource workspace mount — see comment there. Both
-      # services MUST point at the same fixture or planner scope checks
-      # and worktree merges drift (semspec sees one tree, sandbox sees
-      # another).
-      - ../test/e2e/fixtures/${E2E_FIXTURE:-go-project}:/workspace
+      # Shared workspace-snapshot — same volume semspec and semsource use.
+      # Single named volume = single workspace view, no risk of drift
+      # between services (caught take-18 2026-05-13 with separate bind mounts).
+      - workspace-snapshot:/workspace
     deploy:
       resources:
         limits:

--- a/ui/docker-compose.e2e-mock.yml
+++ b/ui/docker-compose.e2e-mock.yml
@@ -37,8 +37,15 @@ services:
     ports:
       - "8191:8090"  # Offset from backend E2E (8190)
     command: ["--addr", ":8090", "--repo", "/workspace"]
+    # Mounts the workspace-snapshot named volume populated by workspace-init
+    # in the base compose. Shared with semspec so agent writes and structural
+    # validation see the same files. Fixture immutability is enforced by the
+    # init container, not by per-service mount mode.
+    depends_on:
+      workspace-init:
+        condition: service_completed_successfully
     volumes:
-      - ../test/e2e/fixtures/${E2E_FIXTURE:-hello-world-py}:/workspace
+      - workspace-snapshot:/workspace
     deploy:
       resources:
         limits:

--- a/ui/docker-compose.e2e.yml
+++ b/ui/docker-compose.e2e.yml
@@ -1,4 +1,29 @@
 services:
+  # workspace-init snapshots the fixture into a named volume at stack-up.
+  # Rationale: in production, /workspace is the user's actual repo (bind-mount
+  # — semspec writing project.json timestamps is fine because they own the
+  # file). In e2e, the fixture is supposed to be IMMUTABLE test data; a
+  # bind-mount conflates "test seed" and "scratch workspace" and any runtime
+  # write to .semspec/* leaks back into the parent semspec repo as drift.
+  # `find -delete; cp -a` makes the snapshot deterministic per stack-up so
+  # the fixture-as-snapshot invariant holds regardless of what agents (or
+  # project-manager PATCHes) do during a run.
+  workspace-init:
+    image: alpine:3.19
+    # chown after cp so the sandbox user (uid SANDBOX_UID:1000 — runs git
+    # ops in /workspace and trips git's "dubious ownership" guard otherwise)
+    # owns the snapshot. semspec + qa-runner run as root and can rw any
+    # uid via root's normal access; only the sandbox user needs to be the
+    # nominal owner for git to operate.
+    command:
+      - sh
+      - -c
+      - "find /target -mindepth 1 -delete && cp -a /fixture/. /target/ && chown -R ${SANDBOX_UID:-1000}:${SANDBOX_GID:-1000} /target"
+    volumes:
+      - ../test/e2e/fixtures/${E2E_FIXTURE:-go-project}:/fixture:ro
+      - workspace-snapshot:/target
+    restart: "no"
+
   nats:
     image: nats:2.12-alpine
     ports:
@@ -39,8 +64,10 @@ services:
       # avoid the backend E2E stack's 9090.
       - "9190:9090"
     volumes:
-      - ../test/e2e/fixtures/${E2E_FIXTURE:-go-project}:/workspace
+      - workspace-snapshot:/workspace
     depends_on:
+      workspace-init:
+        condition: service_completed_successfully
       nats:
         condition: service_healthy
       # Gate on small-model graph stack so graph-embedding worker doesn't
@@ -239,6 +266,8 @@ services:
     ports:
       - "8291:8091"
     depends_on:
+      workspace-init:
+        condition: service_completed_successfully
       nats:
         condition: service_healthy
       # semspec creates the WORKFLOW stream during startup; qa-runner's
@@ -253,7 +282,7 @@ services:
       - PROJECT_HOST_PATH=${SEMSPEC_REPO:-/workspace}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ../test/e2e/fixtures/${E2E_FIXTURE:-go-project}:/workspace
+      - workspace-snapshot:/workspace
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8091/health"]
       interval: 10s
@@ -263,6 +292,7 @@ services:
 
 volumes:
   ui-nats-data:
+  workspace-snapshot:
 
 networks:
   default:

--- a/ui/e2e/health.spec.ts
+++ b/ui/e2e/health.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { waitForHydration } from './helpers/hydration';
+import { ensurePlansMode } from './helpers/leftPanelMode';
 import { connectionStatus } from './helpers/selectors';
 
 test.describe('@t0 @smoke health check', () => {
@@ -28,15 +29,12 @@ test.describe('@t0 @smoke health check', () => {
 		await waitForHydration(page);
 		// LeftPanel auto-switches to Feed mode when loops exist (c50c87f).
 		// Under mock stack, earlier @t0 specs create plans that spawn loops, so
-		// this test routinely lands on Feed. Click Plans and wait for the
-		// aria-checked flip before asserting on Plans-mode UI — otherwise the
-		// getByTitle('New Plan') query hits a stale DOM where PlansList isn't
-		// mounted yet.
-		const plansRadio = page.getByRole('radio', { name: 'Plans' });
-		if ((await plansRadio.getAttribute('aria-checked')) !== 'true') {
-			await plansRadio.click();
-			await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
-		}
+		// this test routinely lands on Feed. ensurePlansMode clicks Plans
+		// unconditionally (locks manualOverride=true) and awaits the Filter
+		// plans radiogroup — without that handshake the auto-switch $effect
+		// races us and the New Plan button query times out against a DOM
+		// where PlansList isn't mounted.
+		await ensurePlansMode(page);
 		await page.getByTitle('New Plan').click();
 		await expect(page).toHaveURL('/plans/new');
 		await expect(page.getByLabel('What do you want to build?')).toBeVisible();

--- a/ui/e2e/helpers/leftPanelMode.ts
+++ b/ui/e2e/helpers/leftPanelMode.ts
@@ -1,0 +1,22 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Ensure LeftPanel is in Plans mode and stays in Plans mode for the rest of
+ * the test. Click is unconditional because we need `manualOverride=true` in
+ * `LeftPanel.svelte` — a one-shot `aria-checked` read can miss the auto-switch
+ * `$effect` that fires when `activityStore.loopLastSeen` picks up SSE updates
+ * from earlier specs' loops. Wait on the "Filter plans" radiogroup so callers
+ * know `PlansList` (not `ActivityFeed`) is actually mounted before reaching for
+ * filter chips, plan list items, or the New Plan button.
+ *
+ * Use this in any spec that interacts with Plans-mode UI in the left panel.
+ * History: extracted from `plan-list.spec.ts` after PR #9 fixed the race
+ * there; PR follow-up after `health.spec.ts` was caught hitting the same
+ * pattern in a cold lifecycle triage run.
+ */
+export async function ensurePlansMode(page: Page): Promise<void> {
+	const plansRadio = page.getByRole('radio', { name: 'Plans' });
+	await plansRadio.click();
+	await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
+	await expect(page.getByRole('radiogroup', { name: 'Filter plans' })).toBeVisible();
+}

--- a/ui/e2e/plan-list.spec.ts
+++ b/ui/e2e/plan-list.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { waitForHydration } from './helpers/hydration';
 import { createPlan, deletePlan } from './helpers/api';
+import { ensurePlansMode } from './helpers/leftPanelMode';
 import {
 	filterChip,
 	planListItem,
@@ -8,20 +9,6 @@ import {
 	plansModeRadio,
 	feedModeRadio
 } from './helpers/selectors';
-
-/**
- * Ensure Plans mode is active and stays active. Click is unconditional because
- * we need manualOverride=true in LeftPanel — a one-shot aria-checked read can
- * miss the auto-switch effect that fires when activityStore picks up SSE
- * replays from prior tests' loops. Wait on the "Filter plans" radiogroup so
- * we know PlansList (not ActivityFeed) is actually mounted before proceeding.
- */
-async function ensurePlansMode(page: import('@playwright/test').Page) {
-	const plansRadio = page.getByRole('radio', { name: 'Plans' });
-	await plansRadio.click();
-	await expect(plansRadio).toHaveAttribute('aria-checked', 'true');
-	await expect(page.getByRole('radiogroup', { name: 'Filter plans' })).toBeVisible();
-}
 
 test.describe('@t0 plan-list', () => {
 	let createdSlugs: string[] = [];


### PR DESCRIPTION
## Summary

The e2e fixture mount has long conflated two roles: **immutable test seed** and **scratch workspace for the run**. Bind-mounting `test/e2e/fixtures/<name>` directly into `/workspace` means every `project-manager` PATCH that touches `.semspec/project.json` and every agent file write leaks back to the host as drift in the parent semspec repo's `git status`. That's correct in **production** (where /workspace IS the user's repo and writes should persist), but in **e2e** it makes the fixture a working copy instead of a snapshot.

This PR splits the two roles via a `workspace-init` alpine container that snapshots the fixture into a per-stack-up `workspace-snapshot` named volume. semspec / sandbox / qa-runner / semsource all mount the same named volume — one workspace view, no drift.

## Changes

- **`ui/docker-compose.e2e.yml`** — adds `workspace-init` + `workspace-snapshot` named volume. semspec and qa-runner mount the volume; both `depends_on: workspace-init: service_completed_successfully`.
- **`ui/docker-compose.e2e-mock.yml`** — sandbox switches to the snapshot.
- **`ui/docker-compose.e2e-llm.yml`** — sandbox + semsource switch to the snapshot. Single workspace view for every consumer.
- **`ui/docker-compose.e2e-epic.yml`** — drops the hardcoded `osh-driver-meshtastic` paths. Now relies on `E2E_FIXTURE` from the task wrapper (`task e2e:ui:test:llm -- claude hard` already sets `E2E_FIXTURE=osh-driver-meshtastic`).
- **`taskfiles/e2e.yml`** — `reset-fixtures` now restores `.semspec/` from the parent repo's HEAD after the fixture's own `git reset --hard ROOT`. Without this, osh-driver-meshtastic's nested-git ROOT commit silently reverts the parent's authoritative `qa_level=integration` override on every reset.

Init container `chown -R ${SANDBOX_UID:-1000}:${SANDBOX_GID:-1000} /target` so the sandbox user (which runs git ops) owns the snapshot and git's "dubious ownership" guard doesn't fire. semspec / qa-runner run as root and can rw any uid via root access.

## Test plan

- [x] `task e2e:ui:test:mock` cold (no warm stack, no manual env) — **121 passed / 5 skipped / 0 failed / 0 did-not-run in 36.9 s**
- [x] `git status` after the cold lifecycle is clean — no drift in `test/e2e/fixtures/`
- [x] `docker-compose.yml` / `docker-compose.local.yml` / `docker-compose.noconflict.yml` not touched (production stays bind-mount)

## Out of scope

- **Backend e2e** (`docker/compose/e2e.yml`) — its `qa-runner` uses `${PWD}/test/e2e/workspace:${PWD}/test/e2e/workspace` so `act`'s `--bind` resolves the same host path on both sides of `docker.sock`. Doesn't map cleanly to a named volume. Backend e2e doesn't currently have observed drift, so deferred. Follow-up if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)