### PR TITLE
config: drop qwen3-coder:30b from default Ollama chains, simplify local positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,26 @@ SEMSPEC_REPO=/path/to/your/project docker compose up -d
 
 **Option B: Ollama** (local, no API key)
 
-Ollama loads models on demand — pull just the one that fits your hardware:
-
 ```bash
-# 16 GB RAM (recommended starting point):
-ollama pull qwen3:14b           # 8.5 GB — handles all capabilities via the default fallback chain
-
-# 32+ GB RAM (stronger coding-specific quality):
-ollama pull qwen3-coder:30b     # 19 GB — coder-specialized model
+ollama pull qwen3:14b           # 8.5 GB — handles all general capabilities
+ollama pull qwen3:1.7b          # 1.4 GB — optional, for the `fast` capability
 
 SEMSPEC_REPO=/path/to/your/project docker compose up -d
 ```
 
-On a 16 GB system the default config still tries `qwen3-coder:30b` first
-(returns model-not-found, falls through to `qwen3:14b` after a brief
-delay per dispatch). To skip the fallthrough latency, follow the
-[Local-Only setup](docs/model-configuration.md#local-only-no-api-keys)
-to point the capability chains directly at the model you pulled — or
-swap to `qwen2.5-coder:7b` (4.7 GB) and re-route the chains to the
-`ollama-coder` endpoint.
+> **Be honest about what local-only buys you.** `qwen3:14b` is the
+> realistic floor for local dev — fine for well-defined, simple tasks
+> on demo scenarios (`easy` tier). Complex multi-step prompts
+> (`medium`/`hard` tiers) likely exceed its capability today. We're
+> still empirically calibrating where that floor sits per tier — see
+> [Real-LLM Expectations](docs/real-llm-expectations.md). For
+> production work, an API key on a frontier model is the realistic
+> path; Ollama is for evaluation and iteration on your spec quality.
+
+Power users who want stronger coding-specific quality can pull
+`qwen3-coder:30b` (19 GB, needs 32+ GB RAM) and re-route the coding
+capability — see
+[Model Configuration](docs/model-configuration.md#adding-a-stronger-coding-model).
 
 Open **http://localhost:8080**. See [Model Configuration](docs/model-configuration.md) for
 larger models and capability tuning.
@@ -139,8 +140,15 @@ curl -X POST http://localhost:8080/project-manager/init \    # Generate all thre
 | Setup | RAM | Disk | GPU |
 |-------|-----|------|-----|
 | Cloud API only | 4 GB | 2 GB | None |
-| Ollama `qwen2.5-coder:7b` | 16 GB | 8 GB | Recommended |
-| Ollama `qwen3-coder:30b` | 32 GB+ | 20 GB | Required |
+| Ollama `qwen3:14b` (default local) | 16 GB | 10 GB | Recommended |
+| Ollama `qwen3:14b` + `qwen3:1.7b` (default + fast) | 16 GB | 12 GB | Recommended |
+
+Heavier local models (e.g. `qwen3-coder:30b` at 32+ GB RAM) are not
+default — operators who want them know how to add them. See
+[Model Configuration](docs/model-configuration.md) for the full
+capability/endpoint reference and
+[Real-LLM Expectations](docs/real-llm-expectations.md) for the empirical
+floor we've measured per tier.
 
 See [Model Configuration](docs/model-configuration.md#development-minimal-resources) for
 lightweight setups and [Troubleshooting](docs/model-configuration.md#troubleshooting) for

--- a/configs/semspec.json
+++ b/configs/semspec.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.1.1",
   "persona_preset": "bmad",
   "platform": {
     "org": "semspec",
@@ -15,8 +15,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "writing": {
@@ -25,8 +24,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "coding": {
@@ -35,7 +33,6 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen",
           "qwen3"
         ]
       },
@@ -45,8 +42,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "plan_review": {
@@ -56,8 +52,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "architecture": {
@@ -67,8 +62,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "fast": {
@@ -78,7 +72,7 @@
         ],
         "fallback": [
           "qwen3-fast",
-          "qwen"
+          "qwen3"
         ]
       },
       "requirement_generation": {
@@ -87,8 +81,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "scenario_generation": {
@@ -97,8 +90,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "qa": {
@@ -107,8 +99,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       },
       "lesson_decomposition": {
@@ -118,8 +109,7 @@
           "claude-sonnet"
         ],
         "fallback": [
-          "qwen3",
-          "qwen"
+          "qwen3"
         ]
       }
     },
@@ -189,7 +179,7 @@
       }
     },
     "defaults": {
-      "model": "qwen",
+      "model": "qwen3",
       "max_concurrent_global": 10
     }
   },
@@ -245,7 +235,7 @@
       "enabled": true,
       "config": {
         "default_role": "general",
-        "default_model": "qwen",
+        "default_model": "qwen3",
         "auto_continue": false,
         "stream_name": "USER",
         "permissions": {

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -7,21 +7,31 @@ This guide explains how to configure models for your setup.
 
 Semspec defines 11 capabilities. Each capability has a preferred chain (cloud) and a fallback
 chain (local). When a task requires a capability, semspec tries preferred models first, then
-falls back to local Ollama models.
+falls back to local Ollama models. The default local fallback is `qwen3:14b` for every general
+capability; `qwen3:1.7b` handles `fast`. Heavier models are not in default chains — see
+[Adding a stronger coding model](#adding-a-stronger-coding-model) for the opt-in pattern.
 
 | Capability | Description | Preferred | Fallback |
 | ---------- | ----------- | --------- | -------- |
-| `planning` | High-level reasoning, architecture decisions | claude-opus → claude-sonnet | qwen3 → qwen |
-| `plan_review` | Strategic plan assessment, SOP compliance | claude-opus → claude-sonnet | qwen3 → qwen |
-| `architecture` | Technology choices, component boundaries | claude-opus → claude-sonnet | qwen3 → qwen |
-| `requirement_generation` | Requirement decomposition from plans | claude-sonnet | qwen3 → qwen |
-| `scenario_generation` | BDD scenario generation from requirements | claude-sonnet | qwen3 → qwen |
-| `coding` | Code generation, implementation | claude-sonnet | qwen → qwen3 |
-| `reviewing` | Code review, quality analysis | claude-sonnet | qwen3 → qwen |
-| `qa` | QA rollup review, integration validation | claude-sonnet | qwen3 → qwen |
-| `writing` | Documentation, proposals, specifications | claude-sonnet | qwen3 → qwen |
-| `fast` | Quick responses, simple tasks | claude-haiku | qwen3-fast → qwen |
-| `lesson_decomposition` | Atomic-triple extraction for the lessons pipeline (ADR-033) | claude-opus → claude-sonnet | qwen3 → qwen |
+| `planning` | High-level reasoning, architecture decisions | claude-opus → claude-sonnet | qwen3 |
+| `plan_review` | Strategic plan assessment, SOP compliance | claude-opus → claude-sonnet | qwen3 |
+| `architecture` | Technology choices, component boundaries | claude-opus → claude-sonnet | qwen3 |
+| `requirement_generation` | Requirement decomposition from plans | claude-sonnet | qwen3 |
+| `scenario_generation` | BDD scenario generation from requirements | claude-sonnet | qwen3 |
+| `coding` | Code generation, implementation | claude-sonnet | qwen3 |
+| `reviewing` | Code review, quality analysis | claude-sonnet | qwen3 |
+| `qa` | QA rollup review, integration validation | claude-sonnet | qwen3 |
+| `writing` | Documentation, proposals, specifications | claude-sonnet | qwen3 |
+| `fast` | Quick responses, simple tasks | claude-haiku | qwen3-fast → qwen3 |
+| `lesson_decomposition` | Atomic-triple extraction for the lessons pipeline (ADR-033) | claude-opus → claude-sonnet | qwen3 |
+
+> **Be honest about the local-only floor.** `qwen3:14b` is the realistic
+> default for local dev — fine for well-defined, simple tasks on demo
+> scenarios (`easy` tier). Complex multi-step prompts (`medium`/`hard`)
+> likely exceed its capability. We're still calibrating where the floor
+> sits per tier; see [Real-LLM Expectations](real-llm-expectations.md).
+> For production work, a frontier API key is the realistic path; Ollama
+> is for evaluation and spec-quality iteration.
 
 ## Configured Endpoints
 
@@ -32,10 +42,10 @@ These are the model endpoints defined in `configs/semspec.json`:
 | `claude-opus` | anthropic | claude-opus-4-6 |
 | `claude-sonnet` | anthropic | claude-sonnet-4-6 |
 | `claude-haiku` | anthropic | claude-haiku-4-5-20251001 |
-| `qwen` | ollama | qwen3-coder:30b |
-| `qwen3` | ollama | qwen3:14b |
-| `qwen3-fast` | ollama | qwen3:1.7b |
-| `ollama-coder` | ollama | qwen2.5-coder:7b |
+| `qwen` | ollama | qwen3-coder:30b (defined, not in any default chain — opt-in) |
+| `qwen3` | ollama | qwen3:14b (default local fallback for every general capability) |
+| `qwen3-fast` | ollama | qwen3:1.7b (default for `fast` capability) |
+| `ollama-coder` | ollama | qwen2.5-coder:7b (defined, opt-in only — small or well-defined tasks) |
 
 ## Configuration Reference
 
@@ -48,7 +58,7 @@ Models are configured in `configs/semspec.json` under `model_registry`:
       "coding": {
         "description": "Code generation, implementation",
         "preferred": ["claude-sonnet"],
-        "fallback": ["qwen", "qwen3"]
+        "fallback": ["qwen3"]
       }
     },
     "endpoints": {
@@ -60,7 +70,7 @@ Models are configured in `configs/semspec.json` under `model_registry`:
       }
     },
     "defaults": {
-      "model": "qwen"
+      "model": "qwen3"
     }
   }
 }
@@ -110,12 +120,43 @@ documented context limit.
 ### Local-Only (No API Keys)
 
 ```bash
-ollama pull qwen3-coder:30b   # Coding tasks (default model)
-ollama pull qwen3:14b          # Reasoning tasks
-ollama pull qwen3:1.7b         # Fast tasks
+ollama pull qwen3:14b          # Default fallback for every general capability
+ollama pull qwen3:1.7b         # Default for the `fast` capability (optional)
 ```
 
-All capabilities fall back to local models automatically.
+That's the whole setup. Every capability's local fallback resolves to
+`qwen3:14b`. Pulling `qwen3:1.7b` is optional but recommended — the
+`fast` capability falls back to `qwen3:14b` if the lighter model isn't
+available, so nothing breaks without it; it's just less efficient for
+quick lookups.
+
+Local-only is best treated as evaluation territory, not production.
+See the floor-honesty note above the capability table.
+
+### Adding a stronger coding model
+
+If you have 32+ GB RAM and want coder-specialized quality for the
+`coding` capability, the `qwen` endpoint is already defined (it points
+at `qwen3-coder:30b`) but is not in any default chain. To opt in:
+
+```bash
+ollama pull qwen3-coder:30b
+```
+
+Then edit `configs/semspec.json` to add `qwen` to the coding
+fallback chain:
+
+```json
+"coding": {
+  "description": "Code generation, implementation",
+  "preferred": ["claude-sonnet"],
+  "fallback": ["qwen", "qwen3"]
+}
+```
+
+Bump the `version` field at the top of `semspec.json` (e.g.
+`"1.1.1"` → `"1.1.2"`) so the KV reconciler picks up your change on
+next boot.
 
 ### Claude (Cloud + Local Fallback)
 
@@ -143,17 +184,33 @@ GEMINI_API_KEY=... docker compose up -d
 
 Any OpenAI-compatible API works the same way (OpenRouter, vLLM, etc.).
 
-### Development (Minimal Resources)
+### Development (Minimal Resources — small or well-defined tasks only)
+
+For very constrained systems or quick smoke-test work, you can drop
+to `qwen2.5-coder:7b`:
 
 ```bash
-ollama pull qwen2.5-coder:7b  # 4.7GB, fits 16GB RAM
+ollama pull qwen2.5-coder:7b  # 4.7 GB, fits 16 GB RAM with comfortable headroom
 ```
 
-Use a single model for all capabilities by setting the default:
+Then add `ollama-coder` to capability chains you care about, e.g.:
+
+```json
+"coding": {
+  "preferred": ["claude-sonnet"],
+  "fallback": ["qwen3", "ollama-coder"]
+}
+```
+
+Or as a global default:
 
 ```json
 "defaults": { "model": "ollama-coder" }
 ```
+
+**This is genuinely small-task territory.** Going below `qwen3:14b`
+typically doesn't work out unless the task is small and well-defined.
+See the floor-honesty note above the capability table.
 
 ## Adding a New Model
 


### PR DESCRIPTION
## Summary

User-direction call: 14b is the realistic floor for local dev laptops. If operators want stronger coding-specific quality, they're likely the kind of users who know how to add it back. Defaults should be honest about positioning rather than clever about chains.

**Why not the "flip [qwen, qwen3] → [qwen3, qwen]" approach PR #16 deferred**: pre-flight revealed only the `coding` capability had that order (most capabilities were already `[qwen3, qwen]`), AND flipping `coding` would silently downgrade 32 GB Ollama-only users who pulled `qwen3-coder:30b`. Drop is more honest than flip.

## Config changes (`configs/semspec.json`, version 1.1.0 → 1.1.1)

- All 9 non-coding/non-fast capabilities: `[qwen3, qwen]` → `[qwen3]`
- `coding`: `[qwen, qwen3]` → `[qwen3]`
- `fast`: `[qwen3-fast, qwen]` → `[qwen3-fast, qwen3]` (14b as tail instead of 30b)
- `defaults.model`: `"qwen"` → `"qwen3"`
- `agentic-dispatch.default_model`: `"qwen"` → `"qwen3"`
- `qwen` endpoint definition KEPT — operator hint for the opt-in path documented below

## README changes

- Quick Start Option B simplified to a single pull (`qwen3:14b`) plus optional `qwen3:1.7b` for the `fast` capability
- Honesty paragraph added: 14b is fine for well-defined simple tasks on the easy tier; complex multi-step prompts likely exceed its capability; floor calibration is ongoing — link to `docs/real-llm-expectations.md`
- System Requirements table drops the `qwen3-coder:30b` row

## docs/model-configuration.md changes

- Capability table fallback column simplified to `qwen3` everywhere
- Floor-honesty note above the capability table (matches README tone)
- Endpoint table annotations clarify default vs opt-in
- **New "Adding a stronger coding model" section** — exact recipe for power users to opt 30b back in for the `coding` capability, including the version bump step
- "Local-Only" section simplified to one pull + optional fast model
- "Development (Minimal Resources)" reframed: going below 14b is small-task territory only

## Verification

- [x] `jq empty configs/semspec.json` — JSON valid
- [x] `go build ./...` — clean
- [ ] Live calibration against real `qwen3:14b` is the "still finding the floor" work in `docs/real-llm-expectations.md` — out of scope for this PR. This is positioning + documentation honesty, not a quality claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)