### PR TITLE
docs(harness): align ownership prose with ADR-039 services rendering

### DIFF
--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -137,7 +137,7 @@ plan at creation so policy changes don't retroactively affect in-flight work.
 | `none` | — | No QA gate; plan goes straight to `complete` | Doc-only hotfixes |
 | `synthesis` | qa-reviewer only | LLM verdict on plan artifacts, no test execution | Default; fast, content-based check |
 | `unit` | sandbox | `go test ./...` (or language default) against the merged worktree | Most projects |
-| `integration` | qa-runner + `act` | `.github/workflows/qa.yml` job `integration` — typically tagged integration tests with real service dependencies started by test code | Projects with integration suites |
+| `integration` | qa-runner + `act` | `.github/workflows/qa.yml` job `integration` — tagged integration tests against real service dependencies. Per ADR-039 the catalog `services`-class profiles render as qa.yml `services:` blocks brought up by qa-runner; `testcontainers` and `pure-fixture` profiles are started by the test code itself. | Projects with integration suites |
 | `full` | qa-runner + `act` | Both `integration` + `e2e` jobs — adds Playwright browser flows | Projects with UI + browser tests |
 
 Configure via `.semspec/project.json`:
@@ -164,10 +164,26 @@ container semspec uses for per-task structural validation. **qa-runner**
 (level=integration/full) invokes nektos/act against `.github/workflows/qa.yml`
 using the host Docker daemon via a mounted socket — tests run in real GitHub
 Actions runner images (catthehacker/ubuntu:act-latest). The qa.yml template is
-scaffolded by `POST /project-manager/init` when missing. Catalog-backed harness
-profiles are test-code responsibilities: start SITL, databases, brokers, or other
-fixtures from the project tests (for example via Testcontainers) rather than
-adding GitHub Actions `services:` entries for semspec-owned profiles.
+scaffolded by `POST /project-manager/init` when missing.
+
+Catalog-backed harness profiles split into three orchestration types
+(`harnesscatalog.Profile.Orchestration`, per ADR-039):
+
+- **`services`** — heavy or persistent integration peers (e.g. PX4 SITL via
+  `mavlink.px4-sitl.mavsdk-smoke`). Plan-manager renders `services:` blocks
+  into qa.yml from the catalog entry's `images`, `ports`, `env`, and
+  `readiness` fields. qa-runner brings the stack up; **tests are consumers**
+  that read the endpoint from the env qa-runner injects and never start the
+  service themselves.
+- **`testcontainers`** — lightweight per-test fixtures the test code spins
+  up via the Testcontainers library (uses the docker socket act mounts into
+  runner containers). No qa.yml-level `services:` blocks needed.
+- **`pure-fixture`** — in-process fixtures the test code holds directly.
+
+The structural-validator's `harness-profile-discipline` check verifies the
+dev's tests carry the catalog's required evidence anchors regardless of
+orchestration type. The architect selects profiles by `profile_id`; concrete
+images/ports/env/readiness live in the catalog and render downstream.
 
 Artifacts from every QA run land at `.semspec/qa-artifacts/{plan-slug}/{run-id}/`:
 - `act.log` — combined act stdout+stderr

--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -466,11 +466,14 @@ func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow
 // level=unit        → StatusReadyForQA (sandbox runs project tests first)
 // level=integration → StatusReadyForQA (qa-runner via act in a clean-room
 //
-//	runner; dev's TDD already exercised the same tests
-//	against Testcontainers-spawned services in the
-//	sandbox — this is the reproducibility gate that
-//	catches "passes with dev's working state, fails
-//	fresh checkout" cases)
+//	runner against the rendered .github/workflows/qa.yml.
+//	Per ADR-039, services-class harness profiles render
+//	as qa.yml services: blocks from the catalog and
+//	qa-runner brings them up. For testcontainers-class
+//	profiles dev's TDD already exercised them via the
+//	docker socket mounted on the sandbox, so qa-runner
+//	doubles as a reproducibility gate catching "passes
+//	with dev's working state, fails fresh checkout" cases.)
 //
 // level=full        → StatusReadyForQA (qa-runner runs the integration
 //
@@ -478,11 +481,13 @@ func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow
 //	adding Playwright/browser flows on top of
 //	integration tests)
 //
-// The Testcontainers-led integration tier (2026-05-15) means dev's
-// TDD loop is already exercising real upstream services via the docker
-// socket mounted on the sandbox; qa-runner is the second, clean-room
-// run that catches sandbox-state leakage. Both layers exercise the
-// same test code — the difference is the execution environment.
+// Two integration models coexist on the same qa.yml:
+//   - services-class profiles (e.g. PX4 SITL via
+//     mavlink.px4-sitl.mavsdk-smoke) introduce real services FIRST at
+//     qa-runner — dev never saw them. ADR-039 wires the rendering.
+//   - testcontainers-class profiles run in dev's TDD via the docker
+//     socket AND again at qa-runner as a reproducibility check.
+// Orchestration type lives on the catalog Profile (ADR-039 Phase 1a).
 //
 // qa-reviewer owns the ready_for_qa → reviewing_qa transition via
 // plan.mutation.qa.start, mirroring plan-reviewer's mutation-driven shape.

--- a/processor/project-manager/qa_workflow.go
+++ b/processor/project-manager/qa_workflow.go
@@ -36,7 +36,7 @@ func EnsureQAWorkflow(workspacePath string, projectConfig *workflow.ProjectConfi
 		return fmt.Errorf("write qa.yml: %w", err)
 	}
 	if logger != nil {
-		logger.Info("Scaffolded default QA workflow — keep catalog harness orchestration in project tests",
+		logger.Info("Scaffolded default QA workflow — services-class harness profiles render as qa.yml services from the catalog (ADR-039); testcontainers and pure-fixture profiles stay in project test code",
 			"path", workflowPath, "language", primaryLanguage(projectConfig))
 	}
 	return nil
@@ -62,11 +62,18 @@ type Logger interface {
 // absence of --job filter). qa-runner uses --job integration at
 // qa_level=integration to skip the e2e job for faster feedback.
 //
-// Note: Testcontainers usage doesn't need any qa.yml-level service
-// declaration — the dev's test code spins up containers via the
-// Testcontainers library, which uses the docker socket that act
-// mounts into runner containers. The qa.yml just needs the language
-// toolchain + the test command.
+// Note: harness profiles split into three orchestration types (see
+// prompt/domain/software_render.go:harnessProfilesIntro and ADR-039):
+//   - services: qa-runner renders services: blocks into qa.yml from
+//     the catalog (images/ports/env/readiness). Tests are consumers
+//     that read the endpoint from the env qa-runner injects.
+//   - testcontainers: dev's test code spins up containers via the
+//     Testcontainers library, which uses the docker socket act mounts
+//     into runner containers. No qa.yml-level services: needed.
+//   - pure-fixture: dev's test code holds the fixture directly.
+// This default template ships the language toolchain + test command;
+// services-class blocks are injected later by plan-manager rendering
+// from the architecture's selected harness_profiles[].
 func BuildQAWorkflow(pc *workflow.ProjectConfig) string {
 	switch primaryLanguage(pc) {
 	case "Java", "Kotlin":
@@ -115,10 +122,14 @@ func javaQAWorkflow(pc *workflow.ProjectConfig) string {
 # integration: runs at qa_level=integration AND qa_level=full.
 # e2e:         runs at qa_level=full only (Playwright browser flows).
 #
-# Testcontainers usage in test code does not require services: blocks
-# here — the dev's tests spawn containers via the Testcontainers
-# library, which uses the docker socket that act mounts into runner
-# containers.
+# Harness profiles split into three orchestration types (ADR-039):
+#   - services: qa-runner renders services: blocks into this file from
+#     the catalog. Tests read the endpoint from the env qa-runner injects.
+#   - testcontainers: tests spawn containers via the Testcontainers
+#     library (uses the docker socket act mounts into runner containers).
+#   - pure-fixture: tests hold the fixture directly.
+# This default scaffold ships the toolchain + test command; services-class
+# blocks are injected by plan-manager from architecture.harness_profiles[].
 on: [push, pull_request]
 jobs:
   integration:
@@ -279,9 +290,18 @@ func goQAWorkflow(pc *workflow.ProjectConfig) string {
 # qa_level=integration so the e2e job is skipped for faster feedback. At
 # qa_level=full act runs the full workflow, exercising both jobs.
 #
-# Catalog harness profiles are test-code responsibilities, not GitHub Actions
-# services: entries. Keep Testcontainers/SITL orchestration in the project test
-# suite so qa-runner, act, and GitHub-hosted runners execute the same path.
+# Harness profiles split into three orchestration types (ADR-039):
+#   - services: qa-runner renders services: blocks into this file from
+#     the catalog (e.g. PX4 SITL via mavlink.px4-sitl.mavsdk-smoke).
+#     Tests are consumers; they read the endpoint from the env qa-runner
+#     injects, never start the service themselves.
+#   - testcontainers: tests spawn containers via the Testcontainers
+#     library (uses the docker socket act mounts into runner containers).
+#   - pure-fixture: tests hold the fixture directly.
+# qa-runner, act, and GitHub-hosted runners all execute the same rendered
+# file — services-class blocks come from plan-manager rendering the
+# architecture's harness_profiles[]; testcontainers and pure-fixture stay
+# in the project test suite.
 on: [push, pull_request]
 jobs:
   integration:

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -138,8 +138,12 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// Catalog-backed harness profile discipline check — fires whenever modified
 	// files include test files in ANY supported language (not just Go).
 	// Verifies that selected required catalog profiles are evidenced by the
-	// dev's tests. The catalog owns images, ports, readiness, and assertions;
-	// qa.yml remains generic and project tests own Testcontainers/SITL startup.
+	// dev's tests. The catalog owns images, ports, readiness, and assertions.
+	// Per ADR-039, services-class profiles render as qa.yml services: blocks
+	// from the catalog (qa-runner brings the stack up; tests are consumers).
+	// testcontainers-class and pure-fixture profiles stay in project test code.
+	// This check is orchestration-agnostic: it verifies the dev's tests carry
+	// the required evidence anchors regardless of who starts the services.
 	// Loads selections from .semspec/plans/<slug>/plan.json on disk;
 	// greenfield projects (no architecture) trivially pass.
 	if len(filterTestFiles(trigger.FilesModified)) > 0 {


### PR DESCRIPTION
## Summary

- Fixes #39 — four files (seven sites) describing harness profiles as test-code-only responsibilities now distinguish the three orchestration types (`services` / `testcontainers` / `pure-fixture`) per ADR-039.
- The codebase already had the right vocabulary at `prompt/domain/software_render.go:636` (`harnessProfilesIntro`, landed via ADR-039 Phase 1a / PR #23). This PR aligns the laggard files to that anchor.
- No behavior change. The industry-vocab rename (harness_profile → "test environment", evidence anchors → "required test assertions", qa_level → "test depth", etc.) is out of scope and deferred to ADR-041.

## Why this PR is small and ships now

The worst contradiction sites were inside `project-manager`'s scaffolded `qa.yml` template — every new semspec project picks up `.github/workflows/qa.yml` with comment blocks telling devs to "keep Testcontainers/SITL orchestration in the project test suite," directly contradicting ADR-039's "qa-runner renders services from the catalog." That seam is the upstream of the run-#3 / mavlink-hard non-convergence pattern (issue #37): the dev persona reads the stale qa.yml comments, the req-reviewer reads the scenarios written against ADR-039's services-class model, they argue past each other because the codebase is arguing with itself.

Decks-clearing before ADR-041 lands so the new structural work doesn't inherit the contradiction.

## Files changed

| File | Change |
|---|---|
| `processor/project-manager/qa_workflow.go` | Log msg + 3 comment blocks (1 Go code, 2 scaffolded qa.yml templates for Java + Go) now distinguish all three orchestration types |
| `processor/structural-validator/executor.go` | `harness-profile-discipline` check comment notes it's orchestration-agnostic; points to ADR-039 for who starts services |
| `processor/plan-manager/execution_events.go` | `targetForQALevel` comment block replaces single-tier "Testcontainers-led integration tier (2026-05-15)" framing with two-model coexistence |
| `docs/project-setup.md` | QA tier table row + post-table paragraph describe all three orchestration types |

Sponsor packs (`docs/sponsor-packages/{take-30,mavlink-decode-2026-05-28}`) intentionally untouched — frozen historical artifacts.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./processor/project-manager/` ok
- [x] `go test ./processor/structural-validator/` ok
- [x] `go test ./processor/plan-manager/` ok
- [x] Grep verification — zero hits across `processor/`, `docs/project-setup.md`, `docs/adr/`, `prompt/` for the six old-shape phrases:
  - `test-code responsibilit`
  - `Testcontainers-led integration tier`
  - `harness orchestration in project tests`
  - `project tests own.*SITL`
  - `tests.*start SITL`
  - `Catalog harness profiles are test-code`

## Related

- Issue #39 (this PR's tracking issue)
- Issue #37 (req-reviewer non-convergent rejections — the downstream symptom this contradiction enables)
- Issue #36 (combinatorial retry budget — the money-burn enabler)
- ADR-039 (the source of truth being contradicted)
- ADR-040 PR #23 (introduced the `Orchestration` field that made the three-way distinction possible)
- ADR-041 (proposed; will land the bigger industry-vocab rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)