### PR TITLE
fix(requirement-executor): reset RetryCount on recovery resume (#36)

### DIFF
--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -171,8 +171,39 @@ func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirem
 	exec.terminated = false
 	exec.recoveryRestarts++
 
-	// Reset DAG state — like restructure, but without incrementing the
-	// normal RetryCount. Recovery restart is out-of-band budget.
+	// Reset DAG state AND per-recovery retry budget. Each recovery
+	// resumption is a fresh shot at the requirement — re-decompose, retry
+	// up to MaxRequirementRetries again. recoveryRestarts is the outer cap
+	// (incremented above); RetryCount is the inner per-recovery budget.
+	//
+	// Before issue #36 fix (2026-05-31): RetryCount was preserved across
+	// resumptions, which meant every recovery resume immediately exhausted
+	// on the first req-review attempt (RetryCount=2 >= MaxRetries=2 fired
+	// at L1650 of component.go before any meaningful work) and deferred
+	// back to recovery — wasting an outer budget slot per cycle. Each
+	// recovery then yielded only 1 round of (impl+test+req-review) before
+	// the next defer, defeating the point of giving the requirement
+	// another chance.
+	//
+	// Reset semantics matches restructure (startRestructureRetryLocked at
+	// component.go:1835), which already starts fresh; recovery resumption
+	// is conceptually identical (wipe everything, start over with feedback)
+	// except that recovery is human/auto-decision-driven rather than
+	// reviewer-verdict-driven.
+	//
+	// Worst-case cycle math after this fix:
+	//   - Per recovery: (1 initial + MaxRequirementRetries fixable retries)
+	//     × max_tdd_cycles per node = 3 × 5 = 15 dev dispatches with
+	//     default config
+	//   - Across recoveries: × (1 + MaxRecoveryRestarts) = × 3 = 45
+	//     dev dispatches lifetime max
+	// Operators concerned about worst-case spend should lower
+	// max_recovery_restarts (default 1; hybrid-gpt5 uses 2). A future
+	// PR may add a stuck-pattern detector (consecutive identical
+	// reviewer verdicts → human gate) as defense-in-depth, but the
+	// underlying non-convergence is fixed structurally by ADR-041 — the
+	// req-reviewer's tier-aware contract makes the run-#3-shape
+	// failure mode impossible.
 	exec.DAG = nil
 	exec.SortedNodeIDs = nil
 	exec.NodeIndex = nil
@@ -184,6 +215,7 @@ func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirem
 	exec.ReviewVerdict = ""
 	exec.ReviewFeedback = ""
 	exec.ReviewRetryCount = 0
+	exec.RetryCount = 0
 	exec.ScenarioVerdicts = nil
 
 	if c.sandbox != nil && exec.RequirementBranch != "" {

--- a/processor/requirement-executor/awaiting_recovery_test.go
+++ b/processor/requirement-executor/awaiting_recovery_test.go
@@ -231,6 +231,53 @@ func TestResumeFromRecoveryLocked_ClearsAwaitingAndIncrementsRestarts(t *testing
 	}
 }
 
+// Issue #36: prior to the fix, resumeFromRecoveryLocked preserved
+// exec.RetryCount, which meant every recovery resume exhausted on the
+// first req-review attempt (RetryCount >= MaxRetries fired immediately)
+// and deferred back to recovery — wasting outer budget. Verify the
+// per-recovery retry budget is reset to 0 on resume so each recovery
+// gets a real chance at the requirement before the next exhaustion.
+//
+// Mavlink-hard run 2026-05-31 surfaced this empirically: 4
+// implement-lifecycle attempts + 3 test-lifecycle + 1 unknown + 2
+// requirement-rev worktrees observed in the sandbox, with ~$40-50
+// burned on a single requirement before operator kill.
+func TestResumeFromRecoveryLocked_ResetsRetryCount(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-rc", "req-rc")
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	// Simulate having burned the per-recovery budget before the resume.
+	exec.RetryCount = 2
+	exec.MaxRetries = 2
+	exec.ReviewRetryCount = 1
+
+	exec.mu.Lock()
+	_ = c.deferToAwaitingRecoveryLocked(context.Background(), exec, "exhausted")
+	exec.mu.Unlock()
+
+	if !exec.awaitingRecovery {
+		t.Fatal("precondition: exec should be awaiting recovery")
+	}
+
+	exec.mu.Lock()
+	c.resumeFromRecoveryLocked(context.Background(), exec)
+	exec.mu.Unlock()
+
+	if exec.RetryCount != 0 {
+		t.Errorf("exec.RetryCount = %d, want 0 (per-recovery budget reset on resume)", exec.RetryCount)
+	}
+	if exec.MaxRetries != 2 {
+		t.Errorf("exec.MaxRetries = %d, want 2 (operator-config budget cap preserved)", exec.MaxRetries)
+	}
+	if exec.ReviewRetryCount != 0 {
+		t.Errorf("exec.ReviewRetryCount = %d, want 0 (reviewer parse-retry budget reset on resume)", exec.ReviewRetryCount)
+	}
+	if exec.recoveryRestarts != 1 {
+		t.Errorf("exec.recoveryRestarts = %d, want 1 (outer recovery budget incremented)", exec.recoveryRestarts)
+	}
+}
+
 // Idempotent timeout: when resume already cleared awaitingRecovery, a
 // late-firing timer must not increment failed-counter or transition
 // state again.


### PR DESCRIPTION
## Summary

Fixes #36 — the combinatorial retry budget burn that produced ~\$40-50 of paid LLM cost on a single requirement during the mavlink-hard run on 2026-05-31.

**One-line behavioral change** in `processor/requirement-executor/awaiting_recovery.go:resumeFromRecoveryLocked`: add `exec.RetryCount = 0` to the recovery-resume reset block. Each recovery resumption now gets a fresh per-recovery fixable-retry budget, matching the semantics of `startRestructureRetryLocked` (which already does a full reset).

Outer budget (`recoveryRestarts` vs `max_recovery_restarts`) unchanged — it remains the operator-configured cap on total recovery attempts.

## What broke before

```
Round 1 (RetryCount=0): impl + test + req-review = 3 cycles, exhausts at 2
Recovery 1: DAG wiped, RetryCount preserved at 2 → first req-review
  immediately exhausts (RetryCount=2 >= MaxRetries=2 at
  component.go:1650) → defers back to recovery, wasting an outer slot
Recovery 2: same — 1 wasted cycle, defers
Recovery cap (max_recovery_restarts=2): markFailedLocked
```

Mavlink-hard run on 2026-05-31 surfaced this empirically: 4 implement-lifecycle + 3 test-lifecycle + 1 unknown + 2 requirement-rev worktrees observed, ~\$40-50 burned on req 1 alone with 3 more requirements untouched at operator kill.

## What's different after

```
Round 1 (RetryCount=0): impl + test + req-review = up to 3 cycles
If exhausted → defer → auto-accept-recovery resumes with RetryCount=0
Recovery 1 (recoveryRestarts=1, RetryCount=0): full fresh budget = up to 3 cycles
Recovery 2 (recoveryRestarts=2, RetryCount=0): full fresh budget = up to 3 cycles
Recovery cap (max_recovery_restarts=2): markFailedLocked
```

## Trade-off (documented in the code comment)

Worst-case cycle math:
- **Before fix:** ~5 (impl+test+req-review) cycles before final fail
- **After fix:** up to 9 (impl+test+req-review) cycles before final fail (3 × (1 + max_recovery_restarts))

This is WORSE worst-case but DRAMATICALLY better average case — each recovery now has a real budget to fix the issue rather than burning an outer slot on the first immediate exhaustion.

**Operators concerned about worst-case spend** should lower `max_recovery_restarts` (default 1; hybrid-gpt5 config uses 2). The hybrid-gpt5 fixture's choice of 2 was made before this fix's semantics existed; you might want to dial it back to 1 once this lands.

## Why this PR alone isn't the full fix

The underlying non-convergence in the mavlink-hard run (issue #37) is the req-reviewer demanding integration-tier validation in a unit-tier sandbox. **Without ADR-041 (PR #42), the req-reviewer keeps rejecting integration-tier behavior the dev sandbox can't observe**, so no amount of retry budget tuning would help.

This PR is a budget-correctness fix that makes the operator's `max_recovery_restarts` setting actually meaningful. **ADR-041 is the load-bearing structural fix** for the run-#3-shape non-convergence pattern.

## Deferred follow-ups

A future PR may add:
- **Stuck-pattern detector**: consecutive identical reviewer verdicts → human-gated PlanDecision (defense-in-depth even when ADR-041 is in place)
- **Lifetime cycle cap**: separate `MaxLifetimeRetries` config that survives recovery resumption (alternative to the multiplicative budget)

Both are out of scope here — small contained PR principle.

## Test plan

- [x] New test `TestResumeFromRecoveryLocked_ResetsRetryCount` asserts `RetryCount=0` + `ReviewRetryCount=0` after resume while `MaxRetries` is preserved and `recoveryRestarts` is incremented
- [x] Existing tests pass: `TestResumeFromRecoveryLocked_ClearsAwaitingAndIncrementsRestarts`, `TestRecoveryTimeout_NoOpAfterResume`, `TestDeferToAwaitingRecoveryLocked_*` family, `TestFindAwaitingByRequirement`
- [x] `go build ./...` clean
- [x] `go test -count=1 ./processor/requirement-executor/` ok

## Related

- Issue #36 (this fix)
- Issue #37 (root-cause non-convergence — fixed structurally by ADR-041)
- PR #42 (ADR-041 proposed)
- Mavlink-hard run forensics: `/tmp/semspec-watch-hybrid-gpt5-mavlink-hard-20260530-195642/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)