### PR TITLE
fix: qa-rejection fires RecoveryRequested + test seam closes coverage gap on all three trigger sites

### DIFF
--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -178,6 +178,15 @@ type Component struct {
 	errors              atomic.Int64
 	lastActivityMu      sync.RWMutex
 	lastActivity        time.Time
+
+	// recoveryPublisher is the seam tests use to intercept RecoveryRequested
+	// publishes without needing a real natsClient. Nil means "use the real
+	// publishRecoveryRequested method." Production code never sets this; tests
+	// install a stub that captures the payload for assertion. Closes the
+	// pre-existing coverage gap surfaced 2026-05-28 — the iteration-exhaustion
+	// trigger at markEscalatedLocked had no unit-level proof that the publish
+	// actually happens with the expected payload shape.
+	recoveryPublisher func(ctx context.Context, req *payloads.RecoveryRequested)
 }
 
 // NewComponent creates a new execution-orchestrator from raw JSON config.
@@ -1295,9 +1304,17 @@ func (c *Component) markEscalatedLocked(ctx context.Context, exec *taskExecution
 		"tdd_cycle", exec.TDDCycle,
 		"reason", reason,
 	)
-	trajectory.LogSummary(ctx, c.logger, c.natsClient, exec.DeveloperLoopID, "tdd-escalated", 0)
+	// trajectory.LogSummary requires a real natsClient — guard against the
+	// typed-nil interface case (a nil *natsclient.Client wrapped in a non-nil
+	// Requester interface, where Fetch's `client == nil` check returns false
+	// and Request panics on the unset client). Mirrors the nil-guard inside
+	// publishRecoveryRequested. Surfaced 2026-05-28 during recovery-publish
+	// test authoring.
+	if c.natsClient != nil {
+		trajectory.LogSummary(ctx, c.logger, c.natsClient, exec.DeveloperLoopID, "tdd-escalated", 0)
+	}
 
-	c.publishRecoveryRequested(ctx, &payloads.RecoveryRequested{
+	c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
 		RecoveryID:          uuid.New().String(),
 		Layer:               payloads.RecoveryLayerPhaseLocal,
 		Slug:                exec.Slug,
@@ -1313,6 +1330,18 @@ func (c *Component) markEscalatedLocked(ctx context.Context, exec *taskExecution
 
 	c.publishEntity(context.Background(), NewTaskExecutionEntity(exec).WithPhase(phaseEscalated).WithErrorReason(reason))
 	c.cleanupExecutionLocked(exec)
+}
+
+// emitRecoveryRequested is the test-friendly entry point. In production it
+// delegates to publishRecoveryRequested; in tests c.recoveryPublisher is set
+// to a capturing stub so assertions can verify the wire fires at the
+// iteration-exhaustion trigger site (markEscalatedLocked).
+func (c *Component) emitRecoveryRequested(ctx context.Context, req *payloads.RecoveryRequested) {
+	if c.recoveryPublisher != nil {
+		c.recoveryPublisher(ctx, req)
+		return
+	}
+	c.publishRecoveryRequested(ctx, req)
 }
 
 // publishRecoveryRequested fires an ADR-037 stage-1 phase-local recovery

--- a/processor/execution-manager/recovery_publish_test.go
+++ b/processor/execution-manager/recovery_publish_test.go
@@ -1,0 +1,78 @@
+package executionmanager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// captureRecoveryPublisher returns a stub that records every RecoveryRequested
+// emitted by the Component and a fetch closure to read the captured slice.
+// Mirrors the helper in plan-manager/recovery_publish_test.go — same pattern
+// kept consistent across components so the test seam reads identically wherever
+// recovery publishing is wired.
+func captureRecoveryPublisher() (func(ctx context.Context, req *payloads.RecoveryRequested), func() []*payloads.RecoveryRequested) {
+	var captured []*payloads.RecoveryRequested
+	publisher := func(_ context.Context, req *payloads.RecoveryRequested) {
+		captured = append(captured, req)
+	}
+	return publisher, func() []*payloads.RecoveryRequested { return captured }
+}
+
+// TestMarkEscalatedLocked_FiresRecoveryRequested closes a pre-existing coverage
+// gap: TestMarkEscalatedLocked_IncrementsCounters asserted counter side effects
+// but not whether RecoveryRequested actually gets published at the trigger.
+// If publishRecoveryRequested were silently broken (wrong subject, malformed
+// payload, nil-guard accidentally skipping), the counter assertions would still
+// pass. This test catches that class of regression by intercepting the wire.
+func TestMarkEscalatedLocked_FiresRecoveryRequested(t *testing.T) {
+	c := newTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	exec := newTestExec("recovery-fires-slug", "task-recovery")
+	exec.RequirementID = "req-recovery-1"
+	exec.DeveloperLoopID = "loop-developer-1"
+	exec.Feedback = "Reviewer rejected: missing tests for the 5xx path."
+	exec.TraceID = "trace-recovery-1"
+
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	exec.mu.Lock()
+	c.markEscalatedLocked(testCtx(t), exec, "fixable rejections exceeded TDD cycle budget")
+	exec.mu.Unlock()
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 RecoveryRequested publish at iteration exhaustion, got %d", len(got))
+	}
+	r := got[0]
+	if r.Slug != "recovery-fires-slug" {
+		t.Errorf("Slug = %q, want recovery-fires-slug", r.Slug)
+	}
+	if r.RequirementID != "req-recovery-1" {
+		t.Errorf("RequirementID = %q, want req-recovery-1", r.RequirementID)
+	}
+	if r.TaskID != "task-recovery" {
+		t.Errorf("TaskID = %q, want task-recovery", r.TaskID)
+	}
+	if r.LoopID != "loop-developer-1" {
+		t.Errorf("LoopID = %q, want loop-developer-1", r.LoopID)
+	}
+	if r.Layer != payloads.RecoveryLayerPhaseLocal {
+		t.Errorf("Layer = %q, want phase_local", r.Layer)
+	}
+	if r.EscalationReason != "fixable rejections exceeded TDD cycle budget" {
+		t.Errorf("EscalationReason = %q, want the exhaustion reason verbatim", r.EscalationReason)
+	}
+	if r.LastFailureFeedback != exec.Feedback {
+		t.Errorf("LastFailureFeedback = %q, want exec.Feedback verbatim", r.LastFailureFeedback)
+	}
+	if r.TraceID != "trace-recovery-1" {
+		t.Errorf("TraceID = %q, want trace-recovery-1", r.TraceID)
+	}
+	if r.RecoveryID == "" {
+		t.Error("RecoveryID should be populated with a fresh UUID")
+	}
+}

--- a/processor/plan-manager/component.go
+++ b/processor/plan-manager/component.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c360studio/semspec/tools/sandbox"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
+	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/nats-io/nats.go/jetstream"
@@ -54,6 +55,15 @@ type Component struct {
 	startTime time.Time
 	mu        sync.RWMutex
 	cancel    context.CancelFunc
+
+	// recoveryPublisher is the seam tests use to intercept RecoveryRequested
+	// publishes without needing a real natsClient. Nil means "use the real
+	// publishRecoveryRequested method." Production code never sets this; tests
+	// install a stub that captures the payload for assertion. Closes the
+	// pre-existing coverage gap surfaced 2026-05-28 — without this seam there
+	// is no way to assert publishRecoveryRequested actually fires at the
+	// revision-cap / iteration-exhaustion / QA-rejection trigger points.
+	recoveryPublisher func(ctx context.Context, req *payloads.RecoveryRequested)
 }
 
 // loadPlanCached loads a plan from the store (cache → KV → graph fallback).

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -656,7 +656,7 @@ func (c *Component) escalateRevision(ctx context.Context, ps *planStore, plan *w
 		"iteration", plan.ReviewIteration,
 		"max", maxIterations)
 
-	c.publishRecoveryRequested(ctx, &payloads.RecoveryRequested{
+	c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
 		RecoveryID:          uuid.New().String(),
 		Layer:               payloads.RecoveryLayerPhaseLocal,
 		Slug:                req.Slug,
@@ -666,6 +666,20 @@ func (c *Component) escalateRevision(ctx context.Context, ps *planStore, plan *w
 	})
 
 	return MutationResponse{Success: true}
+}
+
+// emitRecoveryRequested is the test-friendly entry point. In production it
+// delegates to publishRecoveryRequested; in tests c.recoveryPublisher is set
+// to a capturing stub so assertions can verify the wire fires at every
+// trigger site. The seam closes the pre-existing coverage gap: before this
+// indirection, escalation tests asserted plan-state changes but had no way
+// to verify the RecoveryRequested NATS publish actually happened.
+func (c *Component) emitRecoveryRequested(ctx context.Context, req *payloads.RecoveryRequested) {
+	if c.recoveryPublisher != nil {
+		c.recoveryPublisher(ctx, req)
+		return
+	}
+	c.publishRecoveryRequested(ctx, req)
 }
 
 // publishRecoveryRequested fires an ADR-037 stage-1 phase-local recovery
@@ -988,6 +1002,29 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save plan after QA verdict", "slug", req.Slug, "error", err)
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
+	}
+
+	// Fire phase-local recovery for non-approved verdicts. Mirrors the
+	// revision-cap-exhaustion path at handleRevisionEscalationMutation —
+	// every other wedge-shaped state transition published RecoveryRequested
+	// except this one until 2026-05-28 (verified on the gemini mavlink-
+	// decode run where qa-reviewer correctly diagnosed flaky time.Sleep
+	// timing but the plan terminated at rejected with no retry).
+	//
+	// EscalationReason carries the verdict kind so recovery-agent's prompt
+	// can distinguish "the tests failed and we should try again" from
+	// "the plan is structurally unsalvageable." LastFailureFeedback carries
+	// the qa-reviewer's actionable summary so the recovery agent sees the
+	// concrete diagnosis (e.g., "replace time.Sleep with active polling").
+	if req.Verdict == workflow.QAVerdictNeedsChanges || req.Verdict == workflow.QAVerdictRejected {
+		c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
+			RecoveryID:          uuid.New().String(),
+			Layer:               payloads.RecoveryLayerPhaseLocal,
+			Slug:                req.Slug,
+			EscalationReason:    fmt.Sprintf("QA verdict %s at level %s", req.Verdict, req.Level),
+			LastFailureFeedback: req.Summary,
+			TraceID:             req.TraceID,
+		})
 	}
 
 	return MutationResponse{Success: true}

--- a/processor/plan-manager/recovery_publish_test.go
+++ b/processor/plan-manager/recovery_publish_test.go
@@ -1,0 +1,233 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// captureRecoveryPublisher returns a stub that records every RecoveryRequested
+// emitted by the Component. The returned closure goes onto Component.recoveryPublisher
+// for the lifetime of the test; the returned function returns the captured slice
+// on each call. Use it for tests that need to assert RecoveryRequested was
+// published at a specific trigger site without spinning up a real natsClient.
+func captureRecoveryPublisher() (func(ctx context.Context, req *payloads.RecoveryRequested), func() []*payloads.RecoveryRequested) {
+	var captured []*payloads.RecoveryRequested
+	publisher := func(_ context.Context, req *payloads.RecoveryRequested) {
+		captured = append(captured, req)
+	}
+	return publisher, func() []*payloads.RecoveryRequested { return captured }
+}
+
+// ---------------------------------------------------------------------------
+// QA verdict trigger — the new wire added 2026-05-28 after the gemini
+// mavlink-decode run showed the plan terminating at rejected with no retry
+// even though qa-reviewer rendered an actionable diagnosis.
+// ---------------------------------------------------------------------------
+
+func TestHandleQAVerdictMutation_NeedsChangesFiresRecoveryRequested(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "qa-needs-changes-fires-recovery"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingQA
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictNeedsChanges,
+		Summary: "Integration test has hardcoded time.Sleep — replace with active polling.",
+		TraceID: "trace-qa-1",
+	}
+	data, _ := json.Marshal(event)
+
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 RecoveryRequested publish, got %d", len(got))
+	}
+	r := got[0]
+	if r.Slug != slug {
+		t.Errorf("Slug = %q, want %q", r.Slug, slug)
+	}
+	if r.Layer != payloads.RecoveryLayerPhaseLocal {
+		t.Errorf("Layer = %q, want phase_local", r.Layer)
+	}
+	if r.LastFailureFeedback != event.Summary {
+		t.Errorf("LastFailureFeedback = %q, want qa summary verbatim", r.LastFailureFeedback)
+	}
+	if r.TraceID != "trace-qa-1" {
+		t.Errorf("TraceID = %q, want trace-qa-1", r.TraceID)
+	}
+	if r.RecoveryID == "" {
+		t.Error("RecoveryID should be populated with a fresh UUID")
+	}
+	if r.EscalationReason == "" {
+		t.Error("EscalationReason should name the verdict and level")
+	}
+}
+
+func TestHandleQAVerdictMutation_RejectedFiresRecoveryRequested(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "qa-rejected-fires-recovery"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingQA
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictRejected,
+		Summary: "Unrecoverable: scope drift across all requirements.",
+		TraceID: "trace-qa-2",
+	}
+	data, _ := json.Marshal(event)
+
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 RecoveryRequested publish for rejected verdict, got %d", len(got))
+	}
+}
+
+func TestHandleQAVerdictMutation_ApprovedDoesNotFireRecoveryRequested(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "qa-approved-no-recovery"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingQA
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictApproved,
+		Summary: "All requirements met.",
+		TraceID: "trace-qa-3",
+	}
+	data, _ := json.Marshal(event)
+
+	// The approved branch attempts a plan-level merge via the sandbox. With
+	// no sandbox configured, the assemble step is a no-op (nil-guarded
+	// upstream) and the mutation succeeds. We don't assert mutation success
+	// here — we ONLY assert that recovery did not fire. A future change to
+	// the approved path that swaps merge behavior should not regress this
+	// guarantee.
+	_ = c.handleQAVerdictMutation(ctx, data)
+
+	if got := fetch(); len(got) != 0 {
+		t.Errorf("expected 0 RecoveryRequested publishes on approved verdict, got %d", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Drive-by coverage for the two pre-existing trigger sites. Both previously
+// had zero assertions on whether publishRecoveryRequested actually fires —
+// the only existing tests checked plan-state side effects. These tests close
+// that gap. Discovered 2026-05-28 while investigating why qa-rejection had
+// no retry path: the wire pattern was correct at two of three sites but
+// nothing actually verified it.
+// ---------------------------------------------------------------------------
+
+func TestHandleRevisionMutation_EscalationAtCapFiresRecoveryRequested(t *testing.T) {
+	ctx := context.Background()
+	c := setupRevisionComponent(t, 2) // cap = 2
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "revision-escalation-fires-recovery"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingDraft
+	plan.ReviewIteration = 1 // already at 1, cap is 2
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	req := RevisionMutationRequest{
+		Slug:    slug,
+		Round:   1,
+		Verdict: "needs_changes",
+		Summary: "Still too vague",
+	}
+	data := marshalRevision(t, req)
+
+	resp := c.handleRevisionMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("revision mutation failed: %s", resp.Error)
+	}
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 RecoveryRequested publish at revision cap, got %d", len(got))
+	}
+	r := got[0]
+	if r.Slug != slug {
+		t.Errorf("Slug = %q, want %q", r.Slug, slug)
+	}
+	if r.Layer != payloads.RecoveryLayerPhaseLocal {
+		t.Errorf("Layer = %q, want phase_local", r.Layer)
+	}
+	if r.EscalationReason == "" {
+		t.Error("EscalationReason should be populated from plan.LastError")
+	}
+}
+
+func TestHandleRevisionMutation_BelowCapDoesNotFireRecoveryRequested(t *testing.T) {
+	ctx := context.Background()
+	c := setupRevisionComponent(t, 3) // cap = 3, well above iteration
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "revision-below-cap-no-recovery"
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingDraft
+	plan.ReviewIteration = 0
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	req := RevisionMutationRequest{
+		Slug:    slug,
+		Round:   1,
+		Verdict: "needs_changes",
+		Summary: "Needs refinement",
+	}
+	data := marshalRevision(t, req)
+
+	resp := c.handleRevisionMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("revision mutation failed: %s", resp.Error)
+	}
+
+	if got := fetch(); len(got) != 0 {
+		t.Errorf("expected 0 RecoveryRequested publishes when below revision cap, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

The 2026-05-28 gemini mavlink-decode verification run reached `reviewing_qa` for the first time on a real-LLM mavlink scope. qa-reviewer rendered an actionable diagnosis (*"Integration test has hardcoded `time.Sleep` delays for UDP initialization — replace with active polling"*) but the plan terminated at `rejected` with no retry path.

Investigation found that recovery-agent (wired since ADR-037 stage-1, consuming `recovery.requested.<slug>`, emitting PlanDecisions back via `plan.mutation.plan_decision.add`) **never fired** because the QA verdict handler didn't publish `RecoveryRequested`. Two of three wedge-shaped state transitions did; QA verdict was the missing third.

Investigation also surfaced a pre-existing coverage gap: neither of the two working sites had test assertions on whether the publish actually happens. If `publishRecoveryRequested` were silently broken at any of the three sites — wrong subject, malformed payload, nil-guard accidentally skipping when it shouldn't — the existing tests would still pass.

## What this PR does

1. **Wires `publishRecoveryRequested` into `handleQAVerdictMutation`** for both `needs_changes` and `rejected` verdicts. `EscalationReason` names the verdict + level so recovery-agent's prompt can distinguish "tests failed, try again" from "structurally unsalvageable." `LastFailureFeedback` carries the qa-reviewer summary verbatim.

2. **Introduces a test seam** on both plan-manager and execution-manager Components: a `recoveryPublisher` func field that defaults to nil (= use the real `publishRecoveryRequested` method) and can be set by tests to a capturing stub. Production behavior unchanged.

3. **Adds six tests** covering all three trigger sites:
   - QA verdict needs_changes fires RecoveryRequested with the summary as `LastFailureFeedback`
   - QA verdict rejected fires RecoveryRequested
   - QA verdict approved does NOT fire RecoveryRequested
   - Existing revision-cap escalation fires RecoveryRequested (pre-existing site, no prior wire-coverage)
   - Below-cap revision does NOT fire RecoveryRequested
   - `markEscalatedLocked` (iteration exhaustion) fires RecoveryRequested with full payload shape (slug, RequirementID, TaskID, LoopID, etc.)

4. **Drive-by fix**: `markEscalatedLocked` called `trajectory.LogSummary` with a typed-nil `natsClient`. `Fetch`'s `client == nil` check returns false on a typed-nil interface (a nil `*natsclient.Client` wrapped in a non-nil `Requester`), and `Request` panics on the unset client. Guarded with the same nil-check pattern `publishRecoveryRequested` uses two lines later. The latent bug never tripped before because the existing `TestMarkEscalatedLocked_IncrementsCounters` left `DeveloperLoopID` empty (LogSummary short-circuits on empty loopID); the new test caught it when it set a non-empty value.

## Why this matters

The user-facing question after the mavlink-decode run was *"why didn't qa-rejection retry?"* The honest answer is that the plumbing existed but wasn't wired through to QA. This PR closes that, and the test seam means future regressions on any of the three trigger sites get caught at unit-test time instead of in real-LLM runs that cost tokens to surface.

## Test plan

- [x] `go test ./processor/plan-manager/...` — clean (existing + 5 new)
- [x] `go test ./processor/execution-manager/...` — clean (existing + 1 new)
- [x] `go test ./...` — zero failures across the tree
- [x] `task lint` — clean

## Deliberately NOT in this PR

- Recovery-agent emissions for QA-rejection wedges populate `AffectedReqIDs` so the existing auto-accept watcher (`plan-decision-handler/recovery_autoaccept.go`, gated by `Config.AutoAcceptRecovery`, filter `Kind=requirement_change + len(AffectedReqIDs)>0`) can fire **end-to-end without operator intervention**. Needs either a new field on `RecoveryRequested` (e.g. `AffectedRequirementIDs []string`) or a plan-state fetch inside recovery-agent's `emitPlanDecision`. Scoped as a follow-up so reviewers see the trigger wire + test coverage cleanly before the autonomy policy decision lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)