### PR TITLE
feat(adr-043): PR 4c — enable Sarah in production, state machine for Sarah→Bob handoff

### DIFF
--- a/configs/e2e-mock-ui.json
+++ b/configs/e2e-mock-ui.json
@@ -524,6 +524,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah is enabled in production (configs/semspec.json) as of PR 4c, but UI mock e2e stays on the legacy path until mock-story-preparer.json fixtures + a story_preparation capability mapping land.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": false,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/configs/e2e-mock.json
+++ b/configs/e2e-mock.json
@@ -767,6 +767,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah is enabled in production (configs/semspec.json) as of PR 4c, but mock e2e stays on the legacy architecture_generated → generating_scenarios path until a future PR authors mock-story-preparer.json fixtures and a story_preparation capability mapping. Override here keeps mock e2e scenarios running unchanged.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": false,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "project-manager": {
       "name": "project-manager",
       "type": "processor",

--- a/configs/semspec.json
+++ b/configs/semspec.json
@@ -323,12 +323,12 @@
       }
     },
     "story-preparer": {
-      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). PR 3 ships with config.enabled=false so architecture_generated → scenarios_generated flow is unchanged. PR 4 flips on alongside execution-manager + scenario-generator rewiring.",
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). PR 3 shipped dormant; PR 4c flipped on alongside the state-machine fix (architecture_generated → preparing_stories → stories_generated → generating_scenarios). The execution-manager per-Story rewrite + decomposer deletion remain for PR 4d; until then execution continues per-Requirement with Stories populated as structural validation evidence (Sarah's docs-only fingerprint closure is the value Sarah ships at this stage).",
       "name": "story-preparer",
       "type": "processor",
       "enabled": true,
       "config": {
-        "enabled": false,
+        "enabled": true,
         "default_capability": "planning",
         "max_generation_retries": 2
       }

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -324,9 +324,13 @@ func (c *Component) handleArchitectureMutation(ctx context.Context, data []byte)
 }
 
 // handleStoriesMutation persists Sarah's emitted Stories inline on the plan
-// and advances preparing_stories → ready_for_execution (ADR-043 Move 3).
-// Plan-reviewer R3 (mergeStoryFindings) fires on the new
-// ready_for_execution state via the normal review pipeline.
+// and advances preparing_stories → stories_generated (ADR-043 PR 4c).
+// Bob (scenario-generator) watches stories_generated as one of its source
+// states and dispatches scenario generation per Requirement — until PR 4d
+// rewires for per-Story scenario emission.
+//
+// Plan-reviewer R3 (mergeStoryFindings) fires on stories_generated via the
+// normal review pipeline.
 //
 // Validates the wire payload (workflow.ValidateStories — the same gate
 // story-preparer runs pre-publish) before persistence. Validation
@@ -355,12 +359,12 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 	}
 
 	current := plan.EffectiveStatus()
-	if !current.CanTransitionTo(workflow.StatusReadyForExecution) {
-		return MutationResponse{Success: false, Error: fmt.Sprintf("invalid transition: %s → ready_for_execution", current)}
+	if !current.CanTransitionTo(workflow.StatusStoriesGenerated) {
+		return MutationResponse{Success: false, Error: fmt.Sprintf("invalid transition: %s → stories_generated", current)}
 	}
 
 	plan.Stories = req.Stories
-	plan.Status = workflow.StatusReadyForExecution
+	plan.Status = workflow.StatusStoriesGenerated
 
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save stories via mutation", "slug", req.Slug, "error", err)

--- a/processor/scenario-generator/plan_watcher.go
+++ b/processor/scenario-generator/plan_watcher.go
@@ -28,7 +28,7 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 	}
 	defer watcher.Stop()
 
-	c.logger.Info("Watching PLAN_STATES for architecture_generated")
+	c.logger.Info("Watching PLAN_STATES for architecture_generated / stories_generated")
 
 	for entry := range watcher.Updates() {
 		if entry == nil {
@@ -42,7 +42,12 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 		if json.Unmarshal(entry.Value(), &plan) != nil {
 			continue
 		}
-		if plan.Status != workflow.StatusArchitectureGenerated {
+		// ADR-043 PR 4c — Bob's watch source widened. Legacy path:
+		// arch_generated (when Sarah is dormant). Post-Sarah path:
+		// stories_generated (Sarah's terminal state). Either claims
+		// generating_scenarios next.
+		if plan.Status != workflow.StatusArchitectureGenerated &&
+			plan.Status != workflow.StatusStoriesGenerated {
 			continue
 		}
 		if len(plan.Requirements) == 0 {

--- a/workflow/story_task_test.go
+++ b/workflow/story_task_test.go
@@ -336,6 +336,10 @@ func TestStatusPreparingStoriesTransitions(t *testing.T) {
 		want     bool
 	}{
 		{StatusArchitectureGenerated, StatusPreparingStories, true},
+		// ADR-043 PR 4c — preparing_stories now targets stories_generated as
+		// the primary terminal. ready_for_execution is kept for back-compat
+		// with PR 3's initial wire shape.
+		{StatusPreparingStories, StatusStoriesGenerated, true},
 		{StatusPreparingStories, StatusReadyForExecution, true},
 		{StatusPreparingStories, StatusArchitectureGenerated, true},
 		{StatusPreparingStories, StatusRejected, true},
@@ -344,6 +348,45 @@ func TestStatusPreparingStoriesTransitions(t *testing.T) {
 		// Reject jumps
 		{StatusPreparingStories, StatusImplementing, false},
 		{StatusPreparingStories, StatusCreated, false},
+	}
+	for _, tc := range cases {
+		name := string(tc.from) + "→" + string(tc.to)
+		t.Run(name, func(t *testing.T) {
+			if got := tc.from.CanTransitionTo(tc.to); got != tc.want {
+				t.Errorf("%s = %v, want %v", name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusStoriesGeneratedIsValidAndNotInProgress(t *testing.T) {
+	if !StatusStoriesGenerated.IsValid() {
+		t.Errorf("StatusStoriesGenerated not in IsValid set")
+	}
+	if StatusStoriesGenerated.IsInProgress() {
+		t.Errorf("StatusStoriesGenerated should NOT be IsInProgress (terminal phase state)")
+	}
+}
+
+func TestStatusStoriesGeneratedTransitions(t *testing.T) {
+	cases := []struct {
+		from, to Status
+		want     bool
+	}{
+		// Happy path: Bob picks up stories_generated to generate scenarios per requirement.
+		{StatusStoriesGenerated, StatusGeneratingScenarios, true},
+		// Auto-cascade fallback when scenario-generator claims and dispatches in one step.
+		{StatusStoriesGenerated, StatusScenariosGenerated, true},
+		// R3 retry: story_reprepare PlanDecision sends Sarah back for another cycle.
+		{StatusStoriesGenerated, StatusPreparingStories, true},
+		// Change proposal cascade.
+		{StatusStoriesGenerated, StatusChanged, true},
+		// Escalation.
+		{StatusStoriesGenerated, StatusRejected, true},
+		// Disallowed jumps.
+		{StatusStoriesGenerated, StatusImplementing, false},
+		{StatusStoriesGenerated, StatusReadyForExecution, false},
+		{StatusStoriesGenerated, StatusCreated, false},
 	}
 	for _, tc := range cases {
 		name := string(tc.from) + "→" + string(tc.to)

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -99,6 +99,15 @@ const (
 	// (ADR-040 Move 1) is ready to claim and produce Goal/Context/Scope.
 	// Terminal for the analyst sub-phase (not in-progress).
 	StatusExplored Status = "explored"
+
+	// StatusStoriesGenerated indicates Sarah (story-preparer) has finished
+	// sharding requirements into Stories. Terminal for the story-prep phase;
+	// downstream the scenario-generator claims to generate scenarios per
+	// requirement (PR 4c) — PR 4d rewires per-Story dispatch. Pre-ADR-043
+	// plans skip this state entirely (Sarah dormant: architecture_generated
+	// → generating_scenarios). Post-ADR-043 plans: architecture_generated →
+	// preparing_stories → stories_generated → generating_scenarios → ...
+	StatusStoriesGenerated Status = "stories_generated"
 )
 
 // String returns the string representation of the status.
@@ -169,7 +178,7 @@ func (s Status) IsValid() bool {
 		StatusExploring, StatusExplored,
 		StatusDrafting, StatusReviewingDraft, StatusGeneratingRequirements,
 		StatusGeneratingArchitecture, StatusGeneratingScenarios, StatusReviewingScenarios,
-		StatusPreparingStories:
+		StatusPreparingStories, StatusStoriesGenerated:
 		return true
 	default:
 		return false
@@ -255,12 +264,23 @@ func (s Status) CanTransitionTo(target Status) bool {
 			target == StatusPreparingStories ||
 			target == StatusChanged || target == StatusRejected
 	case StatusPreparingStories:
-		// preparing_stories → ready_for_execution (Sarah done; plan-reviewer R3 will fire on this state per ADR-043 PR 3)
+		// preparing_stories → stories_generated (Sarah done; ADR-043 PR 4c — Bob still needs to run after this)
+		// preparing_stories → ready_for_execution (legacy PR 3 wire shape; kept for back-compat until story-preparer.enabled becomes the only path)
 		// preparing_stories → architecture_generated (R3 phase-targeted retry — architect must reshape components)
 		// preparing_stories → rejected (escalation: readiness gate exhausted retries)
-		return target == StatusReadyForExecution ||
+		return target == StatusStoriesGenerated ||
+			target == StatusReadyForExecution ||
 			target == StatusArchitectureGenerated ||
 			target == StatusRejected
+	case StatusStoriesGenerated:
+		// stories_generated → generating_scenarios (Bob claims; ADR-043 PR 4c — Bob now watches BOTH architecture_generated and stories_generated)
+		// stories_generated → scenarios_generated (auto-cascade fallback when scenario-generator can claim and dispatch in one step)
+		// stories_generated → preparing_stories (R3 retry — Sarah re-prep on accepted story_reprepare PlanDecision)
+		// stories_generated → changed (change proposal deprecated requirements; cascade restarts the plan-prep chain)
+		// stories_generated → rejected (escalation)
+		return target == StatusGeneratingScenarios || target == StatusScenariosGenerated ||
+			target == StatusPreparingStories ||
+			target == StatusChanged || target == StatusRejected
 	case StatusGeneratingScenarios:
 		return target == StatusScenariosGenerated || target == StatusRejected
 	case StatusScenariosGenerated:


### PR DESCRIPTION
## Summary

ADR-043 PR 4c of 5 — **Sarah goes live in production**. The state-machine race between Sarah and Bob (both watching `architecture_generated`) is resolved by introducing `StatusStoriesGenerated` as Sarah's terminal state and widening Bob's watch source to accept both. Sarah's structural value — closing the docs-only fingerprint at the architecture + story layers — ships now.

Execution continues per-Requirement using the existing decomposer + requirement-executor path (no regression). PR 4d rewires execution-manager for per-Story dispatch, deletes the decomposer, and adds the `story_reprepare` recovery action.

7 files / +107/-13.

## What landed

- **`StatusStoriesGenerated`** constant + transitions (`preparing_stories → stories_generated → generating_scenarios | scenarios_generated | preparing_stories | changed | rejected`)
- **`handleStoriesMutation`** transitions to `stories_generated` (was `ready_for_execution`)
- **scenario-generator watch loop** accepts both `architecture_generated` (legacy when Sarah dormant) AND `stories_generated` (post-Sarah)
- **Sarah enabled** in `configs/semspec.json` (`story-preparer.config.enabled` flipped true)
- **Mock e2e overrides** in `configs/e2e-mock.json` + `configs/e2e-mock-ui.json` keep Sarah disabled there until a future PR authors `mock-story-preparer.json` fixtures
- **State-machine tests** cover the new positive transitions + disallowed jumps; `IsValid` extended; `IsInProgress` NOT extended (terminal phase state)

## Deferred to PR 4d

- execution-manager per-Story dispatch
- `tools/decompose/` deletion + requirement-executor decomposer dispatch path retired
- ADR-037 `story_reprepare` PlanDecision action class (only has callers once execution dispatches per-Story)
- Bob's classifier becomes story-aware (one scenario set per Story instead of per Requirement)
- Mock e2e re-enablement (fixtures + capability mapping)

## Validation path

- **Mock e2e**: 21 scenarios stay green on the legacy path; full pipeline still exercised end-to-end.
- **Real-LLM smoke** (post-merge): gemini @easy should reach `ready_for_execution` via `architecture_generated → preparing_stories → stories_generated → generating_scenarios → scenarios_generated → …`. Sarah's docs-only fingerprint closure is observable in trajectory data (Sarah emits Stories whose `files_owned` must contain ≥1 source file; the architecture-side rule already blocks docs-only components from PR 2).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` clean
- [x] State-machine tests cover new transitions
- [x] Mock e2e overrides validated (story-preparer.config.enabled=false in both e2e-mock configs)

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)