### PR TITLE
feat(adr-043): PR 4f — decomposer LLM bypass when plan.Stories present

### DIFF
--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -609,24 +609,37 @@ func (c *Component) handleDecomposerCompleteLocked(ctx context.Context, event *a
 	// Successful parse — clear retry state.
 	exec.DecomposerLastError = ""
 
-	// Topological sort for serial execution order.
-	sorted, err := topoSort(&dagResponse.DAG)
+	c.applyParsedDAGLocked(ctx, exec, &dagResponse.DAG, "decomposer-llm")
+}
+
+// applyParsedDAGLocked is the post-parse downstream shared by both the
+// legacy decomposer-LLM path (handleDecomposerCompleteLocked) and the
+// ADR-043 PR 4f decomposer-bypass path (dispatchDecomposerLocked, when
+// plan.Stories supplies the DAG without an LLM round-trip). It topo-sorts
+// the DAG, populates exec state for the per-node dispatch loop, persists
+// to EXECUTION_STATES, publishes graph entities, and kicks off the first
+// node dispatch.
+//
+// source identifies the DAG origin for telemetry ("decomposer-llm" vs
+// "stories-synthesis"). All callers must hold exec.mu.
+func (c *Component) applyParsedDAGLocked(ctx context.Context, exec *requirementExecution, dag *decompose.TaskDAG, source string) {
+	sorted, err := topoSort(dag)
 	if err != nil {
 		c.markFailedLocked(ctx, exec, fmt.Sprintf("topological sort failed: %v", err))
 		return
 	}
 
-	exec.DAG = &dagResponse.DAG
+	exec.DAG = dag
 	exec.SortedNodeIDs = sorted
-	exec.NodeIndex = make(map[string]*decompose.TaskNode, len(dagResponse.DAG.Nodes))
-	for i := range dagResponse.DAG.Nodes {
-		exec.NodeIndex[dagResponse.DAG.Nodes[i].ID] = &dagResponse.DAG.Nodes[i]
+	exec.NodeIndex = make(map[string]*decompose.TaskNode, len(dag.Nodes))
+	for i := range dag.Nodes {
+		exec.NodeIndex[dag.Nodes[i].ID] = &dag.Nodes[i]
 	}
 
 	// Persist DAG state to EXECUTION_STATES for crash recovery.
 	// The DAGRaw + SortedNodeIDs fields let reconcileFromKV rebuild the full
 	// execution state without re-running the decomposer.
-	dagRaw, _ := json.Marshal(dagResponse.DAG)
+	dagRaw, _ := json.Marshal(*dag)
 
 	nodeCount := len(sorted)
 	if err := c.sendReqPhase(ctx, exec.storeKey, phaseExecuting, map[string]any{
@@ -640,10 +653,11 @@ func (c *Component) handleDecomposerCompleteLocked(ctx context.Context, event *a
 	c.logger.Info("Decomposition complete, starting serial execution",
 		"entity_id", exec.EntityID,
 		"node_count", len(sorted),
+		"source", source,
 	)
 
 	// Publish each DAG node as a graph entity so the knowledge graph captures
-	// the full execution hierarchy.  Best-effort: failure does not abort execution.
+	// the full execution hierarchy. Best-effort: failure does not abort execution.
 	c.publishDAGNodes(ctx, exec)
 
 	// Dispatch the first node.
@@ -962,6 +976,27 @@ func (c *Component) recordNodeSuccessLocked(ctx context.Context, exec *requireme
 // ---------------------------------------------------------------------------
 
 func (c *Component) dispatchDecomposerLocked(ctx context.Context, exec *requirementExecution) {
+	// ADR-043 PR 4f — when plan.Stories carries Sarah-authored Stories for
+	// this requirement, synthesize the TaskDAG locally instead of dispatching
+	// the decomposer LLM. The downstream after parse is shared; both paths
+	// funnel through applyParsedDAGLocked. Fall through to the legacy LLM
+	// path when no Stories are present (pre-ADR-043 plans, or plans that
+	// reached requirement-execution before story-preparer was enabled).
+	if plan, err := c.loadPlanFromKV(ctx, exec.Slug); err == nil && plan != nil {
+		dag, synthErr := synthesizeTaskDAGFromStories(plan, exec.RequirementID)
+		if synthErr != nil {
+			c.logger.Warn("Story DAG synthesis failed, falling back to decomposer LLM",
+				"entity_id", exec.EntityID, "requirement_id", exec.RequirementID, "error", synthErr)
+		} else if dag != nil {
+			c.logger.Info("Bypassing decomposer LLM with synthesized DAG from plan.Stories",
+				"entity_id", exec.EntityID, "requirement_id", exec.RequirementID,
+				"node_count", len(dag.Nodes))
+			exec.DecomposerLastError = ""
+			c.applyParsedDAGLocked(ctx, exec, dag, "stories-synthesis")
+			return
+		}
+	}
+
 	taskID := fmt.Sprintf("decompose-%s-%s", exec.EntityID, uuid.New().String())
 	exec.DecomposerTaskID = taskID
 
@@ -1270,6 +1305,34 @@ func (c *Component) loadPlanScope(ctx context.Context, slug string) *workflow.Sc
 		return nil
 	}
 	return plan.Scope
+}
+
+// loadPlanFromKV reads the full plan from PLAN_STATES KV. Returns nil
+// (with error nil) when the bucket / entry is missing — the decomposer
+// bypass path treats that as "no Stories available, fall through to
+// legacy LLM decomposition". A non-nil error signals a parse failure;
+// the caller logs and falls through too. Used by ADR-043 PR 4f.
+func (c *Component) loadPlanFromKV(ctx context.Context, slug string) (*workflow.Plan, error) {
+	if c.natsClient == nil {
+		return nil, nil
+	}
+	js, err := c.natsClient.JetStream()
+	if err != nil {
+		return nil, nil
+	}
+	bucket, err := js.KeyValue(ctx, "PLAN_STATES")
+	if err != nil {
+		return nil, nil
+	}
+	entry, err := bucket.Get(ctx, slug)
+	if err != nil {
+		return nil, nil
+	}
+	var plan workflow.Plan
+	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
+		return nil, fmt.Errorf("unmarshal plan %q: %w", slug, err)
+	}
+	return &plan, nil
 }
 
 // buildReviewPrompt constructs the prompt for requirement-level review.

--- a/processor/requirement-executor/synthesize_dag.go
+++ b/processor/requirement-executor/synthesize_dag.go
@@ -1,0 +1,139 @@
+package requirementexecutor
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semspec/tools/decompose"
+	"github.com/c360studio/semspec/workflow"
+)
+
+// synthesizeTaskDAGFromStories converts Sarah's Stories (ADR-043 Move 3 +
+// PR 4e positional shape, persisted by plan-manager from
+// StoriesGeneratedEvent) into a decompose.TaskDAG that the
+// requirement-executor's existing downstream consumes unchanged. This is
+// the PR 4f decomposer-bypass: when the plan carries Sarah-authored
+// Stories for the requirement, the LLM decomposer call is skipped — the
+// DAG comes directly from the structured Story.Tasks.
+//
+// Mapping:
+//   - Each Task in each Story for the requirement becomes one TaskNode.
+//   - TaskNode.ID = Task.ID (canonical task.<slug>.<reqseq>.<storyseq>.<taskseq>).
+//   - TaskNode.Prompt = Task.Description (Sarah's 1-line intent).
+//   - TaskNode.Role = "developer" (matches the decomposer's default role
+//     for code-producing tasks; future ADR-043 work may differentiate
+//     review / qa nodes here).
+//   - TaskNode.DependsOn = intra-story Task.DependsOn (canonical IDs),
+//     extended on entry tasks (Tasks with empty DependsOn) with the exit
+//     tasks of cross-story prereqs from Story.DependsOn.
+//   - TaskNode.FileScope = parent Story.FilesOwned.
+//   - TaskNode.ScenarioIDs = IDs of scenarios whose StoryID == this story
+//     (populated by Bob's attachStoryIDs in PR 4b; empty for legacy plans).
+//
+// Returns (nil, nil) when no Stories own the requirement — signals the
+// caller to fall back to the legacy decomposer-LLM dispatch path.
+// Returns (nil, err) when the synthesis produces a structurally invalid
+// DAG (caller surfaces as a parse-style failure).
+func synthesizeTaskDAGFromStories(plan *workflow.Plan, requirementID string) (*decompose.TaskDAG, error) {
+	if plan == nil || requirementID == "" {
+		return nil, nil
+	}
+	stories := plan.StoriesForRequirement(requirementID)
+	if len(stories) == 0 {
+		return nil, nil
+	}
+
+	// Pre-compute per-story exit tasks (tasks no other task in the same
+	// story depends on) so cross-story DependsOn can expand to concrete
+	// node-level prereqs.
+	exitTasksByStoryID := storyExitTasks(stories)
+
+	nodes := make([]decompose.TaskNode, 0)
+	for _, s := range stories {
+		if len(s.Tasks) == 0 {
+			// Empty Tasks on a story is a Sarah readiness-gate violation —
+			// caught upstream by workflow.ValidateStories. Surface as a
+			// synthesis error here so the caller knows the bypass can't
+			// proceed.
+			return nil, fmt.Errorf("story %q has no tasks; cannot synthesize DAG", s.ID)
+		}
+		if len(s.FilesOwned) == 0 {
+			return nil, fmt.Errorf("story %q has empty files_owned; cannot synthesize DAG (Sarah's gate should have caught this)", s.ID)
+		}
+
+		// Collect cross-story prereqs: exit tasks of every story this story
+		// depends on. Entry tasks (Task.DependsOn empty) inherit them.
+		var crossPrereqs []string
+		for _, depStoryID := range s.DependsOn {
+			crossPrereqs = append(crossPrereqs, exitTasksByStoryID[depStoryID]...)
+		}
+
+		// ScenarioIDs come from the plan's scenarios whose StoryID matches.
+		var scenarioIDs []string
+		for _, sc := range plan.ScenariosForStory(s.ID) {
+			scenarioIDs = append(scenarioIDs, sc.ID)
+		}
+
+		// FileScope: clone Story.FilesOwned (each TaskNode gets the
+		// full story scope; per-task file partitioning is a refinement
+		// PR 4g+ may introduce).
+		files := append([]string(nil), s.FilesOwned...)
+
+		for _, t := range s.Tasks {
+			deps := append([]string(nil), t.DependsOn...)
+			if len(t.DependsOn) == 0 && len(crossPrereqs) > 0 {
+				// Entry task — inherit cross-story prereqs.
+				deps = append(deps, crossPrereqs...)
+			}
+			nodes = append(nodes, decompose.TaskNode{
+				ID:          t.ID,
+				Prompt:      t.Description,
+				Role:        "developer",
+				DependsOn:   deps,
+				FileScope:   files,
+				ScenarioIDs: append([]string(nil), scenarioIDs...),
+			})
+		}
+	}
+
+	if len(nodes) == 0 {
+		// Should be unreachable given the per-story empty-Tasks guard above,
+		// but defensive — the caller fallback path is well-tested.
+		return nil, nil
+	}
+
+	dag := &decompose.TaskDAG{Nodes: nodes}
+	if err := dag.Validate(); err != nil {
+		return nil, fmt.Errorf("synthesized DAG fails validation: %w", err)
+	}
+	return dag, nil
+}
+
+// storyExitTasks returns a map from Story.ID to the list of Task.IDs that
+// no other task in the same story depends on (the "exit" tasks). A
+// cross-story DependsOn edge expands to "the exit tasks of the prereq
+// story" so the consuming story waits on the actual terminal work, not
+// intermediate steps.
+func storyExitTasks(stories []workflow.Story) map[string][]string {
+	out := make(map[string][]string, len(stories))
+	for _, s := range stories {
+		if len(s.Tasks) == 0 {
+			continue
+		}
+		// Build a set of task IDs that ARE depended on by some other task
+		// in the same story.
+		dependedOn := make(map[string]struct{}, len(s.Tasks))
+		for _, t := range s.Tasks {
+			for _, dep := range t.DependsOn {
+				dependedOn[dep] = struct{}{}
+			}
+		}
+		var exits []string
+		for _, t := range s.Tasks {
+			if _, ok := dependedOn[t.ID]; !ok {
+				exits = append(exits, t.ID)
+			}
+		}
+		out[s.ID] = exits
+	}
+	return out
+}

--- a/processor/requirement-executor/synthesize_dag_test.go
+++ b/processor/requirement-executor/synthesize_dag_test.go
@@ -1,0 +1,235 @@
+package requirementexecutor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestSynthesizeTaskDAGFromStories_NoStoriesReturnsNil(t *testing.T) {
+	plan := &workflow.Plan{Slug: "x", Requirements: []workflow.Requirement{{ID: "req.x.1"}}}
+	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if dag != nil {
+		t.Errorf("expected nil DAG (fallthrough signal), got %+v", dag)
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_NilPlanReturnsNil(t *testing.T) {
+	dag, err := synthesizeTaskDAGFromStories(nil, "req.x.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if dag != nil {
+		t.Errorf("expected nil DAG, got %+v", dag)
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_SingleStoryLinearTasks(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:         "x",
+		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
+		Stories: []workflow.Story{
+			{
+				ID: "story.x.1.1", RequirementID: "req.x.1",
+				FilesOwned: []string{"src/x.go"},
+				Tasks: []workflow.Task{
+					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "tests"},
+					{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "impl", DependsOn: []string{"task.x.1.1.1"}},
+					{ID: "task.x.1.1.3", StoryID: "story.x.1.1", Description: "verify", DependsOn: []string{"task.x.1.1.2"}},
+				},
+			},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.1", RequirementID: "req.x.1", StoryID: "story.x.1.1"},
+		},
+	}
+	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if dag == nil {
+		t.Fatal("expected non-nil DAG")
+	}
+	if len(dag.Nodes) != 3 {
+		t.Fatalf("want 3 nodes, got %d", len(dag.Nodes))
+	}
+	// Node 0 is entry (no DependsOn).
+	if len(dag.Nodes[0].DependsOn) != 0 {
+		t.Errorf("entry task should have empty DependsOn, got %v", dag.Nodes[0].DependsOn)
+	}
+	// Node 1 depends on node 0.
+	if len(dag.Nodes[1].DependsOn) != 1 || dag.Nodes[1].DependsOn[0] != "task.x.1.1.1" {
+		t.Errorf("node[1].DependsOn = %v, want [task.x.1.1.1]", dag.Nodes[1].DependsOn)
+	}
+	// FileScope = Story.FilesOwned.
+	for i, n := range dag.Nodes {
+		if len(n.FileScope) != 1 || n.FileScope[0] != "src/x.go" {
+			t.Errorf("node[%d].FileScope = %v, want [src/x.go]", i, n.FileScope)
+		}
+	}
+	// ScenarioIDs from plan.ScenariosForStory.
+	for i, n := range dag.Nodes {
+		if len(n.ScenarioIDs) != 1 || n.ScenarioIDs[0] != "scen.1" {
+			t.Errorf("node[%d].ScenarioIDs = %v, want [scen.1]", i, n.ScenarioIDs)
+		}
+	}
+	// Role assigned to "developer".
+	if dag.Nodes[0].Role != "developer" {
+		t.Errorf("Role = %q, want developer", dag.Nodes[0].Role)
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_CrossStoryDependsOnExpansion(t *testing.T) {
+	// Story B depends on story A. The entry task(s) of B should inherit
+	// the exit task(s) of A as DependsOn.
+	plan := &workflow.Plan{
+		Slug:         "x",
+		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
+		Stories: []workflow.Story{
+			{
+				ID: "story.x.1.1", RequirementID: "req.x.1",
+				FilesOwned: []string{"src/a.go"},
+				Tasks: []workflow.Task{
+					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "A1"},
+					{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "A2", DependsOn: []string{"task.x.1.1.1"}},
+				},
+			},
+			{
+				ID: "story.x.1.2", RequirementID: "req.x.1",
+				FilesOwned: []string{"src/b.go"},
+				DependsOn:  []string{"story.x.1.1"},
+				Tasks: []workflow.Task{
+					{ID: "task.x.1.2.1", StoryID: "story.x.1.2", Description: "B1"},
+				},
+			},
+		},
+	}
+	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// Find B1 node.
+	var b1 *struct {
+		ID, Prompt string
+		DependsOn  []string
+	}
+	for _, n := range dag.Nodes {
+		if n.ID == "task.x.1.2.1" {
+			b1 = &struct {
+				ID, Prompt string
+				DependsOn  []string
+			}{n.ID, n.Prompt, n.DependsOn}
+		}
+	}
+	if b1 == nil {
+		t.Fatal("did not find task.x.1.2.1")
+	}
+	// B1 had no intra-story DependsOn; cross-story expansion adds A's exit (task.x.1.1.2, the last task in A's chain).
+	if len(b1.DependsOn) != 1 || b1.DependsOn[0] != "task.x.1.1.2" {
+		t.Errorf("B1.DependsOn = %v, want [task.x.1.1.2] (A's exit task)", b1.DependsOn)
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_EmptyTasksReturnsError(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:         "x",
+		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
+		Stories: []workflow.Story{
+			{
+				ID: "story.x.1.1", RequirementID: "req.x.1",
+				FilesOwned: []string{"src/x.go"},
+				Tasks:      nil,
+			},
+		},
+	}
+	_, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err == nil {
+		t.Fatal("expected error for story with no tasks")
+	}
+	if !strings.Contains(err.Error(), "no tasks") {
+		t.Errorf("error %q missing phrase 'no tasks'", err.Error())
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_EmptyFilesOwnedReturnsError(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:         "x",
+		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
+		Stories: []workflow.Story{
+			{
+				ID: "story.x.1.1", RequirementID: "req.x.1",
+				FilesOwned: nil,
+				Tasks: []workflow.Task{
+					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "tests"},
+				},
+			},
+		},
+	}
+	_, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err == nil {
+		t.Fatal("expected error for story with empty files_owned")
+	}
+	if !strings.Contains(err.Error(), "empty files_owned") {
+		t.Errorf("error %q missing phrase 'empty files_owned'", err.Error())
+	}
+}
+
+func TestSynthesizeTaskDAGFromStories_OtherRequirementSkipped(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:         "x",
+		Requirements: []workflow.Requirement{{ID: "req.x.1"}, {ID: "req.x.2"}},
+		Stories: []workflow.Story{
+			{
+				ID: "story.x.2.1", RequirementID: "req.x.2", // belongs to req 2
+				FilesOwned: []string{"src/y.go"},
+				Tasks:      []workflow.Task{{ID: "task.x.2.1.1", StoryID: "story.x.2.1", Description: "y"}},
+			},
+		},
+	}
+	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if dag != nil {
+		t.Errorf("expected nil DAG (no stories for req.x.1), got %+v", dag)
+	}
+}
+
+func TestStoryExitTasks(t *testing.T) {
+	stories := []workflow.Story{
+		{
+			ID: "s1",
+			Tasks: []workflow.Task{
+				{ID: "t1"},
+				{ID: "t2", DependsOn: []string{"t1"}},
+				{ID: "t3", DependsOn: []string{"t2"}},
+				// t3 is the exit (nothing depends on it).
+			},
+		},
+		{
+			ID: "s2",
+			Tasks: []workflow.Task{
+				{ID: "u1"},
+				// u1 has no dependents → exit.
+			},
+		},
+		{
+			ID:    "s3-empty",
+			Tasks: nil, // skipped entirely
+		},
+	}
+	got := storyExitTasks(stories)
+	if exits, ok := got["s1"]; !ok || len(exits) != 1 || exits[0] != "t3" {
+		t.Errorf("s1 exits = %v, want [t3]", exits)
+	}
+	if exits, ok := got["s2"]; !ok || len(exits) != 1 || exits[0] != "u1" {
+		t.Errorf("s2 exits = %v, want [u1]", exits)
+	}
+	if _, ok := got["s3-empty"]; ok {
+		t.Errorf("empty-tasks story s3-empty should not appear in exit map")
+	}
+}


### PR DESCRIPTION
## Summary

When Sarah's Stories exist for a requirement, **requirement-executor synthesizes the TaskDAG directly from `Story.Tasks` instead of dispatching a decomposer LLM call**. First surgical step toward the full execution rewrite — keeps the existing per-node dispatch downstream + DAGNode entity hierarchy + crash recovery surface unchanged, replacing only the DAG-source step.

Legacy decomposer-LLM path remains as fallthrough for pre-ADR-043 plans. `tools/decompose/` + decomposer prompt fragments stay in place; deletion waits until a real-LLM smoke confirms the bypass works end-to-end.

3 files / +445/-8.

## What landed

### New: `processor/requirement-executor/synthesize_dag.go`
- `synthesizeTaskDAGFromStories(plan, requirementID)` — pure function. Returns `(nil, nil)` when no Stories own the requirement (signals fallthrough); `(nil, err)` on structural violations; `(dag, nil)` on success.
- Mapping: `TaskNode.{ID=Task.ID, Prompt=Task.Description, Role="developer", DependsOn=intra-story Task.DependsOn, FileScope=Story.FilesOwned, ScenarioIDs=plan.ScenariosForStory}`.
- **Cross-story `Story.DependsOn` expansion**: entry tasks (`Task.DependsOn` empty) inherit the exit tasks of every prereq story — preserves DAG semantics through the existing downstream.

### Refactor: `component.go`
- Extracted `applyParsedDAGLocked` from `handleDecomposerCompleteLocked`. Post-parse downstream (topo sort → state population → sendReqPhase → publishDAGNodes → dispatchNextNodeLocked) is now shared. `source` parameter (`"decomposer-llm"` vs `"stories-synthesis"`) flows into telemetry.
- `dispatchDecomposerLocked` entry: load plan, synthesize, branch. Falls through to legacy LLM dispatch when synthesis returns nil or errors.
- New `loadPlanFromKV` helper (best-effort: nil-with-nil-error on missing bucket/entry; non-nil error only on JSON parse failure).

### Tests
- 8 cases: no-stories nil DAG, nil-plan nil DAG, single-story linear-task happy path (verifies entry/exit DependsOn + FileScope + ScenarioIDs + Role), cross-story DependsOn expansion (B inherits A's exit), empty Tasks error, empty FilesOwned error, other-requirement skipped, `storyExitTasks` helper directly.

## What's deferred (tracked in `project_adr043_pr4_split_state.md`)

- `tools/decompose/` deletion + decomposer prompt fragment removal — waits for real-LLM smoke confirmation.
- execution-manager per-Story dispatch (currently per-Requirement; multiple Stories per requirement flatten via cross-story DependsOn expansion).
- ADR-037 `story_reprepare` PlanDecision action class.
- Bob's classifier becomes story-aware.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` (revive v1.5.1) clean
- [x] 8 unit tests cover synthesis happy paths + error cases + the helper

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)