### PR TITLE
feat(adr-043): PR 4i — story_reprepare recovery action vocabulary

### DIFF
--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -701,11 +701,21 @@ func (c *Component) deriveDecision(loop *agentic.LoopEntity, escalationReason st
 // through requirement_change so the cascade dirty-marks the req for
 // re-run; terminal actions go through execution_exhausted so plan-manager
 // auto-archives when the subject req reaches a non-failed terminal state.
+//
+// story_reprepare (ADR-043 PR 4i) maps to requirement_change because the
+// cascade target is the same: dirty-mark the parent requirement so the
+// downstream chain (Sarah's preparing_stories → ready_for_execution)
+// re-runs. The distinction between story_reprepare and the other
+// requirement_change actions surfaces in the PlanDecision rationale text,
+// which plan-manager threads into Sarah's RecoveryHint on the next
+// dispatch — Sarah sees "the wedge happened because <X>; re-shard with
+// <Y> in mind."
 func recoveryActionToPlanDecisionKind(action payloads.RecoveryActionKind) workflow.PlanDecisionKind {
 	switch action {
 	case payloads.RecoveryActionRefinePrompt,
 		payloads.RecoveryActionNarrowScope,
-		payloads.RecoveryActionSplitReq:
+		payloads.RecoveryActionSplitReq,
+		payloads.RecoveryActionStoryReprepare:
 		return workflow.PlanDecisionKindRequirementChange
 	case payloads.RecoveryActionEscalateHuman, payloads.RecoveryActionMarkUnrecoverable:
 		return workflow.PlanDecisionKindExecutionExhausted

--- a/processor/recovery-agent/result.go
+++ b/processor/recovery-agent/result.go
@@ -90,6 +90,7 @@ func parseRecoveryResult(raw string) (*parsedRecoveryResult, error) {
 	case payloads.RecoveryActionRefinePrompt,
 		payloads.RecoveryActionNarrowScope,
 		payloads.RecoveryActionSplitReq,
+		payloads.RecoveryActionStoryReprepare,
 		payloads.RecoveryActionEscalateHuman,
 		payloads.RecoveryActionMarkUnrecoverable:
 	default:

--- a/processor/recovery-agent/result_test.go
+++ b/processor/recovery-agent/result_test.go
@@ -71,6 +71,25 @@ func TestParseRecoveryResult(t *testing.T) {
 		}
 	})
 
+	// ADR-043 PR 4i — story_reprepare is the new action class for wedges
+	// whose root cause is Sarah's Story-shaping (wrong task DAG, missing
+	// files_owned, mis-selected components). Reaches back to story-preparer
+	// for a re-prep cycle. Callers materialize once execution dispatches
+	// per-Story (PR 4h).
+	t.Run("happy path story_reprepare", func(t *testing.T) {
+		raw := `{"action":"story_reprepare","diagnosis":"Sarah's task DAG missed integration smoke; dev loop has no scaffold to verify against PX4 SITL.","recovery_succeeded":true}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected ok, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionStoryReprepare {
+			t.Errorf("Action: got %q, want story_reprepare", got.Action)
+		}
+		if !strings.Contains(got.Diagnosis, "Sarah") {
+			t.Errorf("diagnosis content lost: %q", got.Diagnosis)
+		}
+	})
+
 	cases := []struct {
 		name string
 		raw  string

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1696,14 +1696,23 @@ Rules:
 			Content: `Output Format — submit_work arguments
 
 Required fields:
-- action: one of refine_prompt | narrow_scope | split_req | escalate_human | mark_unrecoverable
+- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | escalate_human | mark_unrecoverable
 - diagnosis: 2-6 sentences describing what the trajectory shows the agent doing wrong and what the underlying mistake is. REQUIRED for every action.
-- recovery_succeeded: true when refine_prompt | narrow_scope | split_req plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
+- recovery_succeeded: true when refine_prompt | narrow_scope | split_req | story_reprepare plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
 
 Action-specific fields:
 - refine_prompt requires: refined_prompt — a complete replacement task prompt that, when handed to the wedged role, would produce the work the agent should have produced.
 - narrow_scope and split_req require: scope_changes — a structured JSON object describing the reduction (which files / which sub-requirements / which concerns to keep, which to drop).
+- story_reprepare: no extra fields beyond diagnosis — the diagnosis becomes Sarah's RecoveryHint when she re-shards the requirement's Stories.
 - escalate_human and mark_unrecoverable: no extra fields beyond diagnosis.
+
+Choosing between actions (ADR-043 PR 4i):
+- refine_prompt: the dev had the answer in front of it but didn't act. Same task, sharper prompt.
+- narrow_scope: the task's file surface was too broad; reduce it. Same DAG node, fewer files.
+- split_req: the plan-level decomposition was wrong; the requirement was too coarse. Heavier — mutates plan structure.
+- story_reprepare: Sarah's Story-shaping is the root cause — wrong task DAG, missing files_owned, mis-selected components. Reaches back to story-preparer for a re-prep cycle on the affected requirement; the diagnosis carries forward as Sarah's RecoveryHint.
+- escalate_human: analysis is the deliverable; no programmatic action fits.
+- mark_unrecoverable: the wedge cannot succeed from current state regardless of refinements.
 
 Quote 1-3 short trajectory excerpts in diagnosis when available — these become the evidence trail the lessons pipeline keys off.`,
 		},

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -41,6 +41,28 @@ const (
 	// (e.g. upstream artifact doesn't exist, fixture is malformed). Plan
 	// continues with reduced scope or fails cleanly with diagnostic.
 	RecoveryActionMarkUnrecoverable RecoveryActionKind = "mark_unrecoverable"
+
+	// RecoveryActionStoryReprepare — wedge analysis points at Sarah's
+	// Story-shaping (ADR-043 Move 3) as the source. The plan-time DAG is
+	// wrong: a Story's tasks don't cover the work, files_owned misses a
+	// path the dev needed, or the components selected don't match the
+	// implementation. Reaches back to story-preparer for a re-prep cycle
+	// on the affected requirement (cascade dirty-marks the requirement →
+	// plan-manager transitions back to preparing_stories → Sarah runs
+	// again with the recovery diagnosis as RecoveryHint).
+	//
+	// Distinct from split_req: split_req mutates plan structure at the
+	// requirement layer (one big req → two smaller reqs); story_reprepare
+	// keeps the requirements as authored and asks Sarah to re-shard.
+	// Distinct from narrow_scope: narrow_scope reduces the task's file
+	// surface; story_reprepare re-authors the task DAG itself.
+	//
+	// ADR-043 PR 4i lands the action vocabulary; callers materialize once
+	// execution dispatches per-Story (PR 4h). Until then this action is
+	// reserved infrastructure — the closed-set parser accepts it and the
+	// PlanDecision routing maps it, but no recovery dispatch currently
+	// emits it.
+	RecoveryActionStoryReprepare RecoveryActionKind = "story_reprepare"
 )
 
 // RecoveryLayer identifies which recovery layer attempted the action. Per


### PR DESCRIPTION
## Summary

Adds the ADR-037 + ADR-043 `story_reprepare` PlanDecision action class. **Reserved infrastructure** — callers materialize once execution dispatches per-Story (PR 4h). Until then the parser accepts it, the routing maps it, and recovery agents see it as an option in their persona prompt, but no dispatch path currently emits it.

5 files / +64/-3.

## What landed

- **`workflow/payloads/recovery.go`** — New `RecoveryActionStoryReprepare = "story_reprepare"` constant with ADR-043 doc-comment. Distinct from `split_req` (mutates plan structure at the requirement layer) and `narrow_scope` (reduces task file surface) — `story_reprepare` re-authors the task DAG itself.
- **`processor/recovery-agent/result.go`** — `parseRecoveryResult`'s closed-set switch accepts the new action.
- **`processor/recovery-agent/result_test.go`** — New happy-path subtest with Sarah-focused diagnosis.
- **`processor/recovery-agent/component.go`** — `recoveryActionToPlanDecisionKind` maps `story_reprepare` to `PlanDecisionKindRequirementChange`. Cascade target identical to other requirement_change actions (dirty-mark parent req → downstream chain re-runs); the distinction surfaces in the PlanDecision rationale text, which plan-manager threads into Sarah's `RecoveryHint` on the next dispatch.
- **`prompt/domain/software.go`** (recovery-agent output-format fragment) — Persona prose extended with `story_reprepare` in the action list + a new "Choosing between actions" disambiguation block.

## Deferred to PR 4h

- Dispatch path that actually emits `story_reprepare` PlanDecisions. Today execution dispatches per-Requirement; per-Story wedges don't surface until PR 4h reworks the dispatch model.
- `plan-manager` cascade handling: when an accepted `story_reprepare` PlanDecision lands, transition back to `preparing_stories` with the diagnosis threaded into Sarah's `RecoveryHint`. Currently the requirement_change-kind cascade re-runs Sarah's downstream chain through the normal happy path; explicit RecoveryHint threading is a future enhancement.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] `task lint:default` (revive v1.5.1) clean
- [x] New parser test exercises the positive path (story_reprepare accepted with valid diagnosis)
- [x] Existing closed-set rejection test still passes (unknown actions still rejected)

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)