### PR TITLE
feat(recovery): autonomous qa-rejection retry via AffectedRequirementIDs

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -668,6 +668,45 @@ func (c *Component) escalateRevision(ctx context.Context, ps *planStore, plan *w
 	return MutationResponse{Success: true}
 }
 
+// collectActiveRequirementIDsForRecovery returns the IDs of every still-
+// active requirement on plan, used to populate
+// RecoveryRequested.AffectedRequirementIDs on QA-verdict wedges. The
+// recovery-agent threads this list into PlanDecision.AffectedReqIDs;
+// without it, the auto-accept watcher (plan-decision-handler/
+// recovery_autoaccept.go, gated by Config.AutoAcceptRecovery, filter
+// Kind=requirement_change + len(AffectedReqIDs)>0) cannot fire, and every
+// QA-rejection would require manual operator acceptance to drive a retry
+// — defeating the autonomous issue-to-PR shape Phase 1c was built for.
+//
+// Status == "" is the unset default for requirements drafted before the
+// lifecycle field landed and for newly-created requirements where the
+// producer relies on the JSON `omitempty` convention.
+// RequirementStatus.IsValid() rejects empty string, but in practice
+// active requirements emit no status — so the empty branch is the
+// "active by default" path, equivalent to RequirementStatusActive.
+// Deprecated and superseded entries are excluded: those are no longer
+// the source of truth, so retrying them would be wrong work.
+//
+// Returns nil (not empty slice) when no active requirements exist so the
+// payload's `omitempty` JSON tag drops the field cleanly. Logs a warning
+// in that case — a plan reaching reviewing_qa with zero active
+// requirements shouldn't happen but if it does the auto-accept watcher
+// correctly bails (its len>0 filter rejects) and the recovery PlanDecision
+// requires manual acceptance.
+func (c *Component) collectActiveRequirementIDsForRecovery(plan *workflow.Plan, verdict workflow.QAVerdict) []string {
+	var affected []string
+	for _, r := range plan.Requirements {
+		if r.Status == "" || r.Status == workflow.RequirementStatusActive {
+			affected = append(affected, r.ID)
+		}
+	}
+	if len(affected) == 0 {
+		c.logger.Warn("QA verdict with zero active requirements — recovery PlanDecision will require manual acceptance",
+			"slug", plan.Slug, "verdict", verdict)
+	}
+	return affected
+}
+
 // emitRecoveryRequested is the test-friendly entry point. In production it
 // delegates to publishRecoveryRequested; in tests c.recoveryPublisher is set
 // to a capturing stub so assertions can verify the wire fires at every
@@ -1018,12 +1057,13 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 	// concrete diagnosis (e.g., "replace time.Sleep with active polling").
 	if req.Verdict == workflow.QAVerdictNeedsChanges || req.Verdict == workflow.QAVerdictRejected {
 		c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
-			RecoveryID:          uuid.New().String(),
-			Layer:               payloads.RecoveryLayerPhaseLocal,
-			Slug:                req.Slug,
-			EscalationReason:    fmt.Sprintf("QA verdict %s at level %s", req.Verdict, req.Level),
-			LastFailureFeedback: req.Summary,
-			TraceID:             req.TraceID,
+			RecoveryID:             uuid.New().String(),
+			Layer:                  payloads.RecoveryLayerPhaseLocal,
+			Slug:                   req.Slug,
+			EscalationReason:       fmt.Sprintf("QA verdict %s at level %s", req.Verdict, req.Level),
+			LastFailureFeedback:    req.Summary,
+			TraceID:                req.TraceID,
+			AffectedRequirementIDs: c.collectActiveRequirementIDsForRecovery(plan, req.Verdict),
 		})
 	}
 

--- a/processor/plan-manager/recovery_publish_test.go
+++ b/processor/plan-manager/recovery_publish_test.go
@@ -80,6 +80,79 @@ func TestHandleQAVerdictMutation_NeedsChangesFiresRecoveryRequested(t *testing.T
 	}
 }
 
+// TestHandleQAVerdictMutation_NeedsChangesPopulatesAffectedRequirementIDs
+// is the autonomy contract: recovery-agent's emitted PlanDecision needs
+// AffectedReqIDs non-empty for the auto-accept watcher
+// (plan-decision-handler/recovery_autoaccept.go) to fire without operator
+// intervention. plan-manager populates AffectedRequirementIDs from the
+// plan's active requirements; recovery-agent's emitPlanDecision threads
+// the list into PlanDecision.AffectedReqIDs.
+//
+// This test verifies the plan-manager half of that contract by setting up
+// a plan with three requirements in mixed lifecycle states and asserting
+// that only the active ones (including empty-string default) land in the
+// payload.
+func TestHandleQAVerdictMutation_NeedsChangesPopulatesAffectedRequirementIDs(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	slug := "qa-affected-req-ids"
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID(slug),
+		Slug:   slug,
+		Title:  slug,
+		Status: workflow.StatusReviewingQA,
+		Requirements: []workflow.Requirement{
+			{ID: "req-active-explicit", Status: workflow.RequirementStatusActive},
+			{ID: "req-active-default"}, // empty Status — the "active by default" path
+			{ID: "req-deprecated", Status: workflow.RequirementStatusDeprecated},
+			{ID: "req-superseded", Status: workflow.RequirementStatusSuperseded},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	event := workflow.QAVerdictEvent{
+		Slug:    slug,
+		Level:   workflow.QALevelIntegration,
+		Verdict: workflow.QAVerdictNeedsChanges,
+		Summary: "Coverage gap on the 5xx path.",
+		TraceID: "trace-qa-affected",
+	}
+	data, _ := json.Marshal(event)
+
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 RecoveryRequested publish, got %d", len(got))
+	}
+	r := got[0]
+	if len(r.AffectedRequirementIDs) != 2 {
+		t.Fatalf("AffectedRequirementIDs length = %d, want 2 active reqs only; got %v",
+			len(r.AffectedRequirementIDs), r.AffectedRequirementIDs)
+	}
+	wantSet := map[string]bool{"req-active-explicit": false, "req-active-default": false}
+	for _, id := range r.AffectedRequirementIDs {
+		if _, ok := wantSet[id]; !ok {
+			t.Errorf("unexpected ID in AffectedRequirementIDs: %q (deprecated/superseded reqs should be excluded)", id)
+			continue
+		}
+		wantSet[id] = true
+	}
+	for id, seen := range wantSet {
+		if !seen {
+			t.Errorf("missing expected ID in AffectedRequirementIDs: %q", id)
+		}
+	}
+}
+
 func TestHandleQAVerdictMutation_RejectedFiresRecoveryRequested(t *testing.T) {
 	ctx := context.Background()
 	c := setupTestComponent(t)

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -717,15 +717,14 @@ func recoveryActionToPlanDecisionKind(action payloads.RecoveryActionKind) workfl
 	}
 }
 
-// emitPlanDecision sends a workflow.PlanDecision via plan.mutation.
-// plan_decision.add (same wire shape used by qa-reviewer + req-executor).
-// Best-effort: failure logs but does not block subsequent recovery work.
-func (c *Component) emitPlanDecision(ctx context.Context, req *payloads.RecoveryRequested, loop *agentic.LoopEntity, action payloads.RecoveryActionKind, diagnosis string, succeeded bool) {
-	if c.natsClient == nil {
-		return
-	}
-
-	now := time.Now()
+// buildRecoveryPlanDecision is the pure-function shape of the recovery
+// PlanDecision construction. Extracted so unit tests can verify the
+// AffectedReqIDs propagation contract (plan-scoped list preferred over
+// single requirement ID, both empty leaves field nil for human review)
+// without needing a real natsClient. Called only from emitPlanDecision in
+// production. now is passed in rather than taking time.Now() inside so
+// tests get deterministic CreatedAt values.
+func buildRecoveryPlanDecision(req *payloads.RecoveryRequested, loop *agentic.LoopEntity, action payloads.RecoveryActionKind, diagnosis string, succeeded bool, now time.Time) workflow.PlanDecision {
 	kind := recoveryActionToPlanDecisionKind(action)
 
 	title := fmt.Sprintf("Recovery: %s", action)
@@ -735,14 +734,24 @@ func (c *Component) emitPlanDecision(ctx context.Context, req *payloads.Recovery
 
 	rationale := buildRecoveryRationale(req, loop, action, diagnosis, succeeded)
 
+	// Prefer the plan-scoped affected list (populated by plan-manager on QA
+	// verdict wedges where the qa-reviewer's verdict applies to all
+	// assembled requirements) over the single requirement ID (populated by
+	// execution-manager iteration exhaustion). Both empty leaves
+	// AffectedReqIDs nil — the auto-accept watcher then leaves the decision
+	// for human review (the correct outcome for plan-review wedges where
+	// the plan itself is wrong, not any specific requirement).
 	var affectedReqs []string
-	if req.RequirementID != "" {
+	switch {
+	case len(req.AffectedRequirementIDs) > 0:
+		affectedReqs = append(affectedReqs, req.AffectedRequirementIDs...)
+	case req.RequirementID != "":
 		affectedReqs = []string{req.RequirementID}
 	}
 
 	decisionID := fmt.Sprintf("plan-decision.%s.recovery.%s", req.Slug, req.RecoveryID[:8])
 
-	decision := workflow.PlanDecision{
+	return workflow.PlanDecision{
 		ID:             decisionID,
 		PlanID:         workflow.PlanEntityID(req.Slug),
 		Kind:           kind,
@@ -753,6 +762,17 @@ func (c *Component) emitPlanDecision(ctx context.Context, req *payloads.Recovery
 		AffectedReqIDs: affectedReqs,
 		CreatedAt:      now,
 	}
+}
+
+// emitPlanDecision sends a workflow.PlanDecision via plan.mutation.
+// plan_decision.add (same wire shape used by qa-reviewer + req-executor).
+// Best-effort: failure logs but does not block subsequent recovery work.
+func (c *Component) emitPlanDecision(ctx context.Context, req *payloads.RecoveryRequested, loop *agentic.LoopEntity, action payloads.RecoveryActionKind, diagnosis string, succeeded bool) {
+	if c.natsClient == nil {
+		return
+	}
+
+	decision := buildRecoveryPlanDecision(req, loop, action, diagnosis, succeeded, time.Now())
 
 	addReq := struct {
 		Slug     string                `json:"slug"`
@@ -790,10 +810,10 @@ func (c *Component) emitPlanDecision(ctx context.Context, req *payloads.Recovery
 	c.logger.Info("Emitted recovery PlanDecision",
 		"slug", req.Slug,
 		"recovery_id", req.RecoveryID,
-		"decision_id", decisionID,
-		"kind", kind,
+		"decision_id", decision.ID,
+		"kind", decision.Kind,
 		"action", action,
-		"affected_reqs", affectedReqs)
+		"affected_reqs", decision.AffectedReqIDs)
 }
 
 // buildRecoveryRationale assembles the PlanDecision Rationale text. The

--- a/processor/recovery-agent/plan_decision_build_test.go
+++ b/processor/recovery-agent/plan_decision_build_test.go
@@ -1,0 +1,96 @@
+package recoveryagent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestBuildRecoveryPlanDecision_PrefersAffectedRequirementIDsOverSingleID is
+// the autonomy contract from the recovery-agent side: when plan-manager
+// populates RecoveryRequested.AffectedRequirementIDs (QA verdict wedges),
+// the emitted PlanDecision's AffectedReqIDs threads through the list
+// verbatim. plan-decision-handler/recovery_autoaccept.go gates auto-accept
+// on len(dec.AffectedReqIDs) > 0; without this propagation the QA-rejection
+// retry loop sits waiting for a human click forever.
+func TestBuildRecoveryPlanDecision_PrefersAffectedRequirementIDsOverSingleID(t *testing.T) {
+	req := &payloads.RecoveryRequested{
+		RecoveryID:             "12345678-aaaa-bbbb-cccc-dddddddddddd",
+		Slug:                   "qa-rejection-multi-req",
+		Layer:                  payloads.RecoveryLayerPhaseLocal,
+		EscalationReason:       "QA verdict needs_changes at level integration",
+		AffectedRequirementIDs: []string{"req-1", "req-2", "req-3"},
+		// RequirementID intentionally left empty — the QA wedge is plan-scoped.
+	}
+
+	dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionRefinePrompt, "diagnosis text", true, time.Now())
+
+	if len(dec.AffectedReqIDs) != 3 {
+		t.Fatalf("AffectedReqIDs length = %d, want 3 (from AffectedRequirementIDs); got %v",
+			len(dec.AffectedReqIDs), dec.AffectedReqIDs)
+	}
+	wantSet := map[string]bool{"req-1": false, "req-2": false, "req-3": false}
+	for _, id := range dec.AffectedReqIDs {
+		if _, ok := wantSet[id]; !ok {
+			t.Errorf("unexpected ID in AffectedReqIDs: %q", id)
+			continue
+		}
+		wantSet[id] = true
+	}
+	for id, seen := range wantSet {
+		if !seen {
+			t.Errorf("missing expected ID: %q", id)
+		}
+	}
+	if dec.ProposedBy != componentName {
+		t.Errorf("ProposedBy = %q, want %q", dec.ProposedBy, componentName)
+	}
+	if dec.Status != workflow.PlanDecisionStatusProposed {
+		t.Errorf("Status = %q, want proposed", dec.Status)
+	}
+}
+
+// TestBuildRecoveryPlanDecision_FallsBackToSingleRequirementID covers the
+// execution-manager iteration-exhaustion path: a single TDD task wedged
+// against one requirement, RequirementID is set on the payload,
+// AffectedRequirementIDs is empty. The emitted PlanDecision should target
+// just that one requirement so auto-accept retries the right scope.
+func TestBuildRecoveryPlanDecision_FallsBackToSingleRequirementID(t *testing.T) {
+	req := &payloads.RecoveryRequested{
+		RecoveryID:       "12345678-eeee-ffff-0000-111111111111",
+		Slug:             "iteration-exhaustion-single-req",
+		Layer:            payloads.RecoveryLayerPhaseLocal,
+		EscalationReason: "fixable rejections exceeded TDD cycle budget",
+		RequirementID:    "req-only",
+		// AffectedRequirementIDs intentionally empty.
+	}
+
+	dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionRefinePrompt, "diagnosis", true, time.Now())
+
+	if len(dec.AffectedReqIDs) != 1 || dec.AffectedReqIDs[0] != "req-only" {
+		t.Errorf("AffectedReqIDs = %v, want [req-only] (single-ID fallback)", dec.AffectedReqIDs)
+	}
+}
+
+// TestBuildRecoveryPlanDecision_BothEmptyLeavesAffectedReqIDsNil covers the
+// plan-review revision-cap wedge: the plan itself is wrong, neither a
+// specific requirement nor a plan-scoped retry list applies. AffectedReqIDs
+// is nil so the auto-accept watcher's `len > 0` filter rejects auto-accept
+// and the PlanDecision waits for human review. That's the correct outcome
+// — silently retrying the wrong plan would just re-wedge.
+func TestBuildRecoveryPlanDecision_BothEmptyLeavesAffectedReqIDsNil(t *testing.T) {
+	req := &payloads.RecoveryRequested{
+		RecoveryID:       "12345678-1111-2222-3333-444444444444",
+		Slug:             "plan-review-cap-no-reqs",
+		Layer:            payloads.RecoveryLayerPhaseLocal,
+		EscalationReason: "plan review revision cap reached",
+	}
+
+	dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionRefinePrompt, "diagnosis", false, time.Now())
+
+	if len(dec.AffectedReqIDs) != 0 {
+		t.Errorf("AffectedReqIDs = %v, want nil — auto-accept should not fire on plan-level wedges", dec.AffectedReqIDs)
+	}
+}

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -99,9 +99,28 @@ type RecoveryRequested struct {
 	// Slug is the plan slug — routing key and trace-deep-link.
 	Slug string `json:"slug"`
 
-	// RequirementID is set when the wedge is requirement-scoped. Empty for
-	// plan-phase wedges that don't bind to a single requirement.
+	// RequirementID is set when the wedge is requirement-scoped to a single
+	// requirement (e.g., execution-manager iteration exhaustion on one TDD
+	// task). Empty for plan-phase wedges.
 	RequirementID string `json:"requirement_id,omitempty"`
+
+	// AffectedRequirementIDs lists the requirement IDs the wedge implicates
+	// when there is more than one. Populated by plan-manager on QA verdict
+	// wedges where the qa-reviewer's verdict applies to all assembled
+	// requirements (e.g., "the implementation is flaky across the plan").
+	// When set, supersedes RequirementID — recovery-agent's emitPlanDecision
+	// uses this list to populate PlanDecision.AffectedReqIDs, which is what
+	// the existing auto-accept watcher
+	// (plan-decision-handler/recovery_autoaccept.go) requires non-empty
+	// before firing without operator intervention.
+	//
+	// Empty (the default) preserves pre-2026-05-28 behavior: the single
+	// RequirementID is used if set, else PlanDecision.AffectedReqIDs is
+	// empty and the auto-accept watcher leaves the decision for human
+	// review. That fallback remains correct for plan-review revision-cap
+	// wedges where the PLAN itself is wrong and human gating is the right
+	// outcome.
+	AffectedRequirementIDs []string `json:"affected_requirement_ids,omitempty"`
 
 	// TaskID identifies the specific TDD task that wedged. Empty for
 	// plan-phase wedges.


### PR DESCRIPTION
## Summary

Stacks on #29. Closes the autonomy gap that PR left explicitly open: with the trigger wired and tests in place, qa-reviewer's `needs_changes` verdict now flows through to recovery-agent — but the emitted PlanDecision had empty `AffectedReqIDs` because `RecoveryRequested.RequirementID` is empty for plan-scoped wedges. The auto-accept watcher (gated by `Config.AutoAcceptRecovery`) requires `len(AffectedReqIDs) > 0` before firing, so QA-rejection retries silently sat in `proposed` state waiting for an operator click — defeating the autonomous issue-to-PR shape Phase 1c was built for.

This PR threads the affected requirement IDs end-to-end.

## Changes

1. **New optional field** `AffectedRequirementIDs []string` on `RecoveryRequested` payload. Backward-compat: empty preserves pre-2026-05-28 behavior where the single `RequirementID` is used.

2. **`plan-manager.collectActiveRequirementIDsForRecovery`** extracts active requirement IDs from the plan on QA verdict and threads them onto the payload. Excludes deprecated/superseded entries (no longer source of truth). Warns when active set is empty so operator notices the un-actionable decision.

3. **`recovery-agent.buildRecoveryPlanDecision`** is the extracted pure-function shape of the PlanDecision construction. Prefers the plan-scoped affected list, falls back to single `RequirementID`, leaves nil for plan-review wedges where the plan itself is wrong and human gating is the right outcome.

## Tests

Both sides of the contract covered with unit tests on pure functions:

- **`TestHandleQAVerdictMutation_NeedsChangesPopulatesAffectedRequirementIDs`** — plan with 4 requirements in mixed lifecycle states (active explicit, active default empty-string, deprecated, superseded); asserts only the 2 active ones land in the payload.
- **`TestBuildRecoveryPlanDecision_PrefersAffectedRequirementIDsOverSingleID`** — multi-req QA-rejection shape; asserts threading to PlanDecision.
- **`TestBuildRecoveryPlanDecision_FallsBackToSingleRequirementID`** — iteration-exhaustion shape.
- **`TestBuildRecoveryPlanDecision_BothEmptyLeavesAffectedReqIDsNil`** — plan-review revision-cap shape; asserts the correct human-review outcome.

## Config

No config changes needed: every verification config already has `auto_accept_recovery=true`:

```
configs/e2e-gemini.json:697   auto_accept_recovery: true
configs/e2e-hybrid.json:892   auto_accept_recovery: true
configs/e2e-mock.json:860     auto_accept_recovery: true
configs/e2e-mock-ui.json:634  auto_accept_recovery: true
```

Production default in `processor/plan-decision-handler/config.go:46` stays `false` — autonomous in test envs, conservative in production unless explicitly opted in.

## Verification chain that now works end-to-end

```
qa-reviewer needs_changes
  → handleQAVerdictMutation
  → publishRecoveryRequested with AffectedRequirementIDs=[active reqs]
  → recovery-agent.OnMsg
  → buildRecoveryPlanDecision sets AffectedReqIDs from list
  → emitPlanDecision via plan.mutation.plan_decision.add
  → auto-accept watcher's len>0 filter matches
  → plan.mutation.plan_decision.accept
  → requirement-executor.handlePlanDecisionAccepted
  → resume from awaiting_recovery
  → re-implement
```

Every link tested in unit form. Real-LLM verification on the next mavlink-decode run.

## Review

go-reviewer pass on the combined diff (this PR + #29): first pass flagged AffectedRequirementIDs test coverage, empty-string Status comment clarity, and zero-requirements defensive log — all addressed. Second pass approved with "ship it."

## Filed separately (not in this PR)

- `recovery-agent/component.go:753` — `req.RecoveryID[:8]` panics if RecoveryID < 8 chars. Pre-existing; `uuid.New().String()` always returns 36 chars so safe in practice.
- `internal/trajectory/trajectory.go:107` typed-nil interface check is a class-of-bug magnet (`if client == nil` returns false for `(*Client)(nil)` wrapped in non-nil `Requester`). Surfaced by exec-manager nil-check in #29; worth an upstream refactor.

## Test plan

- [x] `go test ./...` — zero failures
- [x] `task lint` — clean (no findings)
- [ ] Real-LLM mavlink-decode retry (separate run after merge of #27, #29, this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)