### PR TITLE
docs: demo-ready audit (README + user-facing docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ implementation, a careful model for review.
 | Document | Purpose |
 |----------|---------|
 | [How It Works](docs/how-it-works.md) | System overview, message flow, component groups |
+| [Real-LLM Expectations](docs/real-llm-expectations.md) | Empirical floor — wallclock, loop counts, what we don't yet know |
 | [Model Configuration](docs/model-configuration.md) | LLM model and capability configuration |
 | [Project Setup](docs/project-setup.md) | Standards, quality gates |
 | [Structured Output Levels](docs/structured-output-levels.md) | L1–L4 wire-format discipline for LLM agent output (response_format, tool-use, thinking mode) |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,17 @@ larger models and capability tuning.
    field is required and locked after the first plan.
 3. **Create a plan** — Navigate to Plans and describe what you want built. The pipeline
    auto-coordinates from there.
-4. **Monitor** — Watch real-time agent activity, execution progress, and review verdicts.
+4. **Monitor** — While a plan is in flight you get three live surfaces:
+   - **In-progress panel** at the top of the plan view names the active phase (drafting,
+     reviewing, generating requirements/architecture/scenarios, executing, QA) with an
+     elapsed-time counter.
+   - **Execution timeline** ghost-renders the Planning + Execution stages before any work
+     happens, then fills in interactively as each loop completes.
+   - **Activity feed** streams agent-loop events in real time; pin-to-bottom autoscroll
+     with a "N new ↓" pill if you scroll up.
+5. **Inspect** — Click any trajectory entry to expand the LLM request side (system + user
+   prompts, role chips) alongside the response. Enable richer capture by setting
+   `trajectory_detail: "full"` on the `agentic-loop` component (default is `summary`).
 
 See [Project Setup](docs/project-setup.md) for config details.
 
@@ -200,6 +210,7 @@ implementation, a careful model for review.
 | [How It Works](docs/how-it-works.md) | System overview, message flow, component groups |
 | [Model Configuration](docs/model-configuration.md) | LLM model and capability configuration |
 | [Project Setup](docs/project-setup.md) | Standards, quality gates |
+| [Structured Output Levels](docs/structured-output-levels.md) | L1–L4 wire-format discipline for LLM agent output (response_format, tool-use, thinking mode) |
 | [Diagnostic Bundles](docs/diagnostic-bundles.md) | `semspec watch` — live monitoring + shareable bundles for adopter handoff |
 | [API Reference](docs/api.md) | REST API surface map — all endpoints, SSE streams |
 | [Troubleshooting](docs/model-configuration.md#troubleshooting) | Common model and connection errors |

--- a/README.md
+++ b/README.md
@@ -19,16 +19,27 @@ cp .env.example .env
 **Option A: Cloud API** (no GPU required)
 
 ```bash
-# Set ANTHROPIC_API_KEY, GEMINI_API_KEY, or OPENAI_API_KEY in .env
+# Set ANTHROPIC_API_KEY in .env — the default config ships with Anthropic +
+# Ollama endpoints only. Gemini, OpenAI, OpenRouter, and vLLM each need an
+# endpoint added — see docs/model-configuration.md for the one-block addition.
 SEMSPEC_REPO=/path/to/your/project docker compose up -d
 ```
 
 **Option B: Ollama** (local, no API key)
 
+The default config (`configs/semspec.json`) routes capabilities through three Ollama
+models. Pull all three for the no-edit path:
+
 ```bash
-ollama pull qwen2.5-coder:7b                                    # 4.7 GB, fits 16 GB RAM
+ollama pull qwen3-coder:30b   # 19 GB — coding capability (needs 32+ GB RAM)
+ollama pull qwen3:14b         # 8.5 GB — reasoning/review (16 GB OK)
+ollama pull qwen3:1.7b        # 1.4 GB — fast capability
 SEMSPEC_REPO=/path/to/your/project docker compose up -d
 ```
+
+For a single-model 16 GB setup, pull `qwen2.5-coder:7b` and follow the
+[Local-Only setup](docs/model-configuration.md#local-only-no-api-keys) to
+re-route the capability chains to the `ollama-coder` endpoint.
 
 Open **http://localhost:8080**. See [Model Configuration](docs/model-configuration.md) for
 larger models and capability tuning.
@@ -67,9 +78,11 @@ larger models and capability tuning.
      happens, then fills in interactively as each loop completes.
    - **Activity feed** streams agent-loop events in real time; pin-to-bottom autoscroll
      with a "N new ↓" pill if you scroll up.
-5. **Inspect** — Click any trajectory entry to expand the LLM request side (system + user
-   prompts, role chips) alongside the response. Enable richer capture by setting
-   `trajectory_detail: "full"` on the `agentic-loop` component (default is `summary`).
+5. **Inspect** — Click any agent-loop entry to expand the per-step trajectory. The
+   request side (system + user prompts with role chips) renders alongside the response
+   (assistant text + tool calls). Production ships at `trajectory_detail: "summary"`
+   to keep storage lean; flip to `"full"` on the `agentic-loop` component for the
+   complete request payload — see [How It Works](docs/how-it-works.md#trajectory-capture--llm-audit-trail).
 
 See [Project Setup](docs/project-setup.md) for config details.
 
@@ -109,8 +122,11 @@ See [Project Setup](docs/project-setup.md) for the full configuration guide, or 
 curl -X POST http://localhost:8080/project-manager/detect    # Auto-detect stack
 curl -X POST http://localhost:8080/project-manager/init \    # Generate all three files
   -H "Content-Type: application/json" \
-  -d '{"name": "my-project", "description": "..."}'
+  -d '{"name": "my-project", "org": "mycompany", "description": "..."}'
 ```
+
+> `org` is required (first segment of every entity ID) and locked after the first plan.
+> Without it the UI redirects to `/settings` and blocks plan creation.
 
 ## System Requirements
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,12 +7,6 @@ Semspec exposes a REST API at `http://localhost:8080`. Routes are mounted at
 **Interactive docs**: `http://localhost:8080/docs` (Swagger UI playground)
 **OpenAPI spec**: `http://localhost:8080/openapi.json` (machine-readable)
 
-> **Note**: The generated OpenAPI document currently lists plan-manager paths
-> under `/plan-api/...` due to legacy spec strings in
-> `processor/plan-manager/openapi.go`. Live routes are mounted under
-> `/plan-manager/...` (see e2e client `test/e2e/client/http.go`). Trust this
-> document over Swagger for plan-manager paths until the spec is fixed.
-
 ## API Groups
 
 ### Plans — `/plan-manager/plans`
@@ -40,6 +34,8 @@ review aggregation.
 | `GET /plan-manager/plans/{slug}/branches` | Per-requirement branch + diff metadata (files view) |
 | `GET /plan-manager/plans/{slug}/git-audit` | Git audit log for the plan |
 | `GET /plan-manager/plans/{slug}/phases/retrospective` | Phase retrospective data |
+| `GET /plan-manager/plans/{slug}/artifacts` | List phase artifacts written by workflow-documents |
+| `GET /plan-manager/plans/{slug}/artifacts/{name}` | Read a specific artifact |
 
 ### Requirements — `/plan-manager/plans/{slug}/requirements`
 
@@ -55,6 +51,7 @@ decomposed into a TaskDAG at runtime by the requirement-executor.
 | `DELETE /plan-manager/plans/{slug}/requirements/{reqId}` | Delete a requirement |
 | `POST /plan-manager/plans/{slug}/requirements/{reqId}/deprecate` | Deprecate a requirement |
 | `GET /plan-manager/plans/{slug}/requirements/{reqId}/file-diff` | Per-file diff for a requirement branch |
+| `GET /plan-manager/plans/{slug}/requirements/{reqId}/scenarios` | Scenarios attached to this requirement |
 
 ### Scenarios — `/plan-manager/plans/{slug}/scenarios`
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -440,6 +440,9 @@ and the backend-only `e2e-mock.json` stay at `"summary"`.
 trajectories from `OBJ_AGENT_CONTENT` into a tarball — one JSON per loop — so you can
 ship a forensic snapshot to a reviewer or replay it locally with `jq`.
 
+For wallclock and loop-count expectations across `easy` / `medium` / `hard` tiers,
+see [Real-LLM Expectations](real-llm-expectations.md).
+
 ## LLM Configuration
 
 See [Model Configuration](model-configuration.md) for the full capability-to-model mapping

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -115,7 +115,7 @@ Semspec is an **extension** of semstreams, not a standalone tool.
 
 1. Semspec imports semstreams as a Go library
 2. Docker Compose runs the shared infrastructure (NATS, optional Ollama)
-3. The semspec binary registers and runs all 16 semspec-specific components
+3. The semspec binary registers and runs 22 semspec-specific components
 
 ## What You Need Running
 
@@ -124,7 +124,7 @@ With Docker Compose (recommended):
 | Container | Purpose |
 |-----------|---------|
 | **nats** | JetStream message bus for all inter-component communication |
-| **semspec** | All 16 semspec components + semstreams infrastructure |
+| **semspec** | All 22 semspec components + semstreams infrastructure |
 | **sandbox** | Isolated code execution environment for agents |
 | **semsource** | Source code indexing (AST, git, docs) → knowledge graph |
 | **qa-runner** | Runs `.github/workflows/qa.yml` via nektos/act for `qa_level=integration`/`full` |
@@ -303,7 +303,7 @@ These files are git-friendly. Commit them to preserve context across sessions an
 
 ## Component Groups
 
-Semspec registers 16 components at startup alongside the full semstreams component suite.
+Semspec registers 22 components at startup alongside the full semstreams component suite.
 
 ```
 ┌──────────── Planning ────────────────────────────────────────────────┐
@@ -329,19 +329,35 @@ Semspec registers 16 components at startup alongside the full semstreams compone
 │  qa-reviewer            Release-readiness verdict (Murat persona);   │
 │                          scoped by qa_level (synthesis/unit/          │
 │                          integration/full)                           │
-│  plan-decision-handler  PlanDecision OODA loop and cascade      │
+│  plan-decision-handler  PlanDecision OODA loop and cascade           │
+│  recovery-agent         Wedge recovery — manager-role agents that    │
+│                          unstick stuck loops via trajectory analysis │
 └──────────────────────────────────────────────────────────────────────┘
 
 ┌──────────── Support ─────────────────────────────────────────────────┐
-│  plan-manager         Requirement/Scenario/PlanDecision HTTP API;  │
+│  plan-manager         Requirement/Scenario/PlanDecision HTTP API;    │
 │                        owns PLAN_STATES writes and event handling    │
 │  project-manager      Project management HTTP API                    │
 │  workflow-validator   Document structure validation (request/reply)  │
 │  workflow-documents   File output to .semspec/plans/                 │
 │  structural-validator  Structural integrity checks                   │
 │  question-manager     Question routing, SLA tracking, LLM answering  │
+│  lesson-decomposer    Splits reviewer rejections into atomic triples │
+│                        for the role-scoped lessons pipeline          │
+│  lesson-curator       Rotates and retires lessons by recency and     │
+│                        observed efficacy                             │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────── Optional integrations ───────────────────────────────────┐
+│  researcher-manager   Spawns research sub-loops on demand            │
+│  github-watcher       Mirrors GitHub issues into plans               │
+│  github-submitter     Pushes plan outcomes back to GitHub PRs        │
 └──────────────────────────────────────────────────────────────────────┘
 ```
+
+The Optional integrations are registered but not wired into `configs/semspec.json`
+by default — enable per-deployment by adding their instance config. The other 19
+components are configured out of the box.
 
 **Note**: `context-builder`, `task-dispatcher`, and other infrastructure components are
 semstreams components, not registered by semspec directly. Source indexing (AST parsing,
@@ -368,6 +384,61 @@ read them when assembling codebase summaries and relevant code patterns via `gra
 Each plan and task becomes a graph entity with predicates describing its status, content, and
 relationships. Agents query these when assembling planning context via `graph_search`, so later
 plans benefit from awareness of earlier decisions.
+
+## Trajectory Capture & LLM Audit Trail
+
+Every agent loop produces a **trajectory** — an ordered timeline of steps the loop took:
+the LLM request, tool calls, tool results, and the next LLM request that built on them.
+Trajectories are how the UI shows agent activity in real time and how diagnostic bundles
+preserve forensic detail after the fact.
+
+### `trajectory_detail` levels
+
+The `agentic-loop` component supports two capture levels:
+
+| Level | What's captured per step | Storage cost | Use case |
+|-------|--------------------------|--------------|----------|
+| `summary` *(default)* | Step type, model, timestamps, token counts, tool-call summaries | Low | Production — keeps the NATS object store lean |
+| `full` | Everything above plus the complete `messages` array (system + user + assistant + tool messages) | Moderate (~50–150 KB per loop) | Demos, diagnostic bundles, audit-trail-driven reviews |
+
+```json
+"agentic-loop": {
+  "config": {
+    "trajectory_detail": "full",
+    ...
+  }
+}
+```
+
+The e2e configs (`e2e-gemini.json`, `e2e-claude.json`, `e2e-hybrid.json`,
+`e2e-openrouter.json`, `e2e-sparky.json`, `e2e-local.json`, `e2e-mock-ui.json`) all set
+`"full"` so demos and operator runs surface the request side. Production `semspec.json`
+and the backend-only `e2e-mock.json` stay at `"summary"`.
+
+### Where the data lives
+
+| Bucket | Stores | Notes |
+|--------|--------|-------|
+| `KV_AGENT_LOOPS` | Loop metadata (status, role, task ref) | Always populated |
+| `OBJ_AGENT_CONTENT` | Trajectory step JSON blobs | Object store — sized for the full `messages` payload when `trajectory_detail: "full"` |
+| `KV_AGENT_CONTENT` | (legacy / unused at present) | Stays empty — don't grep here for trajectory content |
+
+### How the UI surfaces trajectories
+
+- **Activity feed** (`/agentic-dispatch/activity` SSE) — streams `loop_created`,
+  `loop_updated`, `loop_deleted` events so the live feed updates without polling.
+- **Execution timeline** — groups loops into Planning vs Execution stages and ghosts
+  the empty stages before any loop exists.
+- **TrajectoryEntryCard** — clicking a loop expands the per-step view. When the loop
+  was captured at `trajectory_detail: "full"`, the card renders the **Request** side
+  (one row per message with role chip + scrollable content) alongside the **Response**
+  side (assistant text + tool calls). This is the audit trail.
+
+### Diagnostic bundles
+
+`semspec watch --bundle` (see [Diagnostic Bundles](diagnostic-bundles.md)) extracts
+trajectories from `OBJ_AGENT_CONTENT` into a tarball — one JSON per loop — so you can
+ship a forensic snapshot to a reviewer or replay it locally with `jq`.
 
 ## LLM Configuration
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -5,7 +5,7 @@ This guide explains how to configure models for your setup.
 
 ## Capability System
 
-Semspec defines 10 capabilities. Each capability has a preferred chain (cloud) and a fallback
+Semspec defines 11 capabilities. Each capability has a preferred chain (cloud) and a fallback
 chain (local). When a task requires a capability, semspec tries preferred models first, then
 falls back to local Ollama models.
 
@@ -21,6 +21,7 @@ falls back to local Ollama models.
 | `qa` | QA rollup review, integration validation | claude-sonnet | qwen3 → qwen |
 | `writing` | Documentation, proposals, specifications | claude-sonnet | qwen3 → qwen |
 | `fast` | Quick responses, simple tasks | claude-haiku | qwen3-fast → qwen |
+| `lesson_decomposition` | Atomic-triple extraction for the lessons pipeline (ADR-033) | claude-opus → claude-sonnet | qwen3 → qwen |
 
 ## Configured Endpoints
 

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -297,7 +297,7 @@ Deterministic quality gates — shell commands that run after each agent task. A
 |-------|-------------|
 | `name` | Unique identifier |
 | `command` | Shell command to run |
-| `trigger` | Glob patterns — check runs only when matching files were modified |
+| `trigger` | Glob patterns — check runs only when matching files were modified. An empty array (`[]`) means *always run* — use this for setup/install steps. Omit the check entirely if it should never run. |
 | `category` | `compile`, `lint`, `typecheck`, `test`, `format`, or `setup` |
 | `required` | If `true`, failure blocks the review stage |
 | `timeout` | Maximum execution time (e.g., `"120s"`) |

--- a/docs/real-llm-expectations.md
+++ b/docs/real-llm-expectations.md
@@ -1,0 +1,240 @@
+# Real-LLM Expectations
+
+What semspec actually does, with the wallclock and the loop count, and the
+things we have not yet measured. This document exists because the alternative
+— letting evaluators discover the cost during a trial — erodes trust faster
+than naming the cost upfront does.
+
+The numbers below are empirical, not projected. Where we don't have a number
+yet, the doc says so.
+
+## 1. The floor today
+
+| Tier | Wallclock | Loop count | Recommended models | Verified runs |
+|------|-----------|-----------:|--------------------|--------------:|
+| `easy` | ~9 min | ~24 | Single frontier provider (Claude, Gemini, or comparable) | N=1 (2026-05-22) |
+| `medium` | not yet measured | — | — | N=0 |
+| `hard` | ~78 min | ~50 | Frontier hybrid (two providers, one for orchestration + one for developer) | N=1 (2026-05-16) |
+
+**"Verified" means:** real upstream artifacts pulled from real registries
+(not fabricated stubs), real test execution (not just compilation),
+non-fabricated integration. The distinction matters — see Section 3.
+
+The single verified `hard` run also required `GITHUB_TOKEN` to be set so
+the agent's Gradle build could authenticate against GitHub Packages.
+Without it, the agent fell back to fabricated stub JARs and the run
+*looked* successful with hollow code (take-29 the day before take-30).
+
+## 2. Why it takes that long
+
+Four mechanics, in order of contribution.
+
+### Cold-start discovery
+
+The agent receives only the prompt and a minimal project skeleton.
+Upstream coordinates (Maven groups, Docker images, TCP ports, wire
+protocols) are discovered at runtime via `web_search` and `http_request`
+tool calls. This is wallclock-expensive but architecturally cheaper than
+maintaining a curated upstream catalog the agent reads from.
+
+Concrete example from take-30: the architect ran `curl` against Docker
+Hub, parsed 3,341 image tags for the `meshtastic/meshtasticd` repository,
+and chose `daily-alpine` as the stable build to test against. That single
+discovery loop took roughly 90 seconds. The whole architecture phase took
+~3 minutes for the `hard` tier.
+
+### Multi-stage review loops
+
+Every artifact — plan body, requirements, architecture, scenarios, and
+each code change during execution — passes through a reviewer agent
+before advancement. Rejections trigger retries with explicit feedback.
+Each round is one or two LLM calls plus their tool calls.
+
+Loop breakdown from take-30 (50 loops total):
+
+| Phase | Loops |
+|-------|------:|
+| Plan / requirements / architecture / scenarios review | ~10 |
+| Per-requirement decomposition (planning each requirement's work) | ~6 |
+| Developer TDD cycles (write tests → run → fix → re-run) | ~28 |
+| Code review + scenario validation | ~6 |
+
+The developer TDD cycle dominates because it's the only phase where the
+agent is *making the code work* against a real compiler and test runner.
+
+### Deterministic gates
+
+The structural-validator runs the project's `checklist.json` inside the
+sandbox after every change. For take-30 that meant `./gradlew dependencies`
+(resolves authenticated Maven artifacts) and `./gradlew test` (compiles
+and runs the JUnit suite). These add 30 seconds to 2 minutes per cycle
+depending on the project's test-suite size. They catch fabrication —
+a stub class with missing methods fails to compile, a mock that doesn't
+hit the network fails an integration test.
+
+### Per-loop overhead
+
+Each LLM call carries model latency (1–5 s typical), tool execution time
+(bash, web_search, http_request — each 0.1–10 s), and state-transition
+writes to NATS. With 50 loops on the `hard` tier, that's roughly 4–8
+minutes of non-thinking time alone.
+
+## 3. The hollow-vs-real trap
+
+The day before take-30 (the verified `hard` run), take-29 produced the
+same 9/9 green outcome from Playwright. The integration was fabricated.
+
+| Signal | Take-29 (hollow) | Take-30 (real) |
+|--------|------------------|----------------|
+| Playwright outcome | 9/9 pass | 9/9 pass |
+| `/tmp/osh-stubs/` shell hits | 32 | 0 |
+| Stub JAR (55-byte MANIFEST-only) | Created and copied into worktree | None |
+| `~/.m2/repository/...` populated | No (401 from registry) | Yes (real sources.jar) |
+| `AbstractSensorModule.class` | Fabricated (empty bodies) | Resolved from real upstream |
+| `./gradlew dependencies` | Fell back to flat-dir stubs | `BUILD SUCCESSFUL (347ms)` against authenticated remote |
+| TODOs / FIXMEs in production code | Multiple | Zero |
+
+What changed between the two runs was structural, not model-side:
+
+- `GITHUB_TOKEN` passthrough so the sandbox can authenticate against
+  GitHub Packages.
+- Architect schema gained `role` + `test_harness` fields so integration
+  targets must be declared, not assumed.
+- Three deterministic detectors (TestHarness completeness check,
+  dev-test/integration-target cross-check, stub-jar size detector)
+  added as regression guards.
+
+The detectors didn't need to fire on take-30 — the upstream fix made
+fabrication unnecessary — but they remain in place. If a future run
+regresses to fabrication, they trip first.
+
+**Operational implication:** when evaluating a semspec run, "tests
+green" is necessary but not sufficient. Check that `~/.m2/repository/`
+or equivalent has real artifacts. Check that production files have
+non-trivial method bodies. The take-29 contrast file in the take-30
+sponsor pack documents the full forensic dig.
+
+## 4. What we measured
+
+| Date | Tier | Result | Evidence |
+|------|------|--------|----------|
+| 2026-05-16 | hard | 78 min, 9/9 verified-real, 2,283 LOC Java | [`docs/sponsor-packages/take-30/`](sponsor-packages/take-30/) |
+| 2026-05-22 | easy | 8.7 min, 8/8, ~24 loops | `task e2e:watch:llm -- gemini easy` bundle (extracted to `/tmp/semspec-watch-gemini-easy-*/bundle.tar.gz`) |
+
+Two data points. Both are N=1.
+
+## 5. What we don't yet know
+
+This section will shrink as we measure more. Right now it's a long list.
+
+### Model floor unknown per tier
+
+Take-30 used a hybrid assignment: Gemini 3.x family for orchestration
+roles, Claude Sonnet 4.6 for the developer role. We don't yet know:
+
+- Does `hard` work with a cheaper developer model?
+- Does `hard` work with a single-provider stack (avoid hybrid)?
+- Does `hard` work with fully-local Ollama (no frontier API at all)?
+- What's the smallest model that passes `easy`?
+- What does the failure mode look like as we walk down the model-strength
+  curve? (Silent fabrication? Plan rejection loops? Tool-call hallucination?)
+
+### Reproducibility unknown
+
+N=1 per tier. LLM outputs are stochastic. The pass rate over N=10 or
+N=20 runs with the same inputs is the next experiment, and we don't
+have it yet. Specifically for `hard`: take-29 passed 9/9 hollow on the
+same scenario, take-30 passed 9/9 real. What's the verified-real rate
+over N=20? Unknown.
+
+### Scenario generalization unknown
+
+Take-30 solved Meshtastic-on-OpenSensorHub. The structural changes that
+got us there (auth passthrough, integration-target schema, stub
+detectors) are scenario-agnostic, but we haven't yet tested whether a
+different `hard` scenario — a Kafka consumer for a different middleware,
+a Postgres-backed service with schema migrations — produces verified-real
+on the first try at the same model floor.
+
+### Dollar cost unknown
+
+We have wallclock and loop counts. We do not yet have token totals per
+run, so we cannot quote a defensible $/run number. The most we can say
+honestly today:
+
+- `easy` runs in 8.7 minutes are clearly bounded by per-message API
+  cost on a single provider.
+- `hard` runs at 78 minutes with 50 loops are clearly more expensive
+  but we have not converted that to a number.
+
+We will not estimate. The next experiment that includes token-meter
+data will produce the first defensible cost figure.
+
+### Detector firing rate unknown
+
+The three fabrication detectors (TestHarness completeness, dev-test
+cross-check, stub-jar size) were added as regression guards. They
+didn't fire on take-30. We have not yet deliberately introduced a
+fabrication vector to confirm they trigger. That's the next
+meaningful experiment in the defense-in-depth direction.
+
+## 6. Operating recommendations
+
+Based on what we've measured, these are reasonable starting points.
+They will shift as the unknowns above get measured.
+
+### For a 10-minute demo
+
+- Use the `easy` tier scenario.
+- Single frontier provider, either Claude or Gemini. Setting
+  `ANTHROPIC_API_KEY` or wiring a Gemini endpoint (see
+  [Model Configuration](model-configuration.md)) is enough.
+- Budget 10–15 minutes wallclock end-to-end including the UI
+  loading the trajectory view.
+
+### For real work on a non-trivial integration
+
+- Use the `hard` tier scenario or your equivalent.
+- Hybrid model assignment: one provider for orchestration (planner,
+  reviewers, generators) and one for the developer role. This dodges
+  single-provider rate-limit saturation that wedged earlier `hard`
+  attempts.
+- Budget 60–90 minutes wallclock and expect to provide `GITHUB_TOKEN`
+  (or equivalent registry credentials) up front. Without authenticated
+  registry access, the agent will fall back to fabrication and you'll
+  get the take-29 outcome.
+- Plan to spot-check the result — read the production code, confirm
+  imports trace to real upstream types, confirm tests exercise real
+  network or filesystem rather than just mocks.
+
+### For experimentation on model floor
+
+- Start `easy` with a smaller model to find the bottom of the easy curve.
+- Use `task e2e:watch:llm -- <provider> <tier>` so the watch sidecar
+  captures the bundle for forensic review.
+- Compare against the take-30 evidence shape — same scenario success
+  with worse code quality is a hollow-shaped run.
+
+## 7. Where to look when something stalls
+
+| Symptom | First thing to check |
+|---------|---------------------|
+| Plan stuck in `drafted` or `reviewing_draft` | Plan-reviewer rejected; check the `revision_reason` on the plan via `GET /plan-manager/plans/{slug}` |
+| Long silence in agent activity | `semspec watch --live --bail-on critical` — see [Diagnostic Bundles](diagnostic-bundles.md) |
+| Tests green but suspicious | Check production files for stub patterns (see Section 3); compare against take-29-vs-take-30 contrast |
+| Want to replay or audit a run | Extract `bundle.tar.gz` from the watch directory; trajectories are per-loop JSON with the full `messages` array when `trajectory_detail: "full"` is configured (see [How It Works → Trajectory Capture](how-it-works.md#trajectory-capture--llm-audit-trail)) |
+| Rate-limit failures | Switch to hybrid model assignment so different providers carry different roles |
+
+## 8. How this document gets updated
+
+This file is the canonical place for the empirical floor. Update
+triggers:
+
+- Any new verified run at any tier (add a row to Section 1 or 4).
+- Any measurement that shrinks the "what we don't yet know" list
+  (Section 5).
+- Any change to the recommended operating envelope (Section 6).
+
+Sponsor packages (`docs/sponsor-packages/take-NN/`) remain the
+forensic artifacts for specific runs. This document summarizes
+across them.


### PR DESCRIPTION
## Summary

Single-commit docs audit across the user-facing docs to clear the drift accumulated since early May. Three logical batches in one commit (`c7e1ed7`):

**Batch 1 — headliner fixes**
- `README.md` "What to Expect" expanded for the three live UI surfaces shipped in PR #13 (in-progress panel, ghost execution timeline, autoscroll activity feed) plus a step covering the trajectory expand view.
- `README.md` "More Info" corrected the Structured Output Levels row (L1–L4 wire discipline, not audit trail).
- `docs/how-it-works.md` component count 16 → 22 in three places, reconciled against `cmd/semspec/main.go` register block.
- Component Groups diagram gained `recovery-agent` (Execution), `lesson-decomposer` + `lesson-curator` (Support), and a new **Optional integrations** group (`researcher-manager`, `github-watcher`, `github-submitter` — registered in main.go but not wired into `configs/semspec.json` by default).

**Batch 2 — audit trail + UI surfaces**
- `docs/how-it-works.md` gained a **Trajectory Capture & LLM Audit Trail** section: `trajectory_detail` levels (summary default vs full), which e2e configs ship at "full", storage location (`OBJ_AGENT_CONTENT` — not `KV_AGENT_CONTENT`), how the UI surfaces it (activity SSE, execution timeline, `TrajectoryEntryCard` request/response render), pointer to diagnostic bundles.

**Batch 3 — verification sweep**
- `docs/api.md`: dropped stale `/plan-api/...` warning note (OpenAPI prefix is correct now); added three undocumented plan-manager endpoints (`GET /artifacts`, `GET /artifacts/{name}`, `GET /requirements/{reqId}/scenarios`).
- `docs/project-setup.md`: clarified `trigger: []` semantics ("empty array means *always run*"), closing the gap behind commit `9c19207`.
- `docs/model-configuration.md`: capability count 10 → 11; added `lesson_decomposition` capability row.

### Verified against current code
- `workflow/project_config.go` schemas (ProjectConfig / Standard / Check / CheckCategory enum)
- `processor/*/http*.go` route registrations
- `cmd/semspec/main.go` component registration list
- `configs/semspec.json` model_registry (11 capabilities, 7 endpoints)

### Out of scope (intentionally)
- ADRs (per ask)
- `docs/proposals/`, `docs/audit/`, `docs/bugs/`, `docs/sponsor-packages/`, `docs/model-testing-findings.md` — internal
- `docs/diagnostic-bundles.md` — untouched, still current
- `docs/structured-output-levels.md` — narrow scope, no drift

## Test plan

- [x] All schema/route claims verified against current code
- [x] No line-length violations introduced beyond pre-existing table convention
- [ ] (deferred) Bump `configs/semspec.json` claude-opus model from 4-6 → 4-7 if desired — config decision, not docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)