### PR TITLE
docs(readme): fix Ollama Quick Start — pull one model, not three

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,25 @@ SEMSPEC_REPO=/path/to/your/project docker compose up -d
 
 **Option B: Ollama** (local, no API key)
 
-The default config (`configs/semspec.json`) routes capabilities through three Ollama
-models. Pull all three for the no-edit path:
+Ollama loads models on demand — pull just the one that fits your hardware:
 
 ```bash
-ollama pull qwen3-coder:30b   # 19 GB — coding capability (needs 32+ GB RAM)
-ollama pull qwen3:14b         # 8.5 GB — reasoning/review (16 GB OK)
-ollama pull qwen3:1.7b        # 1.4 GB — fast capability
+# 16 GB RAM (recommended starting point):
+ollama pull qwen3:14b           # 8.5 GB — handles all capabilities via the default fallback chain
+
+# 32+ GB RAM (stronger coding-specific quality):
+ollama pull qwen3-coder:30b     # 19 GB — coder-specialized model
+
 SEMSPEC_REPO=/path/to/your/project docker compose up -d
 ```
 
-For a single-model 16 GB setup, pull `qwen2.5-coder:7b` and follow the
-[Local-Only setup](docs/model-configuration.md#local-only-no-api-keys) to
-re-route the capability chains to the `ollama-coder` endpoint.
+On a 16 GB system the default config still tries `qwen3-coder:30b` first
+(returns model-not-found, falls through to `qwen3:14b` after a brief
+delay per dispatch). To skip the fallthrough latency, follow the
+[Local-Only setup](docs/model-configuration.md#local-only-no-api-keys)
+to point the capability chains directly at the model you pulled — or
+swap to `qwen2.5-coder:7b` (4.7 GB) and re-route the chains to the
+`ollama-coder` endpoint.
 
 Open **http://localhost:8080**. See [Model Configuration](docs/model-configuration.md) for
 larger models and capability tuning.


### PR DESCRIPTION
## Summary

Fixes the Quick Start Ollama block I shipped in PR #14. It told every user to pull all three default-chain Ollama models. Problems caught on re-read:

1. **16 GB RAM users were told to pull a 19 GB model they cannot run.** `qwen3-coder:30b` needs 32+ GB per the System Requirements table *on this same README*. Pure wasted disk + bandwidth.
2. **"Pull all three" wrong even on 32 GB systems.** Ollama loads on demand; single-GPU setups can only hold one in VRAM at a time.
3. **Undocumented latency tax on the 16 GB path.** The default capability fallback chain is `[qwen3-coder:30b, qwen3:14b]` for most capabilities. A 16 GB user who pulled only `qwen3:14b` still pays a failed dispatch to the 30b on every loop before fallthrough.

## After

- 16 GB: pull `qwen3:14b` only (handles all capabilities via fallback)
- 32+ GB: pull `qwen3-coder:30b` (coder-specialized)
- Honest one-paragraph disclosure that the 16 GB path still pays fallthrough latency until you point capability chains directly at the model you pulled — links to Model Configuration's Local-Only setup
- Mentions the `qwen2.5-coder:7b` + `ollama-coder` route as the fully-tuned lightweight alternative

## Deliberately not in this PR

A config-side change that would flip the default fallback order (`qwen3` before `qwen`) to make the 16 GB path truly no-edit. That's a `configs/semspec.json` change with its own doc updates — tracked as follow-up so we don't couple docs to config changes.

## Test plan

- [x] `git diff` reads cleanly — no broken markdown structure
- [x] System Requirements table on the same README still aligns with the new pull instructions
- [x] Link to `docs/model-configuration.md#local-only-no-api-keys` resolves (existing anchor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)