### PR TITLE
feat(structural-validator): @integration scenario authoring checks (ADR-041 PR 4 / Move 5)

### DIFF
--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -158,7 +158,8 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 				Stdout:   fmt.Sprintf("load harness catalog: %v", err),
 			})
 		} else {
-			results = append(results, CheckHarnessProfileDiscipline(workDir, trigger.FilesModified, selections, catalog))
+			scenarios := loadScenarios(e.repoPath, trigger.Slug)
+			results = append(results, CheckHarnessProfileDiscipline(workDir, trigger.FilesModified, selections, scenarios, catalog))
 		}
 	}
 

--- a/processor/structural-validator/testcontainers_discipline.go
+++ b/processor/structural-validator/testcontainers_discipline.go
@@ -13,9 +13,25 @@ import (
 )
 
 // CheckHarnessProfileDiscipline scans modified test files for evidence that
-// selected required harness profiles are actually exercised. The architect
-// selects catalog profile IDs; the catalog owns the strings that must appear in
-// tests (profile ID, image/port/assertion anchors, etc.).
+// selected required harness profiles are actually exercised AND, per ADR-041
+// Move 5, that @integration scenarios' authoring obligations are met:
+//
+//  1. The catalog's required test assertions (formerly evidence anchors) for
+//     each required profile appear somewhere in the modified test files —
+//     the existing rule, unchanged in behavior.
+//  2. For each @integration scenario with HarnessProfileIDs, at least one
+//     modified test file contains each bound profile ID as a string literal.
+//     Proves the test code is bound to a catalog profile by name so
+//     qa-runner can route via the tag selector.
+//  3. For each @integration scenario whose bound profile is services-class
+//     or testcontainers-class, at least one modified test file contains an
+//     environment-variable key from the catalog Profile's Env map. Proves
+//     the test reads its endpoint from the harness-injected env instead of
+//     hardcoding a host/port (pure-fixture profiles are exempt — no peer
+//     process, no endpoint to inject).
+//
+// The check name (harness-profile-discipline) stays as the stable operator
+// identifier; messaging and behavior expand. ADR-041 Move 5.
 //
 // No-op cases (pass without enforcement):
 //   - No harness profiles selected (greenfield / runtime_dep-only).
@@ -23,8 +39,9 @@ import (
 //     integration coverage is verified by other scenarios that DO
 //     produce tests).
 //
-// Unknown profile IDs and missing required-profile evidence are hard failures.
-func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selections []workflow.HarnessProfileSelection, catalog *harnesscatalog.Catalog) payloads.CheckResult {
+// Unknown profile IDs, missing required-profile evidence, missing harness-
+// binding strings, and missing env-var consumption are hard failures.
+func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selections []workflow.HarnessProfileSelection, scenarios []workflow.Scenario, catalog *harnesscatalog.Catalog) payloads.CheckResult {
 	if len(selections) == 0 {
 		return passHarnessResult("no test environment profiles selected — nothing to enforce")
 	}
@@ -51,6 +68,10 @@ func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selec
 		}
 	}
 
+	// ADR-041 Move 5: @integration scenario authoring checks.
+	violations = append(violations, integrationBindingViolations(scenarios, contents, catalog)...)
+	violations = append(violations, integrationEnvConsumptionViolations(scenarios, contents, catalog)...)
+
 	if len(violations) == 0 {
 		return payloads.CheckResult{
 			Name:     "harness-profile-discipline",
@@ -70,10 +91,135 @@ func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selec
 	}
 }
 
+// integrationBindingViolations returns one violation per @integration scenario
+// whose bound HarnessProfileIDs aren't referenced as string literals anywhere
+// in the modified test files. Proves the dev's tests carry the catalog
+// cross-reference qa-runner needs to route tagged invocations.
+//
+// ADR-041 Move 5 check (1).
+func integrationBindingViolations(scenarios []workflow.Scenario, contents []string, _ *harnesscatalog.Catalog) []string {
+	var out []string
+	for _, s := range scenarios {
+		if !scenarioHasTag(s, workflow.TierIntegration) {
+			continue
+		}
+		var missing []string
+		for _, id := range s.HarnessProfileIDs {
+			if id == "" {
+				continue
+			}
+			if !containsAny(contents, id) {
+				missing = append(missing, id)
+			}
+		}
+		if len(missing) > 0 {
+			out = append(out, fmt.Sprintf(
+				"@integration scenario %q binds harness profile id(s) %s but no modified test file contains the id as a string literal — qa-runner's tag selector cannot route this scenario",
+				s.ID, strings.Join(quoteStrings(missing), ", ")))
+		}
+	}
+	return out
+}
+
+// integrationEnvConsumptionViolations returns one violation per @integration
+// scenario whose bound services/testcontainers profile declares Env keys
+// none of which appear in the modified test files. Catches hardcoded
+// host/port values that would break qa-runner's harness injection. Pure-
+// fixture profiles are exempt — no peer process means no endpoint to
+// inject.
+//
+// Heuristic: at least one of the catalog Profile.Env keys must appear as a
+// substring in some modified test file. False negatives (test reads env via
+// a wrapper utility that doesn't mention the key) are acceptable —
+// operators can override; the rule's purpose is to catch obvious hardcoded
+// endpoints. ADR-041 Move 5 check (2).
+func integrationEnvConsumptionViolations(scenarios []workflow.Scenario, contents []string, catalog *harnesscatalog.Catalog) []string {
+	if catalog == nil {
+		return nil
+	}
+	var out []string
+	for _, s := range scenarios {
+		if !scenarioHasTag(s, workflow.TierIntegration) {
+			continue
+		}
+		for _, id := range s.HarnessProfileIDs {
+			profile, ok := catalog.Profiles[id]
+			if !ok {
+				continue
+			}
+			orch := profile.EffectiveOrchestration()
+			if orch != harnesscatalog.OrchestrationServices && orch != harnesscatalog.OrchestrationTestcontainers {
+				continue
+			}
+			if len(profile.Env) == 0 {
+				continue
+			}
+			envKeys := make([]string, 0, len(profile.Env))
+			for k := range profile.Env {
+				envKeys = append(envKeys, k)
+			}
+			if anyEnvKeyReferenced(contents, envKeys) {
+				continue
+			}
+			out = append(out, fmt.Sprintf(
+				"@integration scenario %q binds harness profile %q (orchestration=%s) but no modified test file references any of the profile's declared env keys (%s) — the test appears to be reading hardcoded endpoints instead of consuming the harness-injected env",
+				s.ID, id, orch, strings.Join(quoteStrings(envKeys), ", ")))
+		}
+	}
+	return out
+}
+
+// scenarioHasTag reports whether the scenario carries the given tag.
+func scenarioHasTag(s workflow.Scenario, tag string) bool {
+	for _, t := range s.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// anyEnvKeyReferenced reports whether any of envKeys appears as a substring
+// in any of the test file contents.
+func anyEnvKeyReferenced(contents []string, envKeys []string) bool {
+	for _, k := range envKeys {
+		if k == "" {
+			continue
+		}
+		if containsAny(contents, k) {
+			return true
+		}
+	}
+	return false
+}
+
 // loadHarnessProfiles reads the plan.json for the given slug and returns the
 // architect-selected harness profiles. Returns nil when the plan or architecture
 // is absent.
 func loadHarnessProfiles(repoPath, slug string) []workflow.HarnessProfileSelection {
+	plan := loadPlanForDiscipline(repoPath, slug)
+	if plan == nil || plan.Architecture == nil {
+		return nil
+	}
+	return plan.Architecture.HarnessProfiles
+}
+
+// loadScenarios reads the plan.json for the given slug and returns the
+// scenarios. Returns nil when plan.json is absent or unparseable. The
+// scenarios are consumed by CheckHarnessProfileDiscipline's ADR-041 Move 5
+// checks (@integration binding + env consumption).
+func loadScenarios(repoPath, slug string) []workflow.Scenario {
+	plan := loadPlanForDiscipline(repoPath, slug)
+	if plan == nil {
+		return nil
+	}
+	return plan.Scenarios
+}
+
+// loadPlanForDiscipline is the shared plan.json reader for loadHarnessProfiles
+// + loadScenarios. Returns nil on I/O or parse failure — callers treat that
+// as "no data, skip enforcement" rather than blocking.
+func loadPlanForDiscipline(repoPath, slug string) *workflow.Plan {
 	if repoPath == "" || slug == "" {
 		return nil
 	}
@@ -86,10 +232,7 @@ func loadHarnessProfiles(repoPath, slug string) []workflow.HarnessProfileSelecti
 	if err := json.Unmarshal(data, &plan); err != nil {
 		return nil
 	}
-	if plan.Architecture == nil {
-		return nil
-	}
-	return plan.Architecture.HarnessProfiles
+	return &plan
 }
 
 // filterTestFiles returns the subset of files whose names match common

--- a/processor/structural-validator/testcontainers_discipline_test.go
+++ b/processor/structural-validator/testcontainers_discipline_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCheckHarnessProfileDiscipline_NoSelections(t *testing.T) {
 	catalog := mustCatalog(t)
-	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/Foo.java"}, nil, catalog)
+	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/Foo.java"}, nil, nil, catalog)
 	if !result.Passed {
 		t.Errorf("greenfield project (no harness profiles) should pass, got: %s", result.Stdout)
 	}
@@ -28,7 +28,7 @@ func TestCheckHarnessProfileDiscipline_NoTestFilesModified(t *testing.T) {
 		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
 	}
 
-	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/main/java/Driver.java", "build.gradle"}, selections, catalog)
+	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/main/java/Driver.java", "build.gradle"}, selections, nil, catalog)
 	if !result.Passed {
 		t.Errorf("scenarios producing no tests should pass (other scenarios cover integration): %s", result.Stdout)
 	}
@@ -53,7 +53,7 @@ class MavlinkDriverTest {
 		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
 	}
 
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
 	if !result.Passed {
 		t.Errorf("test file with required profile evidence should pass: %s", result.Stdout)
 	}
@@ -72,7 +72,7 @@ class MavlinkDriverTest {
 		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
 	}
 
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
 	if result.Passed {
 		t.Errorf("test file missing required evidence should fail: %s", result.Stdout)
 	}
@@ -93,7 +93,7 @@ func TestCheckHarnessProfileDiscipline_CompatibilityProfileDoesNotHardFail(t *te
 		{ProfileID: "mavlink.ardupilot-sitl.compat", Purpose: "compatibility sweep"},
 	}
 
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
 	if !result.Passed {
 		t.Errorf("compatibility-only profile should not hard-fail developer validation: %s", result.Stdout)
 	}
@@ -106,7 +106,7 @@ func TestCheckHarnessProfileDiscipline_UnknownProfileHardFails(t *testing.T) {
 		{ProfileID: "mavlink.not-real", Purpose: "bad selection"},
 	}
 
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
 	if result.Passed {
 		t.Errorf("unknown harness profile should fail: %s", result.Stdout)
 	}
@@ -115,6 +115,233 @@ func TestCheckHarnessProfileDiscipline_UnknownProfileHardFails(t *testing.T) {
 	}
 	if !strings.Contains(result.Stdout, "unknown harness profile") {
 		t.Errorf("failure should name unknown profile: %s", result.Stdout)
+	}
+}
+
+// TestCheckHarnessProfileDiscipline_IntegrationBindingPresent pins ADR-041
+// Move 5 check (1): an @integration scenario binding a profile ID must
+// surface that ID as a string literal in at least one modified test file.
+// Present → pass.
+func TestCheckHarnessProfileDiscipline_IntegrationBindingPresent(t *testing.T) {
+	dir := t.TempDir()
+	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
+package com.example;
+
+class MavlinkDriverTest {
+    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
+    static final String IMAGE = "px4io/px4-sitl:latest";
+    static final int PORT = 14540;
+    void smoke() {
+        // PX4_SIM_MODEL is the env key the catalog declares for this profile.
+        String model = System.getenv("PX4_SIM_MODEL");
+        assert true : "mavsdk_core_connected";
+        assert true : "HEARTBEAT";
+    }
+}
+`)
+	selections := []workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "scn.1",
+			RequirementID:     "r1",
+			Given:             "the SITL is configured via $PX4_SIM_MODEL",
+			When:              "the driver starts",
+			Then:              []string{"a HEARTBEAT is received"},
+			Tags:              []string{workflow.TierIntegration},
+			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+		},
+	}
+
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
+	if !result.Passed {
+		t.Errorf("test file with profile-id binding + env consumption should pass: %s", result.Stdout)
+	}
+}
+
+// TestCheckHarnessProfileDiscipline_IntegrationBindingMissing pins that a
+// missing harness-binding string literal surfaces a violation naming the
+// scenario + the missing profile_id, so the regen LLM has a targeted
+// directive to add the literal. ADR-041 Move 5 check (1).
+func TestCheckHarnessProfileDiscipline_IntegrationBindingMissing(t *testing.T) {
+	dir := t.TempDir()
+	// Test file contains all the catalog evidence anchors EXCEPT the
+	// profile_id string itself — isolates the binding check from the
+	// pre-existing required-assertions check.
+	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
+package com.example;
+
+class MavlinkDriverTest {
+    static final String IMAGE = "px4io/px4-sitl:latest";
+    static final int PORT = 14540;
+    void smoke() {
+        String endpoint = System.getenv("SITL_ENDPOINT");
+        assert true : "mavsdk_core_connected";
+        assert true : "HEARTBEAT";
+    }
+}
+`)
+	selections := []workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "scn.1",
+			Tags:              []string{workflow.TierIntegration},
+			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+		},
+	}
+
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
+	if result.Passed {
+		t.Fatalf("missing harness-binding string literal should fail; got passed with stdout: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "scn.1") {
+		t.Errorf("violation should name the scenario: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "mavlink.px4-sitl.mavsdk-smoke") {
+		t.Errorf("violation should name the unbound profile id: %s", result.Stdout)
+	}
+}
+
+// TestCheckHarnessProfileDiscipline_EnvConsumptionMissing pins ADR-041
+// Move 5 check (2): a test file referencing the profile_id but NOT any of
+// the catalog's declared env keys is treated as hardcoding the endpoint.
+// The mavlink.px4-sitl.mavsdk-smoke catalog entry declares SITL_ENDPOINT in
+// its Env map; a test file that contains the profile_id but not
+// SITL_ENDPOINT should fail.
+func TestCheckHarnessProfileDiscipline_EnvConsumptionMissing(t *testing.T) {
+	dir := t.TempDir()
+	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
+package com.example;
+
+class MavlinkDriverTest {
+    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
+    static final String IMAGE = "px4io/px4-sitl:latest";
+    static final int PORT = 14540;
+    void smoke() {
+        // Hardcoded endpoint — no env var reference.
+        String endpoint = "udp://127.0.0.1:14540";
+        assert true : "mavsdk_core_connected";
+        assert true : "HEARTBEAT";
+    }
+}
+`)
+	selections := []workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "scn.1",
+			Tags:              []string{workflow.TierIntegration},
+			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+		},
+	}
+
+	catalog := mustCatalog(t)
+	// Only run the env-consumption assertion if the catalog actually
+	// declares env keys for this profile. (Catalog evolution should not
+	// break this test silently.)
+	profile, ok := catalog.Profiles["mavlink.px4-sitl.mavsdk-smoke"]
+	if !ok || len(profile.Env) == 0 {
+		t.Skipf("mavlink.px4-sitl.mavsdk-smoke profile has no Env keys declared in the built-in catalog; check the env-consumption rule with a catalog override")
+	}
+
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, catalog)
+	if result.Passed {
+		t.Fatalf("hardcoded endpoint (no env key reference) should fail: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "scn.1") {
+		t.Errorf("violation should name the scenario: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Stdout, "env") {
+		t.Errorf("violation should reference 'env': %s", result.Stdout)
+	}
+}
+
+// TestCheckHarnessProfileDiscipline_PureFixtureSkipsEnvCheck pins that
+// pure-fixture profiles don't trigger the env-consumption check — there's
+// no peer process and no endpoint to inject. Binding check still applies
+// (the test file should still reference the profile_id as a literal).
+func TestCheckHarnessProfileDiscipline_PureFixtureSkipsEnvCheck(t *testing.T) {
+	// We need a synthetic catalog with a pure-fixture profile because the
+	// built-in catalog may not have a profile shaped this way at this layer.
+	pureFixtureCatalog := &harnesscatalog.Catalog{
+		Profiles: map[string]harnesscatalog.Profile{
+			"test.pure-fixture": {
+				ID:                 "test.pure-fixture",
+				Tier:               harnesscatalog.TierRequired,
+				Orchestration:      harnesscatalog.OrchestrationPureFixture,
+				EvidenceAnchors:    []string{"FIXTURE_LOADED"},
+				RequiredAssertions: []string{"FIXTURE_LOADED"},
+				Env:                map[string]string{"SHOULD_BE_IGNORED": "x"},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	testFile := writeTestFile(t, dir, "src/test/java/FixtureTest.java", `
+package com.example;
+class FixtureTest {
+    static final String PROFILE = "test.pure-fixture";
+    void smoke() {
+        // No SHOULD_BE_IGNORED reference — fine for pure-fixture.
+        assert true : "FIXTURE_LOADED";
+    }
+}
+`)
+	selections := []workflow.HarnessProfileSelection{
+		{ProfileID: "test.pure-fixture", Purpose: "in-process fixture"},
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "scn.1",
+			Tags:              []string{workflow.TierIntegration},
+			HarnessProfileIDs: []string{"test.pure-fixture"},
+		},
+	}
+
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, pureFixtureCatalog)
+	if !result.Passed {
+		t.Errorf("pure-fixture profile should not trigger env-consumption check: %s", result.Stdout)
+	}
+}
+
+// TestCheckHarnessProfileDiscipline_UnitScenariosIgnored pins that @unit
+// scenarios DO NOT trigger the binding or env-consumption checks — those
+// fire only for @integration. Without this guard, every @unit scenario
+// would falsely demand harness-binding string literals.
+func TestCheckHarnessProfileDiscipline_UnitScenariosIgnored(t *testing.T) {
+	dir := t.TempDir()
+	testFile := writeTestFile(t, dir, "src/test/java/UnitTest.java", `
+package com.example;
+class UnitTest {
+    // No profile_id, no env var — but this is a @unit scenario, so the new
+    // checks must NOT fire. Existing evidence-anchor check IS still in effect
+    // for the selected profile; we satisfy it by adding the anchor strings.
+    static final String PROFILE_ANCHOR = "mavlink.px4-sitl.mavsdk-smoke";
+    static final String IMAGE = "px4io/px4-sitl:latest";
+    static final int PORT = 14540;
+    void test() {
+        assert true : "mavsdk_core_connected";
+        assert true : "HEARTBEAT";
+    }
+}
+`)
+	selections := []workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:   "scn.unit",
+			Tags: []string{workflow.TierUnit},
+		},
+	}
+
+	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
+	if !result.Passed {
+		t.Errorf("@unit scenarios should not trigger Move 5 checks: %s", result.Stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends `CheckHarnessProfileDiscipline` with two new sub-checks per ADR-041 Move 5. The check name (`harness-profile-discipline`) stays as the stable operator identifier; behavior expands.

This is the **dev-time gate** in the four-layer defense ADR-041 builds:
- PR 1 — wire shape (validators on parse)
- PR 2 — emission shape (Bob emits tier-tagged scenarios)
- PR 3 — plan-time gate (plan-reviewer scenario-tag rules) — #46
- **PR 4 — dev-time gate (THIS PR)**
- PR 5 — review-time gate (req-reviewer tier-aware contract — load-bearing #37 fix)

Independent of #46; can review/merge in either order.

## The two new checks

### (1) Harness-binding string literal presence
For each `@integration` scenario with `HarnessProfileIDs`, at least one modified test file must contain each bound profile ID as a string literal. Proves the dev's tests carry the catalog cross-reference qa-runner needs to route tagged invocations.

Missing literal → hard failure naming the scenario + the unbound profile id (per-binding granularity so the regen LLM gets targeted directives).

### (2) Env-var consumption pattern
For each `@integration` scenario whose bound profile is **services-class** or **testcontainers-class**, at least one modified test file must reference one of the catalog `Profile.Env` keys as a substring. Catches hardcoded host/port values that break qa-runner's harness injection.

Pure-fixture profiles are exempt — no peer process means no endpoint to inject.

Heuristic notes:
- Keyword-substring based, not parse-based. False negatives (test reads env via a wrapper utility that doesn't mention the key) are acceptable; operators can override at review time. The rule's purpose is to catch obvious hardcoded endpoints.
- `@unit` scenarios don't trigger either Move 5 check. Tested explicitly to prevent regression — a future refactor that drops the tag filter would falsely demand harness-binding string literals on every unit test.

## Wire-up

- New `loadScenarios(repoPath, slug)` helper reads `plan.Scenarios` from `plan.json` the same way `loadHarnessProfiles` reads `plan.Architecture`. Both share a new `loadPlanForDiscipline` base function.
- `executor.go` calls `loadScenarios` and threads the result into `CheckHarnessProfileDiscipline` alongside the existing selections.

## Real-data discovery (operator-facing)

The `mavlink.px4-sitl.mavsdk-smoke` catalog profile declares `PX4_SIM_MODEL`, not `SITL_ENDPOINT`, as the env key. Initial test fixture used a fabricated `SITL_ENDPOINT` and surfaced this mismatch on first run. Fixture corrected; the env-consumption rule is now grounded against the real catalog shape.

**Worth knowing for future @integration scenario authoring**: copy env keys from the catalog (`workflow/harnesscatalog/catalog/<domain>.yaml`), don't invent them. The Mary/Bob persona prompts in PR #45 instruct the LLM to do this; this PR's tests pin the verifier side.

## Tests (5 new cases)

- `IntegrationBindingPresent`: profile_id + env key both present → pass
- `IntegrationBindingMissing`: profile_id absent from test file → fail with per-scenario violation naming the unbound id
- `EnvConsumptionMissing`: profile_id present, env key absent → fail naming the scenario + `env` reference (catalog-dependent — skips test if the built-in catalog declares no `Env` for the profile so catalog evolution doesn't break it silently)
- `PureFixtureSkipsEnvCheck`: pure-fixture orchestration is exempt from the env check even when the synthetic profile declares `Env` (uses an in-test catalog override since the built-in catalog may not have a pure-fixture profile with `Env` at this layer)
- `UnitScenariosIgnored`: `@unit` scenarios with empty `HarnessProfileIDs` don't trigger Move 5 checks; existing evidence-anchor check still applies to the architecturally-selected profile

## Test plan

- [x] `go test ./...` — green
- [x] `task lint` — clean (revive v1.5.1, CI-aligned)
- [x] `go build ./...` — clean
- [ ] CI lint-and-test + Docker build (reviewer to confirm green)

## Deferred to subsequent PRs

- **PR 5** — Req-reviewer tier-aware contract (load-bearing #37 fix)
- **PR 6** — OpenSpec round-trip syntax + rule 7b update

🤖 Generated with [Claude Code](https://claude.com/claude-code)