### PR TITLE
fix(sandbox)+feat(prompt): kill process group on bash timeout + dev circuit-breaker for bash failures

### DIFF
--- a/cmd/sandbox/exec.go
+++ b/cmd/sandbox/exec.go
@@ -15,12 +15,24 @@ import (
 // code. Output is capped at maxOutputBytes per stream.
 //
 // The subprocess is run in its own process group so that a timeout kill reaches
-// all child processes, not just the immediate shell.
+// all child processes, not just the immediate shell. On deadline we eagerly
+// SIGKILL the entire process group BEFORE waiting for the leader to exit —
+// otherwise, when a child inherits the stdout/stderr pipe FDs and never closes
+// them (e.g. a backgrounded `go run` that hangs in time.Sleep), Wait blocks
+// indefinitely because the pipe stays open as long as any descendant holds it.
+// Without the eager group-kill, the deadline path never executes and child
+// processes leak into the sandbox container, accumulating across calls
+// (verified empirically 2026-05-28 during the gemini mavlink-decode run: a
+// dev agent's `go run generator.go` hangs left 14 zombie processes over
+// 33 minutes of accumulation).
 func execCommand(ctx context.Context, dir, cmd string, timeout time.Duration, maxOutputBytes int) (stdout, stderr string, exitCode int, timedOut bool) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	c := exec.CommandContext(ctx, "/bin/sh", "-c", cmd)
+	// Build a bare exec.Command (not CommandContext) so we control cancellation
+	// ourselves — CommandContext only SIGKILLs the leader, which is the bug
+	// this function exists to fix.
+	c := exec.Command("/bin/sh", "-c", cmd)
 	c.Dir = dir
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	c.Env = []string{
@@ -37,15 +49,27 @@ func execCommand(ctx context.Context, dir, cmd string, timeout time.Duration, ma
 	c.Stdout = &outBuf
 	c.Stderr = &errBuf
 
-	runErr := c.Run()
+	if err := c.Start(); err != nil {
+		errBuf.Write([]byte(err.Error()))
+		return outBuf.String(), errBuf.String(), 1, false
+	}
 
-	// Determine whether we hit the deadline.
-	if ctx.Err() == context.DeadlineExceeded {
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- c.Wait() }()
+
+	var runErr error
+	select {
+	case runErr = <-waitErr:
+		// Process exited on its own (success, failure, or self-imposed signal).
+	case <-ctx.Done():
+		// Deadline. Kill the entire process group — leader plus every child
+		// holding the inherited stdout/stderr pipe FDs. Wait() returns once
+		// the kernel reaps them and the pipes close.
 		timedOut = true
-		// Kill the entire process group.
 		if c.Process != nil {
 			_ = syscall.Kill(-c.Process.Pid, syscall.SIGKILL)
 		}
+		runErr = <-waitErr
 	}
 
 	// Extract exit code.

--- a/cmd/sandbox/exec_test.go
+++ b/cmd/sandbox/exec_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecCommand_HangingBackgroundedChildKilledWithinDeadline(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process-group semantics differ on this OS")
+	}
+	dir := t.TempDir()
+
+	// Background a long sleep so the shell exits immediately but a child
+	// holds the inherited stdout/stderr pipe FDs open. This is the exact
+	// failure pattern that left zombies in the gemini mavlink-decode run:
+	// a `go run` (or any forked long-runner) outlives the parent shell and
+	// keeps the stdout pipe open, so naive c.Run()-then-check-deadline
+	// blocks forever in Wait().
+	start := time.Now()
+	stdout, stderr, exitCode, timedOut := execCommand(
+		context.Background(),
+		dir,
+		"(sleep 300 &) ; echo started ; sleep 300",
+		500*time.Millisecond,
+		64*1024,
+	)
+	elapsed := time.Since(start)
+
+	if !timedOut {
+		t.Errorf("timedOut = false, want true (stdout=%q stderr=%q exit=%d)", stdout, stderr, exitCode)
+	}
+	// 500ms deadline + ~100ms group-kill propagation budget. If the bug is
+	// back, this test blocks until t.Failed() at framework timeout (minutes).
+	if elapsed > 3*time.Second {
+		t.Errorf("execCommand took %v, want < 3s; Wait() is blocking on child-held pipe FDs (the bug this test guards)", elapsed)
+	}
+}
+
+func TestExecCommand_NoChildLeakAfterTimeout(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("process-group semantics differ on this OS")
+	}
+	dir := t.TempDir()
+
+	// Spawn a uniquely-named child via the shell, time it out, then verify
+	// no process bearing that name survives. Marker keeps the test self-
+	// contained: we only assert about the specific child this test
+	// created, not the developer's whole process list.
+	marker := "leakguard-" + t.Name() + "-" + time.Now().Format("150405.000000")
+	cmd := "(sleep 30 ; : " + marker + ") & echo started ; sleep 30"
+
+	_, _, _, timedOut := execCommand(
+		context.Background(),
+		dir,
+		cmd,
+		500*time.Millisecond,
+		64*1024,
+	)
+	if !timedOut {
+		t.Fatalf("execCommand did not time out as expected")
+	}
+
+	// Group kill is asynchronous w.r.t. Wait return; give the kernel a
+	// moment to reap before grepping ps.
+	time.Sleep(200 * time.Millisecond)
+
+	out, _ := exec.Command("ps", "-eo", "args").CombinedOutput()
+	if strings.Contains(string(out), marker) {
+		t.Errorf("child process bearing marker %q survived the timeout — process group kill did not propagate.\nps output:\n%s",
+			marker, string(out))
+	}
+}
+
+func TestExecCommand_NormalCommandStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	stdout, _, exitCode, timedOut := execCommand(
+		context.Background(),
+		dir,
+		"echo hello",
+		2*time.Second,
+		64*1024,
+	)
+	if exitCode != 0 {
+		t.Errorf("exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(stdout, "hello") {
+		t.Errorf("stdout = %q, want it to contain 'hello'", stdout)
+	}
+	if timedOut {
+		t.Errorf("timedOut = true, want false")
+	}
+}
+
+func TestExecCommand_NonZeroExitPreserved(t *testing.T) {
+	dir := t.TempDir()
+	_, _, exitCode, timedOut := execCommand(
+		context.Background(),
+		dir,
+		"exit 7",
+		2*time.Second,
+		64*1024,
+	)
+	if exitCode != 7 {
+		t.Errorf("exit code = %d, want 7", exitCode)
+	}
+	if timedOut {
+		t.Errorf("timedOut = true, want false")
+	}
+}

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -237,6 +237,40 @@ Scope is mandatory, not advisory:
 			},
 		},
 		{
+			// Bash-failure recovery rule. Added after the gemini mavlink-decode
+			// run on 2026-05-28 where the dev hit 4 consecutive bash timeouts
+			// (and used bash for ALL 8 tool calls — 0 scratchpad, 0 write_todos,
+			// 0 web_search) while iterating on shell-process-management tricks
+			// instead of diagnosing the underlying program. Existing prompt
+			// guidance says "use scratchpad for non-trivial work" — too
+			// general to fire as a circuit-breaker. This fragment names a
+			// concrete trigger condition (timeout or 2nd similar failure) so
+			// the recovery path is unambiguous. Kept narrow on purpose:
+			// scenario-specific patterns (generator-must-terminate, daemon-
+			// API misuse, etc.) belong in the role-scoped lessons system
+			// where they fire on signal match, not in the base prompt where
+			// they become dead weight for unrelated dev work.
+			ID:       "software.developer.bash-failure-recovery",
+			Category: prompt.CategoryRoleContext,
+			Roles:    []prompt.Role{prompt.RoleDeveloper},
+			Content: `BASH FAILURE IS A DIAGNOSTIC SIGNAL — not infrastructure noise.
+
+A bash timeout, non-zero exit, or [command timed out] message is the system telling you something is wrong with EITHER your program OR your invocation. Three causes, three different fixes:
+
+1. Your program won't terminate (deadlock, infinite loop, daemon-style API used for one-shot work). Re-read the source you wrote and find what's preventing exit. Do NOT try a different shell wrapping of the same hung program.
+2. The command genuinely needs more time (large compile, large test suite). Split the work or explicitly extend the timeout; don't blind-retry.
+3. The command is waiting on input you didn't provide (heredoc missing EOF, prompt expecting stdin). Provide the input or change approach.
+
+CIRCUIT BREAKER — when bash fails twice in a row on functionally similar work:
+
+STOP. Do not issue a third bash call. Instead:
+
+- Call scratchpad and write one paragraph: "Attempt 1 did X, failed with Y. Attempt 2 did X', failed with Y'. The pattern suggests the issue is in (program source / command structure / environment). Next I will try Z because W."
+- If the diagnosis points at your program source, re-read it with bash('cat path/to/file') and fix the specific lines preventing success BEFORE the next bash-test.
+- If the diagnosis points at an external library you're misusing, call web_search or http_request for the official docs of the specific API surface. 30 seconds of lookup saves a 3-minute timeout retry.
+- If you cannot diagnose after the scratchpad pause, call ask_question with a concrete hypothesis. Clean blockers are cheaper than 10 more iterations of bash-roulette.`,
+		},
+		{
 			ID:       "software.developer.test-surface",
 			Category: prompt.CategoryRoleContext,
 			Roles:    []prompt.Role{prompt.RoleDeveloper},


### PR DESCRIPTION
## Summary

Two complementary defenses against the bash-tool wedge pattern observed during the gemini mavlink-decode real-LLM verification run for ADR-039 Phase 1c on 2026-05-28:

1. **Sandbox fix (commit `8e5ad78`)** — `cmd/sandbox/exec.go:execCommand` mounted children in a process group via `SysProcAttr.Setpgid: true` but never actually delivered the timeout kill to that group. The deadline path was structurally unreachable: it sat AFTER `c.Run()`, which only returns once stdout/stderr pipe writers close — which a child holding inherited FDs never does. Result on real workloads: every timed-out `go run` / `./gen` left its children alive in the sandbox, accumulating across calls. Run #1 hit 14 zombies over 33 minutes.

2. **Dev prompt circuit-breaker (commit `1af8b08`)** — adds `software.developer.bash-failure-recovery` fragment that names a concrete trigger condition (2 consecutive bash failures on similar work) and prescribes a recovery action (scratchpad diagnosis → re-read source / web_search / ask_question). Existing prompt guidance said "use scratchpad for non-trivial work" — too general to fire as a circuit-breaker on a specific pattern. Run #1 trajectory: 16 steps, bash=8, every other tool=0.

The pieces are complementary: the sandbox fix cleans up after a wedge so subsequent retries don't compound; the prompt tweak tries to keep the agent from entering the wedge in the first place.

## Verification

**Sandbox fix:**
- New regression tests `TestExecCommand_HangingBackgroundedChildKilledWithinDeadline` + `TestExecCommand_NoChildLeakAfterTimeout` reproduce the failure pattern; without the fix they block at framework timeout and panic in `os/exec.(*Cmd).writerDescriptor.func1`. With the fix they pass in <1s.
- **Live real-LLM run (gemini mavlink-decode, 2026-05-28 post-fix)**: sandbox `ps` showed zero zombie processes across the entire 13.8min run, vs 14 in the pre-fix run.

**Prompt tweak:**
- Prompt assembler verified empirically: developer role assembles 10 fragments (16,815 chars) including the new `BASH FAILURE IS A DIAGNOSTIC SIGNAL` + `CIRCUIT BREAKER` text. Existing scratchpad guidance (4 occurrences) and write_todos guidance (1 occurrence) remain intact.
- **Live run**: circuit-breaker did NOT fire because gemini-pro completed implementation cleanly this time (different sampling — 55-step + 39-step dev loops, no timeouts). So we can confirm the tweak does not break or bloat anything but cannot yet confirm it helps on a future wedge. Same-PR grouping is intentional: both defend against the same failure mode and the runtime cost of including the tweak is bounded (~30 lines in the dev prompt).

**End-to-end impact** of both changes together:

| Metric | Run #1 (vanilla) | Run #2 (this PR) |
|---|---|---|
| Sandbox zombie processes | 14 over 33 min | 0 |
| Dev loop completes implementation | ❌ wedged | ✅ 2 dev cycles, both submit_work |
| Plan reaches `reviewing_qa` | ❌ never | ✅ first ever on mavlink-decode |
| Phase 1c invoked correctly | never executed | ✅ `Skipping qa.yml service injection reason="no services-orchestrated harness profiles selected"` then `Scaffolded default QA workflow path=...qa.yml language=Go` |
| qa-runner invokes act | never reached | ✅ ran integration job |
| Final stage | aborted at ~33min | `reviewing_qa → rejected` (qa-reviewer correctly flagged flaky test timing) |
| Total wall clock | aborted | 13.8 min |

## Test plan

- [x] `go test ./...` — clean across the tree
- [x] `task lint` — clean
- [x] `go test ./cmd/sandbox/ -run TestExecCommand` — 4/4 pass (regression-guards)
- [x] `go test ./prompt/...` — clean
- [x] Live real-LLM run (gemini mavlink-decode) — sandbox stayed clean, Phase 1c rendered correctly, qa-reviewer rendered a real verdict with concrete feedback on flaky test timing

## Follow-ups (separate work)

- Sponsor pack update — `docs/sponsor-packages/mavlink-decode-2026-05-28/README.md` QA limitations section moves from "designed-for but not built-or-tested" to "shipped and verified end-to-end on real LLM". Separate PR (docs-only).
- qa-rejection auto-retry — qa-reviewer's `needs_changes` verdict transitions plan to `rejected` and there it sits; dev/reviewer have an auto-retry loop, qa does not. Worth a design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)