### PR TITLE
feat(workflow): scenario tier tags + harness binding + capability surfaces (ADR-041 PR 1)

### DIFF
--- a/model/registry.go
+++ b/model/registry.go
@@ -205,11 +205,11 @@ func NewDefaultRegistry() *Registry {
 // Resolve returns the preferred model for a capability.
 // Returns the first model in the preferred list.
 // Fallback handling is done by agentic-model on failure (lazy approach).
-func (r *Registry) Resolve(cap Capability) string {
+func (r *Registry) Resolve(c Capability) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if cfg, ok := r.capabilities[cap]; ok && len(cfg.Preferred) > 0 {
+	if cfg, ok := r.capabilities[c]; ok && len(cfg.Preferred) > 0 {
 		return cfg.Preferred[0]
 	}
 	return r.defaults.Model
@@ -217,11 +217,11 @@ func (r *Registry) Resolve(cap Capability) string {
 
 // GetFallbackChain returns all models for a capability in order of preference.
 // Used by agentic-model when primary fails to try alternatives.
-func (r *Registry) GetFallbackChain(cap Capability) []string {
+func (r *Registry) GetFallbackChain(c Capability) []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if cfg, ok := r.capabilities[cap]; ok {
+	if cfg, ok := r.capabilities[c]; ok {
 		chain := make([]string, 0, len(cfg.Preferred)+len(cfg.Fallback))
 		chain = append(chain, cfg.Preferred...)
 		chain = append(chain, cfg.Fallback...)
@@ -253,14 +253,14 @@ func (r *Registry) GetEndpoint(modelName string) *EndpointConfig {
 }
 
 // SetCapability updates or adds a capability configuration.
-func (r *Registry) SetCapability(cap Capability, cfg *CapabilityConfig) {
+func (r *Registry) SetCapability(c Capability, cfg *CapabilityConfig) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.capabilities == nil {
 		r.capabilities = make(map[Capability]*CapabilityConfig)
 	}
-	r.capabilities[cap] = cfg
+	r.capabilities[c] = cfg
 }
 
 // SetEndpoint updates or adds an endpoint configuration.
@@ -374,8 +374,8 @@ func (r *Registry) ListEndpoints() []string {
 // GetToolCapableEndpoints returns the fallback chain for a capability,
 // filtered to only endpoints that support tool calling.
 // Returns empty slice if no tool-capable endpoints are available.
-func (r *Registry) GetToolCapableEndpoints(cap Capability) []string {
-	chain := r.GetFallbackChain(cap)
+func (r *Registry) GetToolCapableEndpoints(c Capability) []string {
+	chain := r.GetFallbackChain(c)
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/processor/execution-manager/loop_completions.go
+++ b/processor/execution-manager/loop_completions.go
@@ -348,9 +348,9 @@ func buildLoopFailureFeedback(event *agentic.LoopCompletedEvent) string {
 	// tool. Substring match against the semstreams error string
 	// ("max iterations (50) reached" / similar).
 	if strings.Contains(errMsg, "max iterations") {
-		max := maxIter
-		if max == 0 {
-			max = event.Iterations
+		budget := maxIter
+		if budget == 0 {
+			budget = event.Iterations
 		}
 		return fmt.Sprintf(
 			"Your previous attempt exhausted its iteration budget "+
@@ -361,7 +361,7 @@ func buildLoopFailureFeedback(event *agentic.LoopCompletedEvent) string {
 				"and any output. If you are stuck or uncertain, call "+
 				"submit_work with a partial summary that explicitly "+
 				"describes the obstacle — do not keep refining.",
-			event.Iterations, max,
+			event.Iterations, budget,
 		)
 	}
 

--- a/processor/plan-reviewer/component.go
+++ b/processor/plan-reviewer/component.go
@@ -716,13 +716,13 @@ func (c *Component) emitParseIncident(ctx context.Context, role, loopID, model, 
 // truncatePreview collapses newlines and bounds length so a model
 // response can be embedded in a single structured-log field without
 // blowing the log shipper. Empty input returns empty.
-func truncatePreview(s string, max int) string {
-	if max <= 0 || len(s) == 0 {
+func truncatePreview(s string, maxBytes int) string {
+	if maxBytes <= 0 || len(s) == 0 {
 		return ""
 	}
 	out := strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " ")
-	if len(out) > max {
-		out = out[:max] + "…"
+	if len(out) > maxBytes {
+		out = out[:maxBytes] + "…"
 	}
 	return out
 }

--- a/processor/qa-reviewer/component.go
+++ b/processor/qa-reviewer/component.go
@@ -1004,13 +1004,13 @@ func (c *Component) emitParseIncident(ctx context.Context, role, loopID, model, 
 // suitable for embedding in a structured log field. Newlines collapse
 // to spaces so the WARN line stays parseable; max bounds the bytes so
 // 50KB model dumps don't blow the log shipper.
-func truncatePreview(s string, max int) string {
-	if max <= 0 || len(s) == 0 {
+func truncatePreview(s string, maxBytes int) string {
+	if maxBytes <= 0 || len(s) == 0 {
 		return ""
 	}
 	out := strings.ReplaceAll(strings.ReplaceAll(s, "\n", " "), "\r", " ")
-	if len(out) > max {
-		out = out[:max] + "…"
+	if len(out) > maxBytes {
+		out = out[:maxBytes] + "…"
 	}
 	return out
 }

--- a/taskfiles/lint.yml
+++ b/taskfiles/lint.yml
@@ -1,5 +1,11 @@
 version: '3'
 
+# Revive version is pinned in CI (.github/workflows/ci.yml installs v1.5.1).
+# Local devs must match — otherwise revive 1.3.9 (or older) misses the
+# Go 1.21+ builtin shadows (max, min, clear) the v1.5.x release catches.
+# Run `go install github.com/mgechev/revive@v1.5.1` if your local version
+# drifts.
+
 tasks:
   default:
     desc: Run Go linters (vet, fmt, revive)
@@ -7,3 +13,8 @@ tasks:
       - go vet ./...
       - go fmt ./...
       - revive -config revive.toml -formatter friendly ./...
+
+  install-revive:
+    desc: Install the pinned revive version (matches CI)
+    cmds:
+      - go install github.com/mgechev/revive@v1.5.1

--- a/vocabulary/semspec/predicates.go
+++ b/vocabulary/semspec/predicates.go
@@ -699,6 +699,13 @@ const (
 	// was imported from. Reserved for ADR-040 Move 4 (inbound import).
 	// Empty for capabilities authored inside semspec.
 	CapabilityExternalSpec = "semspec.capability.external_spec"
+
+	// CapabilitySurface records a user-observable surface the capability
+	// exposes (ADR-041 Move 2). Multi-valued — one triple per surface.
+	// Values: "ui", "api", "background". Populated by the analyst sub-phase
+	// (Mary). The scenario-generator emits @e2e scenarios only for
+	// capabilities whose surfaces include "ui".
+	CapabilitySurface = "semspec.capability.surface"
 )
 
 // Scenario predicates define attributes for behavioral contracts.
@@ -727,6 +734,25 @@ const (
 
 	// ScenarioUpdatedAt is the RFC3339 last update timestamp.
 	ScenarioUpdatedAt = "semspec.scenario.updated_at"
+
+	// ScenarioTag records a tier or facet tag on the scenario (ADR-041 Move 1).
+	// Multi-valued — one triple per tag. Each scenario carries exactly one
+	// tier tag (@unit/@integration/@smoke/@e2e) per ValidateScenarioTags;
+	// additional operator-defined facet tags (@flaky, @security, @slow) pass
+	// through as informational metadata. Tag bodies are alphanumeric + '-'
+	// only — see ADR-041 §"Why colon-bearing tags fail".
+	ScenarioTag = "semspec.scenario.tag"
+
+	// ScenarioHarnessProfile binds the scenario to a harness profile in the
+	// catalog (ADR-041 Move 1). Multi-valued — one triple per bound profile.
+	// Values are catalog profile IDs (e.g. "mavlink.px4-sitl.mavsdk-smoke"),
+	// NOT hashed entity IDs — these are cross-reference strings into the
+	// harnesscatalog, not graph edges to other entities. Plan-reviewer rule
+	// scenario.harness_id_unresolved (Move 4) validates each ID resolves
+	// into the catalog. Underscore in property segment matches the existing
+	// semspec.requirement.depends_on / semspec.capability.depends_on
+	// convention (rev-5 ADR-040 predicate naming).
+	ScenarioHarnessProfile = "semspec.scenario.harness_profile"
 )
 
 // PlanDecision predicates define attributes for mid-stream change proposals.
@@ -1929,6 +1955,11 @@ func registerCapabilityPredicates() {
 		vocabulary.WithDescription("External entity ID this Capability was imported from (ADR-040 Move 4)"),
 		vocabulary.WithDataType("entity_id"),
 		vocabulary.WithIRI(Namespace+"capabilityExternalSpec"))
+
+	vocabulary.Register(CapabilitySurface,
+		vocabulary.WithDescription("User-observable surface this capability exposes (ui/api/background; ADR-041 Move 2)"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"capabilitySurface"))
 }
 
 func registerRequirementPredicates() {
@@ -2038,6 +2069,16 @@ func registerScenarioPredicates() {
 		vocabulary.WithDescription("Last update timestamp (RFC3339)"),
 		vocabulary.WithDataType("datetime"),
 		vocabulary.WithIRI("http://purl.org/dc/terms/modified"))
+
+	vocabulary.Register(ScenarioTag,
+		vocabulary.WithDescription("Tier or facet tag on the scenario (@unit/@integration/@smoke/@e2e or operator-defined facet; ADR-041 Move 1)"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"scenarioTag"))
+
+	vocabulary.Register(ScenarioHarnessProfile,
+		vocabulary.WithDescription("Harness profile ID this scenario binds to (catalog cross-reference; ADR-041 Move 1)"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"scenarioHarnessProfile"))
 }
 
 func registerPlanDecisionPredicates() {

--- a/vocabulary/semspec/predicates_test.go
+++ b/vocabulary/semspec/predicates_test.go
@@ -47,6 +47,10 @@ func TestPredicatesRegistered(t *testing.T) {
 		semspec.CapabilityPlan,
 		semspec.CapabilityDependsOn,
 		semspec.CapabilityExternalSpec,
+		// ADR-041: scenario tag + harness binding + capability surface predicates
+		semspec.CapabilitySurface,
+		semspec.ScenarioTag,
+		semspec.ScenarioHarnessProfile,
 	}
 
 	for _, predicate := range predicates {
@@ -188,10 +192,13 @@ func TestCapabilityPredicateValues(t *testing.T) {
 		{"CapabilityPlan", semspec.CapabilityPlan, "semspec.capability.plan"},
 		{"CapabilityDependsOn", semspec.CapabilityDependsOn, "semspec.capability.depends_on"},
 		{"CapabilityExternalSpec", semspec.CapabilityExternalSpec, "semspec.capability.external_spec"},
+		{"CapabilitySurface", semspec.CapabilitySurface, "semspec.capability.surface"},
 		{"PlanExploration", semspec.PlanExploration, "semspec.plan.exploration"},
 		{"PlanOpenQuestions", semspec.PlanOpenQuestions, "semspec.plan.open_questions"},
 		{"RequirementCapability", semspec.RequirementCapability, "semspec.requirement.capability"},
 		{"RequirementExternalSpec", semspec.RequirementExternalSpec, "semspec.requirement.external_spec"},
+		{"ScenarioTag", semspec.ScenarioTag, "semspec.scenario.tag"},
+		{"ScenarioHarnessProfile", semspec.ScenarioHarnessProfile, "semspec.scenario.harness_profile"},
 	}
 
 	for _, tc := range tests {
@@ -218,6 +225,9 @@ func TestCapabilityPredicatesAreThreePart(t *testing.T) {
 		semspec.CapabilityPlan,
 		semspec.CapabilityDependsOn,
 		semspec.CapabilityExternalSpec,
+		semspec.CapabilitySurface,
+		semspec.ScenarioTag,
+		semspec.ScenarioHarnessProfile,
 	}
 	for _, p := range preds {
 		t.Run(p, func(t *testing.T) {

--- a/workflow/plan_capability.go
+++ b/workflow/plan_capability.go
@@ -73,6 +73,12 @@ func writeCapabilityTriples(ctx context.Context, tw *graphutil.TripleWriter, cap
 	for _, dep := range cap.DependsOn {
 		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDependsOn, HashInstanceID(slug, dep))
 	}
+
+	// Multi-valued surfaces (ADR-041 Move 2). One triple per declared surface;
+	// SurfaceUI is the gate for downstream @e2e scenario emission.
+	for _, surface := range cap.Surfaces {
+		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilitySurface, string(surface))
+	}
 	return nil
 }
 
@@ -100,6 +106,9 @@ func ValidateCapabilitySet(caps []Capability) error {
 		if _, dup := names[caps[i].Name]; dup {
 			return fmt.Errorf("capability %q declared more than once", caps[i].Name)
 		}
+		if err := ValidateCapabilitySurfaces(caps[i]); err != nil {
+			return err
+		}
 		names[caps[i].Name] = struct{}{}
 	}
 	// depends_on resolution + simple cycle detection.
@@ -111,6 +120,27 @@ func ValidateCapabilitySet(caps []Capability) error {
 		}
 	}
 	return detectCapabilityCycle(caps)
+}
+
+// ValidateCapabilitySurfaces enforces that every entry in c.Surfaces resolves
+// to a defined CapabilitySurface constant and that no surface appears more
+// than once. Empty Surfaces is allowed — downstream consumers treat it as
+// "unknown" and default to SurfaceAPI. ADR-041 Move 2.
+func ValidateCapabilitySurfaces(c Capability) error {
+	if len(c.Surfaces) == 0 {
+		return nil
+	}
+	seen := make(map[CapabilitySurface]struct{}, len(c.Surfaces))
+	for i, s := range c.Surfaces {
+		if !s.IsValid() {
+			return fmt.Errorf("capability %q surfaces[%d] %q is not one of ui/api/background", c.Name, i, s)
+		}
+		if _, dup := seen[s]; dup {
+			return fmt.Errorf("capability %q declares surface %q more than once", c.Name, s)
+		}
+		seen[s] = struct{}{}
+	}
+	return nil
 }
 
 // detectCapabilityCycle performs a DFS over the depends_on edges to flag

--- a/workflow/plan_capability.go
+++ b/workflow/plan_capability.go
@@ -52,31 +52,31 @@ func SaveCapabilities(ctx context.Context, tw *graphutil.TripleWriter, explorati
 // writeCapabilityTriples writes the predicate set for a single Capability.
 // Hash each depends_on name into the same EntityID suffix scheme so the
 // stored object resolves back to the corresponding Capability entity.
-func writeCapabilityTriples(ctx context.Context, tw *graphutil.TripleWriter, cap *Capability, slug, planEntityID string) error {
+func writeCapabilityTriples(ctx context.Context, tw *graphutil.TripleWriter, c *Capability, slug, planEntityID string) error {
 	if tw == nil {
 		return nil
 	}
-	entityID := CapabilityEntityID(slug, cap.Name)
+	entityID := CapabilityEntityID(slug, c.Name)
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityName, cap.Name)
-	if err := tw.WriteTriple(ctx, entityID, semspec.CapabilityLifecycle, string(cap.Lifecycle)); err != nil {
+	_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityName, c.Name)
+	if err := tw.WriteTriple(ctx, entityID, semspec.CapabilityLifecycle, string(c.Lifecycle)); err != nil {
 		return fmt.Errorf("write capability lifecycle: %w", err)
 	}
-	if cap.Description != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDescription, cap.Description)
+	if c.Description != "" {
+		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDescription, c.Description)
 	}
 	_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityPlan, planEntityID)
 
 	// Multi-valued depends_on — one triple per edge, value is the hashed
 	// instance ID of the prerequisite Capability (matches the entity-ID
 	// suffix scheme used by RequirementDependsOn).
-	for _, dep := range cap.DependsOn {
+	for _, dep := range c.DependsOn {
 		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDependsOn, HashInstanceID(slug, dep))
 	}
 
 	// Multi-valued surfaces (ADR-041 Move 2). One triple per declared surface;
 	// SurfaceUI is the gate for downstream @e2e scenario emission.
-	for _, surface := range cap.Surfaces {
+	for _, surface := range c.Surfaces {
 		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilitySurface, string(surface))
 	}
 	return nil

--- a/workflow/plan_capability_test.go
+++ b/workflow/plan_capability_test.go
@@ -100,6 +100,87 @@ func TestValidateCapabilitySet(t *testing.T) {
 	}
 }
 
+func TestValidateCapabilitySurfaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		cap     Capability
+		wantErr string
+	}{
+		{
+			name: "empty surfaces is allowed",
+			cap:  Capability{Name: "user-auth", Lifecycle: CapabilityNew},
+		},
+		{
+			name: "single ui surface",
+			cap:  Capability{Name: "user-auth", Lifecycle: CapabilityNew, Surfaces: []CapabilitySurface{SurfaceUI}},
+		},
+		{
+			name: "all three surfaces",
+			cap:  Capability{Name: "mixed", Lifecycle: CapabilityNew, Surfaces: []CapabilitySurface{SurfaceUI, SurfaceAPI, SurfaceBackground}},
+		},
+		{
+			name:    "invalid surface rejected",
+			cap:     Capability{Name: "weird", Lifecycle: CapabilityNew, Surfaces: []CapabilitySurface{"cli"}},
+			wantErr: "not one of ui/api/background",
+		},
+		{
+			name:    "duplicate surface rejected",
+			cap:     Capability{Name: "dup", Lifecycle: CapabilityNew, Surfaces: []CapabilitySurface{SurfaceUI, SurfaceUI}},
+			wantErr: "more than once",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCapabilitySurfaces(tt.cap)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestValidateCapabilitySet_RejectsBadSurfaces guards the wiring between the
+// set-level validator and the per-capability surface validator added in
+// ADR-041 Move 2. Without this, a future refactor that drops the
+// ValidateCapabilitySurfaces call from ValidateCapabilitySet would silently
+// let invalid surfaces through into the graph.
+func TestValidateCapabilitySet_RejectsBadSurfaces(t *testing.T) {
+	caps := []Capability{
+		{Name: "user-auth", Lifecycle: CapabilityNew, Surfaces: []CapabilitySurface{"bogus"}},
+	}
+	err := ValidateCapabilitySet(caps)
+	if err == nil {
+		t.Fatal("expected error for invalid surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "not one of ui/api/background") {
+		t.Errorf("expected surface validation error to bubble up, got: %v", err)
+	}
+}
+
+func TestCapabilitySurface_IsValid(t *testing.T) {
+	for _, s := range []CapabilitySurface{SurfaceUI, SurfaceAPI, SurfaceBackground} {
+		if !s.IsValid() {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	for _, s := range []CapabilitySurface{"", "cli", "tty", "UI"} {
+		if s.IsValid() {
+			t.Errorf("%q should not be valid", s)
+		}
+	}
+}
+
 func TestCapabilityEntityID_UniquenessAcrossPlans(t *testing.T) {
 	// Two different plans declaring the same capability name must get
 	// distinct entity IDs.

--- a/workflow/plan_scenario.go
+++ b/workflow/plan_scenario.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/c360studio/semspec/vocabulary/semspec"
@@ -59,5 +60,102 @@ func writeScenarioTriples(ctx context.Context, tw *graphutil.TripleWriter, s *Sc
 		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioThen, clause)
 	}
 
+	// Tier + facet tags (ADR-041 Move 1). Multi-valued; one triple per tag.
+	for _, tag := range s.Tags {
+		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioTag, tag)
+	}
+
+	// Harness profile bindings (ADR-041 Move 1). Multi-valued; one triple per
+	// bound profile ID. Values are catalog profile IDs (e.g.
+	// "mavlink.px4-sitl.mavsdk-smoke"), not hashed entity IDs — these are
+	// cross-reference strings into the harnesscatalog, not graph edges to
+	// other entities. Plan-reviewer rule scenario.harness_id_unresolved
+	// (Move 4) validates each ID resolves into the catalog.
+	for _, id := range s.HarnessProfileIDs {
+		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioHarnessProfile, id)
+	}
+
+	return nil
+}
+
+// ValidateScenarioTags enforces the structural rules ADR-041 Move 1 places on
+// Scenario.Tags and Scenario.HarnessProfileIDs:
+//
+//  1. Each tag is non-empty, '@'-prefixed, and contains only alphanumeric +
+//     hyphen characters in its body. BDD convention (pytest-bdd rejects '.'
+//     and ':'; behave has compat issues with ':') — see ADR-041 §"Why
+//     colon-bearing tags fail".
+//  2. Exactly one tier tag (@unit/@integration/@smoke/@e2e) is present.
+//     Operator-defined facet tags pass through as informational metadata.
+//  3. No tag appears more than once.
+//  4. Each HarnessProfileID is a non-empty string. Catalog resolution
+//     (scenario.harness_id_unresolved) is the plan-reviewer's job per Move 4,
+//     not this validator's — this layer only enforces the wire shape.
+//
+// Cross-entity rules — "every requirement has @unit", "services-bound
+// requirement has @integration", "@integration scenario needs at least one
+// HarnessProfileID when its architecture binds a services-class profile" —
+// belong to plan-reviewer rules (ADR-041 Move 4), not this per-scenario
+// validator. The scenario-generator (Move 3) emits valid Tags; plan-reviewer
+// gates cross-scenario coverage; the structural-validator (Move 5) gates the
+// dev's test scaffolding against HarnessProfileIDs.
+func ValidateScenarioTags(s Scenario) error {
+	if len(s.Tags) == 0 {
+		return fmt.Errorf("scenario %q has no tags; exactly one tier tag is required", s.ID)
+	}
+	seen := make(map[string]struct{}, len(s.Tags))
+	tierCount := 0
+	for i, tag := range s.Tags {
+		if err := validateTagSyntax(tag); err != nil {
+			return fmt.Errorf("scenario %q tag[%d]: %w", s.ID, i, err)
+		}
+		if _, dup := seen[tag]; dup {
+			return fmt.Errorf("scenario %q declares tag %q more than once", s.ID, tag)
+		}
+		seen[tag] = struct{}{}
+		if IsTierTag(tag) {
+			tierCount++
+		}
+	}
+	if tierCount == 0 {
+		return fmt.Errorf("scenario %q has no tier tag; one of %s/%s/%s/%s is required",
+			s.ID, TierUnit, TierIntegration, TierSmoke, TierE2E)
+	}
+	if tierCount > 1 {
+		return fmt.Errorf("scenario %q has %d tier tags; exactly one is required", s.ID, tierCount)
+	}
+	for i, id := range s.HarnessProfileIDs {
+		if strings.TrimSpace(id) == "" {
+			return fmt.Errorf("scenario %q harness_profile_ids[%d] is empty", s.ID, i)
+		}
+	}
+	return nil
+}
+
+// validateTagSyntax enforces the alphanumeric + hyphen body rule. Tags must
+// start with '@' and contain at least one body character. The strict body
+// charset is what guarantees round-trip compatibility across pytest-bdd,
+// behave, and karate (ADR-041 §"Why colon-bearing tags fail").
+func validateTagSyntax(tag string) error {
+	if tag == "" {
+		return fmt.Errorf("tag is empty")
+	}
+	if tag[0] != '@' {
+		return fmt.Errorf("tag %q must start with '@'", tag)
+	}
+	body := tag[1:]
+	if body == "" {
+		return fmt.Errorf("tag %q has no body after '@'", tag)
+	}
+	for _, r := range body {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return fmt.Errorf("tag %q body contains disallowed character %q (alphanumeric and '-' only)", tag, r)
+		}
+	}
 	return nil
 }

--- a/workflow/plan_scenario_validate_test.go
+++ b/workflow/plan_scenario_validate_test.go
@@ -1,0 +1,225 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestValidateScenarioTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       Scenario
+		wantErr string
+	}{
+		{
+			name: "single @unit tag",
+			s:    Scenario{ID: "s1", Tags: []string{TierUnit}},
+		},
+		{
+			name: "tier tag plus facet tags",
+			s:    Scenario{ID: "s1", Tags: []string{TierIntegration, "@flaky", "@slow"}},
+		},
+		{
+			name: "@integration with harness binding",
+			s: Scenario{
+				ID:                "s1",
+				Tags:              []string{TierIntegration},
+				HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+			},
+		},
+		{
+			name: "@integration multi-binding",
+			s: Scenario{
+				ID:                "s1",
+				Tags:              []string{TierIntegration},
+				HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke", "mavlink.raw-mavlink-direct"},
+			},
+		},
+		{
+			name:    "empty tags rejected",
+			s:       Scenario{ID: "s1"},
+			wantErr: "no tags",
+		},
+		{
+			name:    "no tier tag rejected",
+			s:       Scenario{ID: "s1", Tags: []string{"@flaky"}},
+			wantErr: "no tier tag",
+		},
+		{
+			name:    "two tier tags rejected",
+			s:       Scenario{ID: "s1", Tags: []string{TierUnit, TierIntegration}},
+			wantErr: "2 tier tags",
+		},
+		{
+			name:    "duplicate tag rejected",
+			s:       Scenario{ID: "s1", Tags: []string{TierUnit, TierUnit}},
+			wantErr: "more than once",
+		},
+		{
+			name:    "tag missing @ rejected",
+			s:       Scenario{ID: "s1", Tags: []string{"unit"}},
+			wantErr: "must start with '@'",
+		},
+		{
+			name:    "tag with colon rejected (pytest-bdd compat)",
+			s:       Scenario{ID: "s1", Tags: []string{TierUnit, "@integration:db"}},
+			wantErr: "disallowed character ':'",
+		},
+		{
+			name:    "tag with dot rejected (pytest-bdd compat)",
+			s:       Scenario{ID: "s1", Tags: []string{TierUnit, "@a.b"}},
+			wantErr: "disallowed character '.'",
+		},
+		{
+			name:    "bare @ rejected",
+			s:       Scenario{ID: "s1", Tags: []string{TierUnit, "@"}},
+			wantErr: "no body after '@'",
+		},
+		{
+			name: "empty harness profile id rejected",
+			s: Scenario{
+				ID:                "s1",
+				Tags:              []string{TierIntegration},
+				HarnessProfileIDs: []string{""},
+			},
+			wantErr: "is empty",
+		},
+		{
+			name: "whitespace harness profile id rejected",
+			s: Scenario{
+				ID:                "s1",
+				Tags:              []string{TierIntegration},
+				HarnessProfileIDs: []string{"   "},
+			},
+			wantErr: "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateScenarioTags(tt.s)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestIsTierTag(t *testing.T) {
+	for _, tag := range []string{TierUnit, TierIntegration, TierSmoke, TierE2E} {
+		if !IsTierTag(tag) {
+			t.Errorf("%q should be recognized as a tier tag", tag)
+		}
+	}
+	for _, tag := range []string{"@flaky", "@security", "@slow", "unit", "@", ""} {
+		if IsTierTag(tag) {
+			t.Errorf("%q should not be recognized as a tier tag", tag)
+		}
+	}
+}
+
+// TestScenarioJSONRoundTrip pins the wire shape for the new Tags +
+// HarnessProfileIDs fields. Without this, a future refactor that mistypes
+// a JSON tag would silently break the OpenSpec emitter contract (ADR-041
+// Move 6).
+func TestScenarioJSONRoundTrip(t *testing.T) {
+	original := Scenario{
+		ID:                "scn-1",
+		RequirementID:     "req-1",
+		Given:             "the env is configured",
+		When:              "the driver starts",
+		Then:              []string{"the heartbeat is observed"},
+		Tags:              []string{TierIntegration, "@flaky"},
+		HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+	}
+	blob, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	wantSubstrings := []string{
+		`"tags":["@integration","@flaky"]`,
+		`"harness_profile_ids":["mavlink.px4-sitl.mavsdk-smoke"]`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(string(blob), want) {
+			t.Errorf("expected marshalled JSON to contain %q; got: %s", want, blob)
+		}
+	}
+
+	var decoded Scenario
+	if err := json.Unmarshal(blob, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded.Tags) != 2 || decoded.Tags[0] != TierIntegration {
+		t.Errorf("Tags not round-tripped: %+v", decoded.Tags)
+	}
+	if len(decoded.HarnessProfileIDs) != 1 || decoded.HarnessProfileIDs[0] != "mavlink.px4-sitl.mavsdk-smoke" {
+		t.Errorf("HarnessProfileIDs not round-tripped: %+v", decoded.HarnessProfileIDs)
+	}
+}
+
+// TestScenarioJSONOmitsEmptyTagFields guards back-compat: legacy scenarios
+// produced before ADR-041 lands have no Tags / no HarnessProfileIDs. Their
+// wire output must not gain noisy "tags": null or "harness_profile_ids":
+// null entries that would confuse round-trip tooling and OpenSpec emitter
+// expectations.
+func TestScenarioJSONOmitsEmptyTagFields(t *testing.T) {
+	s := Scenario{ID: "s1", RequirementID: "r1", Given: "a", When: "b", Then: []string{"c"}}
+	blob, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(blob), `"tags"`) {
+		t.Errorf("expected omitempty to drop tags when empty; got: %s", blob)
+	}
+	if strings.Contains(string(blob), `"harness_profile_ids"`) {
+		t.Errorf("expected omitempty to drop harness_profile_ids when empty; got: %s", blob)
+	}
+}
+
+func TestCapabilityJSONRoundTripWithSurfaces(t *testing.T) {
+	original := Capability{
+		Name:        "user-auth",
+		Lifecycle:   CapabilityNew,
+		Description: "Authenticate users.",
+		Surfaces:    []CapabilitySurface{SurfaceUI, SurfaceAPI},
+	}
+	blob, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(blob), `"surfaces":["ui","api"]`) {
+		t.Errorf("expected surfaces in JSON; got: %s", blob)
+	}
+
+	var decoded Capability
+	if err := json.Unmarshal(blob, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded.Surfaces) != 2 || decoded.Surfaces[0] != SurfaceUI {
+		t.Errorf("Surfaces not round-tripped: %+v", decoded.Surfaces)
+	}
+}
+
+func TestCapabilityJSONOmitsEmptySurfaces(t *testing.T) {
+	c := Capability{Name: "x", Lifecycle: CapabilityNew}
+	blob, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(blob), `"surfaces"`) {
+		t.Errorf("expected omitempty to drop surfaces when empty; got: %s", blob)
+	}
+}

--- a/workflow/specimport/structural_check_test.go
+++ b/workflow/specimport/structural_check_test.go
@@ -38,11 +38,11 @@ Sample reasoning.
 `
 }
 
-func sampleSpecMarkdown(cap string) string {
-	return `# Spec: ` + cap + `
+func sampleSpecMarkdown(name string) string {
+	return `# Spec: ` + name + `
 
 ## Overview
-Sample spec for ` + cap + `.
+Sample spec for ` + name + `.
 
 ## Requirements
 

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -1111,6 +1111,47 @@ func (l CapabilityLifecycle) IsValid() bool {
 	}
 }
 
+// CapabilitySurface classifies the user-observable surface(s) a capability
+// exposes. Set by the analyst sub-phase (Mary) per ADR-041 Move 2 so the
+// scenario-generator can decide whether to emit @e2e scenarios for a
+// capability without relying on a prompt-text heuristic.
+//
+// Most capabilities have exactly one surface. Multi-surface capabilities
+// (e.g., an HTTP endpoint that also has a UI shell) are allowed. Empty
+// Surfaces is treated as "unknown" — downstream emitters default to api.
+type CapabilitySurface string
+
+const (
+	// SurfaceUI marks a capability with a user-visible interface (Svelte
+	// component, CLI prompt, web form). Capabilities with SurfaceUI are the
+	// only ones eligible for @e2e scenario emission.
+	SurfaceUI CapabilitySurface = "ui"
+
+	// SurfaceAPI marks a programmatic surface other code or systems consume
+	// (REST endpoint, library function, NATS subject, gRPC method). Default
+	// when the analyst can't decide.
+	SurfaceAPI CapabilitySurface = "api"
+
+	// SurfaceBackground marks a scheduled or event-driven capability with no
+	// human surface (cron jobs, KV watchers, reactive consumers).
+	SurfaceBackground CapabilitySurface = "background"
+)
+
+// String returns the string representation of the capability surface.
+func (s CapabilitySurface) String() string {
+	return string(s)
+}
+
+// IsValid reports whether the surface is one of the defined values.
+func (s CapabilitySurface) IsValid() bool {
+	switch s {
+	case SurfaceUI, SurfaceAPI, SurfaceBackground:
+		return true
+	default:
+		return false
+	}
+}
+
 // Capability is a named unit of system behavior owned by a plan. The analyst
 // sub-phase produces capabilities from the user prompt; the planner sub-phase
 // derives scope from them; the requirement-generator produces one Requirement
@@ -1136,6 +1177,13 @@ type Capability struct {
 	// DependsOn names other capabilities by Name that this capability requires.
 	// Hard constraint: cycles and orphan references are rejected at plan-review.
 	DependsOn []string `json:"depends_on,omitempty"`
+
+	// Surfaces classifies the user-observable surface(s) the capability exposes
+	// (ADR-041 Move 2). Populated by the analyst sub-phase (Mary). Empty
+	// Surfaces is treated as "unknown" by downstream consumers; the
+	// scenario-generator only emits @e2e scenarios for capabilities whose
+	// Surfaces contains SurfaceUI.
+	Surfaces []CapabilitySurface `json:"surfaces,omitempty"`
 }
 
 // Exploration is the analyst sub-phase output. It is the structured input
@@ -1306,6 +1354,45 @@ func (s ScenarioStatus) CanTransitionTo(target ScenarioStatus) bool {
 	}
 }
 
+// Tier tags classify scenarios by test pyramid level per ADR-041 Move 1.
+// Exactly one of these MUST appear in Scenario.Tags. Operator-defined facet
+// tags (@flaky, @security, @slow, etc.) pass through validation as
+// informational metadata but are not structurally interpreted.
+//
+// Tag names are alphanumeric + hyphens only (BDD convention; pytest-bdd
+// rejects '.' and ':', behave has compat issues with ':'). Harness binding
+// lives in Scenario.HarnessProfileIDs, NOT on the tag.
+const (
+	// TierUnit — observable at function/class boundary with fakes, in-process
+	// state, or pure-fixture test environments. Every requirement MUST have
+	// at least one @unit scenario.
+	TierUnit = "@unit"
+
+	// TierIntegration — observable when a services-class or testcontainers-class
+	// test environment is up. Requires Scenario.HarnessProfileIDs binding.
+	TierIntegration = "@integration"
+
+	// TierSmoke — observable in a release-staging environment; scheduled, not
+	// per-PR. Emitted only when operator/architect explicitly directs.
+	TierSmoke = "@smoke"
+
+	// TierE2E — observable in a full-system deployment with UI + persistence +
+	// network. Emitted only for capabilities whose Surfaces contains SurfaceUI.
+	TierE2E = "@e2e"
+)
+
+// IsTierTag reports whether s is one of the four structurally-validated tier
+// tags. Facet tags (@flaky, @security, etc.) return false — they are valid
+// tags but carry no structural meaning.
+func IsTierTag(s string) bool {
+	switch s {
+	case TierUnit, TierIntegration, TierSmoke, TierE2E:
+		return true
+	default:
+		return false
+	}
+}
+
 // Scenario represents a Given/When/Then behavioral contract derived from a Requirement.
 type Scenario struct {
 	ID            string   `json:"id"`
@@ -1315,9 +1402,28 @@ type Scenario struct {
 	Then          []string `json:"then"`
 	// Status is a runtime/execution-time field — see Requirement.Status
 	// note above for the same omitempty rationale (b7r50o9ov 2026-05-08).
-	Status    ScenarioStatus `json:"status,omitempty"`
-	CreatedAt time.Time      `json:"created_at"`
-	UpdatedAt time.Time      `json:"updated_at"`
+	Status ScenarioStatus `json:"status,omitempty"`
+
+	// Tags classify the scenario by test pyramid tier and optionally carry
+	// operator-defined facet metadata (ADR-041 Move 1). Exactly one tier tag
+	// (@unit/@integration/@smoke/@e2e) is required; additional facet tags
+	// (@flaky, @security, @slow, etc.) pass through as informational metadata.
+	// Validated by ValidateScenarioTags. Cross-entity coverage rules (every
+	// requirement has @unit, services-bound requirement has @integration)
+	// belong to plan-reviewer per ADR-041 Move 4.
+	Tags []string `json:"tags,omitempty"`
+
+	// HarnessProfileIDs binds an @integration (or rarely @smoke) scenario to
+	// one or more harness profile IDs in workflow/harnesscatalog (ADR-041
+	// Move 1). The structural-validator (Move 5) checks the dev's tagged
+	// integration tests reference at least one of these IDs as a string
+	// literal. Plan-reviewer rule scenario.harness_id_unresolved (Move 4)
+	// rejects IDs that don't resolve into the catalog. Multi-binding (one
+	// scenario covering two profiles) is allowed.
+	HarnessProfileIDs []string `json:"harness_profile_ids,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // PlanDecisionStatus represents the lifecycle state of a plan decision.


### PR DESCRIPTION
## Summary

Foundation for ADR-041 (Test Evidence Ladder + Scenario Tags). Adds the data model the rest of the six-PR migration consumes — **no behavior changes to any existing pipeline yet**. The scenario-generator still emits scenarios without tags; the plan-reviewer doesn't enforce tier coverage; the req-reviewer's tier-aware contract (the load-bearing fix for issue #37) lands in PR 5.

This PR ships the type system, validators, predicates, and graph projections so PRs 2-6 have a stable foundation to plug into.

Also bundles a follow-up lint fix commit (`c4958b2`) that clears 10 `redefines-builtin-id` warnings the previous chore-lint commit on main missed (local revive v1.3.9 vs CI's v1.5.1 — v1.5.x catches Go 1.21+ builtin shadows `max`/`min`/`clear`). Both main and PR #44 were CI-red on the same warnings. Pins revive version in `taskfiles/lint.yml` so the drift can't recur.

## What lands

**Types (`workflow/types.go`)**
- `Scenario.Tags []string` (omitempty) — tier + facet tags
- `Scenario.HarnessProfileIDs []string` (omitempty) — catalog cross-reference
- `Capability.Surfaces []CapabilitySurface` (omitempty)
- `CapabilitySurface` string type with `SurfaceUI` / `SurfaceAPI` / `SurfaceBackground` constants + `String()` / `IsValid()` (mirrors `CapabilityLifecycle`)
- Tier tag constants: `TierUnit`, `TierIntegration`, `TierSmoke`, `TierE2E`
- `IsTierTag(s string) bool` helper

**Validators**
- `ValidateScenarioTags(s Scenario) error` — exactly one tier tag, no duplicates, strict alphanumeric+hyphen tag body (pytest-bdd / behave / karate compat per ADR-041 §"Why colon-bearing tags fail"), well-formed harness profile IDs
- `ValidateCapabilitySurfaces(c Capability) error` — rejects unknown surfaces + duplicates, invoked from `ValidateCapabilitySet`

**Triple writes** (so the new predicates actually reach `ENTITY_STATES`)
- `writeScenarioTriples`: one triple per tag, one per harness binding
- `writeCapabilityTriples`: one triple per surface

**Predicates (`vocabulary/semspec/predicates.go`)**
- `semspec.scenario.tag` (string, N-card)
- `semspec.scenario.harness_profile` (string profile_id, N-card; catalog cross-reference, NOT entity_id)
- `semspec.capability.surface` (ui|api|background, N-card)
- All three pass the rev-5 three-part dotted-naming guard

**Tests**
- `workflow/plan_scenario_validate_test.go` (new): 15-case tag validator table incl. pytest-bdd anti-patterns (`@a:b`, `@a.b`), `IsTierTag`, JSON round-trip pinning Tags / HarnessProfileIDs / Surfaces wire shape, omitempty guards
- `workflow/plan_capability_test.go`: surface validator cases + set-level bubble-up guard + `CapabilitySurface.IsValid` coverage
- `vocabulary/semspec/predicates_test.go`: three new predicates added to registration, name-mapping, and three-part-naming guard lists

## Scope discipline — deferred to later PRs per ADR-041

- **PR 2** — Mary surface classification + John tier-emission classifier (scenario-generator)
- **PR 3** — Plan-reviewer rules: `scenario.missing_tier_tag` / `scenario.missing_unit_coverage` / `scenario.missing_integration_for_services` / `scenario.harness_id_unresolved` / `scenario.unit_mentions_services`
- **PR 4** — Structural-validator harness-binding string check + env-var pattern check
- **PR 5** — **Req-reviewer tier-aware contract** — load-bearing fix for issue #37
- **PR 6** — OpenSpec round-trip syntax + rule 7b update

Cross-entity coverage rules (every requirement has @unit, services-bound has @integration, harness IDs resolve into catalog) live in plan-reviewer per Move 4. This validator layer only enforces the per-entity wire shape.

## Test plan

- [x] `go test ./workflow/ ./vocabulary/semspec/` (focused)
- [x] `go test ./...` (50+ packages, all green)
- [x] `task lint` — zero warnings with revive v1.5.1 (matches CI)
- [x] `go build ./...` — clean

## Why the e2e fixture promised in the ADR isn't here

ADR-041 PR 1 line item says "One mock e2e fixture asserting `Scenario.Tags` is populated after scenario generation". That requires the scenario-generator to actually emit Tags — which is PR 2's classifier work. JSON round-trip + ENTITY_STATES triple-emission tests cover the wire-shape contract for now; the end-to-end emission proof lands with PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)