### PR TITLE
feat(adr-043): PR 4d — wire story_preparation capability + mock-story-preparer endpoint

### DIFF
--- a/configs/e2e-mock-ui.json
+++ b/configs/e2e-mock-ui.json
@@ -27,6 +27,15 @@
           "mock-fast"
         ]
       },
+      "story_preparation": {
+        "description": "Sarah's Story sharding (ADR-043 Move 3; mock: returns canned Stories)",
+        "preferred": [
+          "mock-story-preparer"
+        ],
+        "fallback": [
+          "mock-planner"
+        ]
+      },
       "writing": {
         "description": "Documentation, plans, specifications (mock)",
         "preferred": [
@@ -196,6 +205,14 @@
         "provider": "ollama",
         "url": "http://mock-llm:11434/v1",
         "model": "mock-architecture-generator",
+        "max_tokens": 32768,
+        "supports_tools": true,
+        "tool_format": "openai"
+      },
+      "mock-story-preparer": {
+        "provider": "ollama",
+        "url": "http://mock-llm:11434/v1",
+        "model": "mock-story-preparer",
         "max_tokens": 32768,
         "supports_tools": true,
         "tool_format": "openai"
@@ -525,13 +542,13 @@
       }
     },
     "story-preparer": {
-      "_comment": "ADR-043 Move 3 — Sarah is enabled in production (configs/semspec.json) as of PR 4c, but UI mock e2e stays on the legacy path until mock-story-preparer.json fixtures + a story_preparation capability mapping land.",
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). UI e2e infrastructure wired in PR 4d (story_preparation capability + mock-story-preparer endpoint above); Sarah enabled flip happens in PR 4e alongside per-scenario fixtures with real requirement IDs.",
       "name": "story-preparer",
       "type": "processor",
       "enabled": true,
       "config": {
         "enabled": false,
-        "default_capability": "planning",
+        "default_capability": "story_preparation",
         "max_generation_retries": 2
       }
     },

--- a/configs/e2e-mock.json
+++ b/configs/e2e-mock.json
@@ -27,6 +27,15 @@
           "mock-fast"
         ]
       },
+      "story_preparation": {
+        "description": "Sarah's Story sharding (ADR-043 Move 3; mock: returns canned Stories)",
+        "preferred": [
+          "mock-story-preparer"
+        ],
+        "fallback": [
+          "mock-planner"
+        ]
+      },
       "writing": {
         "description": "Documentation, plans, specifications (mock)",
         "preferred": [
@@ -188,6 +197,14 @@
         "provider": "ollama",
         "url": "http://mock-llm:11434/v1",
         "model": "mock-architecture-generator",
+        "max_tokens": 32768,
+        "supports_tools": true,
+        "tool_format": "openai"
+      },
+      "mock-story-preparer": {
+        "provider": "ollama",
+        "url": "http://mock-llm:11434/v1",
+        "model": "mock-story-preparer",
         "max_tokens": 32768,
         "supports_tools": true,
         "tool_format": "openai"
@@ -768,13 +785,13 @@
       }
     },
     "story-preparer": {
-      "_comment": "ADR-043 Move 3 — Sarah is enabled in production (configs/semspec.json) as of PR 4c, but mock e2e stays on the legacy architecture_generated → generating_scenarios path until a future PR authors mock-story-preparer.json fixtures and a story_preparation capability mapping. Override here keeps mock e2e scenarios running unchanged.",
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Production is enabled in configs/semspec.json as of PR 4c. PR 4d wires the mock infrastructure (story_preparation capability + mock-story-preparer endpoint above) but keeps Sarah disabled in mock e2e because per-scenario fixtures must reference real requirement IDs (slug-dependent), and authoring 21 of those is its own PR. PR 4e will land the fixtures + re-enable here. The default_capability is set to story_preparation so the day fixtures land, the routing already works.",
       "name": "story-preparer",
       "type": "processor",
       "enabled": true,
       "config": {
         "enabled": false,
-        "default_capability": "planning",
+        "default_capability": "story_preparation",
         "max_generation_retries": 2
       }
     },


### PR DESCRIPTION
## Summary

Tiny PR — lays the mock e2e routing infrastructure for Sarah's pipeline: a `story_preparation` capability mapping + a `mock-story-preparer` LLM endpoint. **Sarah stays disabled in mock e2e** until PR 4e authors per-scenario `mock-story-preparer.json` fixtures.

2 files / +38/-4.

## Infrastructure-without-fixtures stance

- Capability + endpoint pair is mechanical config — landing it separately from fixture authoring keeps each PR focused.
- Production (`configs/semspec.json`) Sarah uses the `planning` capability (real LLMs handle both Mary and Sarah on the same endpoint).
- Mock e2e routing needs a DISTINCT capability because mock-llm fixtures are keyed by model name — Sarah's `storiesSchema` output is shaped differently from Mary's `explorationSchema`.
- The day per-scenario fixtures land, flipping `config.enabled=true` is the only change needed; routing is already wired.

## Why fixtures are their own PR

Sarah's `storiesSchema` requires `story.requirement_id` to match a real `plan.requirement.ID`, and requirement IDs are slug-dependent (`requirement.<slug>.<n>`). Each of the 21 mock e2e scenarios has a different plan slug (derived from the scenario's title at plan-create time), so fixtures need per-scenario customization. A future PR can either:
1. Author 21 hand-written fixtures with matching slugs, OR
2. Change the Story wire shape to use positional references (mirroring Bob's StoryID lookup in PR 4b — `requirement_index` instead of `requirement_id`).

Either path is a focused decision that doesn't belong bundled with the capability + endpoint infrastructure.

## Deferred

- **PR 4e**: mock-story-preparer.json fixtures + Sarah enabled flip in mock e2e.
- **PR 4f**: execution-manager per-Story dispatch + `tools/decompose/` deletion + ADR-037 `story_reprepare` action + Bob's classifier becomes story-aware.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` clean
- [x] Both configs validate as JSON
- [x] Sarah stays disabled in mock e2e — no regression to the 21 mock scenarios

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)