### PR TITLE
feat(workflow): qarender + per-profile orchestration (ADR-039 Phase 1a)

### DIFF
--- a/docs/adr/ADR-039-qa-yml-rendering-from-harness-catalog.md
+++ b/docs/adr/ADR-039-qa-yml-rendering-from-harness-catalog.md
@@ -82,13 +82,31 @@ the qa-runner's host Docker socket, synchronously gate the
 
 Mechanically:
 
-1. **Catalog renderer.** A new internal package (working name
-   `workflow/harnesscatalog/qarender`) converts a list of
+1. **Catalog renderer.** A new internal package
+   (`workflow/harnesscatalog/qarender`) converts a list of
    `ResolvedSelection` entries into a `services:` block compatible with
    GitHub Actions / nektos/act. Each profile entry's `images[0]`
    becomes a service; `ports[]` map to GHA `ports:` syntax;
    `env`/`readiness`/`test_guidance` thread into the rendered service
    metadata.
+
+   **Per-profile orchestration (added during Phase 1a implementation,
+   2026-05-28).** The original framing put GHA `services:` as the
+   primary mechanism with testcontainers as a fallback. Implementation
+   surfaced a cleaner shape: the choice is per-profile, declared by a
+   first-class `orchestration` field on the catalog `Profile` struct.
+   Values are `services` (renderer emits a qa.yml service block from
+   `images`/`ports`/`env`/`readiness`), `testcontainers` (renderer
+   skips; dev agent owns the integration stack in test code), or
+   `pure-fixture` (renderer skips; in-process or captured-frame
+   fixtures, no container). When the field is empty the renderer infers
+   `services` if `images[]` is non-empty and `pure-fixture` otherwise.
+   This makes the orchestration choice visible to the architect at
+   profile-selection time rather than hidden in the rendered output.
+   Alternative B below (testcontainers) remains the right tool for
+   profiles whose stack genuinely varies per test; the field just
+   surfaces that choice in metadata rather than treating it as a
+   fallback.
 
 2. **qa-runner socket mount.** `docker/compose/qa-runner.yml` (or
    wherever the qa-runner is defined) mounts `/var/run/docker.sock`

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -475,6 +475,7 @@ func resolvedHarnessProfilesToPrompt(resolved []harnesscatalog.ResolvedSelection
 		out = append(out, prompt.ResolvedHarnessProfileContext{
 			ProfileID:          p.ID,
 			Tier:               p.Tier,
+			Orchestration:      p.EffectiveOrchestration(),
 			UsedBy:             append([]string(nil), r.Selection.UsedBy...),
 			Purpose:            r.Selection.Purpose,
 			Covers:             append([]string(nil), r.Selection.Covers...),

--- a/processor/execution-manager/harness_prompt_seam_test.go
+++ b/processor/execution-manager/harness_prompt_seam_test.go
@@ -1,0 +1,48 @@
+package executionmanager
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// TestResolvedHarnessProfilesToPromptPropagatesOrchestration pins the
+// catalog→prompt-context seam. A regression that dropped Profile.Orchestration
+// from the constructed ResolvedHarnessProfileContext would silently feed the
+// developer agent profiles without the orchestration directive, leaving the
+// agent to guess whether qa-runner brings services up or the test fixture
+// owns the stack. ADR-039 Phase 1a depends on this propagating end-to-end.
+func TestResolvedHarnessProfilesToPromptPropagatesOrchestration(t *testing.T) {
+	cat, err := harnesscatalog.LoadBuiltIn()
+	if err != nil {
+		t.Fatalf("LoadBuiltIn() error = %v", err)
+	}
+	resolved, err := cat.ResolveSelections([]workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+		{ProfileID: "mavlink.raw-mavlink-direct", Purpose: "round-trip frames"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSelections() error = %v", err)
+	}
+
+	out := resolvedHarnessProfilesToPrompt(resolved)
+	if len(out) != 2 {
+		t.Fatalf("got %d prompt contexts, want 2", len(out))
+	}
+
+	wantOrchestration := map[string]string{
+		"mavlink.px4-sitl.mavsdk-smoke": harnesscatalog.OrchestrationServices,
+		"mavlink.raw-mavlink-direct":    harnesscatalog.OrchestrationPureFixture,
+	}
+	for _, ctx := range out {
+		want, ok := wantOrchestration[ctx.ProfileID]
+		if !ok {
+			t.Errorf("unexpected profile %q in output", ctx.ProfileID)
+			continue
+		}
+		if ctx.Orchestration != want {
+			t.Errorf("profile %q orchestration = %q, want %q", ctx.ProfileID, ctx.Orchestration, want)
+		}
+	}
+}

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -1144,6 +1144,7 @@ func resolvedHarnessProfilesToPrompt(resolved []harnesscatalog.ResolvedSelection
 		out = append(out, prompt.ResolvedHarnessProfileContext{
 			ProfileID:          p.ID,
 			Tier:               p.Tier,
+			Orchestration:      p.EffectiveOrchestration(),
 			UsedBy:             append([]string(nil), r.Selection.UsedBy...),
 			Purpose:            r.Selection.Purpose,
 			Covers:             append([]string(nil), r.Selection.Covers...),

--- a/processor/requirement-executor/harness_prompt_seam_test.go
+++ b/processor/requirement-executor/harness_prompt_seam_test.go
@@ -1,0 +1,47 @@
+package requirementexecutor
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// TestResolvedHarnessProfilesToPromptPropagatesOrchestration pins the same
+// seam as the execution-manager copy of this helper — both must populate
+// ResolvedHarnessProfileContext.Orchestration from the catalog profile's
+// effective orchestration. See execution-manager/harness_prompt_seam_test.go
+// for the rationale.
+func TestResolvedHarnessProfilesToPromptPropagatesOrchestration(t *testing.T) {
+	cat, err := harnesscatalog.LoadBuiltIn()
+	if err != nil {
+		t.Fatalf("LoadBuiltIn() error = %v", err)
+	}
+	resolved, err := cat.ResolveSelections([]workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+		{ProfileID: "mavlink.raw-mavlink-direct", Purpose: "round-trip frames"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSelections() error = %v", err)
+	}
+
+	out := resolvedHarnessProfilesToPrompt(resolved)
+	if len(out) != 2 {
+		t.Fatalf("got %d prompt contexts, want 2", len(out))
+	}
+
+	wantOrchestration := map[string]string{
+		"mavlink.px4-sitl.mavsdk-smoke": harnesscatalog.OrchestrationServices,
+		"mavlink.raw-mavlink-direct":    harnesscatalog.OrchestrationPureFixture,
+	}
+	for _, ctx := range out {
+		want, ok := wantOrchestration[ctx.ProfileID]
+		if !ok {
+			t.Errorf("unexpected profile %q in output", ctx.ProfileID)
+			continue
+		}
+		if ctx.Orchestration != want {
+			t.Errorf("profile %q orchestration = %q, want %q", ctx.ProfileID, ctx.Orchestration, want)
+		}
+	}
+}

--- a/prompt/context.go
+++ b/prompt/context.go
@@ -186,6 +186,7 @@ type TaskContext struct {
 type ResolvedHarnessProfileContext struct {
 	ProfileID          string
 	Tier               string
+	Orchestration      string
 	UsedBy             []string
 	Purpose            string
 	Covers             []string

--- a/prompt/domain/harness_profile_render_test.go
+++ b/prompt/domain/harness_profile_render_test.go
@@ -1,0 +1,91 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/prompt"
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// TestRenderResolvedHarnessProfilesFromRealCatalog pins three load-bearing
+// guarantees for ADR-039 Phase 1a:
+//
+//  1. The intro guidance is the post-ADR-039 shape (services vs testcontainers
+//     vs pure-fixture) — NOT the old "do not edit GitHub Actions services"
+//     string that contradicted what we now ship.
+//  2. Every rendered profile carries an Orchestration line so architect/dev
+//     see the orchestration choice surfaced.
+//  3. services-orchestrated profiles render as `services` and pure-fixture
+//     profiles render as `pure-fixture` from real catalog data — pinning the
+//     EffectiveOrchestration() inference against the built-in mavlink entries.
+func TestRenderResolvedHarnessProfilesFromRealCatalog(t *testing.T) {
+	cat, err := harnesscatalog.LoadBuiltIn()
+	if err != nil {
+		t.Fatalf("LoadBuiltIn() error = %v", err)
+	}
+	resolved, err := cat.ResolveSelections([]workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", UsedBy: []string{"driver"}, Purpose: "SITL smoke"},
+		{ProfileID: "mavlink.raw-mavlink-direct", UsedBy: []string{"parser"}, Purpose: "frame round-trip"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveSelections() error = %v", err)
+	}
+
+	ctxs := make([]prompt.ResolvedHarnessProfileContext, 0, len(resolved))
+	for _, r := range resolved {
+		p := r.Profile
+		ctxs = append(ctxs, prompt.ResolvedHarnessProfileContext{
+			ProfileID:     p.ID,
+			Tier:          p.Tier,
+			Orchestration: p.EffectiveOrchestration(),
+			UsedBy:        r.Selection.UsedBy,
+			Purpose:       r.Selection.Purpose,
+		})
+	}
+
+	out := renderResolvedHarnessProfiles("## Harness Profiles", ctxs)
+
+	if !strings.Contains(out, "`services`-orchestrated profiles, qa-runner brings the stack up") {
+		t.Errorf("intro missing services-orchestrated guidance:\n%s", out)
+	}
+	if !strings.Contains(out, "`testcontainers` or `pure-fixture` profiles, the test fixture owns") {
+		t.Errorf("intro missing testcontainers/pure-fixture guidance:\n%s", out)
+	}
+	if strings.Contains(out, "do not edit GitHub Actions services") {
+		t.Errorf("stale pre-ADR-039 guidance leaked back into intro:\n%s", out)
+	}
+
+	if !strings.Contains(out, "### mavlink.px4-sitl.mavsdk-smoke (required)") {
+		t.Errorf("missing PX4 SITL profile header:\n%s", out)
+	}
+	if !strings.Contains(out, "### mavlink.raw-mavlink-direct (compatibility)") {
+		t.Errorf("missing raw-mavlink-direct profile header:\n%s", out)
+	}
+
+	pxBlock := profileBlock(out, "### mavlink.px4-sitl.mavsdk-smoke")
+	if !strings.Contains(pxBlock, "- **Orchestration:** services") {
+		t.Errorf("PX4 SITL profile missing Orchestration: services line:\n%s", pxBlock)
+	}
+	rawBlock := profileBlock(out, "### mavlink.raw-mavlink-direct")
+	if !strings.Contains(rawBlock, "- **Orchestration:** pure-fixture") {
+		t.Errorf("raw-mavlink-direct profile missing Orchestration: pure-fixture line:\n%s", rawBlock)
+	}
+}
+
+// profileBlock returns the substring of out starting at headerPrefix up to
+// (but not including) the next `### ` header or end-of-string. Helper for
+// per-profile assertions when multiple profiles are rendered.
+func profileBlock(out, headerPrefix string) string {
+	start := strings.Index(out, headerPrefix)
+	if start < 0 {
+		return ""
+	}
+	rest := out[start+len(headerPrefix):]
+	next := strings.Index(rest, "### ")
+	if next < 0 {
+		return out[start:]
+	}
+	return out[start : start+len(headerPrefix)+next]
+}

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -543,6 +543,8 @@ func writeCoversLine(sb *strings.Builder, covers map[string][]string) {
 	fmt.Fprintf(sb, "- **Covers:** %s\n", strings.Join(parts, "; "))
 }
 
+const harnessProfilesIntro = "Use these details when your node touches the selected integration. For `services`-orchestrated profiles, qa-runner brings the stack up as qa.yml services from this catalog metadata — read the endpoint from the host/env qa-runner injects rather than starting your own container. For `testcontainers` or `pure-fixture` profiles, the test fixture owns the integration peer.\n\n"
+
 func renderResolvedHarnessProfiles(title string, profiles []prompt.ResolvedHarnessProfileContext) string {
 	if len(profiles) == 0 {
 		return ""
@@ -550,65 +552,83 @@ func renderResolvedHarnessProfiles(title string, profiles []prompt.ResolvedHarne
 	var sb strings.Builder
 	sb.WriteString(title)
 	sb.WriteString("\n\n")
-	sb.WriteString("Use these details when your node touches the selected integration. Keep orchestration in project test code; do not edit GitHub Actions services for these profiles.\n\n")
+	sb.WriteString(harnessProfilesIntro)
 	for _, p := range profiles {
-		fmt.Fprintf(&sb, "### %s (%s)\n\n", p.ProfileID, p.Tier)
-		writeJoinedLine(&sb, "Used by", p.UsedBy)
-		if p.Purpose != "" {
-			fmt.Fprintf(&sb, "- **Purpose:** %s\n", p.Purpose)
-		}
-		writeJoinedLine(&sb, "Covers", p.Covers)
-		writeJoinedLine(&sb, "Proves", p.Proves)
-		writeJoinedLine(&sb, "Runner support", p.RunnerSupport)
-		if p.Cost != "" {
-			fmt.Fprintf(&sb, "- **Cost:** %s\n", p.Cost)
-		}
-		writeJoinedLine(&sb, "Constraints", p.Constraints)
-		writeJoinedLine(&sb, "Required assertions", p.RequiredAssertions)
-		writeJoinedLine(&sb, "Evidence anchors", p.EvidenceAnchors)
-		if len(p.Images) > 0 {
-			sb.WriteString("- **Images:** ")
-			parts := make([]string, 0, len(p.Images))
-			for _, img := range p.Images {
-				if img.Purpose == "" {
-					parts = append(parts, img.Name)
-				} else {
-					parts = append(parts, fmt.Sprintf("%s (%s)", img.Name, img.Purpose))
-				}
-			}
-			sb.WriteString(strings.Join(parts, "; "))
-			sb.WriteString("\n")
-		}
-		if len(p.Ports) > 0 {
-			sb.WriteString("- **Ports:** ")
-			parts := make([]string, 0, len(p.Ports))
-			for _, port := range p.Ports {
-				value := fmt.Sprintf("%s/%d/%s", port.Name, port.ContainerPort, port.Protocol)
-				if port.Purpose != "" {
-					value = fmt.Sprintf("%s (%s)", value, port.Purpose)
-				}
-				parts = append(parts, value)
-			}
-			sb.WriteString(strings.Join(parts, "; "))
-			sb.WriteString("\n")
-		}
-		if len(p.Env) > 0 {
-			keys := make([]string, 0, len(p.Env))
-			for key := range p.Env {
-				keys = append(keys, key)
-			}
-			sort.Strings(keys)
-			parts := make([]string, 0, len(keys))
-			for _, key := range keys {
-				parts = append(parts, fmt.Sprintf("%s=%s", key, p.Env[key]))
-			}
-			fmt.Fprintf(&sb, "- **Env:** %s\n", strings.Join(parts, "; "))
-		}
-		writeJoinedLine(&sb, "Readiness", p.Readiness)
-		writeJoinedLine(&sb, "Test guidance", p.TestGuidance)
-		sb.WriteString("\n")
+		renderHarnessProfile(&sb, p)
 	}
 	return sb.String()
+}
+
+func renderHarnessProfile(sb *strings.Builder, p prompt.ResolvedHarnessProfileContext) {
+	fmt.Fprintf(sb, "### %s (%s)\n\n", p.ProfileID, p.Tier)
+	if p.Orchestration != "" {
+		fmt.Fprintf(sb, "- **Orchestration:** %s\n", p.Orchestration)
+	}
+	writeJoinedLine(sb, "Used by", p.UsedBy)
+	if p.Purpose != "" {
+		fmt.Fprintf(sb, "- **Purpose:** %s\n", p.Purpose)
+	}
+	writeJoinedLine(sb, "Covers", p.Covers)
+	writeJoinedLine(sb, "Proves", p.Proves)
+	writeJoinedLine(sb, "Runner support", p.RunnerSupport)
+	if p.Cost != "" {
+		fmt.Fprintf(sb, "- **Cost:** %s\n", p.Cost)
+	}
+	writeJoinedLine(sb, "Constraints", p.Constraints)
+	writeJoinedLine(sb, "Required assertions", p.RequiredAssertions)
+	writeJoinedLine(sb, "Evidence anchors", p.EvidenceAnchors)
+	renderHarnessImages(sb, p.Images)
+	renderHarnessPorts(sb, p.Ports)
+	renderHarnessEnv(sb, p.Env)
+	writeJoinedLine(sb, "Readiness", p.Readiness)
+	writeJoinedLine(sb, "Test guidance", p.TestGuidance)
+	sb.WriteString("\n")
+}
+
+func renderHarnessImages(sb *strings.Builder, images []prompt.HarnessImageContext) {
+	if len(images) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(images))
+	for _, img := range images {
+		if img.Purpose == "" {
+			parts = append(parts, img.Name)
+		} else {
+			parts = append(parts, fmt.Sprintf("%s (%s)", img.Name, img.Purpose))
+		}
+	}
+	fmt.Fprintf(sb, "- **Images:** %s\n", strings.Join(parts, "; "))
+}
+
+func renderHarnessPorts(sb *strings.Builder, ports []prompt.HarnessPortContext) {
+	if len(ports) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		value := fmt.Sprintf("%s/%d/%s", port.Name, port.ContainerPort, port.Protocol)
+		if port.Purpose != "" {
+			value = fmt.Sprintf("%s (%s)", value, port.Purpose)
+		}
+		parts = append(parts, value)
+	}
+	fmt.Fprintf(sb, "- **Ports:** %s\n", strings.Join(parts, "; "))
+}
+
+func renderHarnessEnv(sb *strings.Builder, env map[string]string) {
+	if len(env) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, env[key]))
+	}
+	fmt.Fprintf(sb, "- **Env:** %s\n", strings.Join(parts, "; "))
 }
 
 // renderPlanReviewerPrompt produces the plan-reviewer agent's user message.

--- a/revive.toml
+++ b/revive.toml
@@ -16,11 +16,15 @@ warningCode = 0
 [rule.error-strings]
 [rule.error-naming]
 [rule.exported]
+  # Sponsor-pack code is fossilized agent-generated output preserved verbatim
+  # as a historical artifact; do not retroactively add doc comments to it.
+  exclude = ["**/docs/sponsor-packages/**"]
 [rule.if-return]
 [rule.increment-decrement]
 [rule.var-naming]
 [rule.var-declaration]
 [rule.package-comments]
+  exclude = ["**/docs/sponsor-packages/**"]
 [rule.range]
 [rule.receiver-naming]
 [rule.time-naming]

--- a/workflow/harnesscatalog/catalog.go
+++ b/workflow/harnesscatalog/catalog.go
@@ -30,6 +30,20 @@ const (
 	TierHeavy = "heavy"
 )
 
+const (
+	// OrchestrationServices profiles declare an invariant integration stack the
+	// qa-runner renders into qa.yml services from images/ports/env/readiness.
+	OrchestrationServices = "services"
+	// OrchestrationTestcontainers profiles need per-test or dynamic stack
+	// orchestration the dev agent expresses with testcontainers-go (or an
+	// equivalent in-test fixture). The qa renderer emits no services for these.
+	OrchestrationTestcontainers = "testcontainers"
+	// OrchestrationPureFixture profiles need no container — captured frames,
+	// in-process peers, or pure-unit fixtures. The qa renderer emits no
+	// services for these.
+	OrchestrationPureFixture = "pure-fixture"
+)
+
 // Catalog is the merged set of built-in and workspace harness profiles.
 type Catalog struct {
 	Profiles map[string]Profile
@@ -53,6 +67,23 @@ type Profile struct {
 	Env                map[string]string   `yaml:"env" json:"env,omitempty"`
 	Readiness          []string            `yaml:"readiness" json:"readiness,omitempty"`
 	TestGuidance       []string            `yaml:"test_guidance" json:"test_guidance,omitempty"`
+	// Orchestration declares how the qa-runner brings up this profile's
+	// integration stack. Empty defaults to OrchestrationServices when Images
+	// is non-empty and OrchestrationPureFixture otherwise; callers should read
+	// EffectiveOrchestration() rather than this raw field.
+	Orchestration string `yaml:"orchestration" json:"orchestration,omitempty"`
+}
+
+// EffectiveOrchestration returns Orchestration if set, otherwise the inferred
+// default: services when the profile declares images, pure-fixture otherwise.
+func (p Profile) EffectiveOrchestration() string {
+	if o := strings.TrimSpace(p.Orchestration); o != "" {
+		return o
+	}
+	if len(p.Images) > 0 {
+		return OrchestrationServices
+	}
+	return OrchestrationPureFixture
 }
 
 // ImageRef is a container image a profile expects tests to start.
@@ -258,6 +289,10 @@ func validateProfile(p Profile) error {
 		return fmt.Errorf("profile %q cost is required", p.ID)
 	case !validTier(p.Tier):
 		return fmt.Errorf("profile %q has malformed tier %q", p.ID, p.Tier)
+	case !validOrchestration(p.Orchestration):
+		return fmt.Errorf("profile %q has malformed orchestration %q", p.ID, p.Orchestration)
+	case p.Orchestration == OrchestrationServices && len(p.Images) == 0:
+		return fmt.Errorf("profile %q orchestration is services but images is empty", p.ID)
 	case len(p.Proves) == 0:
 		return fmt.Errorf("profile %q proves is required", p.ID)
 	case len(p.Covers) == 0:
@@ -323,6 +358,17 @@ func validateNonEmptyList(profileID, field string, vals []string) error {
 func validTier(tier string) bool {
 	switch tier {
 	case TierRequired, TierCompatibility, TierHeavy:
+		return true
+	default:
+		return false
+	}
+}
+
+// validOrchestration accepts the empty string (caller falls back to inference)
+// or any of the declared orchestration constants.
+func validOrchestration(o string) bool {
+	switch strings.TrimSpace(o) {
+	case "", OrchestrationServices, OrchestrationTestcontainers, OrchestrationPureFixture:
 		return true
 	default:
 		return false

--- a/workflow/harnesscatalog/catalog/mavlink.yaml
+++ b/workflow/harnesscatalog/catalog/mavlink.yaml
@@ -3,6 +3,7 @@ profiles:
     domain: mavlink
     tier: required
     summary: PX4 SITL smoke profile for MAVSDK-backed control and telemetry tests.
+    orchestration: services
     proves:
       - MAVSDK can connect to a real MAVLink-speaking autopilot.
       - Command/control plugins can perform health-gated actions against SITL.
@@ -25,12 +26,12 @@ profiles:
         - failure
     runner_support:
       - local-docker
-      - github-actions-via-testcontainers
+      - github-actions
       - act
     cost: medium
     constraints:
-      - Start SITL inside project tests with Testcontainers or an equivalent test fixture.
-      - Do not add GitHub Actions services; qa.yml remains generic.
+      - qa-runner brings up px4io/px4-sitl as a qa.yml service from this profile; tests connect to mavlink-udp at the rendered host port.
+      - Tests must not start their own SITL container — the rendered service is authoritative for this profile.
       - Gate control assertions on MAVSDK health/connection state before issuing commands.
     required_assertions:
       - Observe a MAVLink heartbeat from the SITL target.
@@ -56,13 +57,14 @@ profiles:
       - Wait for MAVLink HEARTBEAT frames on UDP 14540.
       - Wait for MAVSDK connection state to become connected.
     test_guidance:
-      - Keep SITL startup inside test code so qa-runner and GitHub Actions stay portable.
+      - Read the SITL endpoint from the env/host the qa-runner injects rather than hard-coding localhost or a fixed port.
       - Record the profile ID near the integration test setup so structural validation can bind evidence to the catalog entry.
 
   - id: mavlink.ardupilot-sitl.compat
     domain: mavlink
     tier: compatibility
     summary: ArduPilot SITL compatibility profile for MAVLink dialect and autopilot variance.
+    orchestration: services
     proves:
       - Driver logic is not hard-coded to PX4-only MAVLink behavior.
       - Telemetry parsing tolerates ArduPilot heartbeat/autopilot metadata.
@@ -74,12 +76,12 @@ profiles:
         - common
     runner_support:
       - local-docker
-      - github-actions-via-testcontainers
+      - github-actions
       - act
     cost: medium
     constraints:
+      - qa-runner brings up ardupilot/ardupilot as a qa.yml service from this profile; tests connect to the rendered endpoint.
       - Run as an optional compatibility suite unless the architecture explicitly depends on ArduPilot behavior.
-      - Keep the fixture in project tests, not in qa.yml services.
     required_assertions:
       - Observe an ArduPilot MAVLink heartbeat.
       - Verify at least one telemetry stream parses without PX4-specific assumptions.
@@ -105,6 +107,7 @@ profiles:
     domain: mavlink
     tier: compatibility
     summary: Raw MAVLink direct-wire profile for message encode/decode and fallback coverage.
+    orchestration: pure-fixture
     proves:
       - The implementation can handle MAVLink messages without depending exclusively on MAVSDK plugin abstractions.
       - Low-level command, heartbeat, and telemetry frames round-trip through the parser/serializer.
@@ -119,13 +122,13 @@ profiles:
         - SYS_STATUS
     runner_support:
       - local-docker
-      - github-actions-via-testcontainers
+      - github-actions
       - act
       - pure-unit-fixture
     cost: low
     constraints:
-      - Prefer captured frames or a small in-process MAVLink peer for pure parser tests.
-      - Use a SITL-backed peer when proving behavior that depends on autopilot state.
+      - qa-runner renders no services for this profile; the test fixture owns the MAVLink peer (captured frames or an in-process peer).
+      - If a test needs a live SITL peer for autopilot-state-dependent behavior, select a services-orchestrated profile instead of widening this one.
     required_assertions:
       - Decode HEARTBEAT from a real or captured MAVLink frame.
       - Round-trip at least one command frame and assert the expected ACK or parser result.
@@ -136,7 +139,7 @@ profiles:
       - MAVLink
     readiness:
       - In-process fixtures are ready after the peer binds.
-      - SITL-backed fixtures wait for HEARTBEAT before assertions.
+      - Captured-frame fixtures need no readiness signal.
     test_guidance:
       - Select this when the task claims native MAVLink coverage beyond MAVSDK plugin calls.
 
@@ -144,6 +147,7 @@ profiles:
     domain: mavlink
     tier: heavy
     summary: PX4 plus simulator peripherals profile for camera, gimbal, and richer sensor streams.
+    orchestration: services
     proves:
       - Peripheral-heavy plugins behave with simulator-backed camera/gimbal/sensor traffic.
       - Higher-cost data streams can be exercised without changing qa-runner orchestration.
@@ -161,6 +165,7 @@ profiles:
       - dedicated-ci-runner
     cost: high
     constraints:
+      - qa-runner brings up px4io/px4-sitl with peripheral support as a qa.yml service from this profile.
       - Requires substantially more CPU/GPU and wall-clock than the default smoke profile.
       - Do not require this profile by default for ordinary MAVLink driver work.
     required_assertions:

--- a/workflow/harnesscatalog/catalog_test.go
+++ b/workflow/harnesscatalog/catalog_test.go
@@ -171,6 +171,57 @@ func TestResolveSelectionsRejectsUnknownAndSplitsRequired(t *testing.T) {
 	}
 }
 
+func TestEffectiveOrchestrationInfersFromImages(t *testing.T) {
+	withImage := Profile{Images: []ImageRef{{Name: "x"}}}
+	if got := withImage.EffectiveOrchestration(); got != OrchestrationServices {
+		t.Errorf("profile with images: got %q, want %q", got, OrchestrationServices)
+	}
+	withoutImage := Profile{}
+	if got := withoutImage.EffectiveOrchestration(); got != OrchestrationPureFixture {
+		t.Errorf("profile without images: got %q, want %q", got, OrchestrationPureFixture)
+	}
+	explicit := Profile{Orchestration: OrchestrationTestcontainers, Images: []ImageRef{{Name: "x"}}}
+	if got := explicit.EffectiveOrchestration(); got != OrchestrationTestcontainers {
+		t.Errorf("explicit orchestration: got %q, want %q", got, OrchestrationTestcontainers)
+	}
+}
+
+func TestLoadRejectsMalformedOrchestrationAndServicesWithoutImages(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "malformed orchestration",
+			body: strings.ReplaceAll(validProfileYAML, "tier: required", "tier: required\n    orchestration: sometimes"),
+			want: "malformed orchestration",
+		},
+		{
+			name: "services without images",
+			body: strings.ReplaceAll(validProfileYAML, "tier: required", "tier: required\n    orchestration: services"),
+			want: "orchestration is services but images is empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			dir := filepath.Join(root, ".semspec", "harness-catalog")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := strings.ReplaceAll(tt.body, "$ID", "custom.bad")
+			if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(root)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
 const validProfileYAML = `
 profiles:
   - id: $ID

--- a/workflow/harnesscatalog/qarender/qarender.go
+++ b/workflow/harnesscatalog/qarender/qarender.go
@@ -1,0 +1,181 @@
+// Package qarender renders qa.yml GitHub-Actions-compatible `services:` blocks
+// from harness catalog selections.
+//
+// Phase 1a (ADR-039): pure transformation. Render takes a slice of resolved
+// catalog selections and returns a yaml.Node that callers can splice into a
+// larger qa.yml document. The renderer reads catalog metadata only (no docker,
+// no plan state, no filesystem). Profiles whose Orchestration is anything other
+// than `services` are intentionally skipped — testcontainers and pure-fixture
+// profiles do not get qa-runner service blocks; their integration concerns live
+// in agent test code (testcontainers) or in-process fixtures (pure-fixture).
+package qarender
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// Options tunes rendering. Zero-value Options renders container ports
+// without host-port binding (GHA assigns a random host port at job time).
+type Options struct {
+	// PortOffset, when non-zero, is added to each profile's container_port to
+	// derive an explicit host port. Used by callers (e.g. plan-manager) to
+	// avoid host-port collisions when multiple plans run in parallel against
+	// the same profile. The container-internal port is preserved unchanged so
+	// tests can rely on canonical port constants.
+	PortOffset int
+}
+
+// Render returns a yaml.Node holding the GHA `services:` mapping derived from
+// selections. The returned node is a MappingNode whose keys are service names
+// and whose values are MappingNodes with image/env/ports/options as required by
+// nektos/act and GitHub Actions. An empty selection list (or one with no
+// services-orchestrated entries) yields an empty MappingNode rather than nil so
+// callers can splice the result unconditionally.
+func Render(selections []harnesscatalog.ResolvedSelection, opts Options) (*yaml.Node, error) {
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	if len(selections) == 0 {
+		return root, nil
+	}
+	seenServiceNames := map[string]string{}
+	for i, sel := range selections {
+		if sel.Profile.EffectiveOrchestration() != harnesscatalog.OrchestrationServices {
+			continue
+		}
+		if len(sel.Profile.Images) == 0 {
+			return nil, fmt.Errorf("qarender: profile %q declares orchestration=services but has no images", sel.Profile.ID)
+		}
+		name := ServiceName(sel.Profile.ID)
+		if prev, ok := seenServiceNames[name]; ok {
+			return nil, fmt.Errorf("qarender: profiles %q and %q both render to service name %q", prev, sel.Profile.ID, name)
+		}
+		seenServiceNames[name] = sel.Profile.ID
+
+		serviceNode, err := renderService(sel.Profile, opts)
+		if err != nil {
+			return nil, fmt.Errorf("qarender: render profile[%d] %q: %w", i, sel.Profile.ID, err)
+		}
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: name}
+		keyNode.HeadComment = profileHeadComment(sel.Profile)
+		root.Content = append(root.Content, keyNode, serviceNode)
+	}
+	return root, nil
+}
+
+// RenderYAML marshals Render's output into a YAML string suitable for splicing
+// directly under a `services:` key in qa.yml. The returned string never has a
+// leading `services:` prefix; callers control where to splice it.
+func RenderYAML(selections []harnesscatalog.ResolvedSelection, opts Options) (string, error) {
+	node, err := Render(selections, opts)
+	if err != nil {
+		return "", err
+	}
+	if len(node.Content) == 0 {
+		return "", nil
+	}
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(node); err != nil {
+		return "", fmt.Errorf("qarender: encode yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return "", fmt.Errorf("qarender: close encoder: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// ServiceName converts a catalog profile ID into a GHA-valid service name by
+// replacing dots with hyphens. GHA service names must match [a-zA-Z0-9_-]+ and
+// are used as DNS hostnames inside the job network, so dots are not allowed.
+func ServiceName(profileID string) string {
+	return strings.ReplaceAll(profileID, ".", "-")
+}
+
+func profileHeadComment(p harnesscatalog.Profile) string {
+	var b strings.Builder
+	b.WriteString("Profile: ")
+	b.WriteString(strings.TrimSpace(p.ID))
+	if len(p.Readiness) > 0 {
+		b.WriteString("\nReadiness (operator must enforce in qa-runner; not emitted as docker healthcheck):")
+		for _, r := range p.Readiness {
+			b.WriteString("\n  - ")
+			b.WriteString(strings.TrimSpace(r))
+		}
+	}
+	return b.String()
+}
+
+func renderService(p harnesscatalog.Profile, opts Options) (*yaml.Node, error) {
+	svc := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+	appendScalarKV(svc, "image", p.Images[0].Name)
+
+	if len(p.Env) > 0 {
+		envNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+		keys := make([]string, 0, len(p.Env))
+		for k := range p.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			envNode.Content = append(envNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: k},
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: p.Env[k]},
+			)
+		}
+		svc.Content = append(svc.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "env"},
+			envNode,
+		)
+	}
+
+	if len(p.Ports) > 0 {
+		portsNode := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, port := range p.Ports {
+			mapping, err := portMapping(port, opts)
+			if err != nil {
+				return nil, err
+			}
+			portsNode.Content = append(portsNode.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: mapping},
+			)
+		}
+		svc.Content = append(svc.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "ports"},
+			portsNode,
+		)
+	}
+
+	return svc, nil
+}
+
+func appendScalarKV(parent *yaml.Node, key, value string) {
+	parent.Content = append(parent.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+func portMapping(port harnesscatalog.PortRef, opts Options) (string, error) {
+	if port.ContainerPort <= 0 {
+		return "", fmt.Errorf("port %q has non-positive container_port %d", port.Name, port.ContainerPort)
+	}
+	protocol := strings.ToLower(strings.TrimSpace(port.Protocol))
+	if opts.PortOffset == 0 {
+		if protocol == "" {
+			return fmt.Sprintf("%d", port.ContainerPort), nil
+		}
+		return fmt.Sprintf("%d/%s", port.ContainerPort, protocol), nil
+	}
+	hostPort := port.ContainerPort + opts.PortOffset
+	if protocol == "" {
+		return fmt.Sprintf("%d:%d", hostPort, port.ContainerPort), nil
+	}
+	return fmt.Sprintf("%d:%d/%s", hostPort, port.ContainerPort, protocol), nil
+}

--- a/workflow/harnesscatalog/qarender/qarender_test.go
+++ b/workflow/harnesscatalog/qarender/qarender_test.go
@@ -128,6 +128,42 @@ func TestRenderRejectsServicesProfileWithoutImages(t *testing.T) {
 	}
 }
 
+// TestRenderRealCatalogMixedSelection is the cross-package integration shape
+// for ADR-039 Phase 1a: load the real built-in catalog, select a services
+// profile and a pure-fixture profile in the same call, and verify the renderer
+// emits a services block for the former and skips the latter without error.
+// Mirrors what Phase 1c will actually receive at qa.yml emission time.
+func TestRenderRealCatalogMixedSelection(t *testing.T) {
+	selections := mustResolve(t,
+		"mavlink.raw-mavlink-direct",    // pure-fixture, no images
+		"mavlink.px4-sitl.mavsdk-smoke", // services, images present
+		"mavlink.ardupilot-sitl.compat", // services, images present
+	)
+	got, err := RenderYAML(selections, Options{PortOffset: 12000})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	if got == "" {
+		t.Fatal("RenderYAML() returned empty string; want services block")
+	}
+	if strings.Contains(got, "mavlink-raw-mavlink-direct") {
+		t.Errorf("pure-fixture profile leaked into output:\n%s", got)
+	}
+	for _, want := range []string{
+		"mavlink-px4-sitl-mavsdk-smoke:",
+		"image: px4io/px4-sitl:latest",
+		"- 26540:14540/udp",
+		"mavlink-ardupilot-sitl-compat:",
+		"image: ardupilot/ardupilot:latest",
+		"- 26550:14550/udp",
+		"PX4_SIM_MODEL: iris",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestServiceNameReplacesDots(t *testing.T) {
 	cases := map[string]string{
 		"mavlink.px4-sitl.mavsdk-smoke": "mavlink-px4-sitl-mavsdk-smoke",

--- a/workflow/harnesscatalog/qarender/qarender_test.go
+++ b/workflow/harnesscatalog/qarender/qarender_test.go
@@ -1,0 +1,159 @@
+package qarender
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+func TestRenderEmptySelectionsReturnsEmptyMapping(t *testing.T) {
+	node, err := Render(nil, Options{})
+	if err != nil {
+		t.Fatalf("Render(nil) error = %v", err)
+	}
+	if node == nil {
+		t.Fatal("Render(nil) returned nil node; want non-nil empty mapping")
+	}
+	if len(node.Content) != 0 {
+		t.Errorf("Render(nil) content len = %d, want 0", len(node.Content))
+	}
+}
+
+func TestRenderSkipsPureFixtureAndTestcontainersProfiles(t *testing.T) {
+	selections := []harnesscatalog.ResolvedSelection{
+		{
+			Selection: workflow.HarnessProfileSelection{ProfileID: "x.pure"},
+			Profile: harnesscatalog.Profile{
+				ID:            "x.pure",
+				Orchestration: harnesscatalog.OrchestrationPureFixture,
+			},
+		},
+		{
+			Selection: workflow.HarnessProfileSelection{ProfileID: "x.tc"},
+			Profile: harnesscatalog.Profile{
+				ID:            "x.tc",
+				Orchestration: harnesscatalog.OrchestrationTestcontainers,
+				Images:        []harnesscatalog.ImageRef{{Name: "irrelevant"}},
+			},
+		},
+	}
+	got, err := RenderYAML(selections, Options{})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	if got != "" {
+		t.Errorf("RenderYAML() = %q, want empty string for non-services profiles", got)
+	}
+}
+
+func TestRenderServicesProfileWithoutPortOffset(t *testing.T) {
+	selections := mustResolve(t, "mavlink.px4-sitl.mavsdk-smoke")
+	got, err := RenderYAML(selections, Options{})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	const want = `# Profile: mavlink.px4-sitl.mavsdk-smoke
+# Readiness (operator must enforce in qa-runner; not emitted as docker healthcheck):
+#   - Wait for MAVLink HEARTBEAT frames on UDP 14540.
+#   - Wait for MAVSDK connection state to become connected.
+mavlink-px4-sitl-mavsdk-smoke:
+  image: px4io/px4-sitl:latest
+  env:
+    PX4_SIM_MODEL: iris
+  ports:
+    - 14540/udp
+`
+	if got != want {
+		t.Errorf("RenderYAML() mismatch.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRenderServicesProfileWithPortOffset(t *testing.T) {
+	selections := mustResolve(t, "mavlink.px4-sitl.mavsdk-smoke")
+	got, err := RenderYAML(selections, Options{PortOffset: 12000})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	if !strings.Contains(got, "- 26540:14540/udp") {
+		t.Errorf("expected port mapping 26540:14540/udp in output, got:\n%s", got)
+	}
+}
+
+func TestRenderMultipleServicesProfilesDeterministic(t *testing.T) {
+	selections := mustResolve(t, "mavlink.px4-sitl.mavsdk-smoke", "mavlink.ardupilot-sitl.compat")
+	got, err := RenderYAML(selections, Options{})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	pxIdx := strings.Index(got, "mavlink-px4-sitl-mavsdk-smoke:")
+	apIdx := strings.Index(got, "mavlink-ardupilot-sitl-compat:")
+	if pxIdx < 0 || apIdx < 0 {
+		t.Fatalf("missing expected service names in output:\n%s", got)
+	}
+	if pxIdx >= apIdx {
+		t.Errorf("services rendered out of input order: px4 at %d, ardupilot at %d", pxIdx, apIdx)
+	}
+}
+
+func TestRenderMixedSelectionEmitsOnlyServicesProfiles(t *testing.T) {
+	selections := mustResolve(t,
+		"mavlink.raw-mavlink-direct",
+		"mavlink.px4-sitl.mavsdk-smoke",
+	)
+	got, err := RenderYAML(selections, Options{})
+	if err != nil {
+		t.Fatalf("RenderYAML() error = %v", err)
+	}
+	if strings.Contains(got, "mavlink-raw-mavlink-direct") {
+		t.Errorf("pure-fixture profile leaked into rendered output:\n%s", got)
+	}
+	if !strings.Contains(got, "mavlink-px4-sitl-mavsdk-smoke:") {
+		t.Errorf("services profile missing from rendered output:\n%s", got)
+	}
+}
+
+func TestRenderRejectsServicesProfileWithoutImages(t *testing.T) {
+	bad := []harnesscatalog.ResolvedSelection{{
+		Selection: workflow.HarnessProfileSelection{ProfileID: "x.bad"},
+		Profile: harnesscatalog.Profile{
+			ID:            "x.bad",
+			Orchestration: harnesscatalog.OrchestrationServices,
+		},
+	}}
+	_, err := Render(bad, Options{})
+	if err == nil || !strings.Contains(err.Error(), "no images") {
+		t.Fatalf("Render(services without images) error = %v, want substring 'no images'", err)
+	}
+}
+
+func TestServiceNameReplacesDots(t *testing.T) {
+	cases := map[string]string{
+		"mavlink.px4-sitl.mavsdk-smoke": "mavlink-px4-sitl-mavsdk-smoke",
+		"no.dots.here":                  "no-dots-here",
+		"plain":                         "plain",
+	}
+	for in, want := range cases {
+		if got := ServiceName(in); got != want {
+			t.Errorf("ServiceName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func mustResolve(t *testing.T, ids ...string) []harnesscatalog.ResolvedSelection {
+	t.Helper()
+	catalog, err := harnesscatalog.LoadBuiltIn()
+	if err != nil {
+		t.Fatalf("LoadBuiltIn() error = %v", err)
+	}
+	sels := make([]workflow.HarnessProfileSelection, len(ids))
+	for i, id := range ids {
+		sels[i] = workflow.HarnessProfileSelection{ProfileID: id, Purpose: "test"}
+	}
+	resolved, err := catalog.ResolveSelections(sels)
+	if err != nil {
+		t.Fatalf("ResolveSelections() error = %v", err)
+	}
+	return resolved
+}


### PR DESCRIPTION
## Summary

- **New package `workflow/harnesscatalog/qarender`** — pure transformation `[]ResolvedSelection → GHA services YAML`. Zero infra dependencies; Phase 1b (socket mount) and Phase 1c (qa.yml emission) consume it directly.
- **Per-profile `orchestration` field** on catalog `Profile` (`services` / `testcontainers` / `pure-fixture`) — turns ADR-039's primary-vs-fallback framing into an explicit per-profile metadata declaration. Default inference: `services` if `images[]` non-empty, `pure-fixture` otherwise.
- **Stale guidance fixed** in two places: the four mavlink catalog profiles (constraints that said "Do not add GitHub Actions services" — the OLD shape) and the dev-agent prompt at `prompt/domain/software_render.go:553` (told the dev agent the exact opposite of what ADR-039 ships).
- **ADR-039 amended** — Decision § 1 documents the per-profile field.
- **Lint cleanup** — render function refactored under 50-statement limit; `docs/sponsor-packages/**` excluded from `package-comments` + `exported` rules (fossilized agent output, do not retroactively edit).

## What this enables

Phase 1b (qa-runner socket mount) and Phase 1c (qa.yml emission at `reviewing_qa`) both consume `qarender.RenderYAML(selections, opts)`. The pure-function shape means both downstream phases can be unit-tested without Docker.

The architect now sees the `orchestration` choice surfaced in the prompt at selection time, rather than discovering it implicitly in the rendered qa.yml. PR #20's empirical finding that the architect picks the right profile tier extends naturally to picking the right orchestration model.

## Architectural note

The catalog profile entries used to say "Use testcontainers" / "Do not add GitHub Actions services" as a load-bearing constraint. That was an easy-play decision from before qa-runner had a Docker socket. Once ADR-039 commits to socket-mount + sibling containers, that constraint inverts. Rather than fall back to "primary mechanism = GHA, fallback = testcontainers" (the old framing), the per-profile `orchestration` field lets each profile author declare the right tool for the actual stack shape:

- **`services`** — invariant integration stack, every test in the job uses the same peer (PX4 SITL smoke, ArduPilot compat, Gazebo peripherals)
- **`testcontainers`** — per-test stack variation, dynamic config, multi-instance topologies
- **`pure-fixture`** — no container needed (raw-mavlink-direct's in-process MAVLink peer or captured frames)

## Test plan

- [x] `go test ./workflow/harnesscatalog/...` — catalog validator + renderer goldens pass
- [x] `go test ./prompt/... ./processor/execution-manager/... ./processor/requirement-executor/...` — prompt-context plumbing + constructors green
- [x] `go test ./...` — full repo green
- [x] `task lint` — zero warnings (was 3 pre-existing on main)
- [ ] Phase 3 (separate PR) — verify the rendered qa.yml actually brings up a real PX4 SITL container end-to-end against the mavlink-decode tier

## Files changed

| File | Change |
|---|---|
| `workflow/harnesscatalog/qarender/qarender.go` (new) | Pure renderer: `Render`, `RenderYAML`, `ServiceName`, `Options{PortOffset}` |
| `workflow/harnesscatalog/qarender/qarender_test.go` (new) | Goldens: empty / pure-fixture skip / testcontainers skip / services golden / port offset / multi-profile order / mixed selection / error case |
| `workflow/harnesscatalog/catalog.go` | `Orchestration` field + `EffectiveOrchestration()` + validator + constants |
| `workflow/harnesscatalog/catalog_test.go` | Inference + explicit-value + invalid-value cases |
| `workflow/harnesscatalog/catalog/mavlink.yaml` | All four profiles declare `orchestration:`; constraint strings rewritten; `runner_support` updated |
| `prompt/context.go` | `Orchestration` field on `ResolvedHarnessProfileContext` |
| `processor/execution-manager/component.go` + `processor/requirement-executor/component.go` | Populate from `p.EffectiveOrchestration()` |
| `prompt/domain/software_render.go` | Stale guidance string fixed; function refactored under 50-statement lint; orchestration surfaced in rendered output |
| `revive.toml` | Sponsor-pack exclude for `package-comments` + `exported` |
| `docs/adr/ADR-039-…md` | Decision § 1 amendment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)