### PR TITLE
feat(adr-043): PR 1 — data model + predicates (Story, Task, ComponentDef extensions)

### DIFF
--- a/schemas/plan-manager.v1.json
+++ b/schemas/plan-manager.v1.json
@@ -23,6 +23,12 @@
       "default": false,
       "category": "basic"
     },
+    "cascade_trigger_subject": {
+      "type": "string",
+      "description": "Subject for cascade trigger messages published on accept (must match plan-decision-handler.trigger_subject)",
+      "default": "workflow.trigger.plan-decision-cascade",
+      "category": "advanced"
+    },
     "default_capability": {
       "type": "string",
       "description": "Default model capability for coordination",

--- a/schemas/requirement-executor.v1.json
+++ b/schemas/requirement-executor.v1.json
@@ -24,6 +24,14 @@
       "maximum": 5,
       "category": "advanced"
     },
+    "max_recovery_restarts": {
+      "type": "number",
+      "description": "Max times an exec can be resumed from awaiting-recovery",
+      "default": 1,
+      "minimum": 0,
+      "maximum": 5,
+      "category": "advanced"
+    },
     "max_requirement_retries": {
       "type": "number",
       "description": "Max requirement-level retries on reviewer rejection",
@@ -45,10 +53,24 @@
       "description": "Optional override propagated to req-executor dispatches (empty = use capability registry)",
       "category": "basic"
     },
+    "plan_decision_accepted_subject": {
+      "type": "string",
+      "description": "Subject for accepted-PlanDecision events (must match plan-decision-handler.accepted_subject)",
+      "default": "workflow.events.plan-decision.accepted",
+      "category": "advanced"
+    },
     "ports": {
       "type": "object",
       "description": "Port configuration",
       "category": "basic"
+    },
+    "recovery_timeout_seconds": {
+      "type": "number",
+      "description": "Seconds to wait in phaseAwaitingRecovery before terminal-failing",
+      "default": 60,
+      "minimum": 5,
+      "maximum": 600,
+      "category": "advanced"
     },
     "require_commit_observation": {
       "type": "boolean",

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1333,6 +1333,29 @@ components:
                             - confidence
                         type: object
                     type: array
+                openspec_changes:
+                    items:
+                        properties:
+                            has_design:
+                                type: boolean
+                            has_proposal:
+                                type: boolean
+                            has_tasks:
+                                type: boolean
+                            name:
+                                type: string
+                            path:
+                                type: string
+                            spec_capabilities:
+                                items:
+                                    type: string
+                                type: array
+                        required:
+                            - name
+                            - path
+                            - has_proposal
+                        type: object
+                    type: array
                 proposed_checklist:
                     items:
                         properties:
@@ -1558,6 +1581,29 @@ components:
                                     - name
                                     - marker
                                     - confidence
+                                type: object
+                            type: array
+                        openspec_changes:
+                            items:
+                                properties:
+                                    has_design:
+                                        type: boolean
+                                    has_proposal:
+                                        type: boolean
+                                    has_tasks:
+                                        type: boolean
+                                    name:
+                                        type: string
+                                    path:
+                                        type: string
+                                    spec_capabilities:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - name
+                                    - path
+                                    - has_proposal
                                 type: object
                             type: array
                         proposed_checklist:
@@ -2046,7 +2092,15 @@ components:
                         component_boundaries:
                             items:
                                 properties:
+                                    capabilities:
+                                        items:
+                                            type: string
+                                        type: array
                                     dependencies:
+                                        items:
+                                            type: string
+                                        type: array
+                                    implementation_files:
                                         items:
                                             type: string
                                         type: array
@@ -2054,6 +2108,10 @@ components:
                                         type: string
                                     responsibility:
                                         type: string
+                                    upstream_refs:
+                                        items:
+                                            type: string
+                                        type: array
                                 required:
                                     - name
                                     - responsibility
@@ -2078,6 +2136,26 @@ components:
                                     - title
                                     - decision
                                     - rationale
+                                type: object
+                            type: array
+                        harness_profiles:
+                            items:
+                                properties:
+                                    covers:
+                                        items:
+                                            type: string
+                                        type: array
+                                    profile_id:
+                                        type: string
+                                    purpose:
+                                        type: string
+                                    used_by:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - profile_id
+                                    - purpose
                                 type: object
                             type: array
                         integrations:
@@ -2158,6 +2236,49 @@ components:
                                         type: object
                                     type: array
                             type: object
+                        upstream_resolutions:
+                            items:
+                                properties:
+                                    apis:
+                                        items:
+                                            properties:
+                                                citation:
+                                                    type: string
+                                                kind:
+                                                    type: string
+                                                lifecycle:
+                                                    type: string
+                                                notes:
+                                                    type: string
+                                                signature:
+                                                    type: string
+                                                symbol:
+                                                    type: string
+                                            required:
+                                                - symbol
+                                                - kind
+                                                - signature
+                                                - citation
+                                            type: object
+                                        type: array
+                                    coordinate:
+                                        type: string
+                                    name:
+                                        type: string
+                                    role:
+                                        type: string
+                                    source_ref:
+                                        type: string
+                                    used_by:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - name
+                                    - coordinate
+                                    - source_ref
+                                type: object
+                            type: array
                     required:
                         - technology_choices
                         - component_boundaries
@@ -2182,6 +2303,39 @@ components:
                     items:
                         type: string
                     type: array
+                exploration:
+                    nullable: true
+                    properties:
+                        capabilities:
+                            items:
+                                properties:
+                                    depends_on:
+                                        items:
+                                            type: string
+                                        type: array
+                                    description:
+                                        type: string
+                                    lifecycle:
+                                        type: string
+                                    name:
+                                        type: string
+                                    surfaces:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - name
+                                    - lifecycle
+                                    - description
+                                type: object
+                            type: array
+                        open_questions:
+                            items:
+                                type: string
+                            type: array
+                    required:
+                        - capabilities
+                    type: object
                 github:
                     nullable: true
                     properties:
@@ -2359,9 +2513,41 @@ components:
                         - duration_ms
                         - completed_at
                     type: object
+                qa_verdict_summary:
+                    nullable: true
+                    properties:
+                        dimensions:
+                            properties:
+                                assertion_quality:
+                                    type: string
+                                coverage:
+                                    type: string
+                                flake_judgment:
+                                    type: string
+                                regression_surface:
+                                    type: string
+                                requirement_fulfillment:
+                                    type: string
+                            type: object
+                        level:
+                            type: string
+                        recorded_at:
+                            format: date-time
+                            type: string
+                        summary:
+                            type: string
+                        verdict:
+                            type: string
+                    required:
+                        - verdict
+                        - level
+                        - recorded_at
+                    type: object
                 requirements:
                     items:
                         properties:
+                            capability_name:
+                                type: string
                             created_at:
                                 format: date-time
                                 type: string
@@ -2378,6 +2564,8 @@ components:
                             id:
                                 type: string
                             plan_id:
+                                type: string
+                            recovery_hint:
                                 type: string
                             status:
                                 type: string
@@ -2418,16 +2606,28 @@ components:
                                 type: string
                             given:
                                 type: string
+                            harness_profile_ids:
+                                items:
+                                    type: string
+                                type: array
                             id:
                                 type: string
                             requirement_id:
                                 type: string
                             status:
                                 type: string
+                            story_id:
+                                type: string
+                            tags:
+                                items:
+                                    type: string
+                                type: array
                             then:
                                 items:
                                     type: string
                                 type: array
+                            title:
+                                type: string
                             updated_at:
                                 format: date-time
                                 type: string
@@ -2468,6 +2668,82 @@ components:
                     type: string
                 status:
                     type: string
+                stories:
+                    items:
+                        properties:
+                            components:
+                                items:
+                                    type: string
+                                type: array
+                            created_at:
+                                format: date-time
+                                type: string
+                            depends_on:
+                                items:
+                                    type: string
+                                type: array
+                            files_owned:
+                                items:
+                                    type: string
+                                type: array
+                            id:
+                                type: string
+                            intent:
+                                type: string
+                            prepared_at:
+                                format: date-time
+                                nullable: true
+                                type: string
+                            prepared_by:
+                                type: string
+                            recovery_hint:
+                                type: string
+                            requirement_id:
+                                type: string
+                            status:
+                                type: string
+                            tasks:
+                                items:
+                                    properties:
+                                        created_at:
+                                            format: date-time
+                                            type: string
+                                        depends_on:
+                                            items:
+                                                type: string
+                                            type: array
+                                        description:
+                                            type: string
+                                        id:
+                                            type: string
+                                        status:
+                                            type: string
+                                        story_id:
+                                            type: string
+                                        updated_at:
+                                            format: date-time
+                                            type: string
+                                    required:
+                                        - id
+                                        - story_id
+                                        - description
+                                        - created_at
+                                        - updated_at
+                                    type: object
+                                type: array
+                            title:
+                                type: string
+                            updated_at:
+                                format: date-time
+                                type: string
+                        required:
+                            - id
+                            - requirement_id
+                            - title
+                            - created_at
+                            - updated_at
+                        type: object
+                    type: array
                 title:
                     type: string
             required:
@@ -2528,7 +2804,15 @@ components:
                         component_boundaries:
                             items:
                                 properties:
+                                    capabilities:
+                                        items:
+                                            type: string
+                                        type: array
                                     dependencies:
+                                        items:
+                                            type: string
+                                        type: array
+                                    implementation_files:
                                         items:
                                             type: string
                                         type: array
@@ -2536,6 +2820,10 @@ components:
                                         type: string
                                     responsibility:
                                         type: string
+                                    upstream_refs:
+                                        items:
+                                            type: string
+                                        type: array
                                 required:
                                     - name
                                     - responsibility
@@ -2560,6 +2848,26 @@ components:
                                     - title
                                     - decision
                                     - rationale
+                                type: object
+                            type: array
+                        harness_profiles:
+                            items:
+                                properties:
+                                    covers:
+                                        items:
+                                            type: string
+                                        type: array
+                                    profile_id:
+                                        type: string
+                                    purpose:
+                                        type: string
+                                    used_by:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - profile_id
+                                    - purpose
                                 type: object
                             type: array
                         integrations:
@@ -2640,6 +2948,49 @@ components:
                                         type: object
                                     type: array
                             type: object
+                        upstream_resolutions:
+                            items:
+                                properties:
+                                    apis:
+                                        items:
+                                            properties:
+                                                citation:
+                                                    type: string
+                                                kind:
+                                                    type: string
+                                                lifecycle:
+                                                    type: string
+                                                notes:
+                                                    type: string
+                                                signature:
+                                                    type: string
+                                                symbol:
+                                                    type: string
+                                            required:
+                                                - symbol
+                                                - kind
+                                                - signature
+                                                - citation
+                                            type: object
+                                        type: array
+                                    coordinate:
+                                        type: string
+                                    name:
+                                        type: string
+                                    role:
+                                        type: string
+                                    source_ref:
+                                        type: string
+                                    used_by:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - name
+                                    - coordinate
+                                    - source_ref
+                                type: object
+                            type: array
                     required:
                         - technology_choices
                         - component_boundaries
@@ -2681,6 +3032,39 @@ components:
                     items:
                         type: string
                     type: array
+                exploration:
+                    nullable: true
+                    properties:
+                        capabilities:
+                            items:
+                                properties:
+                                    depends_on:
+                                        items:
+                                            type: string
+                                        type: array
+                                    description:
+                                        type: string
+                                    lifecycle:
+                                        type: string
+                                    name:
+                                        type: string
+                                    surfaces:
+                                        items:
+                                            type: string
+                                        type: array
+                                required:
+                                    - name
+                                    - lifecycle
+                                    - description
+                                type: object
+                            type: array
+                        open_questions:
+                            items:
+                                type: string
+                            type: array
+                    required:
+                        - capabilities
+                    type: object
                 github:
                     nullable: true
                     properties:
@@ -2858,9 +3242,41 @@ components:
                         - duration_ms
                         - completed_at
                     type: object
+                qa_verdict_summary:
+                    nullable: true
+                    properties:
+                        dimensions:
+                            properties:
+                                assertion_quality:
+                                    type: string
+                                coverage:
+                                    type: string
+                                flake_judgment:
+                                    type: string
+                                regression_surface:
+                                    type: string
+                                requirement_fulfillment:
+                                    type: string
+                            type: object
+                        level:
+                            type: string
+                        recorded_at:
+                            format: date-time
+                            type: string
+                        summary:
+                            type: string
+                        verdict:
+                            type: string
+                    required:
+                        - verdict
+                        - level
+                        - recorded_at
+                    type: object
                 requirements:
                     items:
                         properties:
+                            capability_name:
+                                type: string
                             created_at:
                                 format: date-time
                                 type: string
@@ -2877,6 +3293,8 @@ components:
                             id:
                                 type: string
                             plan_id:
+                                type: string
+                            recovery_hint:
                                 type: string
                             status:
                                 type: string
@@ -2917,16 +3335,28 @@ components:
                                 type: string
                             given:
                                 type: string
+                            harness_profile_ids:
+                                items:
+                                    type: string
+                                type: array
                             id:
                                 type: string
                             requirement_id:
                                 type: string
                             status:
                                 type: string
+                            story_id:
+                                type: string
+                            tags:
+                                items:
+                                    type: string
+                                type: array
                             then:
                                 items:
                                     type: string
                                 type: array
+                            title:
+                                type: string
                             updated_at:
                                 format: date-time
                                 type: string
@@ -2969,6 +3399,82 @@ components:
                     type: string
                 status:
                     type: string
+                stories:
+                    items:
+                        properties:
+                            components:
+                                items:
+                                    type: string
+                                type: array
+                            created_at:
+                                format: date-time
+                                type: string
+                            depends_on:
+                                items:
+                                    type: string
+                                type: array
+                            files_owned:
+                                items:
+                                    type: string
+                                type: array
+                            id:
+                                type: string
+                            intent:
+                                type: string
+                            prepared_at:
+                                format: date-time
+                                nullable: true
+                                type: string
+                            prepared_by:
+                                type: string
+                            recovery_hint:
+                                type: string
+                            requirement_id:
+                                type: string
+                            status:
+                                type: string
+                            tasks:
+                                items:
+                                    properties:
+                                        created_at:
+                                            format: date-time
+                                            type: string
+                                        depends_on:
+                                            items:
+                                                type: string
+                                            type: array
+                                        description:
+                                            type: string
+                                        id:
+                                            type: string
+                                        status:
+                                            type: string
+                                        story_id:
+                                            type: string
+                                        updated_at:
+                                            format: date-time
+                                            type: string
+                                    required:
+                                        - id
+                                        - story_id
+                                        - description
+                                        - created_at
+                                        - updated_at
+                                    type: object
+                                type: array
+                            title:
+                                type: string
+                            updated_at:
+                                format: date-time
+                                type: string
+                        required:
+                            - id
+                            - requirement_id
+                            - title
+                            - created_at
+                            - updated_at
+                        type: object
+                    type: array
                 title:
                     type: string
             required:
@@ -3027,6 +3533,8 @@ components:
                     type: string
                 qa_level:
                     type: string
+                qa_skip_service_injection:
+                    type: boolean
                 qa_test_command:
                     type: string
                 repository:

--- a/vocabulary/semspec/predicates.go
+++ b/vocabulary/semspec/predicates.go
@@ -753,6 +753,112 @@ const (
 	// semspec.requirement.depends_on / semspec.capability.depends_on
 	// convention (rev-5 ADR-040 predicate naming).
 	ScenarioHarnessProfile = "semspec.scenario.harness_profile"
+
+	// ScenarioStory links a Scenario to the Story it covers (ADR-043
+	// semantic primary link). ScenarioRequirement stays as a back-pointer
+	// for query convenience; Story is the dispatch unit, so Bob populates
+	// StoryID as the authoritative parent. One triple per scenario.
+	ScenarioStory = "semspec.scenario.story"
+)
+
+// Component predicates define attributes for architecture components
+// (ADR-043 Move 1, BMAD tech-spec scope). ComponentDef previously lived
+// only as a struct inside ArchitectureDocument; with Winston declaring
+// implementation files + capability mappings per component, components
+// become first-class graph entities so plan-reviewer R2 rules and Sarah
+// can query them.
+const (
+	// ComponentImplementationFile is a workspace-relative path housing this
+	// component's code (ADR-043 Move 1). Multi-valued — one triple per file.
+	// Plan-reviewer R2 rule architecture.component_missing_implementation_files
+	// rejects empty sets; architecture.component_implementation_files_doc_only
+	// rejects docs-only sets.
+	ComponentImplementationFile = "semspec.component.implementation_file"
+
+	// ComponentCapability is a kebab-case Capability.Name this component
+	// implements (ADR-043 Move 1). Multi-valued — one triple per capability.
+	// Plan-reviewer R2 rule capability.unresolved_in_architecture rejects
+	// capabilities with no component whose Capabilities list contains them.
+	ComponentCapability = "semspec.component.capability"
+)
+
+// Story predicates define attributes for Sarah-authored dev-ready units
+// (ADR-043 Move 2). A Story shards one Requirement into a single dispatch
+// unit with explicit Components, FilesOwned, DependsOn, and an ordered
+// Task checklist.
+const (
+	// StoryTitle is the human-readable story heading.
+	StoryTitle = "semspec.story.title"
+
+	// StoryIntent is the 1-2 sentence description of what implementing
+	// this story proves.
+	StoryIntent = "semspec.story.intent"
+
+	// StoryRequirement links a Story to its parent Requirement entity.
+	// One triple per story.
+	StoryRequirement = "semspec.story.requirement"
+
+	// StoryComponent records a ComponentDef.Name this story implements.
+	// Multi-valued — one triple per component. Plan-reviewer R3 rule
+	// story.unresolved_components rejects entries that don't match any
+	// declared component.
+	StoryComponent = "semspec.story.component"
+
+	// StoryFilesOwned is a workspace-relative path this story is allowed
+	// to modify (the union of selected components' implementation_files).
+	// Multi-valued — one triple per path. Plan-reviewer R3 rule
+	// story.missing_files_owned rejects empty sets;
+	// story.docs_only_files_owned rejects sets with no source-code file.
+	StoryFilesOwned = "semspec.story.files_owned"
+
+	// StoryDependsOn links a Story to a prerequisite Story entity that
+	// must reach StoryStatusComplete before this Story can dispatch.
+	// Multi-valued — one triple per dependency. Plan-reviewer R3 rules
+	// story.depends_on_orphan and story.depends_on_cycle reject unresolved
+	// IDs and DAG cycles.
+	StoryDependsOn = "semspec.story.depends_on"
+
+	// PredicateStoryStatus is the story lifecycle status predicate.
+	// Values: pending, ready, executing, complete, failed. Prefixed with
+	// Predicate to mirror PredicatePlanStatus / PredicateTaskStatus
+	// convention and avoid colliding with the StoryStatus type name in
+	// the workflow package.
+	PredicateStoryStatus = "semspec.story.status"
+
+	// StoryPreparedBy identifies the persona that signed off readiness.
+	// Value is the BMAD canonical role name — "sarah" — for stories
+	// emitted by the story-preparer; other manager-role agents may
+	// re-prepare during recovery (ADR-037).
+	StoryPreparedBy = "semspec.story.prepared_by"
+
+	// StoryPreparedAt is the RFC3339 timestamp when Sarah's readiness
+	// gate passed.
+	StoryPreparedAt = "semspec.story.prepared_at"
+
+	// StoryCreatedAt is the RFC3339 creation timestamp.
+	StoryCreatedAt = "semspec.story.created_at"
+
+	// StoryUpdatedAt is the RFC3339 last update timestamp.
+	StoryUpdatedAt = "semspec.story.updated_at"
+)
+
+// ADR-043 Task predicates extend the existing semspec.task.* namespace
+// (originally defined for the now-dormant plan-time task entity model
+// before reactive mode landed). Sarah's Task fills that slot:
+// TaskDescription, PredicateTaskStatus, TaskCreatedAt, TaskUpdatedAt are
+// reused unchanged; the new predicates below add the Story link and
+// intra-story DependsOn DAG edges.
+const (
+	// TaskStory links a Task to its parent Story entity. One triple per
+	// task. Replaces the role TaskSpec played for the dormant plan-time
+	// task model.
+	TaskStory = "semspec.task.story"
+
+	// TaskDependsOn links a Task to a prerequisite Task entity within the
+	// same Story (intra-story TDD ordering). Multi-valued — one triple per
+	// dependency. Plan-reviewer R3 rule task.depends_on_cycle rejects DAG
+	// cycles within a single Story.
+	TaskDependsOn = "semspec.task.depends_on"
 )
 
 // PlanDecision predicates define attributes for mid-stream change proposals.
@@ -1105,6 +1211,8 @@ func registerTaskPredicates() {
 	vocabulary.Register(TaskUpdatedAt,
 		vocabulary.WithDescription("Last update timestamp (RFC3339)"),
 		vocabulary.WithDataType("datetime"))
+
+	registerADR043TaskExtensions()
 
 	// Register plan predicates
 	vocabulary.Register(PlanGoal,
@@ -1919,6 +2027,8 @@ func init() {
 	registerErrorCategoryPredicates()
 	registerAgentPredicates()
 	registerCapabilityPredicates()
+	registerComponentPredicates()
+	registerStoryPredicates()
 }
 
 // registerCapabilityPredicates registers predicate metadata for Capability
@@ -2079,6 +2189,104 @@ func registerScenarioPredicates() {
 		vocabulary.WithDescription("Harness profile ID this scenario binds to (catalog cross-reference; ADR-041 Move 1)"),
 		vocabulary.WithDataType("string"),
 		vocabulary.WithIRI(Namespace+"scenarioHarnessProfile"))
+
+	vocabulary.Register(ScenarioStory,
+		vocabulary.WithDescription("Link to the Story this scenario covers (ADR-043 semantic primary; scenarioRequirement stays as a back-pointer)"),
+		vocabulary.WithDataType("entity_id"),
+		vocabulary.WithIRI(Namespace+"scenarioStory"))
+}
+
+// registerADR043TaskExtensions adds the two Task predicates introduced by
+// ADR-043 (TaskStory + TaskDependsOn). Extracted from registerTaskPredicates
+// so it stays under revive's function-length limit; TaskDescription /
+// PredicateTaskStatus / TaskCreatedAt / TaskUpdatedAt are reused unchanged
+// from the dormant plan-time task model.
+func registerADR043TaskExtensions() {
+	vocabulary.Register(TaskStory,
+		vocabulary.WithDescription("Link to parent Story entity (ADR-043 Move 2)"),
+		vocabulary.WithDataType("entity_id"),
+		vocabulary.WithIRI(Namespace+"taskStory"))
+
+	vocabulary.Register(TaskDependsOn,
+		vocabulary.WithDescription("Link to prerequisite Task within the same Story (intra-story DAG); multi-valued"),
+		vocabulary.WithDataType("entity_id"),
+		vocabulary.WithIRI(Namespace+"taskDependsOn"))
+}
+
+// registerComponentPredicates registers predicate metadata for architecture
+// component entities (ADR-043 Move 1). Winston declares implementation_files
+// and capability mappings per component as part of the BMAD tech-spec scope.
+func registerComponentPredicates() {
+	vocabulary.Register(ComponentImplementationFile,
+		vocabulary.WithDescription("Workspace-relative path housing this component's code (ADR-043 Move 1); multi-valued"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"componentImplementationFile"))
+
+	vocabulary.Register(ComponentCapability,
+		vocabulary.WithDescription("Kebab-case Capability.Name this component implements (ADR-043 Move 1); multi-valued"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"componentCapability"))
+}
+
+// registerStoryPredicates registers predicate metadata for Sarah-authored
+// Story entities (ADR-043 Move 2). Stories shard Requirements into
+// dev-ready dispatch units with explicit Components, FilesOwned, DependsOn
+// edges, and an ordered Task checklist.
+func registerStoryPredicates() {
+	vocabulary.Register(StoryTitle,
+		vocabulary.WithDescription("Human-readable story heading (ADR-043 Move 2)"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyTitle"))
+
+	vocabulary.Register(StoryIntent,
+		vocabulary.WithDescription("1-2 sentence description of what implementing this story proves"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyIntent"))
+
+	vocabulary.Register(StoryRequirement,
+		vocabulary.WithDescription("Link to parent Requirement entity"),
+		vocabulary.WithDataType("entity_id"),
+		vocabulary.WithIRI(Namespace+"storyRequirement"))
+
+	vocabulary.Register(StoryComponent,
+		vocabulary.WithDescription("ComponentDef.Name this story implements; multi-valued"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyComponent"))
+
+	vocabulary.Register(StoryFilesOwned,
+		vocabulary.WithDescription("Workspace-relative path this story owns (union of selected components' implementation_files); multi-valued"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyFilesOwned"))
+
+	vocabulary.Register(StoryDependsOn,
+		vocabulary.WithDescription("Link to prerequisite Story entity (DAG edge); multi-valued"),
+		vocabulary.WithDataType("entity_id"),
+		vocabulary.WithIRI(Namespace+"storyDependsOn"))
+
+	vocabulary.Register(PredicateStoryStatus,
+		vocabulary.WithDescription("Story lifecycle status (pending, ready, executing, complete, failed)"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyStatus"))
+
+	vocabulary.Register(StoryPreparedBy,
+		vocabulary.WithDescription("Persona that signed off readiness (typically the BMAD canonical \"sarah\")"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"storyPreparedBy"))
+
+	vocabulary.Register(StoryPreparedAt,
+		vocabulary.WithDescription("Timestamp at which Sarah's readiness gate passed (RFC3339)"),
+		vocabulary.WithDataType("datetime"),
+		vocabulary.WithIRI(Namespace+"storyPreparedAt"))
+
+	vocabulary.Register(StoryCreatedAt,
+		vocabulary.WithDescription("Creation timestamp (RFC3339)"),
+		vocabulary.WithDataType("datetime"),
+		vocabulary.WithIRI(vocabulary.ProvGeneratedAtTime))
+
+	vocabulary.Register(StoryUpdatedAt,
+		vocabulary.WithDescription("Last update timestamp (RFC3339)"),
+		vocabulary.WithDataType("datetime"),
+		vocabulary.WithIRI("http://purl.org/dc/terms/modified"))
 }
 
 func registerPlanDecisionPredicates() {

--- a/vocabulary/semspec/predicates_test.go
+++ b/vocabulary/semspec/predicates_test.go
@@ -51,6 +51,23 @@ func TestPredicatesRegistered(t *testing.T) {
 		semspec.CapabilitySurface,
 		semspec.ScenarioTag,
 		semspec.ScenarioHarnessProfile,
+		// ADR-043: component + story + scenario.story + task extensions
+		semspec.ComponentImplementationFile,
+		semspec.ComponentCapability,
+		semspec.StoryTitle,
+		semspec.StoryIntent,
+		semspec.StoryRequirement,
+		semspec.StoryComponent,
+		semspec.StoryFilesOwned,
+		semspec.StoryDependsOn,
+		semspec.PredicateStoryStatus,
+		semspec.StoryPreparedBy,
+		semspec.StoryPreparedAt,
+		semspec.StoryCreatedAt,
+		semspec.StoryUpdatedAt,
+		semspec.ScenarioStory,
+		semspec.TaskStory,
+		semspec.TaskDependsOn,
 	}
 
 	for _, predicate := range predicates {
@@ -228,6 +245,74 @@ func TestCapabilityPredicatesAreThreePart(t *testing.T) {
 		semspec.CapabilitySurface,
 		semspec.ScenarioTag,
 		semspec.ScenarioHarnessProfile,
+	}
+	for _, p := range preds {
+		t.Run(p, func(t *testing.T) {
+			parts := 1
+			for _, c := range p {
+				if c == '.' {
+					parts++
+				}
+			}
+			if parts != 3 {
+				t.Errorf("predicate %q has %d dotted segments, want 3 (domain.category.property)", p, parts)
+			}
+		})
+	}
+}
+
+func TestComponentStoryPredicateValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		predicate string
+		expected  string
+	}{
+		{"ComponentImplementationFile", semspec.ComponentImplementationFile, "semspec.component.implementation_file"},
+		{"ComponentCapability", semspec.ComponentCapability, "semspec.component.capability"},
+		{"StoryTitle", semspec.StoryTitle, "semspec.story.title"},
+		{"StoryIntent", semspec.StoryIntent, "semspec.story.intent"},
+		{"StoryRequirement", semspec.StoryRequirement, "semspec.story.requirement"},
+		{"StoryComponent", semspec.StoryComponent, "semspec.story.component"},
+		{"StoryFilesOwned", semspec.StoryFilesOwned, "semspec.story.files_owned"},
+		{"StoryDependsOn", semspec.StoryDependsOn, "semspec.story.depends_on"},
+		{"PredicateStoryStatus", semspec.PredicateStoryStatus, "semspec.story.status"},
+		{"StoryPreparedBy", semspec.StoryPreparedBy, "semspec.story.prepared_by"},
+		{"StoryPreparedAt", semspec.StoryPreparedAt, "semspec.story.prepared_at"},
+		{"StoryCreatedAt", semspec.StoryCreatedAt, "semspec.story.created_at"},
+		{"StoryUpdatedAt", semspec.StoryUpdatedAt, "semspec.story.updated_at"},
+		{"ScenarioStory", semspec.ScenarioStory, "semspec.scenario.story"},
+		{"TaskStory", semspec.TaskStory, "semspec.task.story"},
+		{"TaskDependsOn", semspec.TaskDependsOn, "semspec.task.depends_on"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.predicate != tc.expected {
+				t.Errorf("got %q, want %q", tc.predicate, tc.expected)
+			}
+		})
+	}
+}
+
+// TestADR043PredicatesAreThreePart enforces the same three-segment convention
+// for the ADR-043 additions.
+func TestADR043PredicatesAreThreePart(t *testing.T) {
+	preds := []string{
+		semspec.ComponentImplementationFile,
+		semspec.ComponentCapability,
+		semspec.StoryTitle,
+		semspec.StoryIntent,
+		semspec.StoryRequirement,
+		semspec.StoryComponent,
+		semspec.StoryFilesOwned,
+		semspec.StoryDependsOn,
+		semspec.PredicateStoryStatus,
+		semspec.StoryPreparedBy,
+		semspec.StoryPreparedAt,
+		semspec.StoryCreatedAt,
+		semspec.StoryUpdatedAt,
+		semspec.ScenarioStory,
+		semspec.TaskStory,
+		semspec.TaskDependsOn,
 	}
 	for _, p := range preds {
 		t.Run(p, func(t *testing.T) {

--- a/workflow/plan_story.go
+++ b/workflow/plan_story.go
@@ -1,0 +1,274 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Sentinel errors for ADR-043 Story and Task validation. Callers wrap with
+// %w so plan-reviewer and recovery-agent can route on errors.Is, mirroring
+// the ErrInvalidRequirementDAG / ErrInvalidFileOwnership pattern from
+// plan_requirement.go.
+var (
+	ErrInvalidStoryDAG       = errors.New("invalid story DAG")
+	ErrInvalidStoryStructure = errors.New("invalid story structure")
+	ErrInvalidTaskDAG        = errors.New("invalid task DAG")
+	ErrInvalidTaskStructure  = errors.New("invalid task structure")
+)
+
+// ValidateStoryDAG validates that DependsOn references within the provided
+// stories form a valid directed acyclic graph. Mirrors
+// ValidateRequirementDAG's three-color DFS shape.
+func ValidateStoryDAG(stories []Story) error {
+	idIndex := make(map[string]struct{}, len(stories))
+	for _, s := range stories {
+		idIndex[s.ID] = struct{}{}
+	}
+
+	for _, s := range stories {
+		for _, dep := range s.DependsOn {
+			if dep == s.ID {
+				return fmt.Errorf("%w: story %q depends on itself", ErrInvalidStoryDAG, s.ID)
+			}
+			if _, ok := idIndex[dep]; !ok {
+				return fmt.Errorf("%w: story %q depends on unknown story %q", ErrInvalidStoryDAG, s.ID, dep)
+			}
+		}
+	}
+
+	adj := make(map[string][]string, len(stories))
+	for _, s := range stories {
+		adj[s.ID] = s.DependsOn
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(stories))
+
+	var visit func(id string) error
+	visit = func(id string) error {
+		color[id] = gray
+		for _, dep := range adj[id] {
+			switch color[dep] {
+			case gray:
+				return fmt.Errorf("%w: cycle detected — story %q and story %q are in a cycle", ErrInvalidStoryDAG, id, dep)
+			case white:
+				if err := visit(dep); err != nil {
+					return err
+				}
+			}
+		}
+		color[id] = black
+		return nil
+	}
+
+	for _, s := range stories {
+		if color[s.ID] == white {
+			if err := visit(s.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateStory checks structural invariants for a single Story:
+//   - ID and RequirementID and Title non-empty
+//   - FilesOwned non-empty when Sarah has signed off (Status != pending)
+//   - FilesOwned has at least one source-code file when sign-off requires
+//     it (docs-only is rejected by Sarah's readiness gate)
+//   - At least one Task present when Sarah has signed off
+//
+// Plan-reviewer R3 rules (story.missing_files_owned, story.docs_only_files_owned,
+// task.missing_within_story) wrap this as the defensive backstop layer.
+// Sarah's readiness gate is the primary layer (fails fast on the
+// architect's side).
+func ValidateStory(s Story) error {
+	if s.ID == "" {
+		return fmt.Errorf("%w: story missing ID", ErrInvalidStoryStructure)
+	}
+	if s.RequirementID == "" {
+		return fmt.Errorf("%w: story %q missing requirement_id", ErrInvalidStoryStructure, s.ID)
+	}
+	if strings.TrimSpace(s.Title) == "" {
+		return fmt.Errorf("%w: story %q missing title", ErrInvalidStoryStructure, s.ID)
+	}
+
+	// Pending stories are in-flight by Sarah and may not yet have files /
+	// tasks populated. The readiness invariants apply only on sign-off.
+	if s.Status == StoryStatusPending || s.Status == "" {
+		return nil
+	}
+
+	if len(s.FilesOwned) == 0 {
+		return fmt.Errorf("%w: story %q has empty files_owned but status %q indicates Sarah signed off — readiness gate requires at least one workspace-relative path",
+			ErrInvalidStoryStructure, s.ID, s.Status)
+	}
+	if !hasSourceFile(s.FilesOwned) {
+		return fmt.Errorf("%w: story %q files_owned %v contains only documentation files — readiness gate requires at least one source-code file",
+			ErrInvalidStoryStructure, s.ID, s.FilesOwned)
+	}
+	if len(s.Tasks) == 0 {
+		return fmt.Errorf("%w: story %q has empty tasks but status %q indicates Sarah signed off — readiness gate requires at least one task",
+			ErrInvalidStoryStructure, s.ID, s.Status)
+	}
+	return nil
+}
+
+// hasSourceFile reports whether the given paths contain at least one
+// source-code file (anything not matched by isDocumentationPath). Empty
+// slice returns false. Used by Sarah's readiness gate logic + plan-reviewer
+// story.docs_only_files_owned rule.
+func hasSourceFile(paths []string) bool {
+	for _, p := range paths {
+		if !isDocumentationPath(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateStories runs ValidateStory on each entry, ValidateStoryDAG across
+// the set, and additionally validates intra-Story task DAGs. Mode 1 (per-Story
+// structural invariants) runs first so callers see the most specific failure;
+// Mode 2 (cross-Story DAG) runs second; Mode 3 (per-Story task DAG) runs last.
+//
+// Plan-reviewer R3 invokes this on the preparing_stories → ready_for_execution
+// boundary; story-preparer (Sarah) invokes it inside her readiness gate.
+func ValidateStories(stories []Story) error {
+	for _, s := range stories {
+		if err := ValidateStory(s); err != nil {
+			return err
+		}
+	}
+	if err := ValidateStoryDAG(stories); err != nil {
+		return err
+	}
+	for _, s := range stories {
+		if err := ValidateTaskDAG(s.ID, s.Tasks); err != nil {
+			return err
+		}
+		for _, t := range s.Tasks {
+			if err := ValidateTask(s.ID, t); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateTask checks structural invariants for a single Task:
+//   - ID non-empty
+//   - StoryID matches the provided parent story ID
+//   - Description non-empty
+//
+// Per-story Task ordering (intra-story DependsOn) is validated by
+// ValidateTaskDAG.
+func ValidateTask(parentStoryID string, t Task) error {
+	if t.ID == "" {
+		return fmt.Errorf("%w: task in story %q missing ID", ErrInvalidTaskStructure, parentStoryID)
+	}
+	if t.StoryID != parentStoryID {
+		return fmt.Errorf("%w: task %q claims story_id %q but is nested under story %q",
+			ErrInvalidTaskStructure, t.ID, t.StoryID, parentStoryID)
+	}
+	if strings.TrimSpace(t.Description) == "" {
+		return fmt.Errorf("%w: task %q missing description", ErrInvalidTaskStructure, t.ID)
+	}
+	return nil
+}
+
+// ValidateTaskDAG validates that DependsOn references within a single
+// Story's Tasks form a valid DAG. parentStoryID is included in errors so
+// the caller knows which Story tripped the validation.
+func ValidateTaskDAG(parentStoryID string, tasks []Task) error {
+	idIndex := make(map[string]struct{}, len(tasks))
+	for _, t := range tasks {
+		idIndex[t.ID] = struct{}{}
+	}
+
+	for _, t := range tasks {
+		for _, dep := range t.DependsOn {
+			if dep == t.ID {
+				return fmt.Errorf("%w: task %q in story %q depends on itself", ErrInvalidTaskDAG, t.ID, parentStoryID)
+			}
+			if _, ok := idIndex[dep]; !ok {
+				return fmt.Errorf("%w: task %q in story %q depends on unknown task %q", ErrInvalidTaskDAG, t.ID, parentStoryID, dep)
+			}
+		}
+	}
+
+	adj := make(map[string][]string, len(tasks))
+	for _, t := range tasks {
+		adj[t.ID] = t.DependsOn
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(tasks))
+
+	var visit func(id string) error
+	visit = func(id string) error {
+		color[id] = gray
+		for _, dep := range adj[id] {
+			switch color[dep] {
+			case gray:
+				return fmt.Errorf("%w: cycle detected in story %q — task %q and task %q are in a cycle",
+					ErrInvalidTaskDAG, parentStoryID, id, dep)
+			case white:
+				if err := visit(dep); err != nil {
+					return err
+				}
+			}
+		}
+		color[id] = black
+		return nil
+	}
+
+	for _, t := range tasks {
+		if color[t.ID] == white {
+			if err := visit(t.ID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateComponentImplementationFiles checks that every ComponentDef in
+// the architecture document declares at least one ImplementationFiles entry,
+// and that at least one of those entries is a source-code file (docs-only
+// rejected). Skips ComponentDefs with empty Name (downstream architecture
+// validators flag those separately). Mirror of the docs-only rule for
+// requirements (plan_capability.FindDocsOnlyCapabilities) at the
+// architect-side layer (ADR-043 Move 6 — plan-reviewer R2 rules
+// architecture.component_missing_implementation_files and
+// architecture.component_implementation_files_doc_only).
+//
+// Returns nil when components are nil/empty so plans that pre-date ADR-043
+// PR 2's Winston-extension schema enforcement still validate clean — PR 2
+// adds the schema-required guard so post-PR-2 plans always have populated
+// fields.
+func ValidateComponentImplementationFiles(components []ComponentDef) error {
+	for _, c := range components {
+		if c.Name == "" {
+			continue
+		}
+		if len(c.ImplementationFiles) == 0 {
+			return fmt.Errorf("%w: component %q has empty implementation_files — every component must own at least one workspace-relative source path",
+				ErrInvalidStoryStructure, c.Name)
+		}
+		if !hasSourceFile(c.ImplementationFiles) {
+			return fmt.Errorf("%w: component %q implementation_files %v contains only documentation files — every component must own at least one source-code file",
+				ErrInvalidStoryStructure, c.Name, c.ImplementationFiles)
+		}
+	}
+	return nil
+}

--- a/workflow/plan_story_test.go
+++ b/workflow/plan_story_test.go
@@ -1,0 +1,392 @@
+package workflow
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateStoryDAG(t *testing.T) {
+	cases := []struct {
+		name      string
+		stories   []Story
+		wantErr   error
+		errPhrase string
+	}{
+		{
+			name: "empty set is valid",
+		},
+		{
+			name: "linear chain is valid",
+			stories: []Story{
+				{ID: "s1"},
+				{ID: "s2", DependsOn: []string{"s1"}},
+				{ID: "s3", DependsOn: []string{"s2"}},
+			},
+		},
+		{
+			name: "diamond is valid",
+			stories: []Story{
+				{ID: "s1"},
+				{ID: "s2", DependsOn: []string{"s1"}},
+				{ID: "s3", DependsOn: []string{"s1"}},
+				{ID: "s4", DependsOn: []string{"s2", "s3"}},
+			},
+		},
+		{
+			name:      "self-dependency rejected",
+			stories:   []Story{{ID: "s1", DependsOn: []string{"s1"}}},
+			wantErr:   ErrInvalidStoryDAG,
+			errPhrase: "depends on itself",
+		},
+		{
+			name: "orphan reference rejected",
+			stories: []Story{
+				{ID: "s1", DependsOn: []string{"ghost"}},
+			},
+			wantErr:   ErrInvalidStoryDAG,
+			errPhrase: "unknown story",
+		},
+		{
+			name: "cycle rejected",
+			stories: []Story{
+				{ID: "s1", DependsOn: []string{"s2"}},
+				{ID: "s2", DependsOn: []string{"s1"}},
+			},
+			wantErr:   ErrInvalidStoryDAG,
+			errPhrase: "cycle",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateStoryDAG(tc.stories)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want errors.Is sentinel %v", err, tc.wantErr)
+			}
+			if tc.errPhrase != "" && err != nil && !strings.Contains(err.Error(), tc.errPhrase) {
+				t.Errorf("error message %q missing phrase %q", err.Error(), tc.errPhrase)
+			}
+		})
+	}
+}
+
+func TestValidateStory(t *testing.T) {
+	cases := []struct {
+		name      string
+		story     Story
+		wantErr   error
+		errPhrase string
+	}{
+		{
+			name:  "minimal pending story (Sarah in flight) is valid",
+			story: Story{ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusPending},
+		},
+		{
+			name:  "empty status (freshly generated) is treated as pending",
+			story: Story{ID: "s1", RequirementID: "r1", Title: "T"},
+		},
+		{
+			name:      "missing ID rejected",
+			story:     Story{RequirementID: "r1", Title: "T"},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "missing ID",
+		},
+		{
+			name:      "missing requirement_id rejected",
+			story:     Story{ID: "s1", Title: "T"},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "missing requirement_id",
+		},
+		{
+			name:      "missing title rejected",
+			story:     Story{ID: "s1", RequirementID: "r1", Title: "  "},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "missing title",
+		},
+		{
+			name: "ready story without files_owned rejected",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusReady,
+				Tasks: []Task{{ID: "t1", StoryID: "s1", Description: "x"}},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "empty files_owned",
+		},
+		{
+			name: "ready story with docs-only files_owned rejected",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusReady,
+				FilesOwned: []string{"README.md", "docs/coverage.md"},
+				Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "x"}},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "only documentation files",
+		},
+		{
+			name: "ready story without tasks rejected",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusReady,
+				FilesOwned: []string{"src/x.go"},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "empty tasks",
+		},
+		{
+			name: "ready story with source + companion doc + tasks is valid",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusReady,
+				FilesOwned: []string{"src/x.go", "README.md"},
+				Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "x"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateStory(tc.story)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want sentinel %v", err, tc.wantErr)
+			}
+			if tc.errPhrase != "" && err != nil && !strings.Contains(err.Error(), tc.errPhrase) {
+				t.Errorf("error message %q missing phrase %q", err.Error(), tc.errPhrase)
+			}
+		})
+	}
+}
+
+func TestValidateTask(t *testing.T) {
+	cases := []struct {
+		name      string
+		parent    string
+		task      Task
+		wantErr   error
+		errPhrase string
+	}{
+		{
+			name:   "minimal task is valid",
+			parent: "s1",
+			task:   Task{ID: "t1", StoryID: "s1", Description: "x"},
+		},
+		{
+			name:      "missing ID rejected",
+			parent:    "s1",
+			task:      Task{StoryID: "s1", Description: "x"},
+			wantErr:   ErrInvalidTaskStructure,
+			errPhrase: "missing ID",
+		},
+		{
+			name:      "wrong parent rejected",
+			parent:    "s1",
+			task:      Task{ID: "t1", StoryID: "s2", Description: "x"},
+			wantErr:   ErrInvalidTaskStructure,
+			errPhrase: `nested under story "s1"`,
+		},
+		{
+			name:      "empty description rejected",
+			parent:    "s1",
+			task:      Task{ID: "t1", StoryID: "s1", Description: "  "},
+			wantErr:   ErrInvalidTaskStructure,
+			errPhrase: "missing description",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTask(tc.parent, tc.task)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want sentinel %v", err, tc.wantErr)
+			}
+			if tc.errPhrase != "" && err != nil && !strings.Contains(err.Error(), tc.errPhrase) {
+				t.Errorf("error message %q missing phrase %q", err.Error(), tc.errPhrase)
+			}
+		})
+	}
+}
+
+func TestValidateTaskDAG(t *testing.T) {
+	cases := []struct {
+		name      string
+		parent    string
+		tasks     []Task
+		wantErr   error
+		errPhrase string
+	}{
+		{
+			name:   "linear chain is valid",
+			parent: "s1",
+			tasks: []Task{
+				{ID: "t1"},
+				{ID: "t2", DependsOn: []string{"t1"}},
+				{ID: "t3", DependsOn: []string{"t2"}},
+			},
+		},
+		{
+			name:      "self-dep rejected",
+			parent:    "s1",
+			tasks:     []Task{{ID: "t1", DependsOn: []string{"t1"}}},
+			wantErr:   ErrInvalidTaskDAG,
+			errPhrase: "depends on itself",
+		},
+		{
+			name:      "orphan dep rejected",
+			parent:    "s1",
+			tasks:     []Task{{ID: "t1", DependsOn: []string{"ghost"}}},
+			wantErr:   ErrInvalidTaskDAG,
+			errPhrase: "unknown task",
+		},
+		{
+			name:   "cycle rejected",
+			parent: "s1",
+			tasks: []Task{
+				{ID: "t1", DependsOn: []string{"t2"}},
+				{ID: "t2", DependsOn: []string{"t1"}},
+			},
+			wantErr:   ErrInvalidTaskDAG,
+			errPhrase: "cycle",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTaskDAG(tc.parent, tc.tasks)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want sentinel %v", err, tc.wantErr)
+			}
+			if tc.errPhrase != "" && err != nil && !strings.Contains(err.Error(), tc.errPhrase) {
+				t.Errorf("error message %q missing phrase %q", err.Error(), tc.errPhrase)
+			}
+		})
+	}
+}
+
+// TestValidateStoriesAggregate exercises the whole-set validator: per-story
+// structural rules, cross-story DAG rules, and intra-story Task DAG rules
+// all funnel through a single happy-path call and a few targeted failures.
+func TestValidateStoriesAggregate(t *testing.T) {
+	good := []Story{
+		{ID: "s1", RequirementID: "r1", Title: "A", Status: StoryStatusReady,
+			FilesOwned: []string{"src/a.go"},
+			Tasks: []Task{
+				{ID: "t1", StoryID: "s1", Description: "tests"},
+				{ID: "t2", StoryID: "s1", Description: "impl", DependsOn: []string{"t1"}},
+			}},
+		{ID: "s2", RequirementID: "r1", Title: "B", Status: StoryStatusReady,
+			FilesOwned: []string{"src/b.go"},
+			DependsOn:  []string{"s1"},
+			Tasks: []Task{
+				{ID: "t3", StoryID: "s2", Description: "tests"},
+			}},
+	}
+	if err := ValidateStories(good); err != nil {
+		t.Fatalf("expected good set to validate: %v", err)
+	}
+
+	storyDAGBad := append([]Story(nil), good...)
+	storyDAGBad[0].DependsOn = []string{"s2"} // creates s1↔s2 cycle
+	if err := ValidateStories(storyDAGBad); !errors.Is(err, ErrInvalidStoryDAG) {
+		t.Errorf("story DAG error not surfaced: %v", err)
+	}
+
+	taskDAGBad := []Story{
+		{ID: "s1", RequirementID: "r1", Title: "A", Status: StoryStatusReady,
+			FilesOwned: []string{"src/a.go"},
+			Tasks: []Task{
+				{ID: "t1", StoryID: "s1", Description: "x", DependsOn: []string{"t2"}},
+				{ID: "t2", StoryID: "s1", Description: "y", DependsOn: []string{"t1"}},
+			}},
+	}
+	if err := ValidateStories(taskDAGBad); !errors.Is(err, ErrInvalidTaskDAG) {
+		t.Errorf("task DAG error not surfaced: %v", err)
+	}
+
+	storyStructBad := []Story{
+		{ID: "s1", RequirementID: "r1", Title: "A", Status: StoryStatusReady,
+			FilesOwned: []string{"README.md"}, // docs-only
+			Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "x"}}},
+	}
+	if err := ValidateStories(storyStructBad); !errors.Is(err, ErrInvalidStoryStructure) {
+		t.Errorf("story struct error not surfaced: %v", err)
+	}
+}
+
+func TestValidateComponentImplementationFiles(t *testing.T) {
+	cases := []struct {
+		name       string
+		components []ComponentDef
+		wantErr    error
+		errPhrase  string
+	}{
+		{
+			name:       "empty set is valid (pre-PR2 plans)",
+			components: nil,
+		},
+		{
+			name: "all components have source files",
+			components: []ComponentDef{
+				{Name: "a", ImplementationFiles: []string{"src/a.go"}},
+				{Name: "b", ImplementationFiles: []string{"src/b.go", "README.md"}},
+			},
+		},
+		{
+			name: "unnamed component skipped (separate validator)",
+			components: []ComponentDef{
+				{Name: "", ImplementationFiles: nil},
+				{Name: "a", ImplementationFiles: []string{"src/a.go"}},
+			},
+		},
+		{
+			name: "empty files rejected",
+			components: []ComponentDef{
+				{Name: "a"},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "empty implementation_files",
+		},
+		{
+			name: "docs-only files rejected",
+			components: []ComponentDef{
+				{Name: "a", ImplementationFiles: []string{"docs/x.md", "README.md"}},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "only documentation files",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateComponentImplementationFiles(tc.components)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got %v, want sentinel %v", err, tc.wantErr)
+			}
+			if tc.errPhrase != "" && err != nil && !strings.Contains(err.Error(), tc.errPhrase) {
+				t.Errorf("error message %q missing phrase %q", err.Error(), tc.errPhrase)
+			}
+		})
+	}
+}

--- a/workflow/story_task.go
+++ b/workflow/story_task.go
@@ -1,0 +1,248 @@
+package workflow
+
+import "time"
+
+// Story is a Sarah-authored unit of dev-ready work (ADR-043 Move 2). A Story
+// shards a single Requirement into a unit that one developer agent can
+// execute end-to-end: explicit Components selection, explicit FilesOwned
+// (the union of selected components' implementation_files, Sarah-curated),
+// an ordered Task checklist, and DependsOn edges to other Stories that must
+// complete first.
+//
+// Sarah's readiness gate ensures every Story she signs off has non-empty
+// FilesOwned (at least one source-code file), at least one Task, and
+// resolvable DependsOn IDs. The plan-reviewer R3 round (introduced in
+// ADR-043 PR 3) validates the same invariants as a defensive backstop.
+//
+// Execution-manager dispatches per-Story (ADR-043 Move 5; PR 4) instead of
+// the legacy per-Requirement + decomposer-LLM-at-execution-time path.
+type Story struct {
+	// ID is the stable story identifier.
+	// Format: story.<plan-slug>.<reqseq>.<storyseq>
+	ID string `json:"id"`
+
+	// RequirementID is the parent requirement. Sarah's sharding decision —
+	// one requirement may become one Story (single-component) or N Stories
+	// with DependsOn edges (multi-component or prereq-ordered work).
+	RequirementID string `json:"requirement_id"`
+
+	// Title is the human-readable story heading.
+	Title string `json:"title"`
+
+	// Intent is a 1-2 sentence description of what implementing this story
+	// proves.
+	Intent string `json:"intent,omitempty"`
+
+	// Components are kebab-case ComponentDef.Name entries Sarah selected
+	// from the architecture document. Plan-reviewer rule
+	// story.unresolved_components rejects entries that don't match any
+	// declared component.
+	Components []string `json:"components,omitempty"`
+
+	// FilesOwned is the union of the selected Components' implementation_files
+	// (Sarah assembles it explicitly so the dev knows the exact file set).
+	// Plan-reviewer rule story.missing_files_owned rejects empty lists;
+	// story.docs_only_files_owned rejects lists with no source-code file.
+	FilesOwned []string `json:"files_owned,omitempty"`
+
+	// DependsOn are other Story.ID entries that must reach StoryStatusComplete
+	// before this Story can dispatch. Plan-reviewer rules
+	// story.depends_on_orphan and story.depends_on_cycle reject unresolved
+	// IDs and DAG cycles.
+	DependsOn []string `json:"depends_on,omitempty"`
+
+	// Tasks are Sarah's ordered TDD checklist for this Story. A typical
+	// shape is 3-5 tasks: write failing tests, implement to pass,
+	// integration smoke, verify scenarios. The execution-manager runs
+	// Tasks in topo order (intra-story DependsOn); the dev decomposes
+	// further as needed inside the TDD pipeline. Plan-reviewer rule
+	// task.missing_within_story rejects empty Tasks; task.depends_on_cycle
+	// rejects intra-story DAG cycles.
+	Tasks []Task `json:"tasks,omitempty"`
+
+	// Status — see Requirement.Status omitempty rationale (b7r50o9ov 2026-05-08).
+	// Plan-time stories carry empty status (so the plan-reviewer doesn't see
+	// asymmetry across freshly-generated stories); execution-manager sets a
+	// non-empty status on dispatch.
+	Status StoryStatus `json:"status,omitempty"`
+
+	// PreparedBy is the persona that signed off readiness — "sarah" when
+	// the readiness gate passed.
+	PreparedBy string `json:"prepared_by,omitempty"`
+
+	// PreparedAt is the timestamp at which Sarah's readiness gate passed.
+	PreparedAt *time.Time `json:"prepared_at,omitempty"`
+
+	// RecoveryHint mirrors Requirement.RecoveryHint — populated when ADR-037
+	// stage-1 recovery emits a PlanDecision with action=story_reprepare and
+	// plan-decision-handler accepts it. story-preparer (Sarah) prepends this
+	// hint onto Sarah's prompt on the next preparation cycle so she sees the
+	// recovery-agent's recommendation alongside the original requirement
+	// intent. Cleared on story completion.
+	RecoveryHint string `json:"recovery_hint,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// StoryStatus represents the lifecycle state of a Story.
+type StoryStatus string
+
+const (
+	// StoryStatusPending indicates Sarah hasn't completed preparation —
+	// either she's mid-flight or her readiness gate failed.
+	StoryStatusPending StoryStatus = "pending"
+
+	// StoryStatusReady indicates Sarah's readiness gate passed; the story
+	// is ready for the execution-manager to dispatch when prereq Stories
+	// (DependsOn) complete.
+	StoryStatusReady StoryStatus = "ready"
+
+	// StoryStatusExecuting indicates execution-manager has dispatched the
+	// dev TDD pipeline for this Story.
+	StoryStatusExecuting StoryStatus = "executing"
+
+	// StoryStatusComplete indicates dev + per-Story reviewer approved.
+	StoryStatusComplete StoryStatus = "complete"
+
+	// StoryStatusFailed indicates execution exhausted retries and a
+	// PlanDecision (kind=execution_exhausted or recovery_failure) is
+	// required to advance the plan.
+	StoryStatusFailed StoryStatus = "failed"
+)
+
+// String returns the string representation of the story status.
+func (s StoryStatus) String() string {
+	return string(s)
+}
+
+// IsValid returns true if the story status is one of the defined values.
+func (s StoryStatus) IsValid() bool {
+	switch s {
+	case StoryStatusPending, StoryStatusReady,
+		StoryStatusExecuting, StoryStatusComplete, StoryStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// CanTransitionTo returns true if this story status can transition to the
+// target. The status DAG:
+//
+//	pending → ready | failed
+//	ready → executing | failed
+//	executing → complete | failed
+//	complete → ready (re-execute on PlanDecision cascade)
+//	failed → pending (re-prepare on story_reprepare recovery action)
+func (s StoryStatus) CanTransitionTo(target StoryStatus) bool {
+	switch s {
+	case StoryStatusPending:
+		return target == StoryStatusReady || target == StoryStatusFailed
+	case StoryStatusReady:
+		return target == StoryStatusExecuting || target == StoryStatusFailed
+	case StoryStatusExecuting:
+		return target == StoryStatusComplete || target == StoryStatusFailed
+	case StoryStatusComplete:
+		return target == StoryStatusReady
+	case StoryStatusFailed:
+		return target == StoryStatusPending
+	default:
+		return false
+	}
+}
+
+// Task is a Sarah-authored intra-story checklist item (ADR-043 Move 2).
+// Tasks replace the runtime decomposer-LLM call: Sarah authors the DAG at
+// plan time, the execution-manager dispatches in topo order, and the
+// dev TDD pipeline runs structural-validator + code-reviewer per task.
+//
+// Task IDs are scoped under their parent Story; intra-story DependsOn
+// expresses TDD ordering (e.g. "tests-first task" precedes "implementation
+// task"). Cross-story ordering lives on Story.DependsOn, not Task.DependsOn.
+type Task struct {
+	// ID is the stable task identifier.
+	// Format: task.<plan-slug>.<reqseq>.<storyseq>.<taskseq>
+	ID string `json:"id"`
+
+	// StoryID is the parent Story. Plan-reviewer rule task.missing_within_story
+	// rejects orphan tasks; the execution-manager only dispatches Tasks whose
+	// Story is StoryStatusExecuting.
+	StoryID string `json:"story_id"`
+
+	// Description is the 1-line intent for what this task accomplishes
+	// (e.g. "Write failing test for boot lifecycle"). The dev decomposes
+	// further inside the TDD pipeline.
+	Description string `json:"description"`
+
+	// DependsOn are intra-story Task.IDs that must reach TaskStatusComplete
+	// before this Task can dispatch. Plan-reviewer rule task.depends_on_cycle
+	// rejects DAG cycles within a Story.
+	DependsOn []string `json:"depends_on,omitempty"`
+
+	// Status — see Story.Status / Requirement.Status omitempty rationale.
+	Status TaskStatus `json:"status,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TaskStatus represents the lifecycle state of a Task within a Story.
+type TaskStatus string
+
+const (
+	// TaskStatusPending indicates the task has not yet been dispatched.
+	TaskStatusPending TaskStatus = "pending"
+
+	// TaskStatusDispatched indicates the execution-manager has dispatched
+	// this task to a dev TDD pipeline.
+	TaskStatusDispatched TaskStatus = "dispatched"
+
+	// TaskStatusComplete indicates the dev + structural-validator + code
+	// reviewer all approved.
+	TaskStatusComplete TaskStatus = "complete"
+
+	// TaskStatusFailed indicates the task exhausted retries; the parent
+	// Story transitions to failed and the recovery cascade fires.
+	TaskStatusFailed TaskStatus = "failed"
+)
+
+// String returns the string representation of the task status.
+func (s TaskStatus) String() string {
+	return string(s)
+}
+
+// IsValid returns true if the task status is one of the defined values.
+func (s TaskStatus) IsValid() bool {
+	switch s {
+	case TaskStatusPending, TaskStatusDispatched,
+		TaskStatusComplete, TaskStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// CanTransitionTo returns true if this task status can transition to the
+// target. The status DAG:
+//
+//	pending → dispatched | failed
+//	dispatched → complete | failed | pending (retry)
+//	complete → pending (re-dispatch on cascade)
+//	failed → pending (re-dispatch on cascade)
+func (s TaskStatus) CanTransitionTo(target TaskStatus) bool {
+	switch s {
+	case TaskStatusPending:
+		return target == TaskStatusDispatched || target == TaskStatusFailed
+	case TaskStatusDispatched:
+		return target == TaskStatusComplete ||
+			target == TaskStatusFailed ||
+			target == TaskStatusPending
+	case TaskStatusComplete:
+		return target == TaskStatusPending
+	case TaskStatusFailed:
+		return target == TaskStatusPending
+	default:
+		return false
+	}
+}

--- a/workflow/story_task_test.go
+++ b/workflow/story_task_test.go
@@ -1,0 +1,356 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStoryStatusIsValid(t *testing.T) {
+	cases := []struct {
+		s    StoryStatus
+		want bool
+	}{
+		{StoryStatusPending, true},
+		{StoryStatusReady, true},
+		{StoryStatusExecuting, true},
+		{StoryStatusComplete, true},
+		{StoryStatusFailed, true},
+		{StoryStatus(""), false},
+		{StoryStatus("bogus"), false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.s), func(t *testing.T) {
+			if got := tc.s.IsValid(); got != tc.want {
+				t.Errorf("StoryStatus(%q).IsValid() = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStoryStatusCanTransitionTo(t *testing.T) {
+	cases := []struct {
+		from, to StoryStatus
+		want     bool
+	}{
+		// Happy path
+		{StoryStatusPending, StoryStatusReady, true},
+		{StoryStatusReady, StoryStatusExecuting, true},
+		{StoryStatusExecuting, StoryStatusComplete, true},
+		// Failure path
+		{StoryStatusPending, StoryStatusFailed, true},
+		{StoryStatusReady, StoryStatusFailed, true},
+		{StoryStatusExecuting, StoryStatusFailed, true},
+		// Recovery loops
+		{StoryStatusComplete, StoryStatusReady, true},
+		{StoryStatusFailed, StoryStatusPending, true},
+		// Rejected jumps
+		{StoryStatusPending, StoryStatusExecuting, false},
+		{StoryStatusReady, StoryStatusComplete, false},
+		{StoryStatusComplete, StoryStatusExecuting, false},
+		{StoryStatusFailed, StoryStatusComplete, false},
+		// Bogus source
+		{StoryStatus("bogus"), StoryStatusReady, false},
+	}
+	for _, tc := range cases {
+		name := string(tc.from) + "→" + string(tc.to)
+		t.Run(name, func(t *testing.T) {
+			if got := tc.from.CanTransitionTo(tc.to); got != tc.want {
+				t.Errorf("%s = %v, want %v", name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTaskStatusIsValid(t *testing.T) {
+	cases := []struct {
+		s    TaskStatus
+		want bool
+	}{
+		{TaskStatusPending, true},
+		{TaskStatusDispatched, true},
+		{TaskStatusComplete, true},
+		{TaskStatusFailed, true},
+		{TaskStatus(""), false},
+		{TaskStatus("bogus"), false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.s), func(t *testing.T) {
+			if got := tc.s.IsValid(); got != tc.want {
+				t.Errorf("TaskStatus(%q).IsValid() = %v, want %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTaskStatusCanTransitionTo(t *testing.T) {
+	cases := []struct {
+		from, to TaskStatus
+		want     bool
+	}{
+		{TaskStatusPending, TaskStatusDispatched, true},
+		{TaskStatusDispatched, TaskStatusComplete, true},
+		{TaskStatusDispatched, TaskStatusFailed, true},
+		{TaskStatusDispatched, TaskStatusPending, true},
+		{TaskStatusComplete, TaskStatusPending, true},
+		{TaskStatusFailed, TaskStatusPending, true},
+		// Rejected
+		{TaskStatusPending, TaskStatusComplete, false},
+		{TaskStatusComplete, TaskStatusDispatched, false},
+		{TaskStatusFailed, TaskStatusComplete, false},
+	}
+	for _, tc := range cases {
+		name := string(tc.from) + "→" + string(tc.to)
+		t.Run(name, func(t *testing.T) {
+			if got := tc.from.CanTransitionTo(tc.to); got != tc.want {
+				t.Errorf("%s = %v, want %v", name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStoryJSONRoundTrip ensures the Story wire shape survives marshal +
+// unmarshal with omitempty hygiene on optional fields.
+func TestStoryJSONRoundTrip(t *testing.T) {
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	prepared := now.Add(5 * time.Minute)
+	in := Story{
+		ID:            "story.x.1.1",
+		RequirementID: "req.x.1",
+		Title:         "MAVSDK Lifecycle Bootstrap",
+		Intent:        "Boot mavsdk_server and observe HEARTBEAT.",
+		Components:    []string{"mavsdk-server-lifecycle"},
+		FilesOwned:    []string{"src/Lifecycle.java"},
+		DependsOn:     []string{},
+		Tasks: []Task{
+			{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "Write failing test",
+				CreatedAt: now, UpdatedAt: now},
+		},
+		Status:     StoryStatusReady,
+		PreparedBy: "sarah",
+		PreparedAt: &prepared,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out Story
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ID != in.ID || out.RequirementID != in.RequirementID || out.Title != in.Title {
+		t.Errorf("identity fields drifted: in=%+v out=%+v", in, out)
+	}
+	if out.Status != StoryStatusReady {
+		t.Errorf("status drifted: %q", out.Status)
+	}
+	if out.PreparedAt == nil || !out.PreparedAt.Equal(prepared) {
+		t.Errorf("prepared_at drifted: %v", out.PreparedAt)
+	}
+	if len(out.Tasks) != 1 || out.Tasks[0].ID != "task.x.1.1.1" {
+		t.Errorf("tasks drifted: %+v", out.Tasks)
+	}
+}
+
+// TestStoryJSONOmitemptyOnZero ensures that a freshly-generated Story (Status
+// empty, no PreparedAt, no Tasks) marshals without "status":"" / null fields
+// that would poison plan-reviewer asymmetry checks (b7r50o9ov pattern).
+func TestStoryJSONOmitemptyOnZero(t *testing.T) {
+	in := Story{ID: "story.x.1.1", RequirementID: "req.x.1", Title: "Untouched"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, banned := range []string{
+		`"status"`, `"prepared_by"`, `"prepared_at"`, `"recovery_hint"`,
+		`"intent"`, `"components"`, `"files_owned"`, `"depends_on"`, `"tasks"`,
+	} {
+		if strings.Contains(s, banned) {
+			t.Errorf("zero-value Story emitted %s; want omitempty: %s", banned, s)
+		}
+	}
+}
+
+// TestTaskJSONOmitemptyOnZero is the symmetric check for Task.
+func TestTaskJSONOmitemptyOnZero(t *testing.T) {
+	in := Task{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "Write test"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, banned := range []string{`"status"`, `"depends_on"`} {
+		if strings.Contains(s, banned) {
+			t.Errorf("zero-value Task emitted %s; want omitempty: %s", banned, s)
+		}
+	}
+}
+
+// TestComponentDefImplementationFieldsOmitEmpty ensures the new ADR-043
+// fields don't appear on legacy components persisted before PR 2 wired
+// the schema enforcement.
+func TestComponentDefImplementationFieldsOmitEmpty(t *testing.T) {
+	c := ComponentDef{Name: "legacy", Responsibility: "old", Dependencies: []string{}}
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, banned := range []string{`"implementation_files"`, `"capabilities"`} {
+		if strings.Contains(s, banned) {
+			t.Errorf("legacy ComponentDef emitted %s; want omitempty: %s", banned, s)
+		}
+	}
+}
+
+// TestComponentDefRoundTripsADR043Fields verifies that when the new fields
+// are populated they survive marshal + unmarshal.
+func TestComponentDefRoundTripsADR043Fields(t *testing.T) {
+	in := ComponentDef{
+		Name:                "lifecycle",
+		Responsibility:      "boot mavsdk",
+		Dependencies:        []string{},
+		ImplementationFiles: []string{"src/Lifecycle.java", "README.md"},
+		Capabilities:        []string{"mavsdk-bootstrap"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out ComponentDef
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.ImplementationFiles) != 2 || out.ImplementationFiles[0] != "src/Lifecycle.java" {
+		t.Errorf("implementation_files drifted: %v", out.ImplementationFiles)
+	}
+	if len(out.Capabilities) != 1 || out.Capabilities[0] != "mavsdk-bootstrap" {
+		t.Errorf("capabilities drifted: %v", out.Capabilities)
+	}
+}
+
+// TestScenarioStoryIDOmitemptyAndRoundTrip verifies the StoryID field
+// stays omitempty on legacy scenarios but survives a round-trip when set.
+func TestScenarioStoryIDOmitemptyAndRoundTrip(t *testing.T) {
+	legacy := Scenario{ID: "s.x.1.1", RequirementID: "req.x.1", Given: "g", When: "w", Then: []string{"t"}}
+	b, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), `"story_id"`) {
+		t.Errorf("legacy Scenario emitted story_id; want omitempty: %s", string(b))
+	}
+
+	tagged := legacy
+	tagged.StoryID = "story.x.1.1"
+	b, err = json.Marshal(tagged)
+	if err != nil {
+		t.Fatalf("marshal tagged: %v", err)
+	}
+	if !strings.Contains(string(b), `"story_id":"story.x.1.1"`) {
+		t.Errorf("tagged Scenario missing story_id: %s", string(b))
+	}
+	var out Scenario
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal tagged: %v", err)
+	}
+	if out.StoryID != "story.x.1.1" {
+		t.Errorf("story_id drifted: %q", out.StoryID)
+	}
+}
+
+func TestPlanStoryHelpers(t *testing.T) {
+	plan := Plan{
+		ID:   "plan.x",
+		Slug: "x",
+		Requirements: []Requirement{
+			{ID: "req.x.1"},
+			{ID: "req.x.2"},
+		},
+		Stories: []Story{
+			{ID: "story.x.1.1", RequirementID: "req.x.1", Title: "A",
+				Tasks: []Task{
+					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "t1"},
+					{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "t2"},
+				}},
+			{ID: "story.x.1.2", RequirementID: "req.x.1", Title: "B"},
+			{ID: "story.x.2.1", RequirementID: "req.x.2", Title: "C",
+				Tasks: []Task{{ID: "task.x.2.1.1", StoryID: "story.x.2.1", Description: "t3"}}},
+		},
+		Scenarios: []Scenario{
+			{ID: "scen.1", RequirementID: "req.x.1", StoryID: "story.x.1.1"},
+			{ID: "scen.2", RequirementID: "req.x.1", StoryID: "story.x.1.1"},
+			{ID: "scen.3", RequirementID: "req.x.2", StoryID: "story.x.2.1"},
+		},
+	}
+
+	got, idx := plan.FindStory("story.x.1.2")
+	if got == nil || idx != 1 || got.Title != "B" {
+		t.Errorf("FindStory(story.x.1.2) = %+v, %d; want second story", got, idx)
+	}
+	if g, i := plan.FindStory("missing"); g != nil || i != -1 {
+		t.Errorf("FindStory(missing) = %+v, %d; want nil, -1", g, i)
+	}
+
+	storiesForReq1 := plan.StoriesForRequirement("req.x.1")
+	if len(storiesForReq1) != 2 {
+		t.Fatalf("StoriesForRequirement(req.x.1) returned %d stories, want 2", len(storiesForReq1))
+	}
+	if storiesForReq1[0].ID != "story.x.1.1" || storiesForReq1[1].ID != "story.x.1.2" {
+		t.Errorf("StoriesForRequirement returned wrong order: %+v", storiesForReq1)
+	}
+
+	task, si, ti := plan.FindTask("task.x.1.1.2")
+	if task == nil || si != 0 || ti != 1 {
+		t.Errorf("FindTask(task.x.1.1.2) = %+v, %d, %d; want second task of first story", task, si, ti)
+	}
+	if tk, _, _ := plan.FindTask("task.x.2.1.1"); tk == nil || tk.Description != "t3" {
+		t.Errorf("FindTask cross-story lookup failed: %+v", tk)
+	}
+	if tk, si2, ti2 := plan.FindTask("missing"); tk != nil || si2 != -1 || ti2 != -1 {
+		t.Errorf("FindTask(missing) = %+v, %d, %d; want nil, -1, -1", tk, si2, ti2)
+	}
+
+	scens := plan.ScenariosForStory("story.x.1.1")
+	if len(scens) != 2 {
+		t.Errorf("ScenariosForStory returned %d, want 2: %+v", len(scens), scens)
+	}
+}
+
+func TestStatusPreparingStoriesIsValidAndInProgress(t *testing.T) {
+	if !StatusPreparingStories.IsValid() {
+		t.Errorf("StatusPreparingStories not in IsValid set")
+	}
+	if !StatusPreparingStories.IsInProgress() {
+		t.Errorf("StatusPreparingStories should be IsInProgress (Sarah is running)")
+	}
+}
+
+func TestStatusPreparingStoriesTransitions(t *testing.T) {
+	cases := []struct {
+		from, to Status
+		want     bool
+	}{
+		{StatusArchitectureGenerated, StatusPreparingStories, true},
+		{StatusPreparingStories, StatusReadyForExecution, true},
+		{StatusPreparingStories, StatusArchitectureGenerated, true},
+		{StatusPreparingStories, StatusRejected, true},
+		// Legacy architecture→scenarios path still works
+		{StatusArchitectureGenerated, StatusScenariosGenerated, true},
+		// Reject jumps
+		{StatusPreparingStories, StatusImplementing, false},
+		{StatusPreparingStories, StatusCreated, false},
+	}
+	for _, tc := range cases {
+		name := string(tc.from) + "→" + string(tc.to)
+		t.Run(name, func(t *testing.T) {
+			if got := tc.from.CanTransitionTo(tc.to); got != tc.want {
+				t.Errorf("%s = %v, want %v", name, got, tc.want)
+			}
+		})
+	}
+}

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -78,6 +78,15 @@ const (
 	StatusGeneratingScenarios Status = "generating_scenarios"
 	// StatusReviewingScenarios indicates plan-reviewer R2 has claimed scenarios_generated.
 	StatusReviewingScenarios Status = "reviewing_scenarios"
+	// StatusPreparingStories indicates story-preparer (Sarah) has claimed
+	// architecture_generated and is sharding requirements into Stories
+	// with task checklists (ADR-043 Move 3). Sarah's readiness gate runs
+	// inside this state; on completion plan-reviewer R3 fires on
+	// ready_for_execution to validate story.* rules. New state, additive
+	// — wired into the happy path in ADR-043 PR 3 when story-preparer
+	// lands. The legacy architecture_generated → scenarios_generated
+	// path remains valid until PR 4 rewires Bob to consume Stories.
+	StatusPreparingStories Status = "preparing_stories"
 )
 
 const (
@@ -159,7 +168,8 @@ func (s Status) IsValid() bool {
 		StatusChanged, StatusReadyForQA, StatusReviewingQA,
 		StatusExploring, StatusExplored,
 		StatusDrafting, StatusReviewingDraft, StatusGeneratingRequirements,
-		StatusGeneratingArchitecture, StatusGeneratingScenarios, StatusReviewingScenarios:
+		StatusGeneratingArchitecture, StatusGeneratingScenarios, StatusReviewingScenarios,
+		StatusPreparingStories:
 		return true
 	default:
 		return false
@@ -172,7 +182,8 @@ func (s Status) IsInProgress() bool {
 	switch s {
 	case StatusExploring,
 		StatusDrafting, StatusReviewingDraft, StatusGeneratingRequirements,
-		StatusGeneratingArchitecture, StatusGeneratingScenarios, StatusReviewingScenarios:
+		StatusGeneratingArchitecture, StatusGeneratingScenarios, StatusReviewingScenarios,
+		StatusPreparingStories:
 		return true
 	default:
 		return false
@@ -235,12 +246,21 @@ func (s Status) CanTransitionTo(target Status) bool {
 		// generating_architecture → rejected (fatal error)
 		return target == StatusArchitectureGenerated || target == StatusRejected
 	case StatusArchitectureGenerated:
-		// architecture_generated → generating_scenarios (scenario-generator claims)
-		// architecture_generated → scenarios_generated (auto-cascade)
+		// architecture_generated → generating_scenarios (scenario-generator claims; legacy pre-ADR-043 path)
+		// architecture_generated → scenarios_generated (auto-cascade; legacy)
+		// architecture_generated → preparing_stories (ADR-043 PR 3: story-preparer claims)
 		// architecture_generated → changed (change proposal deprecated requirements)
 		// architecture_generated → rejected (validation failure)
 		return target == StatusGeneratingScenarios || target == StatusScenariosGenerated ||
+			target == StatusPreparingStories ||
 			target == StatusChanged || target == StatusRejected
+	case StatusPreparingStories:
+		// preparing_stories → ready_for_execution (Sarah done; plan-reviewer R3 will fire on this state per ADR-043 PR 3)
+		// preparing_stories → architecture_generated (R3 phase-targeted retry — architect must reshape components)
+		// preparing_stories → rejected (escalation: readiness gate exhausted retries)
+		return target == StatusReadyForExecution ||
+			target == StatusArchitectureGenerated ||
+			target == StatusRejected
 	case StatusGeneratingScenarios:
 		return target == StatusScenariosGenerated || target == StatusRejected
 	case StatusScenariosGenerated:
@@ -601,12 +621,19 @@ type Plan struct {
 	// Nil when SkipArchitecture is true or before the phase completes.
 	Architecture *ArchitectureDocument `json:"architecture,omitempty"`
 
-	// Requirements, Scenarios, and PlanDecisions are populated when the plan
-	// is written to the PLAN_STATES KV bucket so downstream watchers have
-	// everything they need without follow-up queries.
-	// Not persisted to graph triples — use SaveRequirements/SaveScenarios/SavePlanDecisions for that.
-	Requirements  []Requirement  `json:"requirements,omitempty"`
-	Scenarios     []Scenario     `json:"scenarios,omitempty"`
+	// Requirements, Scenarios, Stories, and PlanDecisions are populated when
+	// the plan is written to the PLAN_STATES KV bucket so downstream watchers
+	// have everything they need without follow-up queries.
+	// Not persisted to graph triples — use SaveRequirements/SaveScenarios/SaveStories/SavePlanDecisions for that.
+	Requirements []Requirement `json:"requirements,omitempty"`
+	Scenarios    []Scenario    `json:"scenarios,omitempty"`
+
+	// Stories are Sarah-authored dev-ready units sharded from Requirements
+	// (ADR-043 Move 2). Empty on plans persisted before ADR-043 PR 3
+	// landed story-preparer; new plans populate this in the
+	// preparing_stories → ready_for_execution transition.
+	Stories []Story `json:"stories,omitempty"`
+
 	PlanDecisions []PlanDecision `json:"plan_decisions,omitempty"`
 
 	// GitHub contains GitHub integration metadata for plans originating from
@@ -799,6 +826,30 @@ type ComponentDef struct {
 	// component using an external lib has a populated UpstreamRefs" is
 	// a follow-up commit.
 	UpstreamRefs []string `json:"upstream_refs,omitempty"`
+
+	// ImplementationFiles are workspace-relative paths that house this
+	// component's code (ADR-043 Move 1, BMAD tech-spec scope). Sourced
+	// from plan.scope.create for new components or the existing project
+	// tree for modified components. Plan-reviewer R2 rule
+	// architecture.component_missing_implementation_files rejects empty
+	// lists; architecture.component_implementation_files_doc_only rejects
+	// docs-only lists (every component MUST own ≥1 source-code file).
+	//
+	// omitempty for back-compat read of plans persisted before ADR-043
+	// PR 2 landed Winston's schema enforcement; new plans require ≥1
+	// entry per component once PR 2 ships.
+	ImplementationFiles []string `json:"implementation_files,omitempty"`
+
+	// Capabilities are kebab-case Capability.Name entries this component
+	// implements (ADR-043 Move 1). Winston's bidirectional bridge between
+	// Mary's capability list and the file space he just declared.
+	// Plan-reviewer R2 rule capability.unresolved_in_architecture rejects
+	// capabilities that have no component whose Capabilities list contains
+	// them.
+	//
+	// omitempty for the same back-compat reason as ImplementationFiles;
+	// new plans require ≥1 entry per component once PR 2 ships.
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // ArchDecision is a single architecture decision record produced by the architect agent.
@@ -1006,6 +1057,59 @@ func (p *Plan) FindPlanDecision(id string) (*PlanDecision, int) {
 		}
 	}
 	return nil, -1
+}
+
+// FindStory returns a pointer into p.Stories and its index by ID.
+// Returns nil, -1 when the story is not found.
+func (p *Plan) FindStory(id string) (*Story, int) {
+	for i := range p.Stories {
+		if p.Stories[i].ID == id {
+			return &p.Stories[i], i
+		}
+	}
+	return nil, -1
+}
+
+// StoriesForRequirement returns all stories whose RequirementID matches reqID,
+// in their existing Plan.Stories order. ADR-043 Move 2 — one requirement may
+// be sharded into N stories with DependsOn edges between them.
+func (p *Plan) StoriesForRequirement(reqID string) []Story {
+	var out []Story
+	for _, s := range p.Stories {
+		if s.RequirementID == reqID {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// FindTask returns a pointer to a Task with the given ID across all Stories,
+// along with its parent Story's index and its index within that Story's Tasks
+// slice. Returns nil, -1, -1 when the task is not found. Task IDs are
+// plan-unique (format: task.<slug>.<reqseq>.<storyseq>.<taskseq>) so the first
+// hit is authoritative.
+func (p *Plan) FindTask(id string) (*Task, int, int) {
+	for si := range p.Stories {
+		for ti := range p.Stories[si].Tasks {
+			if p.Stories[si].Tasks[ti].ID == id {
+				return &p.Stories[si].Tasks[ti], si, ti
+			}
+		}
+	}
+	return nil, -1, -1
+}
+
+// ScenariosForStory returns all scenarios linked to the given storyID via
+// Scenario.StoryID (ADR-043 semantic primary). Empty for plans persisted
+// before ADR-043 PR 4 wired Bob to populate StoryID.
+func (p *Plan) ScenariosForStory(storyID string) []Scenario {
+	var out []Scenario
+	for _, s := range p.Scenarios {
+		if s.StoryID == storyID {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // LLMCallHistory tracks LLM request IDs per review iteration for both
@@ -1393,10 +1497,18 @@ func IsTierTag(s string) bool {
 	}
 }
 
-// Scenario represents a Given/When/Then behavioral contract derived from a Requirement.
+// Scenario represents a Given/When/Then behavioral contract derived from a
+// Story (ADR-043 semantic primary) or, for legacy plans, a Requirement.
 type Scenario struct {
-	ID            string `json:"id"`
+	ID string `json:"id"`
+	// RequirementID is the parent Requirement (legacy primary link, kept
+	// as a query-convenience back-pointer per ADR-043 Architecture section).
 	RequirementID string `json:"requirement_id"`
+	// StoryID is the parent Story (ADR-043 semantic primary link). Set by
+	// Bob (scenario-generator) post-Sarah when the scenario was authored
+	// against a specific Story; empty on plans persisted before ADR-043
+	// PR 4 wired the Bob/Story link.
+	StoryID string `json:"story_id,omitempty"`
 	// Title is the human-readable scenario heading (e.g. "MAVSDK heartbeat
 	// observed after driver start"). Required in scenariosSchema since
 	// ADR-041 PR 1; carried here as omitempty for back-compat with plans


### PR DESCRIPTION
## Summary

ADR-043 PR 1 of 5 — additive data-model foundation. No behavior changes yet; types are populated starting in PR 2 (Winston) / PR 3 (Sarah) / PR 4 (execution).

- New `workflow.Story` + `workflow.Task` types with lifecycle enums + DAG validators
- `ComponentDef` gains `ImplementationFiles` + `Capabilities` (omitempty until PR 2 schema enforcement)
- `Plan.Stories` and `Scenario.StoryID` wire-shape additions
- New `StatusPreparingStories` with `architecture_generated → preparing_stories → ready_for_execution` transitions
- 16 new predicates under three-part `domain.category.property` convention (2 component.* + 11 story.* + 1 scenario.* + 2 task.*)
- 50+ test cases covering status DAGs, JSON omitempty hygiene, Plan helpers, validators, predicate registration

## Deliberately deferred to PR 4

`Requirement.FilesOwned` removal stays in PR 4 alongside John-narrowing + `requirementsSchema` removal + execution-manager rewrite. Touching it in PR 1 would cascade ~150 LOC across plan_requirement.go validators, capability_rules.go, requirement-generator, prompts, REST handlers, OpenSpec emitters — work PR 4 already owns. Full PR 4 sweep target list captured in the commit body for the reviewer.

## OpenAPI regeneration

`task generate:openapi` surfaces the new fields. Also captures pre-existing schema drift on main (plan-manager.cascade_trigger_subject, requirement-executor.max_recovery_restarts + recovery_timeout_seconds + plan_decision_accepted_subject; output/workflow-documents openspec_changes) — drift was in the code already, just not in the committed specs. Called out so the bundling isn't silent.

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` (revive v1.5.1) clean
- [x] JSON omitempty hygiene verified on Story / Task / ComponentDef / Scenario (no `"status":""` or null arrays in zero-value serialization)
- [x] Status transition DAG matches ADR §"Phase flow + state machine"
- [x] All 16 new predicates registered + three-part naming enforced by test

🤖 Generated with [Claude Code](https://claude.com/claude-code)