### PR TITLE
fix(requirement-executor): resume completed reqs on QA-recovery PlanDecision

### DIFF
--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -150,6 +150,17 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 // dispatch via execution-manager.lookupRecoveryHint, so the manager
 // guidance reaches the wedged role through the existing channel.
 //
+// Two callers as of 2026-05-28:
+//   - handlePlanDecisionAccepted via the existing iteration-exhaustion
+//     path (exec was mid-cycle when markEscalatedLocked deferred it).
+//   - resumeTerminalForRecoveryLocked via the QA-recovery path (exec was
+//     terminal-stage in KV when the plan-level QA verdict rejected; the
+//     wrapper re-marks it awaiting before calling here).
+//
+// The function is identical for both — the only difference upstream is
+// how the exec got into activeExecs (cache-resident vs. KV-loaded then
+// reinserted).
+//
 // Caller must hold exec.mu.
 func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirementExecution) {
 	if exec.recoveryTimer != nil {
@@ -288,19 +299,68 @@ func (c *Component) handlePlanDecisionAccepted(lifecycleCtx, msgCtx context.Cont
 	}
 
 	for _, reqID := range evt.AffectedRequirementIDs {
-		exec := c.findAwaitingByRequirement(evt.Slug, reqID)
-		if exec == nil {
+		// First, the existing awaiting-recovery resume path: covers the
+		// iteration-exhaustion wedge (exec was mid-cycle, got marked
+		// awaiting_recovery by markEscalatedLocked, now we resume it).
+		if exec := c.findAwaitingByRequirement(evt.Slug, reqID); exec != nil {
+			c.logger.Info("Resuming exec on accepted PlanDecision",
+				"slug", evt.Slug,
+				"requirement_id", reqID,
+				"proposal_id", evt.ProposalID,
+			)
+			exec.mu.Lock()
+			c.resumeFromRecoveryLocked(lifecycleCtx, exec)
+			exec.mu.Unlock()
 			continue
 		}
-		c.logger.Info("Resuming exec on accepted PlanDecision",
-			"slug", evt.Slug,
-			"requirement_id", reqID,
-			"proposal_id", evt.ProposalID,
-		)
+
+		// Second, the QA-recovery path: covers the case where the
+		// requirement's per-req gates approved (dev + reviewer signed off,
+		// exec reached completed) but the plan-level QA verdict rejected.
+		// The completed exec was removed from activeExecs at cleanup, so
+		// findAwaitingByRequirement misses it. Without this branch, the
+		// recovery chain hangs at "PlanDecision accepted, nothing happens
+		// downstream" — empirically caught 2026-05-28 on gemini mavlink-
+		// decode run #4 where qa-reviewer rejected for flaky time.Sleep
+		// timing, recovery-agent emitted a refined_prompt PlanDecision,
+		// auto-accept watcher accepted it, but the plan stayed at
+		// `rejected` because no exec was in awaiting_recovery to resume.
+		exec, err := c.loadTerminalReqExecFromKV(msgCtx, evt.Slug, reqID)
+		if err != nil {
+			c.logger.Warn("Failed to load terminal req exec from KV for QA-recovery",
+				"slug", evt.Slug, "requirement_id", reqID, "error", err)
+			continue
+		}
+		if exec == nil {
+			// No match anywhere — the event also fires for non-recovery
+			// proposals and for proposals affecting reqs we never tracked.
+			continue
+		}
+
+		// Budget gate. recoveryRestarts is not persisted on
+		// workflow.RequirementExecution, so rebuildExecFromKV always sets
+		// it to zero — the per-exec gate in deferToAwaitingRecoveryLocked
+		// can never bite on the QA-recovery path. Count accepted
+		// recovery-agent PlanDecisions for this req on the plan instead;
+		// the just-accepted proposal is one of them, so the gate fires
+		// when subsequent retries try to land on top of an exhausted
+		// budget.
+		cycles := c.countAcceptedRecoveryCyclesForReq(msgCtx, evt.Slug, reqID)
+		if cycles > c.maxRecoveryRestarts() {
+			c.logger.Warn("QA-recovery budget exhausted; refusing to resume completed requirement",
+				"slug", evt.Slug,
+				"requirement_id", reqID,
+				"proposal_id", evt.ProposalID,
+				"cycles_observed", cycles,
+				"max_recovery_restarts", c.maxRecoveryRestarts(),
+			)
+			continue
+		}
+
+		c.activeExecs.Set(exec.EntityID, exec)
 		exec.mu.Lock()
-		c.resumeFromRecoveryLocked(lifecycleCtx, exec)
+		c.resumeTerminalForRecoveryLocked(lifecycleCtx, exec, evt.ProposalID)
 		exec.mu.Unlock()
 	}
 	_ = msg.Ack()
-	_ = msgCtx // suppress unused-arg warning in builds where the handler shape changes
 }

--- a/processor/requirement-executor/recover_completed.go
+++ b/processor/requirement-executor/recover_completed.go
@@ -1,0 +1,164 @@
+package requirementexecutor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// loadTerminalReqExecFromKV fetches a terminal-state requirement execution
+// for the given slug + requirement ID directly via the deterministic KV
+// key. Used by handlePlanDecisionAccepted when findAwaitingByRequirement
+// returns nil — covers the QA-rejection wedge shape where the
+// requirement's per-req gates (dev + reviewer) approved but the plan-level
+// QA verdict rejected.
+//
+// Returns nil + nil when no matching entry exists or stage is non-
+// terminal. Returns nil + error only on KV transport failure so the
+// caller can log and skip; non-fatal because the broader chain has other
+// failure surfaces (timeout fallbacks in plan-decision-handler).
+//
+// The returned *requirementExecution is rebuilt via rebuildExecFromKV — it
+// carries DAG, node index, retry counters, branch name, and the storeKey
+// the resume path needs. Caller MUST insert it into c.activeExecs before
+// calling resumeFromRecoveryLocked; the resume path expects the exec to
+// be cache-resident so the dispatched decomposer's completion callback
+// can route back.
+func (c *Component) loadTerminalReqExecFromKV(ctx context.Context, slug, requirementID string) (*requirementExecution, error) {
+	if c.natsClient == nil {
+		return nil, nil
+	}
+
+	bucket, err := c.natsClient.GetKeyValueBucket(ctx, "EXECUTION_STATES")
+	if err != nil {
+		return nil, fmt.Errorf("get EXECUTION_STATES bucket: %w", err)
+	}
+	kvStore := c.natsClient.NewKVStore(bucket)
+
+	key := workflow.RequirementExecutionKey(slug, requirementID)
+	entry, err := kvStore.Get(ctx, key)
+	if err != nil {
+		// Distinguish "no entry" from "transport failure". natsclient maps the
+		// NATS KV not-found path to a wrapped jetstream.ErrKeyNotFound; treat
+		// any not-found-shaped error as a soft miss.
+		if isKVNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+
+	var reqExec workflow.RequirementExecution
+	if err := json.Unmarshal(entry.Value, &reqExec); err != nil {
+		c.logger.Debug("Skipping corrupt EXECUTION_STATES entry during QA-recovery load",
+			"key", key, "error", err)
+		return nil, nil
+	}
+	if !workflow.IsTerminalReqStage(reqExec.Stage) {
+		// Caller already tried the awaiting path. If we're here and the KV
+		// entry is mid-flight, the activeExecs cache lookup just hadn't
+		// landed yet — better to no-op than race the lifecycle.
+		return nil, nil
+	}
+	return c.rebuildExecFromKV(key, &reqExec), nil
+}
+
+// countAcceptedRecoveryCyclesForReq returns how many recovery-agent
+// PlanDecisions have already been accepted for this requirement on this
+// plan. Used as a defense-in-depth budget gate for the QA-recovery path —
+// the per-exec recoveryRestarts counter resets on every KV reload (it's
+// not persisted in workflow.RequirementExecution), so without this check
+// a thrashing QA verdict (needs_changes → recover → still flaky → repeat)
+// could loop indefinitely.
+//
+// Returns 0 on any load/parse failure so a transient KV error doesn't
+// false-fail the recovery — the outer Playwright/operator budget is the
+// last-line guard.
+func (c *Component) countAcceptedRecoveryCyclesForReq(ctx context.Context, slug, requirementID string) int {
+	if c.natsClient == nil {
+		return 0
+	}
+	js, err := c.natsClient.JetStream()
+	if err != nil {
+		c.logger.Debug("QA-recovery budget: jetstream unavailable; allowing resume",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return 0
+	}
+	bucket, err := js.KeyValue(ctx, "PLAN_STATES")
+	if err != nil {
+		c.logger.Debug("QA-recovery budget: PLAN_STATES bucket unavailable; allowing resume",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return 0
+	}
+	entry, err := bucket.Get(ctx, slug)
+	if err != nil {
+		c.logger.Debug("QA-recovery budget: plan not in PLAN_STATES; allowing resume",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return 0
+	}
+	var plan struct {
+		PlanDecisions []workflow.PlanDecision `json:"plan_decisions"`
+	}
+	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
+		c.logger.Debug("QA-recovery budget: plan JSON unmarshal failed; allowing resume",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return 0
+	}
+	count := 0
+	for _, dec := range plan.PlanDecisions {
+		if dec.ProposedBy != "recovery-agent" {
+			continue
+		}
+		if dec.Status != workflow.PlanDecisionStatusAccepted {
+			continue
+		}
+		for _, affected := range dec.AffectedReqIDs {
+			if affected == requirementID {
+				count++
+				break
+			}
+		}
+	}
+	return count
+}
+
+// resumeTerminalForRecoveryLocked transitions a terminal requirement
+// execution back through the recovery flow. Mirrors the awaiting_recovery
+// shape: marks the exec awaiting + records the proposal context, then
+// defers to the existing resumeFromRecoveryLocked which does the actual
+// DAG reset, branch reset, and decomposer dispatch.
+//
+// The caller must hold exec.mu and have inserted exec into c.activeExecs.
+// Splitting this out keeps the new code path's diff small and makes the
+// "state mark before resume" the only NEW behavior — the resume logic
+// itself is unchanged.
+func (c *Component) resumeTerminalForRecoveryLocked(ctx context.Context, exec *requirementExecution, proposalID string) {
+	exec.awaitingRecovery = true
+	exec.recoveryReason = fmt.Sprintf("QA-recovery: completed req re-dispatched (proposal %s)", proposalID)
+	c.logger.Info("Resuming completed requirement from QA-recovery",
+		"entity_id", exec.EntityID,
+		"slug", exec.Slug,
+		"requirement_id", exec.RequirementID,
+		"prior_stage", "terminal",
+		"proposal_id", proposalID,
+	)
+	c.resumeFromRecoveryLocked(ctx, exec)
+}
+
+// isKVNotFound returns true when err is the soft "no entry" shape returned
+// by NATS KV Get. Mirrors the existing pattern in question-manager
+// (component.go:258, 310): accept both the jetstream sentinel and the
+// string-flattened variant some wrappers emit.
+func isKVNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, jetstream.ErrKeyNotFound) {
+		return true
+	}
+	return strings.Contains(err.Error(), "key not found")
+}

--- a/processor/requirement-executor/recover_completed_test.go
+++ b/processor/requirement-executor/recover_completed_test.go
@@ -1,0 +1,88 @@
+package requirementexecutor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestResumeTerminalForRecoveryLocked covers the new branch added 2026-05-28
+// after the gemini mavlink-decode run #4 verified PR #29's
+// publishRecoveryRequested wire fires correctly but the plan stayed at
+// 'rejected' because the requirement_executions were at terminal stage
+// 'completed' and findAwaitingByRequirement missed them.
+//
+// The test asserts: setting awaitingRecovery + recoveryReason then deferring
+// to resumeFromRecoveryLocked produces the same end-state as the existing
+// iteration-exhaustion resume path. We don't try to exercise the KV-loading
+// portion here — that's covered by the integration path in the e2e harness.
+// The unit-level claim this test pins is: "given a terminal-stage exec
+// inserted into activeExecs, the QA-recovery branch correctly transitions
+// it through the recovery flow."
+func TestResumeTerminalForRecoveryLocked_TransitionsThroughRecoveryFlow(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-qa-recovery", "req-qa-recovery-1")
+	// Terminal-stage prelude: in real life exec reached completed and was
+	// removed from activeExecs by cleanupExecutionLocked. For this test we
+	// just need the exec object — the caller-of-resumeTerminalForRecovery
+	// re-inserts it into activeExecs after KV load (or in this case
+	// directly).
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	exec.mu.Lock()
+	c.resumeTerminalForRecoveryLocked(context.Background(), exec, "plan-decision.test.recovery.abc12345")
+	exec.mu.Unlock()
+
+	// After resumeFromRecoveryLocked runs, awaitingRecovery should be
+	// cleared (it was set to true momentarily inside the function so the
+	// resume's lifecycle bookkeeping treats the exec as recovering, then
+	// the resume itself flips it back).
+	if exec.awaitingRecovery {
+		t.Error("exec.awaitingRecovery should be false after resume completes")
+	}
+	if exec.terminated {
+		t.Error("exec.terminated should be false after resume (resumption re-opens the exec)")
+	}
+	if exec.recoveryRestarts != 1 {
+		t.Errorf("exec.recoveryRestarts = %d, want 1 (incremented by the resume path)", exec.recoveryRestarts)
+	}
+	if exec.CurrentNodeIdx != -1 {
+		t.Errorf("exec.CurrentNodeIdx = %d, want -1 (DAG reset by the resume path)", exec.CurrentNodeIdx)
+	}
+	if exec.DAG != nil {
+		t.Errorf("exec.DAG = %v, want nil (DAG reset by the resume path)", exec.DAG)
+	}
+	if exec.ReviewVerdict != "" {
+		t.Errorf("exec.ReviewVerdict = %q, want empty (resumption clears prior verdict)", exec.ReviewVerdict)
+	}
+}
+
+// TestResumeTerminalForRecoveryLocked_RecordsReasonBeforeResume verifies
+// the marking step (awaitingRecovery + recoveryReason) is applied by the
+// wrapper BEFORE resumeFromRecoveryLocked clears awaitingRecovery on the
+// way out. We intercept via the recoveryReason field's persistence across
+// the resume: the existing resume function doesn't touch recoveryReason,
+// so a value set by the wrapper survives the resume's state reset and is
+// observable on the exec afterward.
+//
+// Why this matters: handleRecoveryTimeout's fallback (awaiting_recovery.go:
+// 143) reads exec.recoveryReason and passes it to markFailedLocked if the
+// recovery times out. The wrapper's recoveryReason populates that channel
+// with the QA-recovery proposal context, which surfaces in observability
+// when the post-resume retry also fails.
+func TestResumeTerminalForRecoveryLocked_RecordsReasonBeforeResume(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-reason", "req-reason-1")
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	proposalID := "plan-decision.reason.test.recovery.deadbeef"
+	exec.mu.Lock()
+	c.resumeTerminalForRecoveryLocked(context.Background(), exec, proposalID)
+	gotReason := exec.recoveryReason
+	exec.mu.Unlock()
+
+	want := "QA-recovery: completed req re-dispatched (proposal " + proposalID + ")"
+	if gotReason != want {
+		t.Errorf("recoveryReason after resume = %q, want %q", gotReason, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the final wedge in the autonomous QA-rejection retry chain. The 2026-05-28 gemini mavlink-decode run #4 verified PR #29's \`publishRecoveryRequested\` wire fires correctly on qa-reviewer \`needs_changes\` — the full chain through "Plan decision added" and "Plan decision accepted via mutation accepted_by=auto:recovery" completes in ~22 seconds. But the plan stayed at \`rejected\` indefinitely because \`requirement-executor.handlePlanDecisionAccepted\` only resumed execs in \`awaiting_recovery\` state.

The wedge: the requirement's per-req gates (dev + reviewer sign-off) approved, exec reached \`completed\`, cleanup removed it from \`activeExecs\`. Plan-level QA verdict then rejected. The recovery PlanDecision targets completed reqs the cache no longer holds, \`findAwaitingByRequirement\` returns nil, the handler silently skips.

## Changes

\`processor/requirement-executor/awaiting_recovery.go\` — extends \`handlePlanDecisionAccepted\` with a second branch: when the awaiting lookup fails, fetch the terminal exec directly from EXECUTION_STATES KV via \`workflow.RequirementExecutionKey\`, rebuild via the existing \`rebuildExecFromKV\`, register in \`activeExecs\`, then defer to the existing \`resumeFromRecoveryLocked\` which already does the right work.

\`processor/requirement-executor/recover_completed.go\` (new) — \`loadTerminalReqExecFromKV\` for the KV lookup, \`countAcceptedRecoveryCyclesForReq\` for the defense-in-depth budget gate, \`resumeTerminalForRecoveryLocked\` for the wrapper, \`isKVNotFound\` helper mirroring the question-manager pattern.

## Budget gate

\`recoveryRestarts\` is in-memory only on \`requirementExecution\` (not persisted in \`workflow.RequirementExecution\`), so \`rebuildExecFromKV\` always sets it to zero — the per-exec gate in \`deferToAwaitingRecoveryLocked\` can never bite on the QA-recovery path. Without an independent cap, a thrashing QA verdict could loop forever.

\`countAcceptedRecoveryCyclesForReq\` counts accepted recovery-agent PlanDecisions targeting the req on the plan and refuses to resume when \`cycles > maxRecoveryRestarts\`. The just-accepted proposal is counted, so the gate fires at the next retry attempt. Default \`MaxRecoveryRestarts=1\` → allows exactly one resume per req before requiring operator intervention.

## How feedback flows to the dev

\`plan-manager.applyRecoveryHint\` sets \`Requirement.RecoveryHint\` on the plan when the recovery PlanDecision is accepted (already wired, unchanged). \`resumeFromRecoveryLocked\` dispatches the decomposer, which feeds into execution-manager's developer dispatch. Execution-manager.\`lookupRecoveryHint\` reads the hint and prepends it to dev feedback. So the qa-reviewer's actionable text (e.g., *"replace time.Sleep with active polling"*) reaches the agent as revision context — no new plumbing needed.

## Test plan

- [x] \`go test ./...\` — clean
- [x] \`task lint\` — clean (revive + go vet + go fmt)
- [x] 2 new unit tests cover the state transitions through the new path
- [ ] Re-run \`task e2e:watch:llm -- gemini mavlink-decode\` — expect plan to reach \`complete\` after the QA-recovery cycle drives a fix (or exhaust the cycle budget cleanly if gemini-pro stays flaky)

## Reviewed via go-reviewer pass twice

First pass flagged:
- KV scan should use deterministic key → addressed with direct \`Get\` + \`isKVNotFound\` helper
- \`recoveryRestarts\` budget escape → addressed with \`countAcceptedRecoveryCyclesForReq\`
- Dead \`_ = msgCtx\` → removed; \`msgCtx\` is now used for both KV calls
- Two-caller docstring on \`resumeFromRecoveryLocked\` → added
- Test #2 didn't actually call the function → rewrote to exercise the wrapper

Second pass approved with "ship it."

## Filed separately

- \`isKVNotFound\` helper duplicates the pattern at \`question-manager/component.go:258, 310\` — worth a follow-up consolidation.
- KV access style is mixed in the new file (\`NewKVStore\` vs direct \`js.KeyValue\`) — prefer the wrapped path everywhere for circuit-breaker coverage; doesn't change behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)