### PR TITLE
chore(e2e): pin mavlink-heartbeat-go fixture to qa_level=integration

### DIFF
--- a/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/project.json
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/.semspec/project.json
@@ -12,5 +12,6 @@
     }
   ],
   "tooling": {},
-  "repository": {}
+  "repository": {},
+  "qa_level": "integration"
 }

--- a/test/e2e/fixtures/mavlink-heartbeat-go/README.md
+++ b/test/e2e/fixtures/mavlink-heartbeat-go/README.md
@@ -16,3 +16,21 @@ selection path under real LLM. The agent is expected to:
 
 Initial state is a skeleton `main.go` and an empty `go.mod`. Reset by
 `task reset-fixtures` returns to this state between runs.
+
+## QA depth
+
+`.semspec/project.json` pins `qa_level: integration` so the qa-runner
+actually executes the rendered `.github/workflows/qa.yml` via nektos/act
+after implementation converges. Without this the project falls back to
+`synthesis` (LLM verdict only, no test execution) and the integration-
+test path never runs — defeating the point of a fixture that exists to
+verify the catalog-driven harness selection path.
+
+Because the architect picks `mavlink.raw-mavlink-direct` (orchestration
+= pure-fixture), the qa.yml emitted by ADR-039 Phase 1c is the standard
+language-aware Go scaffold without any `services:` block — captured
+HEARTBEAT frames in `testdata/` are authoritative for this scope, and
+no sibling container is spawned. A SITL-demanding scope variant would
+trigger the architect to pick `mavlink.px4-sitl.mavsdk-smoke` (required
+tier, orchestration=services) and Phase 1c would render the px4-sitl
+service block automatically.


### PR DESCRIPTION
## Summary

Follow-up to PR #25 (ADR-039 Phase 1c). The mavlink-decode tier silently degrades to `qa_level=synthesis` (LLM verdict only, no test execution) because the fixture's `project.json` had no `qa_level` set and `ProjectConfig.EffectiveQALevel()` defaults to synthesis when unset.

Result on the prior gemini mavlink-decode run: qa-runner was never invoked. The integration-test path the fixture exists to verify wasn't exercised — even though Phase 1c made the substrate structurally correct, the gate above the substrate was closed by silent default.

## What this changes

- `test/e2e/fixtures/mavlink-heartbeat-go/.semspec/project.json` — pin `qa_level: integration`.
- `test/e2e/fixtures/mavlink-heartbeat-go/README.md` — document the level pin and the SITL escalation path (scope-driven via architect profile choice → services-orchestrated required-tier profile → Phase 1c renders the px4-sitl service block automatically).

## What this doesn't change

- No SITL container on this scope. The architect picks `mavlink.raw-mavlink-direct` (orchestration=pure-fixture), so Phase 1c's renderer correctly emits no `services:` block. Captured HEARTBEAT frames in `testdata/` are authoritative.
- No code paths. Pure fixture/doc change.
- No changes to qa_level decisioning — option 1 of the design conversation (status quo + fixture fix) keeps project-wide policy operator-owned. Auto-promotion based on profile signal stays a future ADR if usage data later argues for it.

## Test plan

- [ ] Next gemini mavlink-decode real-LLM run actually executes `.github/workflows/qa.yml` via act and runs `go test ./... -tags=integration -v`
- [ ] qa-reviewer interprets the integration job result instead of synthesis-only verdict
- [ ] Plan reaches `complete` through `reviewing_qa` (not via the implementing → complete synthesis fast-path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)