### PR TITLE
feat(workflow): inject catalog services + container into qa.yml (ADR-039 Phase 1c)

### DIFF
--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -399,16 +399,27 @@ func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow
 	// Load project config for test command (language-aware default).
 	pc := workflow.LoadProjectConfigFromDisk(c.resolveRepoRoot())
 
-	// Ensure .github/workflows/qa.yml exists in the workspace before
-	// publishing QARequestedEvent. project-manager scaffolds the file at
-	// /init time, but e2e fixtures (hand-authored) skip that flow; without
-	// this guard qa-runner fails on missing workflow with an opaque act
-	// error. Language-aware template — picks Java/Python/Node/Rust/Go
-	// based on project config primary language. Non-fatal on write error
-	// (qa-runner will surface a clearer act-side error than we can here).
-	if err := projectmanager.EnsureQAWorkflow(c.resolveRepoRoot(), pc, c.logger); err != nil {
-		c.logger.Warn("Failed to scaffold qa.yml before QA dispatch — qa-runner may fail with missing workflow",
-			"slug", plan.Slug, "error", err)
+	// Render the qa.yml. Two paths:
+	//
+	//   1. ADR-039 Phase 1c — when the plan's architecture selected
+	//      services-orchestrated harness profiles and the operator did not
+	//      opt out via qa_skip_service_injection, overwrite the workspace
+	//      qa.yml with a catalog-injected workflow. The injection bundles the
+	//      catalog-derived `services:` block with the act DooD-required
+	//      `container:` block on the integration job
+	//      ([[act-dood-services-require-container-block]]).
+	//
+	//   2. Fallback — call EnsureQAWorkflow, which writes the language-aware
+	//      scaffold only when no qa.yml exists. Preserves operator-owned
+	//      workflows and matches pre-Phase-1c behaviour.
+	//
+	// Both paths are non-fatal: a render or write failure logs a warning and
+	// lets qa-runner surface the clearer act-side error.
+	if !c.maybeRenderQAWithServices(plan, pc) {
+		if err := projectmanager.EnsureQAWorkflow(c.resolveRepoRoot(), pc, c.logger); err != nil {
+			c.logger.Warn("Failed to scaffold qa.yml before QA dispatch — qa-runner may fail with missing workflow",
+				"slug", plan.Slug, "error", err)
+		}
 	}
 
 	req := &payloads.QARequestedPayload{

--- a/processor/plan-manager/qa_workflow_render.go
+++ b/processor/plan-manager/qa_workflow_render.go
@@ -1,0 +1,81 @@
+package planmanager
+
+import (
+	"os"
+	"path/filepath"
+
+	projectmanager "github.com/c360studio/semspec/processor/project-manager"
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// maybeRenderQAWithServices is the ADR-039 Phase 1c entry point on QA
+// dispatch. It returns true when it took ownership of writing qa.yml so the
+// caller skips the legacy EnsureQAWorkflow fallback. Returns false when no
+// catalog injection applies (no architecture, no services-orchestrated
+// selections, operator opt-out, catalog load failure) so the caller writes
+// the language-aware scaffold instead.
+//
+// Render failures log a warning and return false — qa-runner will surface a
+// clearer error against whichever qa.yml is on disk than a silent partial
+// write would.
+func (c *Component) maybeRenderQAWithServices(plan *workflow.Plan, pc *workflow.ProjectConfig) bool {
+	if plan == nil || plan.Architecture == nil || len(plan.Architecture.HarnessProfiles) == 0 {
+		return false
+	}
+
+	repoRoot := c.resolveRepoRoot()
+
+	catalog, err := harnesscatalog.Load(repoRoot)
+	if err != nil {
+		c.logger.Warn("Failed to load harness catalog for qa.yml render — falling back to scaffold",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+
+	selections, err := catalog.ResolveSelections(plan.Architecture.HarnessProfiles)
+	if err != nil {
+		c.logger.Warn("Failed to resolve harness profiles for qa.yml render — falling back to scaffold",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+
+	decision, err := projectmanager.DecideQAWorkflowInjection(selections, pc)
+	if err != nil {
+		c.logger.Warn("Catalog services render failed — falling back to scaffold",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+	if !decision.Inject {
+		c.logger.Info("Skipping qa.yml service injection",
+			"slug", plan.Slug, "reason", decision.Reason)
+		return false
+	}
+
+	base := projectmanager.BuildQAWorkflow(pc)
+	injected, err := projectmanager.InjectServicesIntoIntegrationJob(base, decision.ServicesYAML, decision.ContainerImage)
+	if err != nil {
+		c.logger.Warn("Failed to inject services into qa.yml — falling back to scaffold",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+
+	workflowPath := filepath.Join(repoRoot, ".github", "workflows", "qa.yml")
+	if err := os.MkdirAll(filepath.Dir(workflowPath), 0o755); err != nil {
+		c.logger.Warn("Failed to mkdir .github/workflows for injected qa.yml",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+	if err := os.WriteFile(workflowPath, []byte(injected), 0o644); err != nil {
+		c.logger.Warn("Failed to write injected qa.yml — falling back to scaffold",
+			"slug", plan.Slug, "error", err)
+		return false
+	}
+
+	c.logger.Info("Rendered qa.yml with catalog services + container block (ADR-039 Phase 1c)",
+		"slug", plan.Slug,
+		"path", workflowPath,
+		"profiles", len(plan.Architecture.HarnessProfiles),
+		"container_image", decision.ContainerImage)
+	return true
+}

--- a/processor/project-manager/qa_workflow_services.go
+++ b/processor/project-manager/qa_workflow_services.go
@@ -1,0 +1,247 @@
+package projectmanager
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+	"github.com/c360studio/semspec/workflow/harnesscatalog/qarender"
+)
+
+// defaultActJobImage is the act runner image injected into the `container:`
+// block alongside any catalog-rendered `services:` block. nektos/act only
+// attaches a job to its per-job service network when the job declares a
+// `container:` — without it the job falls back to host networking and
+// service-name DNS resolution fails. Verified empirically 2026-05-28 in
+// ADR-039 Phase 1b. See [[act-dood-services-require-container-block]].
+const defaultActJobImage = "catthehacker/ubuntu:act-latest"
+
+// QAWorkflowDecision captures the pure decision DecideQAWorkflowInjection
+// makes from selections + project config. Returned to callers so the wire-up
+// site can log Reason for forensics and the unit tests can assert on a single
+// struct rather than scraping byproducts.
+//
+// Inject=false means: caller should fall through to EnsureQAWorkflow (write
+// the language-templated scaffold if no qa.yml exists, otherwise leave the
+// operator's file alone).
+//
+// Inject=true means: caller must build the base workflow via BuildQAWorkflow,
+// pass through InjectServicesIntoIntegrationJob with ServicesYAML and
+// ContainerImage, and write the result, overwriting any existing qa.yml.
+type QAWorkflowDecision struct {
+	Inject         bool
+	Reason         string
+	ServicesYAML   string
+	ContainerImage string
+}
+
+// DecideQAWorkflowInjection inspects resolved catalog selections and project
+// config to decide whether plan-manager should inject a services-enriched
+// qa.yml at QA dispatch. Pure: no filesystem, no graph, no network — the
+// seam the wire-up site is expected to test against (see
+// [[feedback_seam_coverage_pattern]]).
+//
+// Returns Inject=false with a Reason string for any case the renderer must
+// not touch the workspace qa.yml: operator opt-out, no services-orchestrated
+// selections, empty catalog render. The wire-up site logs Reason so a
+// missing inject is debuggable post-mortem.
+func DecideQAWorkflowInjection(selections []harnesscatalog.ResolvedSelection, pc *workflow.ProjectConfig) (QAWorkflowDecision, error) {
+	if pc != nil && pc.QASkipServiceInjection {
+		return QAWorkflowDecision{
+			Inject: false,
+			Reason: "operator opted out via qa_skip_service_injection",
+		}, nil
+	}
+
+	yamlBlock, err := qarender.RenderYAML(selections, qarender.Options{})
+	if err != nil {
+		return QAWorkflowDecision{}, fmt.Errorf("render catalog services: %w", err)
+	}
+	if strings.TrimSpace(yamlBlock) == "" {
+		return QAWorkflowDecision{
+			Inject: false,
+			Reason: "no services-orchestrated harness profiles selected",
+		}, nil
+	}
+
+	return QAWorkflowDecision{
+		Inject:         true,
+		Reason:         "injecting catalog services into qa.yml integration job",
+		ServicesYAML:   yamlBlock,
+		ContainerImage: defaultActJobImage,
+	}, nil
+}
+
+// InjectServicesIntoIntegrationJob parses a base qa.yml document, splices a
+// `container:` block and the provided `services:` mapping into the
+// `integration` job, and returns the re-emitted YAML. The base document is
+// expected to come from BuildQAWorkflow — a top-level `jobs.integration:`
+// mapping is required.
+//
+// servicesYAML is the output of qarender.RenderYAML: zero or more service
+// mapping entries, NOT wrapped in a parent `services:` key. The function
+// wraps them under the integration job's `services:` key on splice.
+//
+// containerImage is the image name written under `container:` for the
+// integration job (typically defaultActJobImage). Empty falls through to
+// defaultActJobImage so the act DooD constraint is satisfied by default.
+func InjectServicesIntoIntegrationJob(baseYAML, servicesYAML, containerImage string) (string, error) {
+	if strings.TrimSpace(baseYAML) == "" {
+		return "", fmt.Errorf("baseYAML is empty")
+	}
+	if strings.TrimSpace(servicesYAML) == "" {
+		return baseYAML, nil
+	}
+	if strings.TrimSpace(containerImage) == "" {
+		containerImage = defaultActJobImage
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(baseYAML), &doc); err != nil {
+		return "", fmt.Errorf("parse base qa.yml: %w", err)
+	}
+
+	servicesNode, err := parseServicesYAML(servicesYAML)
+	if err != nil {
+		return "", err
+	}
+
+	integrationJob, err := findIntegrationJob(&doc)
+	if err != nil {
+		return "", err
+	}
+
+	if err := ensureContainerBlock(integrationJob, containerImage); err != nil {
+		return "", err
+	}
+	if err := ensureServicesBlock(integrationJob, servicesNode); err != nil {
+		return "", err
+	}
+
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return "", fmt.Errorf("encode injected qa.yml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return "", fmt.Errorf("close encoder: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// findIntegrationJob walks the document tree to locate jobs.integration. The
+// base templates BuildQAWorkflow emits always carry this key — anything else
+// is a programming error and surfaces as a clear failure rather than silently
+// landing the injection in the wrong place.
+func findIntegrationJob(doc *yaml.Node) (*yaml.Node, error) {
+	if doc == nil || len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("base qa.yml is not a top-level mapping")
+	}
+	top := doc.Content[0]
+	jobs := mappingChild(top, "jobs")
+	if jobs == nil {
+		return nil, fmt.Errorf("base qa.yml has no `jobs:` mapping")
+	}
+	integration := mappingChild(jobs, "integration")
+	if integration == nil {
+		return nil, fmt.Errorf("base qa.yml has no `jobs.integration:` mapping")
+	}
+	return integration, nil
+}
+
+// parseServicesYAML wraps the raw services block in a synthetic root so the
+// yaml decoder produces a MappingNode we can splice. qarender.RenderYAML emits
+// a sequence of `name:` keys without a parent — we add the parent here.
+func parseServicesYAML(servicesYAML string) (*yaml.Node, error) {
+	var holder yaml.Node
+	wrapped := "root:\n" + indentBlock(servicesYAML, "  ")
+	if err := yaml.Unmarshal([]byte(wrapped), &holder); err != nil {
+		return nil, fmt.Errorf("parse services yaml: %w", err)
+	}
+	if len(holder.Content) == 0 || holder.Content[0].Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("services yaml is not a mapping")
+	}
+	root := mappingChild(holder.Content[0], "root")
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("services yaml did not parse to a mapping")
+	}
+	return root, nil
+}
+
+func ensureContainerBlock(job *yaml.Node, image string) error {
+	if existing := mappingChild(job, "container"); existing != nil {
+		return nil
+	}
+	containerNode := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	containerNode.Content = append(containerNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "image"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: image},
+	)
+	keyNode := &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Tag:         "!!str",
+		Value:       "container",
+		HeadComment: "ADR-039 Phase 1c: act DooD requires container: alongside services: so the\njob attaches to the per-job service network and resolves service-name DNS.",
+	}
+	job.Content = insertAfter(job.Content, "runs-on", keyNode, containerNode)
+	return nil
+}
+
+func ensureServicesBlock(job *yaml.Node, services *yaml.Node) error {
+	if existing := mappingChild(job, "services"); existing != nil {
+		return fmt.Errorf("base qa.yml already declares jobs.integration.services; set qa_skip_service_injection to opt out of catalog injection")
+	}
+	keyNode := &yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Tag:         "!!str",
+		Value:       "services",
+		HeadComment: "Rendered from architecture.harness_profiles[] (ADR-039 Phase 1c).",
+	}
+	job.Content = insertAfter(job.Content, "container", keyNode, services)
+	return nil
+}
+
+// insertAfter walks key/value pairs of a mapping and inserts (key, value)
+// immediately after the named key. If anchor is not present, the new pair is
+// appended at the end — keeps the function total even when the base template
+// shape drifts.
+func insertAfter(content []*yaml.Node, anchor string, key, value *yaml.Node) []*yaml.Node {
+	for i := 0; i+1 < len(content); i += 2 {
+		if content[i].Kind == yaml.ScalarNode && content[i].Value == anchor {
+			out := make([]*yaml.Node, 0, len(content)+2)
+			out = append(out, content[:i+2]...)
+			out = append(out, key, value)
+			out = append(out, content[i+2:]...)
+			return out
+		}
+	}
+	return append(content, key, value)
+}
+
+func mappingChild(node *yaml.Node, name string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == name {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func indentBlock(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/processor/project-manager/qa_workflow_services_test.go
+++ b/processor/project-manager/qa_workflow_services_test.go
@@ -1,0 +1,217 @@
+package projectmanager
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// makeServicesSelection returns a single resolved selection whose Profile is a
+// minimal services-orchestrated entry. Used as the positive fixture for
+// DecideQAWorkflowInjection / InjectServicesIntoIntegrationJob tests so they
+// do not depend on the embedded catalog fixture set.
+func makeServicesSelection() []harnesscatalog.ResolvedSelection {
+	return []harnesscatalog.ResolvedSelection{
+		{
+			Selection: workflow.HarnessProfileSelection{ProfileID: "test.services-profile"},
+			Profile: harnesscatalog.Profile{
+				ID:            "test.services-profile",
+				Orchestration: harnesscatalog.OrchestrationServices,
+				Images: []harnesscatalog.ImageRef{
+					{Name: "nginx:alpine"},
+				},
+				Ports: []harnesscatalog.PortRef{
+					{Name: "http", ContainerPort: 80},
+				},
+			},
+		},
+	}
+}
+
+func TestDecideQAWorkflowInjection_OperatorOptOutWins(t *testing.T) {
+	pc := &workflow.ProjectConfig{QASkipServiceInjection: true}
+	got, err := DecideQAWorkflowInjection(makeServicesSelection(), pc)
+	if err != nil {
+		t.Fatalf("DecideQAWorkflowInjection error = %v", err)
+	}
+	if got.Inject {
+		t.Errorf("Inject = true, want false when operator opts out")
+	}
+	if !strings.Contains(got.Reason, "operator opted out") {
+		t.Errorf("Reason = %q, want operator-opt-out signal", got.Reason)
+	}
+}
+
+func TestDecideQAWorkflowInjection_NoServicesSelectionsSkips(t *testing.T) {
+	pc := &workflow.ProjectConfig{}
+	selections := []harnesscatalog.ResolvedSelection{
+		{
+			Selection: workflow.HarnessProfileSelection{ProfileID: "test.pure"},
+			Profile: harnesscatalog.Profile{
+				ID:            "test.pure",
+				Orchestration: harnesscatalog.OrchestrationPureFixture,
+			},
+		},
+	}
+	got, err := DecideQAWorkflowInjection(selections, pc)
+	if err != nil {
+		t.Fatalf("DecideQAWorkflowInjection error = %v", err)
+	}
+	if got.Inject {
+		t.Errorf("Inject = true, want false when no services-orchestrated profiles selected")
+	}
+	if !strings.Contains(got.Reason, "no services-orchestrated") {
+		t.Errorf("Reason = %q, want no-services-selected signal", got.Reason)
+	}
+}
+
+func TestDecideQAWorkflowInjection_EmptyConfigNilSelectionsSkips(t *testing.T) {
+	got, err := DecideQAWorkflowInjection(nil, nil)
+	if err != nil {
+		t.Fatalf("DecideQAWorkflowInjection error = %v", err)
+	}
+	if got.Inject {
+		t.Errorf("Inject = true, want false on empty input")
+	}
+}
+
+func TestDecideQAWorkflowInjection_ServicesProfileEmitsBlock(t *testing.T) {
+	got, err := DecideQAWorkflowInjection(makeServicesSelection(), &workflow.ProjectConfig{})
+	if err != nil {
+		t.Fatalf("DecideQAWorkflowInjection error = %v", err)
+	}
+	if !got.Inject {
+		t.Fatalf("Inject = false, want true; reason = %q", got.Reason)
+	}
+	if got.ContainerImage != defaultActJobImage {
+		t.Errorf("ContainerImage = %q, want %q", got.ContainerImage, defaultActJobImage)
+	}
+	if !strings.Contains(got.ServicesYAML, "test-services-profile:") {
+		t.Errorf("ServicesYAML missing service entry, got:\n%s", got.ServicesYAML)
+	}
+	if !strings.Contains(got.ServicesYAML, "image: nginx:alpine") {
+		t.Errorf("ServicesYAML missing image, got:\n%s", got.ServicesYAML)
+	}
+}
+
+func TestInjectServicesIntoIntegrationJob_EmptyServicesYAMLReturnsBaseUnchanged(t *testing.T) {
+	base := BuildQAWorkflow(&workflow.ProjectConfig{
+		Languages: []workflow.LanguageInfo{{Name: "Go", Primary: true}},
+	})
+	got, err := InjectServicesIntoIntegrationJob(base, "", "")
+	if err != nil {
+		t.Fatalf("InjectServicesIntoIntegrationJob error = %v", err)
+	}
+	if got != base {
+		t.Errorf("empty servicesYAML should pass base through unchanged.\n--- got ---\n%s\n--- base ---\n%s", got, base)
+	}
+}
+
+func TestInjectServicesIntoIntegrationJob_AddsContainerAndServices(t *testing.T) {
+	base := BuildQAWorkflow(&workflow.ProjectConfig{
+		Languages: []workflow.LanguageInfo{{Name: "Go", Primary: true}},
+	})
+	decision, err := DecideQAWorkflowInjection(makeServicesSelection(), &workflow.ProjectConfig{})
+	if err != nil {
+		t.Fatalf("DecideQAWorkflowInjection error = %v", err)
+	}
+	if !decision.Inject {
+		t.Fatalf("expected Inject=true; reason=%q", decision.Reason)
+	}
+
+	got, err := InjectServicesIntoIntegrationJob(base, decision.ServicesYAML, decision.ContainerImage)
+	if err != nil {
+		t.Fatalf("InjectServicesIntoIntegrationJob error = %v", err)
+	}
+
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("re-parse injected qa.yml failed: %v\n%s", err, got)
+	}
+	jobs, ok := doc["jobs"].(map[string]any)
+	if !ok {
+		t.Fatalf("jobs key missing or wrong shape; doc=%v", doc)
+	}
+	integration, ok := jobs["integration"].(map[string]any)
+	if !ok {
+		t.Fatalf("jobs.integration missing or wrong shape; jobs=%v", jobs)
+	}
+
+	container, ok := integration["container"].(map[string]any)
+	if !ok {
+		t.Fatalf("integration.container missing or wrong shape; integration=%v", integration)
+	}
+	if container["image"] != defaultActJobImage {
+		t.Errorf("container.image = %v, want %q", container["image"], defaultActJobImage)
+	}
+
+	services, ok := integration["services"].(map[string]any)
+	if !ok {
+		t.Fatalf("integration.services missing or wrong shape; integration=%v", integration)
+	}
+	svc, ok := services["test-services-profile"].(map[string]any)
+	if !ok {
+		t.Fatalf("services.test-services-profile missing or wrong shape; services=%v", services)
+	}
+	if svc["image"] != "nginx:alpine" {
+		t.Errorf("service.image = %v, want %q", svc["image"], "nginx:alpine")
+	}
+}
+
+func TestInjectServicesIntoIntegrationJob_RejectsPreexistingServices(t *testing.T) {
+	base := `name: QA
+on: [push]
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      preexisting:
+        image: redis:alpine
+    steps:
+      - run: true
+`
+	_, err := InjectServicesIntoIntegrationJob(base, "anything: { image: x }\n", "")
+	if err == nil {
+		t.Fatal("expected error when base already declares services block, got nil")
+	}
+	if !strings.Contains(err.Error(), "qa_skip_service_injection") {
+		t.Errorf("error should reference opt-out flag for operator UX; got %v", err)
+	}
+}
+
+func TestInjectServicesIntoIntegrationJob_MissingIntegrationJobFails(t *testing.T) {
+	base := `name: QA
+on: [push]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+`
+	_, err := InjectServicesIntoIntegrationJob(base, "anything: { image: x }\n", "")
+	if err == nil {
+		t.Fatal("expected error when base has no integration job, got nil")
+	}
+	if !strings.Contains(err.Error(), "integration") {
+		t.Errorf("error should mention integration job; got %v", err)
+	}
+}
+
+func TestInjectServicesIntoIntegrationJob_DefaultsContainerImage(t *testing.T) {
+	base := BuildQAWorkflow(&workflow.ProjectConfig{
+		Languages: []workflow.LanguageInfo{{Name: "Go", Primary: true}},
+	})
+	decision, _ := DecideQAWorkflowInjection(makeServicesSelection(), &workflow.ProjectConfig{})
+
+	got, err := InjectServicesIntoIntegrationJob(base, decision.ServicesYAML, "")
+	if err != nil {
+		t.Fatalf("InjectServicesIntoIntegrationJob error = %v", err)
+	}
+	if !strings.Contains(got, "image: "+defaultActJobImage) {
+		t.Errorf("expected default container image %q in output, got:\n%s", defaultActJobImage, got)
+	}
+}

--- a/workflow/project_config.go
+++ b/workflow/project_config.go
@@ -64,6 +64,13 @@ type ProjectConfig struct {
 	// Empty means "infer from primary language" — see EffectiveTestCommand.
 	// Examples: "go test ./...", "npm test", "pytest", "cargo test".
 	QATestCommand string `json:"qa_test_command,omitempty"`
+
+	// QASkipServiceInjection, when true, disables ADR-039 catalog-driven
+	// service injection into the workspace qa.yml. Operators who hand-author
+	// the workflow file and want full control over the `services:` /
+	// `container:` blocks set this to opt out. Plan-manager then falls back
+	// to the existing write-only-if-missing scaffold (BuildQAWorkflow).
+	QASkipServiceInjection bool `json:"qa_skip_service_injection,omitempty"`
 }
 
 // EffectiveQALevel returns the project's QA level, defaulting to synthesis


### PR DESCRIPTION
## Summary

- Continues the ADR-039 arc: Phase 1a (qarender package, PR #23) → Phase 1b (qa-runner DooD substrate proof, PR #24) → **Phase 1c (this PR): qa.yml emission**.
- At `ready_for_qa` dispatch, plan-manager resolves `plan.Architecture.HarnessProfiles[]` against the catalog and overwrites the workspace `qa.yml` with a services-enriched workflow when any selection declares `orchestration=services`.
- Bundles the catalog-derived `services:` block with the act DooD-required `container:` block on the integration job — without `container:` act puts the job on host networking and service-name DNS fails (verified empirically during Phase 1b).
- New operator opt-out: `qa_skip_service_injection` on `ProjectConfig` falls back to the existing write-only-if-missing scaffold.

## Architecture

- **Pure decision seam** — `DecideQAWorkflowInjection(selections, pc) → QAWorkflowDecision{Inject, Reason, ServicesYAML, ContainerImage}`. No filesystem, no graph, no network. Wire-up logs `Reason` for forensics.
- **YAML-node injector** — `InjectServicesIntoIntegrationJob(baseYAML, servicesYAML, containerImage)` parses the language-aware base from existing `BuildQAWorkflow`, splices `container:` + `services:` into the integration job, re-emits. Rejects pre-existing `services:` blocks with a pointer at the opt-out flag.
- **plan-manager wire-up** — new `maybeRenderQAWithServices` returns `true` when it took ownership of writing qa.yml; the caller falls through to `EnsureQAWorkflow` when it returns `false` (no architecture, no services-orchestrated selections, opt-out, or any render failure).

## Test plan

- [x] `go test ./...` — clean across the tree
- [x] `task lint` — clean
- [x] Tier-1 tests for the decision + injection seam (9 cases covering opt-out, no-services skip, empty input, services emit, base pass-through, splice shape, pre-existing services rejection, missing integration job, default container image)
- [x] `task e2e:mock -- qa-cycle-integration` — green, confirming the no-profiles path falls through to `EnsureQAWorkflow` unchanged
- [ ] Phase 2 (per-cost-tier timeouts) and Phase 3 (required-tier mavlink real-LLM verification) remain follow-up scope per ADR-039

## ADR-039 phasing status

| Phase | Status |
|---|---|
| 1a — qarender package + per-profile orchestration | ✅ PR #23 |
| 1b — qa-runner DooD substrate proof | ✅ PR #24 |
| **1c — qa.yml emission** | **This PR** |
| 2 — Per-cost-tier timeout defaults | Pending |
| 3 — Required-tier verification scenario | Pending |
| 4 — Sponsor-pack update | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)