### PR TITLE
test(e2e): qa-cycle-services scenario proves act services substrate (ADR-039 Phase 1b)

### DIFF
--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -215,6 +215,8 @@ func run(scenarioName string, cfg *config.Config, outputJSON bool, globalTimeout
 		// Tier 2: QA phase — sandbox unit-test executor + qa-reviewer verdict pipeline
 		scenarios.NewQACycleScenario(cfg),
 		scenarios.NewQACycleIntegrationScenario(cfg),
+		// Tier 2: ADR-039 Phase 1b — qa-runner Docker-socket sibling-spawn proof
+		scenarios.NewQACycleServicesScenario(cfg),
 	}
 
 	scenarioMap := make(map[string]scenarios.Scenario)

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-architecture-generator.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-architecture-generator.json
@@ -1,0 +1,13 @@
+{
+  "tool_calls": [
+    {
+      "id": "call_submit_1",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"technology_choices\":[{\"category\":\"language\",\"choice\":\"Go\",\"rationale\":\"go.mod declares example.com/qa-cycle-project on Go 1.21\"}],\"component_boundaries\":[{\"name\":\"math\",\"responsibility\":\"Pure arithmetic primitives (Add, Sub) — no external state\",\"dependencies\":[],\"upstream_refs\":[]},{\"name\":\"server\",\"responsibility\":\"Stub CLI entrypoint at cmd/server\",\"dependencies\":[\"math\"],\"upstream_refs\":[]}],\"data_flow\":\"Callers invoke math.Add and math.Sub directly. Pure stdlib, no IO, no external state.\",\"decisions\":[{\"id\":\"ARCH-001\",\"title\":\"Sub mirrors Add's file shape\",\"decision\":\"Sub lives in a new pkg/math/sub.go alongside math.go with a parallel pkg/math/sub_test.go\",\"rationale\":\"Mirrors the existing Add/math_test.go precedent (pkg/math/math.go + pkg/math/math_test.go) so the test layout stays predictable\"}],\"actors\":[{\"name\":\"Test runner\",\"type\":\"system\",\"triggers\":[\"go test ./...\"],\"permissions\":[]}],\"integrations\":[],\"upstream_resolutions\":[],\"test_surface\":{\"integration_flows\":[],\"e2e_flows\":[]},\"harness_profiles\":[]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-code-reviewer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-code-reviewer.json
@@ -1,0 +1,14 @@
+{
+  "content": "Code review complete. Verdict: approved.",
+  "tool_calls": [
+    {
+      "id": "call_review_approve",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"verdict\": \"approved\", \"feedback\": \"Implementation matches the requirement and passes structural validation.\", \"summary\": \"Code review approved.\"}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.1.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.1.json
@@ -1,0 +1,14 @@
+{
+  "content": "Adding Subtract function and its test to pkg/math.",
+  "tool_calls": [
+    {
+      "id": "call_write_sub",
+      "type": "function",
+      "function": {
+        "name": "bash",
+        "arguments": "{\"command\":\"cat > pkg/math/sub.go << 'GOEOF'\\npackage math\\n\\n// Sub returns the difference a - b.\\nfunc Sub(a, b int) int { return a - b }\\nGOEOF\"}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.2.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.2.json
@@ -1,0 +1,14 @@
+{
+  "content": "Writing the test for Sub.",
+  "tool_calls": [
+    {
+      "id": "call_write_sub_test",
+      "type": "function",
+      "function": {
+        "name": "bash",
+        "arguments": "{\"command\":\"cat > pkg/math/sub_test.go << 'GOEOF'\\npackage math\\n\\nimport \\\"testing\\\"\\n\\nfunc TestSub(t *testing.T) {\\n\\tif got := Sub(5, 3); got != 2 {\\n\\t\\tt.Errorf(\\\"Sub(5, 3) = %d; want 2\\\", got)\\n\\t}\\n}\\nGOEOF\"}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.3.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.3.json
@@ -1,0 +1,14 @@
+{
+  "content": "Submitting work.",
+  "tool_calls": [
+    {
+      "id": "call_submit_work",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.4.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.4.json
@@ -1,0 +1,14 @@
+{
+  "content": "Submitting work.",
+  "tool_calls": [
+    {
+      "id": "call_review_task",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.5.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.5.json
@@ -1,0 +1,14 @@
+{
+  "content": "Submitting work.",
+  "tool_calls": [
+    {
+      "id": "call_review_req",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-coder.json
@@ -1,0 +1,14 @@
+{
+  "content": "Submitting work.",
+  "tool_calls": [
+    {
+      "id": "call_submit_fallback",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-decomposer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-decomposer.json
@@ -1,0 +1,14 @@
+{
+  "content": "Decomposing into a single developer node that writes Sub plus its unit test.",
+  "tool_calls": [
+    {
+      "id": "call_decompose",
+      "type": "function",
+      "function": {
+        "name": "decompose_task",
+        "arguments": "{\"goal\":\"Implement Sub function in pkg/math with a passing unit test\",\"nodes\":[{\"id\":\"implement-sub\",\"prompt\":\"Add a Sub function to pkg/math that returns the difference of two integers. Write pkg/math/sub.go with `package math` and a `func Sub(a, b int) int { return a - b }` exported function with GoDoc. Write pkg/math/sub_test.go with `package math`, `import \\\"testing\\\"`, and a `TestSub` that calls Sub(5, 3) and asserts the result is 2. Run `go test ./...` to confirm both TestAdd and TestSub pass before submitting.\",\"role\":\"developer\",\"depends_on\":[],\"file_scope\":[\"pkg/math/sub.go\",\"pkg/math/sub_test.go\"]}]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-fast.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-fast.json
@@ -1,0 +1,3 @@
+{
+  "response": "Acknowledged. Task completed successfully."
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-lesson-decomposer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-lesson-decomposer.json
@@ -1,0 +1,14 @@
+{
+  "content": "Decomposed the rejection into a single audited lesson.",
+  "tool_calls": [
+    {
+      "id": "call_lesson_decompose_1",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"summary\":\"Run the full test suite before submit_work to catch broken consumers.\",\"detail\":\"The developer's submit_work claimed completion before running the project's full test suite. The reviewer flagged tests that didn't cover the rejected scenario. The trajectory shows per-package compilation but no full-test invocation between the last edit and submit_work.\",\"injection_form\":\"Always run the project's full test command (e.g. go test ./...) before calling submit_work. Per-package builds miss broken consumers.\",\"category_ids\":[\"incomplete_verification\"],\"root_cause_role\":\"developer\",\"evidence_steps\":[{\"loop_id\":\"mock-developer-loop\",\"step_index\":3}],\"evidence_files\":[{\"path\":\"pkg/math/sub.go\",\"line_start\":1,\"line_end\":10,\"commit_sha\":\"mockcommit\"}]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-planner.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-planner.json
@@ -1,0 +1,13 @@
+{
+  "tool_calls": [
+    {
+      "id": "call_submit_1",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"goal\": \"Add a Sub function to pkg/math returning the difference of two integers, mirroring Add's shape with a parallel unit test.\", \"context\": \"The project is a small Go module (example.com/qa-cycle-project). pkg/math/math.go declares the Add function; pkg/math/math_test.go covers it with TestAdd. We add Sub as a parallel arithmetic primitive in a new file. The Makefile test target runs go test ./...; project SOPs require every new function to have at least one passing unit test.\", \"scope\": {\"include\": [\"pkg/math/math.go\", \"pkg/math/math_test.go\"], \"create\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"], \"exclude\": [], \"do_not_touch\": [\"README.md\", \"Makefile\", \"go.mod\"]}}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-qa-reviewer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-qa-reviewer.json
@@ -1,0 +1,14 @@
+{
+  "content": "QA review complete. Verdict: approved.",
+  "tool_calls": [
+    {
+      "id": "call_qa_review",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"verdict\": \"approved\", \"summary\": \"All requirements are implemented and the plan goal is satisfied. Implementation quality is adequate for the qa.level.\", \"dimensions\": {\"requirement_fulfillment\": \"All declared requirements have corresponding implementation. No gaps detected.\"}}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-requirement-generator.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-requirement-generator.json
@@ -1,0 +1,13 @@
+{
+  "tool_calls": [
+    {
+      "id": "call_submit_1",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"requirements\": [{\"title\": \"Sub function returns difference of two integers\", \"description\": \"pkg/math.Sub(a, b int) int returns a - b. Mirror Add's exported-function shape: live in pkg/math/sub.go, package math, package comment on the file, function-level GoDoc. A unit test in pkg/math/sub_test.go must call Sub with at least one positive case and assert the result, mirroring TestAdd's table-free shape.\", \"files_owned\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"], \"depends_on\": []}]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-reviewer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-reviewer.json
@@ -1,0 +1,14 @@
+{
+  "content": "Plan-phase review complete. Verdict: approved.",
+  "tool_calls": [
+    {
+      "id": "call_review",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"verdict\": \"approved\", \"feedback\": \"Plan is well-scoped and consistent across phases. The Sub function mirrors Add's shape; scope.create lists the new files; the SOP testing requirement is addressed by sub_test.go.\", \"findings\": [{\"sop_id\": \"go-testing-sop\", \"sop_title\": \"Every exported function needs a test\", \"severity\": \"info\", \"status\": \"compliant\", \"category\": null, \"phase\": null, \"target_id\": null, \"issue\": null, \"suggestion\": null, \"evidence\": \"pkg/math/sub_test.go is in scope.create alongside pkg/math/sub.go\"}], \"scenario_verdicts\": [], \"summary\": \"Plan-phase artifacts approved — Sub plan, architecture, requirements, and scenarios are coherent and Go-shaped.\", \"rejection_type\": null}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-scenario-generator.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle-services/mock-scenario-generator.json
@@ -1,0 +1,13 @@
+{
+  "tool_calls": [
+    {
+      "id": "call_submit_1",
+      "type": "function",
+      "function": {
+        "name": "submit_work",
+        "arguments": "{\"scenarios\": [{\"title\": \"Sub returns 2 when called with 5 and 3\", \"given\": \"the math package is imported\", \"when\": \"Sub(5, 3) is invoked\", \"then\": [\"the return value is 2\", \"no panic or error occurs\"]}, {\"title\": \"Sub handles negative differences\", \"given\": \"the math package is imported\", \"when\": \"Sub(3, 5) is invoked\", \"then\": [\"the return value is -2\"]}]}"
+      }
+    }
+  ],
+  "finish_reason": "tool_calls"
+}

--- a/test/e2e/scenarios/qa_cycle.go
+++ b/test/e2e/scenarios/qa_cycle.go
@@ -42,6 +42,13 @@ type QACycleScenario struct {
 	qaLevel string
 	// name is the scenario name; also the mock-llm fixture subdirectory.
 	name string
+	// customQAYAML, when non-empty, pre-seeds the workspace qa.yml during
+	// stageSetupWorkspace so the project-manager auto-scaffold leaves it
+	// untouched (EnsureQAWorkflow only writes when no file exists). Used by
+	// the qa-cycle-services variant to ship a services-enriched qa.yml that
+	// exercises act's sibling-container spawn via the mounted Docker socket
+	// (ADR-039 Phase 1b).
+	customQAYAML string
 }
 
 // NewQACycleScenario creates a new QA cycle scenario at qa_level=unit.
@@ -56,6 +63,81 @@ func NewQACycleScenario(cfg *config.Config) *QACycleScenario {
 func NewQACycleIntegrationScenario(cfg *config.Config) *QACycleScenario {
 	return &QACycleScenario{config: cfg, qaLevel: "integration", name: "qa-cycle-integration"}
 }
+
+// NewQACycleServicesScenario creates a qa-cycle variant at qa_level=
+// integration that pre-seeds a services-enriched qa.yml in the workspace.
+// Verifies ADR-039 Phase 1b: qa-runner's host Docker socket mount lets act
+// spawn sibling service containers (nginx:alpine on port 80) that the job
+// steps can reach by service name. A readiness probe (wget --spider) gates
+// the integration test step so a workflow-passing run proves the sibling
+// container actually came up — not just that the syntax parsed.
+//
+// Differs from qa-cycle-integration in exactly two places: the customQAYAML
+// override below, and the scenario name (which selects the mock-LLM fixture
+// directory). The mock-LLM fixtures are an unchanged clone of qa-cycle-
+// integration's because Phase 1b is about the qa-runner substrate, not the
+// orchestration above it.
+func NewQACycleServicesScenario(cfg *config.Config) *QACycleScenario {
+	return &QACycleScenario{
+		config:       cfg,
+		qaLevel:      "integration",
+		name:         "qa-cycle-services",
+		customQAYAML: servicesEnrichedQAYAML,
+	}
+}
+
+// servicesEnrichedQAYAML is the Phase 1b proof workflow. It declares one
+// service (nginx:alpine, port 80) and probes its reachability before running
+// integration tests. If qa-runner's Docker socket mount or act's services
+// support is broken, the readiness probe fails and the workflow exits non-
+// zero — qa-runner reports QACompletedEvent.Passed=false and the scenario
+// fails in stageAssertQACompleted with diagnostic logs in the act archive.
+//
+// Why the `container:` block: nektos/act creates a per-job bridge network
+// for service containers but only attaches the JOB container to that
+// network when the job declares a `container:` block (see act
+// pkg/runner/run_context.go networkName()/jobContainer() — the
+// `containerImage(ctx) != ""` branch). Without it, the job falls back to
+// `network=host` and can't resolve service names by DNS. Empirically
+// validated 2026-05-28 during ADR-039 Phase 1b: omitting `container:` made
+// `wget --spider http://nginx-service:80` time out from inside the job.
+// This is a load-bearing finding for Phase 1c — the catalog renderer must
+// emit a `container:` block alongside any `services:` block.
+//
+// Phase 1c will replace this hand-authored yaml with output from
+// workflow/harnesscatalog/qarender; for now the literal yaml stays in scope.
+const servicesEnrichedQAYAML = `name: QA
+on: [push, pull_request]
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    container:
+      image: catthehacker/ubuntu:act-latest
+    services:
+      nginx-service:
+        image: nginx:alpine
+        ports:
+          - 80
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: false
+      - name: Wait for nginx-service sibling container
+        run: |
+          for i in $(seq 1 30); do
+            if wget -q --spider http://nginx-service:80; then
+              echo "[OK] nginx-service reachable on attempt $i"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "[FAIL] nginx-service unreachable after 30 attempts"
+          exit 1
+      - name: Integration tests
+        run: go test ./... -tags=integration -v
+`
 
 // Name implements Scenario.
 func (s *QACycleScenario) Name() string { return s.name }
@@ -203,6 +285,13 @@ func (s *QACycleScenario) stageSetupWorkspace(_ context.Context, result *Result)
 		// templates a Go workflow because project.json's primary language is Go).
 		// The scenario relies on that auto-scaffold — pre-seeding here was the
 		// pre-2026-05-15 shape, removed to exercise the real wiring end-to-end.
+	}
+
+	// qa-cycle-services pre-seeds a services-enriched qa.yml so the auto-
+	// scaffold leaves it alone (EnsureQAWorkflow respects existing files).
+	// See servicesEnrichedQAYAML for the substrate-proof rationale.
+	if s.customQAYAML != "" {
+		files[".github/workflows/qa.yml"] = s.customQAYAML
 	}
 
 	for path, content := range files {


### PR DESCRIPTION
## Summary

Tier-2 mock scenario proving the **ADR-039 Phase 1b substrate works**: qa-runner's Docker socket mount lets act spawn sibling service containers via the host daemon, AND the job container can reach them by service name. End-to-end through the full plan→qa-runner→act→sibling→success flow.

**Load-bearing finding for Phase 1c:** `qarender` must emit a `container:` block alongside any `services:` block. Without it, act puts the job on host network and DNS resolution for service names fails. With it, both job and services land on act's auto-created bridge and DNS works.

## What it proves

| Question | Before this PR | After this PR |
|---|---|---|
| Does qa-runner's socket mount let act spawn sibling containers? | Architectural claim (ADR-039) | ✅ Empirically verified — two sibling containers visible under host daemon |
| Does the job container reach services by DNS name? | Untested | ✅ `wget --spider http://nginx-service:80` returns OK from job |
| What's the qa.yml shape that makes this work? | Unknown | ✅ Documented in `servicesEnrichedQAYAML` const + comment |
| Does this regress the baseline qa-cycle-integration? | N/A | ✅ Baseline re-run after change: 14/14 green |

## The Phase 1c finding

The investigation surfaced a real act quirk that Phase 1c must handle:

```go
// from act pkg/runner/run_context.go
func (rc *RunContext) networkName() (string, bool) {
    if len(rc.Run.Job().Services) > 0 {
        return fmt.Sprintf("%s-%s-network", ...), true
    }
    // ...
}

// job network attachment:
if rc.containerImage(ctx) != "" {
    jobContainerNetwork = networkName  // <-- attached to services-network
} else if jobContainerNetwork == "" {
    jobContainerNetwork = "host"  // <-- THE PROBLEM
}
```

`containerImage(ctx)` returns the YAML `container:` block image. Without `container:`, the job falls back to host network. With `container:`, the job lands on the same act-generated bridge as services.

**Phase 1c implication:** `workflow/harnesscatalog/qarender` must emit BOTH `container:` and `services:` blocks. The container image can be the same as the runner image (`catthehacker/ubuntu:act-latest`).

## Investigation trail (documented for posterity)

Tried two experiments first, both reverted before commit:

1. **Drop `--bind`** — turned out act's host-network choice is unrelated to `--bind`. Reverted.
2. **Pass `--network ""`** — act collapses empty to the default `"host"`. Reverted.

Both reverts left qa-runner code untouched. The actual fix is the qa.yml shape (`container:` block), which is exactly the kind of thing Phase 1c will need to bake into the renderer.

## Files changed

| File | Change |
|---|---|
| `test/e2e/scenarios/qa_cycle.go` | New `customQAYAML` field, `NewQACycleServicesScenario` constructor, `servicesEnrichedQAYAML` const with `container:` + `services:` + readiness probe + integration test, wired into `stageSetupWorkspace` |
| `test/e2e/fixtures/mock-responses/qa-cycle-services/` | Cloned from `qa-cycle-integration` (16 mock LLM responses; Phase 1b is about substrate, not orchestration variation) |
| `cmd/e2e/main.go` | Registered new scenario in Tier-2 |

## Test plan

- [x] `task e2e:mock -- qa-cycle-services` — 14/14 stages green, qa_completed_passed=true
- [x] `task e2e:mock -- qa-cycle-integration` — regression check after fix: 14/14 still green
- [x] `task lint` — zero warnings
- [x] `go test ./cmd/qa-runner/ ./test/e2e/scenarios/...` — clean
- [ ] CI green
- [ ] Phase 1c follow-up: qarender emits `container:` alongside `services:`; project-manager scaffolder template's stale "Catalog harness profiles are test-code responsibilities, not GitHub Actions services: entries" comment gets updated

## Incidental finding (out of scope, captured for Phase 1c)

`project-manager.EnsureQAWorkflow` scaffolder template contains a comment that needs updating when Phase 1c lands: *"Catalog harness profiles are test-code responsibilities, not GitHub Actions services: entries."* Same shape as the catalog text we fixed in PR #23. Logged in next-session memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)