### PR TITLE
e2e(watch:llm): mavlink-decode tier + workspace snapshot

### DIFF
--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -499,7 +499,12 @@ tasks:
       # real capability test. WITH_EPIC=1 mounts /sources/ as an optional
       # speedup for runs that want cached upstream artifacts instead.
       FIXTURE_DIR:
-        sh: if [ "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" = "hard" ]; then echo 'osh-driver-meshtastic'; else echo 'go-project'; fi
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard) echo 'osh-driver-meshtastic' ;;
+            mavlink-decode) echo 'mavlink-heartbeat-go' ;;
+            *) echo 'go-project' ;;
+          esac
       EPIC_OVERLAY:
         sh: if [ "${WITH_EPIC:-0}" = "1" ] && [ "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" = "hard" ]; then echo '-f ui/docker-compose.e2e-epic.yml'; else echo ''; fi
       EPIC_ON:
@@ -587,7 +592,12 @@ tasks:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $2}' | grep . || echo 'easy'
       E2E_CONFIG: "e2e-{{.PROVIDER}}.json"
       FIXTURE_DIR:
-        sh: if [ "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" = "hard" ]; then echo 'osh-driver-meshtastic'; else echo 'go-project'; fi
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard) echo 'osh-driver-meshtastic' ;;
+            mavlink-decode) echo 'mavlink-heartbeat-go' ;;
+            *) echo 'go-project' ;;
+          esac
       # Epic overlay (e2e-epic.yml) is opt-in via WITH_EPIC=1 — default OFF.
       # The fixture is self-contained (no /sources/ refs), so the agent's
       # default behaviour is to discover upstream coordinates via web_search
@@ -748,11 +758,37 @@ tasks:
             --nats nats://localhost:4223 \
             --nats-monitor http://localhost:8223 || echo "[WATCH:LLM] bundle capture failed (continuing)"
         ignore_error: true
+      # Snapshot the sandbox workspace before the cleanup defer tears it down.
+      # Without this, the agent's generated source code dies with the
+      # container — the bundle preserves trajectories + KV state but the
+      # WORKING TREE the agent produced is gone. Recovering files from
+      # trajectory heredocs is a fragile ~30-line script that misses any
+      # writes done by tools other than `cat << EOF`. `docker cp` keeps the
+      # actual on-disk artifacts for post-mortem inspection regardless of
+      # how they got there. ~5MB for hello-world, scales with project size.
+      # Caught 2026-05-28 mavlink-decode run where we needed to reconstruct
+      # main.go from heredoc tool args after the stack was already gone.
+      - cmd: |
+          echo "[WATCH:LLM] Snapshotting sandbox workspace..."
+          # docker cp exits non-zero if the container is gone (e.g., failed
+          # before sandbox came up). Drop the failure to stderr quietly and
+          # remove the empty/partial tarball so the run-summary skips it.
+          if docker cp ui-sandbox-1:/workspace - 2>/dev/null | gzip > {{.OUT_DIR}}/workspace.tar.gz; then
+            echo "[WATCH:LLM] workspace -> {{.OUT_DIR}}/workspace.tar.gz"
+          else
+            rm -f {{.OUT_DIR}}/workspace.tar.gz
+            echo "[WATCH:LLM] sandbox container not available — workspace snapshot skipped"
+          fi
+        ignore_error: true
       - cmd: |
           echo ""
           echo "[WATCH:LLM] Run summary:"
           echo "  watch log:    {{.OUT_DIR}}/watch.log"
           echo "  final bundle: {{.OUT_DIR}}/bundle.tar.gz"
+          if [ -f {{.OUT_DIR}}/workspace.tar.gz ]; then
+            WSIZE=$(du -h {{.OUT_DIR}}/workspace.tar.gz 2>/dev/null | cut -f1)
+            echo "  workspace:    {{.OUT_DIR}}/workspace.tar.gz (${WSIZE})"
+          fi
           SNAPSHOTS=$(ls -1 {{.OUT_DIR}}/snapshot-*.tar.gz 2>/dev/null | wc -l | tr -d ' ')
           if [ "${SNAPSHOTS}" != "0" ]; then
             LATEST=$(ls -1 {{.OUT_DIR}}/snapshot-*.tar.gz 2>/dev/null | tail -1)
@@ -772,6 +808,12 @@ tasks:
             echo ""
             echo "[WATCH:LLM] First few alerts:"
             grep '^ALERT:' {{.OUT_DIR}}/watch.log | head -5 | sed 's/^/  /'
+          fi
+          if [ -z "$DEBUG" ]; then
+            echo ""
+            echo "[WATCH:LLM] Tip: rerun with DEBUG=1 to keep the stack alive after the test"
+            echo "            for live inspection (docker exec, curl localhost:3000, etc.)."
+            echo "            Tear down manually with: task e2e:ui:down"
           fi
           echo ""
         ignore_error: true

--- a/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/checklist.json
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/checklist.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0.0",
+  "created_at": "2026-05-28T12:00:00.000000000Z",
+  "checks": [
+    {
+      "name": "go-build",
+      "command": "go build ./...",
+      "trigger": [
+        "*.go",
+        "go.mod",
+        "go.sum"
+      ],
+      "category": "compile",
+      "required": true,
+      "timeout": "120s",
+      "description": "Compile all Go packages",
+      "working_dir": "."
+    },
+    {
+      "name": "go-vet",
+      "command": "go vet ./...",
+      "trigger": [
+        "*.go"
+      ],
+      "category": "lint",
+      "required": true,
+      "timeout": "60s",
+      "description": "Run Go static analysis",
+      "working_dir": "."
+    },
+    {
+      "name": "go-test",
+      "command": "go test ./...",
+      "trigger": [
+        "*.go"
+      ],
+      "category": "test",
+      "required": true,
+      "timeout": "300s",
+      "description": "Run Go test suite",
+      "working_dir": "."
+    }
+  ]
+}

--- a/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/project.json
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "mavlink heartbeat go",
+  "org": "semspec",
+  "platform": "local",
+  "version": "1.0.0",
+  "initialized_at": "2026-05-28T12:00:00.000000000Z",
+  "languages": [
+    {
+      "name": "Go",
+      "version": null,
+      "primary": true
+    }
+  ],
+  "tooling": {},
+  "repository": {}
+}

--- a/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/standards.json
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/standards.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0.0",
+  "generated_at": "2026-05-28T12:00:00.000000000Z",
+  "token_estimate": 0,
+  "rules": []
+}

--- a/test/e2e/fixtures/mavlink-heartbeat-go/README.md
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/README.md
@@ -1,0 +1,18 @@
+# mavlink-heartbeat-go
+
+E2E test fixture for verifying the PR #18 catalog-backed harness-profile
+selection path under real LLM. The agent is expected to:
+
+1. Pick `mavlink.raw-mavlink-direct` from the harness catalog (compatibility
+   tier — does not hard-gate evidence anchors, so this exercises the
+   architect's selection logic without the full required-tier wiring).
+2. Add `github.com/bluenviron/gomavlib/v3` (or equivalent) as a `runtime_dep`
+   upstream resolution.
+3. Implement a Go service that listens for MAVLink v2 HEARTBEAT frames on a
+   UDP port and exposes the most-recent heartbeat at an HTTP endpoint as JSON.
+4. Author unit tests against captured HEARTBEAT frames in `testdata/`,
+   satisfying the profile's required assertions (decode HEARTBEAT; round-trip
+   at least one command frame is not required for this scope).
+
+Initial state is a skeleton `main.go` and an empty `go.mod`. Reset by
+`task reset-fixtures` returns to this state between runs.

--- a/test/e2e/fixtures/mavlink-heartbeat-go/go.mod
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/go.mod
@@ -1,0 +1,3 @@
+module example.com/mavlink-heartbeat
+
+go 1.21

--- a/test/e2e/fixtures/mavlink-heartbeat-go/main.go
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/main.go
@@ -1,0 +1,6 @@
+// Package main is the entry point for the mavlink-heartbeat-go E2E test fixture.
+// Starts as a minimal skeleton; the agent populates the MAVLink HEARTBEAT
+// listener and HTTP exposure per the plan goal.
+package main
+
+func main() {}

--- a/ui/e2e/plan-lifecycle-llm-mavlink.spec.ts
+++ b/ui/e2e/plan-lifecycle-llm-mavlink.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect } from '@playwright/test';
+import { createPlan, deletePlan, executePlan, getPlan, promotePlan, waitForGoal } from './helpers/api';
+import type { PlanResponse } from './helpers/api';
+
+/**
+ * @mavlink-decode tier: verifies PR #18 catalog-backed harness-profile
+ * selection under real LLM.
+ *
+ * The architect should pick `mavlink.raw-mavlink-direct` from the harness
+ * catalog (compatibility tier — no hard-gate evidence-anchor enforcement,
+ * so this exercises the selection path without the required-tier wiring).
+ * It should classify `gomavlib` (or equivalent Go MAVLink lib) as a
+ * `runtime_dep` upstream, not an `integration_target` — the UDP autopilot
+ * peer is integration_target territory, but tests use captured frames in
+ * testdata so no SITL container is needed.
+ *
+ * Run with: task e2e:watch:llm -- gemini mavlink-decode
+ *
+ * Fixture: test/e2e/fixtures/mavlink-heartbeat-go (skeleton main.go + empty
+ * go.mod). E2E_FIXTURE=mavlink-heartbeat-go is set by the task wrapper.
+ */
+
+const PLAN_PROMPT = `Add a Go HTTP service that listens for MAVLink v2 HEARTBEAT frames over UDP on port 14540 and exposes the most recent heartbeat at GET /heartbeat as JSON containing 'system_id', 'component_id', 'autopilot_type', 'base_mode', and 'received_at'.
+
+Use a real Go MAVLink library (e.g., github.com/bluenviron/gomavlib) for frame parsing — do not hand-roll the MAVLink wire format.
+
+Include unit tests that decode captured MAVLink HEARTBEAT frames from testdata/ files and assert the parsed fields.`;
+
+const CASCADE_TIMEOUT = Number(process.env.CASCADE_TIMEOUT) || 600_000;
+const EXECUTION_TIMEOUT = Number(process.env.EXECUTION_TIMEOUT) || 2_400_000;
+const POLL_INTERVAL = 3_000;
+
+const TERMINAL_FAILURE_STAGES = ['rejected', 'failed'];
+
+async function waitForStage(
+	slug: string,
+	targetStages: string[],
+	timeoutMs: number,
+	label: string
+): Promise<PlanResponse> {
+	const start = Date.now();
+	let lastStage = '';
+
+	while (Date.now() - start < timeoutMs) {
+		const plan = await getPlan(slug);
+
+		if (plan.stage !== lastStage) {
+			console.log(`[mavlink:${label}] Stage: ${lastStage || '(start)'} -> ${plan.stage} (${((Date.now() - start) / 1000).toFixed(0)}s)`);
+			lastStage = plan.stage;
+		}
+
+		if (TERMINAL_FAILURE_STAGES.includes(plan.stage)) {
+			const diag = JSON.stringify({
+				stage: plan.stage,
+				review_verdict: plan.review_verdict,
+				execution_summary: plan.execution_summary,
+			});
+			throw new Error(`Plan entered terminal failure stage '${plan.stage}' while waiting for [${targetStages}]. Diagnostics: ${diag}`);
+		}
+
+		if (targetStages.includes(plan.stage)) {
+			console.log(`[mavlink:${label}] Reached ${plan.stage} in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+			return plan;
+		}
+
+		if (plan.stage === 'reviewed') {
+			console.log(`[mavlink:${label}] Promoting at reviewed gate`);
+			await promotePlan(slug);
+		}
+		if (plan.stage === 'scenarios_reviewed') {
+			console.log(`[mavlink:${label}] Promoting at scenarios_reviewed gate`);
+			await promotePlan(slug);
+		}
+
+		await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+	}
+
+	const plan = await getPlan(slug);
+	throw new Error(`Timed out waiting for [${targetStages}] after ${timeoutMs}ms. Current stage: ${plan.stage}`);
+}
+
+test.describe('@t2 @mavlink-decode plan-lifecycle-llm-mavlink', () => {
+	let slug: string;
+
+	test.describe.configure({ mode: 'serial' });
+	test.setTimeout(EXECUTION_TIMEOUT);
+
+	test.beforeAll(async () => {
+		const plan = await createPlan(`${PLAN_PROMPT}\n\nTest run: ${Date.now()}`);
+		slug = plan.slug;
+		await waitForGoal(slug, CASCADE_TIMEOUT);
+	});
+
+	test.afterAll(async () => {
+		if (process.env.DEBUG) return;
+		if (slug) await deletePlan(slug).catch(() => {});
+	});
+
+	test('plan created with goal', async () => {
+		const plan = await getPlan(slug);
+		expect(plan.goal).toBeTruthy();
+		console.log(`[mavlink] Goal: ${plan.goal.slice(0, 80)}...`);
+	});
+
+	test('plan reviewed and approved', async () => {
+		const plan = await waitForStage(
+			slug,
+			['approved', 'generating_requirements', 'requirements_generated',
+			 'generating_architecture', 'architecture_generated',
+			 'generating_scenarios', 'scenarios_generated', 'scenarios_reviewed',
+			 'ready_for_execution', 'implementing'],
+			CASCADE_TIMEOUT,
+			'review'
+		);
+
+		expect(plan.approved).toBe(true);
+		console.log(`[mavlink] Review verdict: ${plan.review_verdict || 'auto-approved'}`);
+	});
+
+	test('requirements generated', async () => {
+		await waitForStage(
+			slug,
+			['requirements_generated', 'generating_architecture', 'architecture_generated',
+			 'generating_scenarios', 'scenarios_generated', 'scenarios_reviewed',
+			 'ready_for_execution', 'implementing'],
+			CASCADE_TIMEOUT,
+			'requirements'
+		);
+
+		const res = await fetch(`http://localhost:3000/plan-manager/plans/${slug}/requirements`);
+		const requirements = await res.json();
+		expect(requirements.length).toBeGreaterThan(0);
+		console.log(`[mavlink] ${requirements.length} requirements generated`);
+	});
+
+	test('architecture generated with harness profile selection', async () => {
+		await waitForStage(
+			slug,
+			['architecture_generated', 'generating_scenarios', 'scenarios_generated',
+			 'scenarios_reviewed', 'ready_for_execution', 'implementing'],
+			CASCADE_TIMEOUT,
+			'architecture'
+		);
+
+		const plan = await getPlan(slug);
+		expect(plan.architecture).toBeDefined();
+		expect(plan.architecture).not.toBeNull();
+
+		const arch = plan.architecture!;
+		expect(Array.isArray(arch.actors)).toBe(true);
+		expect(arch.actors.length).toBeGreaterThan(0);
+		expect(Array.isArray(arch.integrations)).toBe(true);
+		expect(arch.integrations.length).toBeGreaterThan(0);
+		expect(arch.test_surface).toBeDefined();
+
+		// Surface harness_profiles for diagnostics. The MAVLink prompt should
+		// drive the architect to select `mavlink.raw-mavlink-direct`. We don't
+		// hard-assert the specific ID — the lesson is what the architect
+		// actually does, not what we hope it does.
+		const profiles = (arch as { harness_profiles?: Array<{ profile_id: string }> }).harness_profiles ?? [];
+		const profileIds = profiles.map((p) => p.profile_id).join(', ') || '(none)';
+		console.log(`[mavlink] Architecture: ${arch.actors.length} actors, ${arch.integrations.length} integrations, harness_profiles=[${profileIds}]`);
+	});
+
+	test('scenarios generated and reviewed', async () => {
+		await waitForStage(
+			slug,
+			['scenarios_reviewed', 'ready_for_execution', 'implementing'],
+			CASCADE_TIMEOUT,
+			'scenarios'
+		);
+
+		const res = await fetch(`http://localhost:3000/plan-manager/plans/${slug}/scenarios`);
+		const scenarios = await res.json();
+		expect(scenarios.length).toBeGreaterThan(0);
+		console.log(`[mavlink] ${scenarios.length} scenarios generated`);
+	});
+
+	test('execution triggered', async () => {
+		let plan = await getPlan(slug);
+
+		if (['scenarios_generated', 'scenarios_reviewed'].includes(plan.stage)) {
+			await promotePlan(slug);
+			plan = await waitForStage(slug, ['ready_for_execution'], 30_000, 'promote-exec');
+		}
+
+		if (['implementing', 'executing', 'reviewing_rollup', 'complete'].includes(plan.stage)) {
+			console.log(`[mavlink] Already executing: stage=${plan.stage}`);
+			return;
+		}
+
+		expect(plan.stage).toBe('ready_for_execution');
+
+		console.log('[mavlink] Triggering execution via API');
+		await executePlan(slug);
+
+		plan = await waitForStage(
+			slug,
+			['implementing', 'executing', 'reviewing_rollup', 'complete'],
+			60_000,
+			'exec-start'
+		);
+
+		console.log(`[mavlink] Execution started: stage=${plan.stage}`);
+	});
+
+	test('execution completes', async () => {
+		const plan = await waitForStage(
+			slug,
+			['complete'],
+			EXECUTION_TIMEOUT,
+			'execution'
+		);
+
+		expect(plan.stage).toBe('complete');
+
+		if (plan.execution_summary) {
+			expect(plan.execution_summary.failed).toBe(0);
+			expect(plan.execution_summary.completed).toBe(plan.execution_summary.total);
+			console.log(`[mavlink] Execution summary: ${plan.execution_summary.completed}/${plan.execution_summary.total} completed, ${plan.execution_summary.failed} failed`);
+		}
+
+		console.log(`[mavlink] Pipeline complete`);
+	});
+
+	test('trajectories exist after execution', async () => {
+		const loopsRes = await fetch('http://localhost:3000/agentic-dispatch/loops');
+		const loops = await loopsRes.json();
+		expect(loops.length).toBeGreaterThan(0);
+		console.log(`[mavlink] ${loops.length} agent loops after execution`);
+
+		const loopId = loops[0].loop_id;
+		const trajRes = await fetch(`http://localhost:3000/agentic-loop/trajectories/${loopId}`);
+		const traj = await trajRes.json();
+		expect(traj.steps?.length).toBeGreaterThan(0);
+		console.log(`[mavlink] Loop ${loopId.slice(0, 8)} has ${traj.steps.length} steps`);
+	});
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -42,6 +42,7 @@ const T1_SPECS = [
 ];
 const T2_SPECS = [
 	'e2e/plan-lifecycle-llm.spec.ts',
+	'e2e/plan-lifecycle-llm-mavlink.spec.ts',
 	'e2e/epic-meshtastic-llm.spec.ts',
 	'e2e/mortgage-calc-llm.spec.ts'
 ];


### PR DESCRIPTION
## Summary

Verifies the populated-array path of PR #18's catalog-backed harness
profiles under real LLM, and preserves the sandbox workspace before
teardown so the agent's generated source survives for post-mortem.

- **New fixture** `test/e2e/fixtures/mavlink-heartbeat-go` — skeleton Go
  project + `.semspec` scaffolding + nested git repo for reset-fixtures
- **New spec** `ui/e2e/plan-lifecycle-llm-mavlink.spec.ts` tagged
  `@mavlink-decode` — drives architect toward
  `mavlink.raw-mavlink-direct` compatibility-tier profile via a UDP
  HEARTBEAT → HTTP /heartbeat prompt
- **Task wiring** in `taskfiles/e2e.yml` — `mavlink-decode` tier maps
  to the new fixture; `watch:llm` now `docker cp`s `/workspace` to
  `workspace.tar.gz` before the cleanup defer fires
- **Run summary** now reports `workspace.tar.gz` size when captured and
  prints a `DEBUG=1` tip for live-stack inspection when not set

## Verification

Ran 2026-05-28 `task e2e:watch:llm -- gemini mavlink-decode`:

- **8/8 specs passed in 20.4 min** (vs 7.4 min gemini easy hello-world)
- Architect selected `mavlink.raw-mavlink-direct` with `used_by:
  [MAVLink Listener]` and matching `covers: [Raw MAVLink Endpoint]`
- `gomavlib` classified as `runtime_dep` with 4 typed API entries
  (Node.Initialize, EndpointUDPServer, EventFrame, MessageHeartbeat),
  each with citation URLs
- "Raw MAVLink Endpoint" classified as `integration_target` linked to
  mavlink.io docs
- Developer authored `main_test.go` with evidence anchors in a comment:
  `// Evidence anchors: mavlink.raw-mavlink-direct, HEARTBEAT`
- 3 TDD cycles burned on the implementation (richer scope vs hello-world);
  ultimately green
- 1 false-positive `RepeatToolFailure` alert during architect's curl/grep
  research iteration on pkg.go.dev — the detector fires on 3 consecutive
  exit-1 results regardless of whether each retry varies its query

## Forensic coverage after the workspace snapshot lands

| Artifact | When captured | Contents |
|---|---|---|
| `watch.log` | streaming | Heartbeats, ALERTs, snapshot markers |
| `snapshot-*.tar.gz` | every 60s | Live trajectories + bundle.json at point-in-time |
| `bundle.tar.gz` | after Playwright | Final trajectories + KV state |
| **`workspace.tar.gz`** ✨ | after bundle, before teardown | Sandbox `/workspace` files |
| `DEBUG=1` live stack | opt-in | `docker exec`, curl `localhost:3000`, NATS monitor |

## Test plan

- [ ] CI green
- [ ] Run `task e2e:watch:llm -- gemini mavlink-decode` locally to confirm
- [ ] Inspect `workspace.tar.gz` post-run; should contain `main.go`,
      `main_test.go`, `go.mod`, `go.sum`, `testdata/*.bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)