### PR TITLE
fix(adr-043): PR 4k — smoke-driven fixes (Sarah missing in real-LLM configs, stale req-gen output-format prompt)

### DIFF
--- a/configs/e2e-claude.json
+++ b/configs/e2e-claude.json
@@ -494,6 +494,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "scenario-generator": {
       "name": "scenario-generator",
       "type": "processor",

--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -586,6 +586,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -777,6 +777,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/configs/e2e-hybrid.json
+++ b/configs/e2e-hybrid.json
@@ -776,6 +776,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/configs/e2e-local.json
+++ b/configs/e2e-local.json
@@ -510,6 +510,17 @@
         "default_capability": "architecture"
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "scenario-generator": {
       "name": "scenario-generator",
       "type": "processor",

--- a/configs/e2e-openrouter.json
+++ b/configs/e2e-openrouter.json
@@ -632,6 +632,17 @@
         "attach_response_format": false
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/configs/e2e-sparky.json
+++ b/configs/e2e-sparky.json
@@ -484,6 +484,17 @@
         "max_generation_retries": 3
       }
     },
+    "story-preparer": {
+      "_comment": "ADR-043 Move 3 — Sarah (BMAD PO). Real-LLM configs run Sarah on the same planning capability endpoint as Mary; the persona prompt + storiesSchema (positional/labeled per PR 4e) carry the differentiation. Added in PR 4k after the gemini @easy smoke caught Sarah dormant on every real-LLM run.",
+      "name": "story-preparer",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "enabled": true,
+        "default_capability": "planning",
+        "max_generation_retries": 2
+      }
+    },
     "plan-manager": {
       "name": "plan-manager",
       "type": "processor",

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -701,11 +701,21 @@ func (c *Component) deriveDecision(loop *agentic.LoopEntity, escalationReason st
 // through requirement_change so the cascade dirty-marks the req for
 // re-run; terminal actions go through execution_exhausted so plan-manager
 // auto-archives when the subject req reaches a non-failed terminal state.
+//
+// story_reprepare (ADR-043 PR 4i) maps to requirement_change because the
+// cascade target is the same: dirty-mark the parent requirement so the
+// downstream chain (Sarah's preparing_stories → ready_for_execution)
+// re-runs. The distinction between story_reprepare and the other
+// requirement_change actions surfaces in the PlanDecision rationale text,
+// which plan-manager threads into Sarah's RecoveryHint on the next
+// dispatch — Sarah sees "the wedge happened because <X>; re-shard with
+// <Y> in mind."
 func recoveryActionToPlanDecisionKind(action payloads.RecoveryActionKind) workflow.PlanDecisionKind {
 	switch action {
 	case payloads.RecoveryActionRefinePrompt,
 		payloads.RecoveryActionNarrowScope,
-		payloads.RecoveryActionSplitReq:
+		payloads.RecoveryActionSplitReq,
+		payloads.RecoveryActionStoryReprepare:
 		return workflow.PlanDecisionKindRequirementChange
 	case payloads.RecoveryActionEscalateHuman, payloads.RecoveryActionMarkUnrecoverable:
 		return workflow.PlanDecisionKindExecutionExhausted

--- a/processor/recovery-agent/result.go
+++ b/processor/recovery-agent/result.go
@@ -90,6 +90,7 @@ func parseRecoveryResult(raw string) (*parsedRecoveryResult, error) {
 	case payloads.RecoveryActionRefinePrompt,
 		payloads.RecoveryActionNarrowScope,
 		payloads.RecoveryActionSplitReq,
+		payloads.RecoveryActionStoryReprepare,
 		payloads.RecoveryActionEscalateHuman,
 		payloads.RecoveryActionMarkUnrecoverable:
 	default:

--- a/processor/recovery-agent/result_test.go
+++ b/processor/recovery-agent/result_test.go
@@ -71,6 +71,25 @@ func TestParseRecoveryResult(t *testing.T) {
 		}
 	})
 
+	// ADR-043 PR 4i — story_reprepare is the new action class for wedges
+	// whose root cause is Sarah's Story-shaping (wrong task DAG, missing
+	// files_owned, mis-selected components). Reaches back to story-preparer
+	// for a re-prep cycle. Callers materialize once execution dispatches
+	// per-Story (PR 4h).
+	t.Run("happy path story_reprepare", func(t *testing.T) {
+		raw := `{"action":"story_reprepare","diagnosis":"Sarah's task DAG missed integration smoke; dev loop has no scaffold to verify against PX4 SITL.","recovery_succeeded":true}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected ok, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionStoryReprepare {
+			t.Errorf("Action: got %q, want story_reprepare", got.Action)
+		}
+		if !strings.Contains(got.Diagnosis, "Sarah") {
+			t.Errorf("diagnosis content lost: %q", got.Diagnosis)
+		}
+	})
+
 	cases := []struct {
 		name string
 		raw  string

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1126,62 +1126,66 @@ Do NOT emit files_owned on Requirements. File-collision sequencing is a per-Stor
 			Roles:    []prompt.Role{prompt.RoleRequirementGenerator},
 			ContentFunc: elideSchemaProse(
 				`When your requirements are ready, call the submit_work tool with these JSON fields:`,
-				`Example 1 — two requirements, chain pattern (one feature + its router wire-up).
-Note how files_owned mixes scope.create entries (the two new goodbye files) with a
-scope.include entry (the existing main.go). Both buckets are valid sources.
-
-Plan it's working from:
-  scope.include: ["main.go"]                             // existing, may modify
-  scope.create:  ["api/handlers/goodbye.go",             // new, will author
-                  "api/handlers/goodbye_test.go"]
+				`Example 1 — two requirements with a capability-level dependency. Notice that
+NO files_owned field appears: ADR-043 Move 4 removed it from the requirement
+wire shape. Files belong to Stories (Sarah authors them after Winston's
+architecture phase); your job stops at intent + acceptance criteria.
 
 {
   "requirements": [
     {
       "title": "Goodbye endpoint returns JSON",
-      "description": "GET /goodbye must return HTTP 200 with Content-Type application/json and a body containing a message field",
-      "files_owned": ["api/handlers/goodbye.go", "api/handlers/goodbye_test.go"]
+      "description": "GET /goodbye MUST return HTTP 200 with Content-Type application/json and a body containing a message field.",
+      "depends_on": [],
+      "capability_name": "goodbye-endpoint"
     },
     {
-      "title": "Goodbye endpoint surfaced through router",
-      "description": "GET /goodbye must be reachable via the main HTTP router, not only the handler in isolation",
+      "title": "UI displays goodbye message from new endpoint",
+      "description": "The browser UI SHALL fetch /goodbye and display the returned message to the user.",
       "depends_on": ["Goodbye endpoint returns JSON"],
-      "files_owned": ["main.go"]
+      "capability_name": "goodbye-ui-integration"
     }
   ]
 }
 
-Example 2 — three requirements, fan-in pattern (multiple features sharing main.go):
+Example 2 — three requirements; standalone capabilities with no cross-deps.
+A multi-capability plan emits one requirement per capability (the analyst's
+classification controls the count). depends_on stays [] when capabilities
+are independent.
 
 {
   "requirements": [
     {
       "title": "Hello endpoint returns JSON",
-      "description": "GET /hello must return HTTP 200 with Content-Type application/json and a body containing a message field",
-      "files_owned": ["api/handlers/hello.go", "api/handlers/hello_test.go"]
+      "description": "GET /hello MUST return HTTP 200 with Content-Type application/json and a body containing a message field.",
+      "depends_on": [],
+      "capability_name": "hello-endpoint"
     },
     {
       "title": "Goodbye endpoint returns JSON",
-      "description": "GET /goodbye must return HTTP 200 with Content-Type application/json and a body containing a message field",
-      "files_owned": ["api/handlers/goodbye.go", "api/handlers/goodbye_test.go"]
+      "description": "GET /goodbye MUST return HTTP 200 with Content-Type application/json and a body containing a message field.",
+      "depends_on": [],
+      "capability_name": "goodbye-endpoint"
     },
     {
       "title": "Endpoints surfaced through router",
-      "description": "Both /hello and /goodbye must be reachable via the main HTTP router",
+      "description": "The HTTP router MUST surface both /hello and /goodbye in the same request-handling chain so neither endpoint shadows the other.",
       "depends_on": ["Hello endpoint returns JSON", "Goodbye endpoint returns JSON"],
-      "files_owned": ["main.go"]
+      "capability_name": "router-integration"
     }
   ]
 }
 
-Note in Example 2: the feature requirements DO NOT list main.go in files_owned — only the final wire-up requirement does, and it depends_on every feature. Never list main.go (or any shared registration file) in multiple requirements' files_owned in parallel; the validator rejects every time.
-
 Required fields per requirement:
-- title (string)
-- description (string)
-- files_owned (array of workspace-relative paths) — MANDATORY. Empty arrays are not acceptable. If a requirement modifies no files, it isn't a code requirement.
-- depends_on (array of titles) — optional, use when one requirement must follow another or when sharing a file with another requirement.
-- capability_name (kebab-case string) — REQUIRED field; the strict response schema rejects requirements without it. When a "## Capabilities" block appears above in this prompt, set to one of the listed capability names exactly. When no Capabilities block appears, set to empty string "". DO NOT OMIT — the wire schema requires the field even when its value is empty.
+- title (string) — short, capability-flavored heading
+- description (string) — 1-3 sentences with SHALL/MUST normative language
+- depends_on (array of titles) — capability-level intent ordering; emit [] when no prereqs exist
+- capability_name (kebab-case string) — set to one of the names listed in the prompt's "## Capabilities" block; set to "" only when no Capabilities block is present. Required on the wire even when empty.
+
+File-path determination is NOT your concern (ADR-043 Move 4). Do NOT emit
+files_owned; the strict schema rejects the field. Winston (architect)
+declares implementation_files per ComponentDef in the next phase; Sarah
+(product owner) maps Stories to those files for execution.
 
 Respond ONLY via the submit_work tool call. No markdown, no preamble, no explanation.`,
 			),

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1696,14 +1696,23 @@ Rules:
 			Content: `Output Format — submit_work arguments
 
 Required fields:
-- action: one of refine_prompt | narrow_scope | split_req | escalate_human | mark_unrecoverable
+- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | escalate_human | mark_unrecoverable
 - diagnosis: 2-6 sentences describing what the trajectory shows the agent doing wrong and what the underlying mistake is. REQUIRED for every action.
-- recovery_succeeded: true when refine_prompt | narrow_scope | split_req plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
+- recovery_succeeded: true when refine_prompt | narrow_scope | split_req | story_reprepare plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
 
 Action-specific fields:
 - refine_prompt requires: refined_prompt — a complete replacement task prompt that, when handed to the wedged role, would produce the work the agent should have produced.
 - narrow_scope and split_req require: scope_changes — a structured JSON object describing the reduction (which files / which sub-requirements / which concerns to keep, which to drop).
+- story_reprepare: no extra fields beyond diagnosis — the diagnosis becomes Sarah's RecoveryHint when she re-shards the requirement's Stories.
 - escalate_human and mark_unrecoverable: no extra fields beyond diagnosis.
+
+Choosing between actions (ADR-043 PR 4i):
+- refine_prompt: the dev had the answer in front of it but didn't act. Same task, sharper prompt.
+- narrow_scope: the task's file surface was too broad; reduce it. Same DAG node, fewer files.
+- split_req: the plan-level decomposition was wrong; the requirement was too coarse. Heavier — mutates plan structure.
+- story_reprepare: Sarah's Story-shaping is the root cause — wrong task DAG, missing files_owned, mis-selected components. Reaches back to story-preparer for a re-prep cycle on the affected requirement; the diagnosis carries forward as Sarah's RecoveryHint.
+- escalate_human: analysis is the deliverable; no programmatic action fits.
+- mark_unrecoverable: the wedge cannot succeed from current state regardless of refinements.
 
 Quote 1-3 short trajectory excerpts in diagnosis when available — these become the evidence trail the lessons pipeline keys off.`,
 		},

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -41,6 +41,28 @@ const (
 	// (e.g. upstream artifact doesn't exist, fixture is malformed). Plan
 	// continues with reduced scope or fails cleanly with diagnostic.
 	RecoveryActionMarkUnrecoverable RecoveryActionKind = "mark_unrecoverable"
+
+	// RecoveryActionStoryReprepare — wedge analysis points at Sarah's
+	// Story-shaping (ADR-043 Move 3) as the source. The plan-time DAG is
+	// wrong: a Story's tasks don't cover the work, files_owned misses a
+	// path the dev needed, or the components selected don't match the
+	// implementation. Reaches back to story-preparer for a re-prep cycle
+	// on the affected requirement (cascade dirty-marks the requirement →
+	// plan-manager transitions back to preparing_stories → Sarah runs
+	// again with the recovery diagnosis as RecoveryHint).
+	//
+	// Distinct from split_req: split_req mutates plan structure at the
+	// requirement layer (one big req → two smaller reqs); story_reprepare
+	// keeps the requirements as authored and asks Sarah to re-shard.
+	// Distinct from narrow_scope: narrow_scope reduces the task's file
+	// surface; story_reprepare re-authors the task DAG itself.
+	//
+	// ADR-043 PR 4i lands the action vocabulary; callers materialize once
+	// execution dispatches per-Story (PR 4h). Until then this action is
+	// reserved infrastructure — the closed-set parser accepts it and the
+	// PlanDecision routing maps it, but no recovery dispatch currently
+	// emits it.
+	RecoveryActionStoryReprepare RecoveryActionKind = "story_reprepare"
 )
 
 // RecoveryLayer identifies which recovery layer attempted the action. Per


### PR DESCRIPTION
## Summary

Two bugs surfaced by today's gemini @easy real-LLM smoke that mock e2e couldn't have caught.

**Smoke evidence** (single hello-world run, killed early once both bugs were diagnosed):

- Plan reached `architecture_generated` after a **clean PR 2 retry cycle** — Winston's first arch output failed `workflow.ValidateCapabilityCoverage` (`capability \"service-health\" has no component whose capabilities list contains it`), validator kicked back, gemini-pro produced a conformant second output, plan advanced. **PR 2 working as designed.** ✅
- Plan then jumped straight `architecture_generated → scenarios_generated` — bypassing `preparing_stories` entirely. **Sarah never dispatched.** PR 4f decomposer-bypass fell back to legacy LLM dispatch because `plan.Stories` was empty. ❌
- Requirement-generator system prompt contained **contradictory instructions**: narrowed John persona said "Do NOT emit `files_owned`" while output-format fragment still listed `files_owned` as MANDATORY with two worked examples authoring it. gemini-pro resolved by trusting the schema (rejects `files_owned`) but the next regen would re-trip. ❌

## Fix 1 — story-preparer missing from real-LLM configs

PR 3 shipped story-preparer dormant. PR 4c enabled it in `configs/semspec.json`. PR 4d added it to mock e2e configs. PR 4e re-enabled in mock e2e with fixtures. The **7 real-LLM provider configs were never touched** — each carries its own `components` map (not a merge with semspec.json), so story-preparer simply doesn't load when any of them is in use.

All 7 configs (`configs/e2e-{claude,gemini,hybrid-gpt5,hybrid,local,openrouter,sparky}.json`) now carry the story-preparer entry with `default_capability=planning` (real LLMs run Sarah on the same model as Mary's planner sub-phase; storiesSchema + persona prompt carry the differentiation — no separate story_preparation capability needed since real LLMs don't need fixture-routing the way mock-llm does).

Text-based insertion preserved per-config formatting (em-dashes in description strings, inline JSON objects in the governance-rule blocks of the hybrid configs).

## Fix 2 — stale requirement-generator output-format fragment

PR 4a's caller-sweep updated John's persona system_prompt and the "Rules" block of the user-prompt renderer but **missed the `software.requirement-generator.output-format` fragment**. That fragment carried two worked examples explicitly authoring `files_owned`, a "Required fields" list naming it MANDATORY, and prose about "Never list main.go in multiple requirements' files_owned in parallel — the validator rejects every time" — all describing pre-ADR-043 wire shape.

Replaced with two new worked examples matching the post-PR-4a wire shape: `title + description + depends_on + capability_name`, no `files_owned`. New tail explicitly says "Do NOT emit `files_owned`; the strict schema rejects the field. Winston (architect) declares `implementation_files` per ComponentDef in the next phase; Sarah (product owner) maps Stories to those files for execution."

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green (`TestSoftwareRequirementGeneratorPostADR043` already pins the new shape; no test pinned the stale phrasing)
- [x] `task lint:default` (revive v1.5.1) clean
- [x] All 7 real-LLM configs validate as JSON + carry expected story-preparer entry
- [ ] **Post-merge: re-run `task e2e:watch:llm -- gemini easy`** to confirm Sarah dispatches end-to-end + the new prompt fragment doesn't contradict the schema.

Smoke artifacts preserved at `/tmp/semspec-watch-gemini-easy-20260601-100903/` (killed-early; bundle.tar.gz and snapshots intact for forensics).

Refs `docs/adr/ADR-043-architect-emits-implementation-files.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)