### PR TITLE
feat(adr-043): PR 4b — scenario-generator populates Scenario.StoryID from plan.Stories

### DIFF
--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -549,7 +549,9 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 
 	// Check if the plan has moved past generating_scenarios while we were working.
 	// If so, our result is stale — discard it without rejecting the plan.
-	if kvPlan, loadErr := c.loadPlanFromKV(ctx, slug); loadErr == nil {
+	// The plan is also our source for ADR-043 StoryID linkage below.
+	kvPlan, loadErr := c.loadPlanFromKV(ctx, slug)
+	if loadErr == nil {
 		status := kvPlan.EffectiveStatus()
 		if status != workflow.StatusGeneratingScenarios {
 			c.logger.Warn("Plan advanced past generating_scenarios, discarding stale result",
@@ -560,6 +562,15 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 			c.retry.Clear(key)
 			return
 		}
+	}
+
+	// ADR-043 Move 4 — populate Scenario.StoryID from plan.Stories. Bob's LLM
+	// emits scenarios linked by RequirementID; the StoryID is filled in
+	// server-side by looking up which Story owns the parent Requirement.
+	// When Sarah is dormant (PR 3 default) plan.Stories is empty and StoryID
+	// stays empty — Scenario.RequirementID remains the only link.
+	if kvPlan != nil && len(kvPlan.Stories) > 0 {
+		attachStoryIDs(scenarios, kvPlan, requirementID)
 	}
 
 	// Build a synthetic trigger for publishResults — it only needs Slug,
@@ -775,6 +786,36 @@ func (c *Component) parseScenariosFromResult(result, slug, requirementID string)
 	}
 
 	return scenarios, nil
+}
+
+// attachStoryIDs walks the scenarios and sets Scenario.StoryID from the
+// plan's Stories list (ADR-043 Move 4). For each scenario, the parent
+// Requirement is resolved through scenario.RequirementID, then the Story
+// owning that Requirement is looked up via plan.StoriesForRequirement.
+//
+// When a Requirement has multiple Stories (Sarah-sharded), the FIRST story
+// in the plan's Stories ordering is assigned. PR 4c refines this when
+// execution-manager rewires for per-Story dispatch — at that point Bob's
+// classifier becomes aware of Stories at scenario-emission time and can
+// emit one scenario set per Story. For PR 4b (this incremental step),
+// the simple "first story owns the scenarios" mapping preserves the
+// existing single-bucket-per-requirement semantics.
+//
+// requirementID is the parent requirement of THIS scenario batch — passed
+// in because every scenario in the batch belongs to the same Requirement
+// (scenario-generator dispatches per-Requirement).
+func attachStoryIDs(scenarios []workflow.Scenario, plan *workflow.Plan, requirementID string) {
+	if plan == nil {
+		return
+	}
+	stories := plan.StoriesForRequirement(requirementID)
+	if len(stories) == 0 {
+		return
+	}
+	firstStoryID := stories[0].ID
+	for i := range scenarios {
+		scenarios[i].StoryID = firstStoryID
+	}
 }
 
 // requirementSequence extracts the trailing sequence suffix from a requirement ID.

--- a/processor/scenario-generator/story_link_test.go
+++ b/processor/scenario-generator/story_link_test.go
@@ -1,0 +1,94 @@
+package scenariogenerator
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestAttachStoryIDs_NoStoriesIsNoop pins the back-compat contract: when
+// the plan has no Stories (Sarah dormant), scenarios keep empty StoryID
+// and Bob's existing RequirementID-only link is preserved.
+func TestAttachStoryIDs_NoStoriesIsNoop(t *testing.T) {
+	plan := &workflow.Plan{Slug: "x"}
+	scenarios := []workflow.Scenario{
+		{ID: "s1", RequirementID: "req.x.1"},
+		{ID: "s2", RequirementID: "req.x.1"},
+	}
+	attachStoryIDs(scenarios, plan, "req.x.1")
+	for _, s := range scenarios {
+		if s.StoryID != "" {
+			t.Errorf("expected empty StoryID with no plan.Stories, got %q on %s", s.StoryID, s.ID)
+		}
+	}
+}
+
+// TestAttachStoryIDs_NilPlan is a defensive guard — should never happen in
+// production but cheap to pin.
+func TestAttachStoryIDs_NilPlan(t *testing.T) {
+	scenarios := []workflow.Scenario{{ID: "s1", RequirementID: "req.x.1"}}
+	attachStoryIDs(scenarios, nil, "req.x.1")
+	if scenarios[0].StoryID != "" {
+		t.Errorf("expected empty StoryID on nil plan, got %q", scenarios[0].StoryID)
+	}
+}
+
+// TestAttachStoryIDs_SingleStoryPerRequirement covers the common case:
+// Sarah sharded one Story per Requirement, scenarios link to that story.
+func TestAttachStoryIDs_SingleStoryPerRequirement(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "x",
+		Stories: []workflow.Story{
+			{ID: "story.x.1.1", RequirementID: "req.x.1", Title: "T"},
+			{ID: "story.x.2.1", RequirementID: "req.x.2", Title: "T2"},
+		},
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "s1", RequirementID: "req.x.1"},
+		{ID: "s2", RequirementID: "req.x.1"},
+	}
+	attachStoryIDs(scenarios, plan, "req.x.1")
+	for _, s := range scenarios {
+		if s.StoryID != "story.x.1.1" {
+			t.Errorf("expected StoryID=story.x.1.1 on %s, got %q", s.ID, s.StoryID)
+		}
+	}
+}
+
+// TestAttachStoryIDs_MultiStoryPicksFirst pins the PR 4b "first story wins"
+// behavior. PR 4c will refine this when execution-manager dispatches
+// per-Story and Bob's classifier becomes story-aware at emission time;
+// until then a Requirement sharded into N Stories sees scenarios assigned
+// to the first Story in plan.Stories ordering.
+func TestAttachStoryIDs_MultiStoryPicksFirst(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "x",
+		Stories: []workflow.Story{
+			{ID: "story.x.1.1", RequirementID: "req.x.1", Title: "A"},
+			{ID: "story.x.1.2", RequirementID: "req.x.1", Title: "B"},
+		},
+	}
+	scenarios := []workflow.Scenario{{ID: "s1", RequirementID: "req.x.1"}}
+	attachStoryIDs(scenarios, plan, "req.x.1")
+	if scenarios[0].StoryID != "story.x.1.1" {
+		t.Errorf("expected first story wins (story.x.1.1), got %q", scenarios[0].StoryID)
+	}
+}
+
+// TestAttachStoryIDs_UnresolvedRequirementSkipsAssignment guards against a
+// Requirement that has no owning Story (e.g. a partial regen where Sarah
+// hasn't yet emitted stories for this requirement). The scenarios should
+// keep empty StoryID rather than borrow another requirement's story.
+func TestAttachStoryIDs_UnresolvedRequirementSkipsAssignment(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "x",
+		Stories: []workflow.Story{
+			{ID: "story.x.1.1", RequirementID: "req.x.1", Title: "T"},
+		},
+	}
+	scenarios := []workflow.Scenario{{ID: "s1", RequirementID: "req.x.2"}}
+	attachStoryIDs(scenarios, plan, "req.x.2")
+	if scenarios[0].StoryID != "" {
+		t.Errorf("expected empty StoryID on unresolved requirement, got %q", scenarios[0].StoryID)
+	}
+}


### PR DESCRIPTION
## Summary

ADR-043 PR 4b of 5 — incremental Bob-side wiring. Scenarios now carry `Scenario.StoryID` populated server-side from `plan.StoriesForRequirement` lookup. **Tiny PR** (~140 LOC) — execution-manager rewrite + decomposer deletion + Sarah activation land in PR 4c.

This continues the "data shape first, flow flip second" pattern from PRs 1+4a.

## What landed

- `scenario-generator/component.go` gains `attachStoryIDs(scenarios, plan, requirementID)` — walks scenarios after parse, sets `StoryID` from the first Story owning the parent Requirement (when stories exist)
- `handleLoopCompletion` reuses the existing `loadPlanFromKV` result and calls `attachStoryIDs` between parse and publish (no extra KV read)
- 5 unit test cases: no-Stories no-op, nil-plan no-op, single-story-per-requirement happy path, multi-story first-wins, unresolved-requirement no-assignment

## Why story_id stays out of scenariosSchema

- Adding a required field forces all 21 mock-scenario-generator fixtures to be updated AND trains the LLM to author a value it has no context for (Stories aren't in the prompt yet).
- The Story → Requirement mapping is a deterministic graph lookup; server-side population is structurally cleaner than asking the LLM to guess.
- PR 4c flips `story-preparer.Enabled=true` and at that point Bob's classifier becomes story-aware at emission time. Until then, the simple "first Story owning the Requirement wins" mapping preserves existing single-bucket-per-requirement semantics.

## Coming in PR 4c

- execution-manager rewrites for per-Story dispatch
- `tools/decompose/` deletion + requirement-executor decomposer dispatch path retired
- ADR-037 `story_reprepare` recovery action
- `story-preparer.Enabled` flipped to true (Sarah goes live)
- Bob's classifier becomes story-aware (one scenario set per Story instead of per Requirement)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` clean
- [x] 5 new unit tests cover both the populated path and the back-compat no-op paths
- [x] Mock fixtures unchanged (story_id stays out of the LLM-facing schema)

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)