### PR TITLE
chore(vocab): soft rename to industry CI/CD vocabulary on user-facing surfaces

### DIFF
--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -166,8 +166,8 @@ using the host Docker daemon via a mounted socket — tests run in real GitHub
 Actions runner images (catthehacker/ubuntu:act-latest). The qa.yml template is
 scaffolded by `POST /project-manager/init` when missing.
 
-Catalog-backed harness profiles split into three orchestration types
-(`harnesscatalog.Profile.Orchestration`, per ADR-039):
+Catalog-backed **test environment profiles** split into three orchestration
+types (`harnesscatalog.Profile.Orchestration` in code, per ADR-039):
 
 - **`services`** — heavy or persistent integration peers (e.g. PX4 SITL via
   `mavlink.px4-sitl.mavsdk-smoke`). Plan-manager renders `services:` blocks
@@ -180,10 +180,18 @@ Catalog-backed harness profiles split into three orchestration types
   runner containers). No qa.yml-level `services:` blocks needed.
 - **`pure-fixture`** — in-process fixtures the test code holds directly.
 
-The structural-validator's `harness-profile-discipline` check verifies the
-dev's tests carry the catalog's required evidence anchors regardless of
-orchestration type. The architect selects profiles by `profile_id`; concrete
-images/ports/env/readiness live in the catalog and render downstream.
+The structural-validator's pre-merge test-environment-discipline check
+verifies the dev's tests carry the catalog's required test assertions
+regardless of orchestration type. The architect selects a profile by
+`profile_id`; concrete images/ports/env/readiness live in the catalog
+and render downstream.
+
+> **Vocabulary note**: code keeps the precise type names
+> (`harnesscatalog.Profile`, `harness_profiles[]`, `EvidenceAnchors`) because
+> they're load-bearing for the catalog wire format. User-facing prose calls
+> them "test environment profiles" and "required test assertions" to match
+> standard CI/CD vocabulary. ADR-041 will land the structural surface that
+> makes this distinction the canonical user-facing framing.
 
 Artifacts from every QA run land at `.semspec/qa-artifacts/{plan-slug}/{run-id}/`:
 - `act.log` — combined act stdout+stderr

--- a/docs/real-llm-expectations.md
+++ b/docs/real-llm-expectations.md
@@ -98,9 +98,10 @@ What changed between the two runs was structural, not model-side:
 
 - `GITHUB_TOKEN` passthrough so the sandbox can authenticate against
   GitHub Packages.
-- Architect schema gained `role` + `harness_profiles` fields so integration
-  targets must be declared, not assumed.
-- Three deterministic detectors (harness profile completeness check,
+- Architect schema gained `role` + `harness_profiles` fields (test
+  environment profile selections) so integration targets must be declared,
+  not assumed.
+- Three deterministic detectors (test environment profile completeness check,
   dev-test/integration-target cross-check, stub-jar size detector)
   added as regression guards.
 
@@ -172,8 +173,8 @@ data will produce the first defensible cost figure.
 
 ### Detector firing rate unknown
 
-The three fabrication detectors (harness profile completeness, dev-test
-cross-check, stub-jar size) were added as regression guards. They
+The three fabrication detectors (test environment profile completeness,
+dev-test cross-check, stub-jar size) were added as regression guards. They
 didn't fire on take-30. We have not yet deliberately introduced a
 fabrication vector to confirm they trigger. That's the next
 meaningful experiment in the defense-in-depth direction.

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -143,7 +143,7 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// from the catalog (qa-runner brings the stack up; tests are consumers).
 	// testcontainers-class and pure-fixture profiles stay in project test code.
 	// This check is orchestration-agnostic: it verifies the dev's tests carry
-	// the required evidence anchors regardless of who starts the services.
+	// the required test assertions regardless of who starts the services.
 	// Loads selections from .semspec/plans/<slug>/plan.json on disk;
 	// greenfield projects (no architecture) trivially pass.
 	if len(filterTestFiles(trigger.FilesModified)) > 0 {

--- a/processor/structural-validator/testcontainers_discipline.go
+++ b/processor/structural-validator/testcontainers_discipline.go
@@ -26,14 +26,14 @@ import (
 // Unknown profile IDs and missing required-profile evidence are hard failures.
 func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selections []workflow.HarnessProfileSelection, catalog *harnesscatalog.Catalog) payloads.CheckResult {
 	if len(selections) == 0 {
-		return passHarnessResult("no harness profiles selected — nothing to enforce")
+		return passHarnessResult("no test environment profiles selected — nothing to enforce")
 	}
 	required, err := catalog.RequiredProfiles(selections)
 	if err != nil {
 		return failHarnessResult(err.Error())
 	}
 	if len(required) == 0 {
-		return passHarnessResult("no required harness profiles selected — compatibility/heavy profiles are advisory")
+		return passHarnessResult("no required test environment profiles selected — compatibility/heavy profiles are advisory")
 	}
 
 	testFiles := filterTestFiles(filesModified)
@@ -57,7 +57,7 @@ func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selec
 			Passed:   true,
 			Required: true,
 			Command:  "harness-profile-discipline (internal)",
-			Stdout:   fmt.Sprintf("required harness profiles covered in modified tests: %d", len(required)),
+			Stdout:   fmt.Sprintf("required test environment profiles covered in modified tests: %d", len(required)),
 		}
 	}
 
@@ -179,7 +179,7 @@ func missingEvidenceAnchors(contents []string, anchors []string) []string {
 }
 
 func formatHarnessViolation(r harnesscatalog.ResolvedSelection, missing []string) string {
-	return fmt.Sprintf("required harness profile %q is selected but no modified test file contains required evidence anchors: %s",
+	return fmt.Sprintf("required test environment profile %q is selected but no modified test file contains required test assertions: %s",
 		r.Profile.ID, strings.Join(quoteStrings(missing), ", "))
 }
 

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -327,7 +327,7 @@ qa-reviewer judges coverage against this declared surface.`)
 				return ctx.TaskContext != nil && len(ctx.TaskContext.HarnessProfiles) > 0
 			},
 			ContentFunc: func(ctx *prompt.AssemblyContext) string {
-				return renderResolvedHarnessProfiles("HARNESS PROFILES — selected catalog-backed test harness details for this task.", ctx.TaskContext.HarnessProfiles)
+				return renderResolvedHarnessProfiles("TEST ENVIRONMENTS — selected test environment details from the catalog for this task.", ctx.TaskContext.HarnessProfiles)
 			},
 		},
 		{
@@ -1356,7 +1356,7 @@ BEFORE submit_work:
    - apis: at least one APISurface entry naming a symbol the developer will integrate against. Each APISurface MUST have a citation (file path or URL where you verified the signature). Without citations the surface is a guess; resubmit after the missing reads.
    - used_by: names of component_boundaries entries that depend on this resolution (bidirectional with component_boundaries[].upstream_refs).
    - role: classify how the dep is consumed at test time. "build_dep" = compile-time only (annotation processor, codegen). "runtime_dep" = library/framework called in-process (most cases — the dev imports the JAR/module and tests its methods directly). "integration_target" = a separate process the dev's code talks to over a wire protocol (daemon, broker, database, gRPC service). When you cannot tell, default to "runtime_dep".
-   - integration_target rule: when any resolution uses role == "integration_target", select at least one entry in architecture.harness_profiles[] whose catalog profile covers that target. Use ONLY profile_id values from the "Available test harness profiles" section. Do NOT author images, ports, env, startup order, or readiness here; the catalog owns those details.
+   - integration_target rule: when any resolution uses role == "integration_target", select at least one entry in architecture.harness_profiles[] whose catalog profile covers that target. Use ONLY profile_id values from the "Available test environments" section. Do NOT author images, ports, env, startup order, or readiness here; the catalog owns those details.
    This is the load-bearing rule for upstream-strengthening: the dev no longer needs a research sub-agent because YOU pre-resolved API surfaces and selected a system-owned test harness profile. Take-23 (2026-05-13) wedged at iter=80 with 35 external file reads + 0 worktree writes specifically because architect named OSH classes without resolving their constructor + lifecycle into the deliverable; the dev had to discover them mid-cycle. Take-29 (2026-05-15) hit 9/9 green on hard but with fabricated stub JARs because no integration_target was declared and the reviewer had no anchor to reject mock-based tests.
 
 7. For EVERY component in component_boundaries that depends on an external library: populate component_boundaries[].upstream_refs with the names of the matching upstream_resolutions entries. Bidirectional with upstream_resolutions[].used_by — both sides must agree.

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -592,8 +592,8 @@ func renderArchitectHarnessCards(cards []prompt.HarnessProfileCard) string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString("## Available test harness profiles\n\n")
-	sb.WriteString("Select by profile_id only. These profiles are system-owned; do not invent or copy their images, ports, env vars, startup order, readiness probes, or evidence anchors into the architecture document.\n\n")
+	sb.WriteString("## Available test environments\n\n")
+	sb.WriteString("Select by profile_id only. These test environment profiles are system-owned; do not invent or copy their images, ports, env vars, startup order, readiness probes, or required test assertions into the architecture document.\n\n")
 	for _, card := range cards {
 		fmt.Fprintf(&sb, "### %s\n\n", card.ID)
 		fmt.Fprintf(&sb, "- **Tier:** `%s`\n", card.Tier)

--- a/prompt/domain/software_render_test.go
+++ b/prompt/domain/software_render_test.go
@@ -420,7 +420,7 @@ func TestRenderArchitectPrompt_UsesHarnessProfileCatalogCards(t *testing.T) {
 	})
 
 	required := []string{
-		"Available test harness profiles",
+		"Available test environments",
 		"mavlink.px4-sitl.mavsdk-smoke",
 		"Select by profile_id only",
 		"harness_profiles",

--- a/tools/terminal/schemas.go
+++ b/tools/terminal/schemas.go
@@ -465,13 +465,13 @@ func architectureSchema() map[string]any {
 			},
 			"harness_profiles": map[string]any{
 				"type":        "array",
-				"description": "Catalog-backed test harness profile selections. Populate with profile IDs from the harness catalog only. The catalog owns images, ports, readiness, evidence anchors, and runner compatibility. Emit [] when no integration_target upstreams need a harness.",
+				"description": "Catalog-backed test environment profile selections. Populate with profile IDs from the catalog only. The catalog owns images, ports, readiness, required test assertions, and runner compatibility. Emit [] when no integration_target upstreams need a test environment.",
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
 						"profile_id": map[string]any{
 							"type":        "string",
-							"description": "Stable harness catalog profile ID, for example 'mavlink.px4-sitl.mavsdk-smoke'. Do not invent IDs.",
+							"description": "Stable test environment profile ID from the catalog, for example 'mavlink.px4-sitl.mavsdk-smoke'. Do not invent IDs.",
 						},
 						"used_by": map[string]any{
 							"type":        "array",

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -235,7 +235,7 @@
 			case 'reviewing_scenarios':
 				return 'Reviewing scenarios…';
 			case 'reviewing_qa':
-				return 'Running QA review…';
+				return 'Running tests…';
 			case 'reviewing_rollup':
 				return 'Reviewing rollup…';
 			default:


### PR DESCRIPTION
## Summary

Soft rename to align user-facing surfaces with standard CI/CD vocabulary, per the discussion that surfaced from the mavlink-hard run forensics. Lands before ADR-041 so the structural ADR can be drafted and reviewed in the new vocab from day one.

**Renames (user-facing surfaces only):**
- "harness profile" / "catalog-backed harness profile" → "test environment profile"
- "evidence anchors" → "required test assertions"
- UI stage label `reviewing_qa` → "Running tests…" (was "Running QA review…")

**Preserved (internal precision):**
- Go type names: `harnesscatalog.Profile`, `workflow.HarnessProfileSelection`, `Profile.EvidenceAnchors`
- JSON wire field names: `architecture.harness_profiles[]`, `profile_id`, etc.
- Component identifiers: `harness-profile-discipline` check name (operator-stable)
- Workflow status enum values: `reviewing_qa`, `ready_for_qa` (wire-compat)
- Persona names: `qa-reviewer`, `qa-runner`, Murat — BMAD-aligned (ADR-030)
- Historical records: ADR-039, ADR-038, ADR-040, sponsor packs (frozen)

The vocabulary disconnect between user-facing prose ("test environment profile") and internal wire fields (`harness_profiles[]` in plan JSON) is intentional and documented in `docs/project-setup.md` with a forward reference to the future hard-rename PR.

## Stack

Based on `fix/harness-ownership-docs-code-alignment` (PR #40 — docs/code harness ownership alignment). Will rebase to main after PR #40 merges.

## Why ship this before ADR-041

ADR-041 will introduce the test evidence ladder + scenario tag classifier + plan-reviewer rules for tier-aware test obligations. Writing that ADR against the new vocabulary keeps the doc clean and avoids the "what ADR-038 called X, now called Y" pattern. The rename is mechanical, no semantic change — easy to ship and verify in isolation.

## Out of scope (separate follow-up PRs)

- **Wire-field hard rename**: `architecture.harness_profiles[]` → `test_environments[]`, etc. Breaking for existing plan files; needs schema migration handling with unmarshal aliases. Separate PR after this soft rename has been exercised in real runs.
- **`qa_level` → `test_depth`**: tangles with the QA persona/component name we agreed to keep. Cleanest handled in its own small PR alongside ADR-041 structural work.
- **Rule 7b in `software_render.go:1024`** (plan-reviewer "Integration-target harness profile discipline"): complex interlocking rule with many JSON wire references in its body. The rule will be rewritten for the tier-aware scenario model in ADR-041's implementation — vocabulary update lands there as a natural side effect of that rewrite.

## Files changed

| File | Change |
|---|---|
| `docs/project-setup.md` | Test environment profile prose + new vocabulary note documenting the intentional code/prose split |
| `docs/real-llm-expectations.md` | Three prose references to detectors renamed |
| `prompt/domain/software_render.go` | Architect-facing section header "Available test environments" + intro prose |
| `prompt/domain/software.go` | Developer-facing section title "TEST ENVIRONMENTS"; section back-reference updated to match |
| `prompt/domain/software_render_test.go` | Test expectation aligned with new section header |
| `tools/terminal/schemas.go` | LLM-facing JSON schema description for `architecture.harness_profiles[]` field (the JSON field name itself stays) |
| `processor/structural-validator/testcontainers_discipline.go` | Four user-visible `CheckResult.Stdout` messages renamed |
| `processor/structural-validator/executor.go` | PR #40 comment about "required evidence anchors" updated to "required test assertions" for vocab consistency |
| `ui/src/routes/plans/[slug]/+page.svelte` | Stage label for `reviewing_qa` |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` no failures
- [x] `npm run check` in ui/: 0 errors, 3 pre-existing autofocus warnings (not from this PR)
- [x] One test assertion updated to match new section header (`TestRenderArchitectPrompt_UsesHarnessProfileCatalogCards`)

## Related

- PR #40 (base — docs/code harness ownership alignment)
- Issue #39 (this PR sits one layer above the contradiction fix)
- ADR-041 (forthcoming — test evidence ladder + scenario tags; this PR sets the vocab the ADR will be drafted in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)