### PR TITLE
feat(adr-043): PR 4h — per-Story dispatch (architectural pivot)

### DIFF
--- a/processor/execution-manager/mutations.go
+++ b/processor/execution-manager/mutations.go
@@ -115,6 +115,9 @@ type ReqPhaseRequest struct {
 	// DAG state — persisted after decomposition for crash recovery
 	DAGRaw        json.RawMessage `json:"dag,omitempty"`
 	SortedNodeIDs []string        `json:"sorted_node_ids,omitempty"`
+	// Story sequencing (ADR-043 PR 4h)
+	SortedStoryIDs  []string `json:"sorted_story_ids,omitempty"`
+	CurrentStoryIdx *int     `json:"current_story_idx,omitempty"`
 }
 
 // ReqResetRequest deletes a requirement execution entry from EXECUTION_STATES.
@@ -451,6 +454,12 @@ func (c *Component) handleReqPhaseMutation(ctx context.Context, data []byte) Exe
 	}
 	if len(req.SortedNodeIDs) > 0 {
 		exec.SortedNodeIDs = req.SortedNodeIDs
+	}
+	if len(req.SortedStoryIDs) > 0 {
+		exec.SortedStoryIDs = req.SortedStoryIDs
+	}
+	if req.CurrentStoryIdx != nil {
+		exec.CurrentStoryIdx = *req.CurrentStoryIdx
 	}
 
 	if err := c.store.saveReq(ctx, req.Key, exec); err != nil {

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -504,6 +504,8 @@ func (c *Component) rebuildExecFromKV(key string, reqExec *workflow.RequirementE
 		RequirementBranch: reqExec.RequirementBranch,
 		CurrentNodeIdx:    reqExec.CurrentNodeIdx,
 		SortedNodeIDs:     reqExec.SortedNodeIDs,
+		SortedStoryIDs:    reqExec.SortedStoryIDs,
+		CurrentStoryIdx:   reqExec.CurrentStoryIdx,
 		RetryCount:        reqExec.RetryCount,
 		MaxRetries:        reqExec.MaxRetries,
 		storeKey:          key,
@@ -922,21 +924,72 @@ func (c *Component) dispatchDecomposerLocked(ctx context.Context, exec *requirem
 		return
 	}
 
-	dag, synthErr := synthesizeTaskDAGFromStories(plan, exec.RequirementID)
-	if synthErr != nil {
-		c.markFailedLocked(ctx, exec, fmt.Sprintf("synthesize DAG from plan.Stories failed: %v", synthErr))
-		return
+	// Populate SortedStoryIDs the first time the requirement enters this
+	// path. Subsequent calls (recovery resume, etc.) re-enter with the
+	// list already populated; CurrentStoryIdx is the cursor.
+	if len(exec.SortedStoryIDs) == 0 {
+		stories := plan.StoriesForRequirement(exec.RequirementID)
+		if len(stories) == 0 {
+			c.markFailedLocked(ctx, exec, fmt.Sprintf("no Stories on plan for requirement %s — story-preparer must run before execution", exec.RequirementID))
+			return
+		}
+		sortedIDs, err := topoSortStoryIDs(stories)
+		if err != nil {
+			c.markFailedLocked(ctx, exec, fmt.Sprintf("topo-sort stories failed: %v", err))
+			return
+		}
+		exec.SortedStoryIDs = sortedIDs
+		exec.CurrentStoryIdx = 0
 	}
-	if dag == nil {
-		c.markFailedLocked(ctx, exec, fmt.Sprintf("no Stories on plan for requirement %s — story-preparer must run before execution", exec.RequirementID))
+
+	c.dispatchCurrentStoryLocked(ctx, exec, plan)
+}
+
+// dispatchCurrentStoryLocked synthesizes the DAG for the Story at
+// SortedStoryIDs[CurrentStoryIdx] and hands off to applyParsedDAGLocked.
+// Caller must hold exec.mu.
+func (c *Component) dispatchCurrentStoryLocked(ctx context.Context, exec *requirementExecution, plan *workflow.Plan) {
+	if exec.CurrentStoryIdx < 0 || exec.CurrentStoryIdx >= len(exec.SortedStoryIDs) {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("CurrentStoryIdx %d out of range [0, %d)", exec.CurrentStoryIdx, len(exec.SortedStoryIDs)))
 		return
 	}
 
-	c.logger.Info("Synthesized DAG from plan.Stories",
+	currentStoryID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
+	story, ok := findStoryByID(plan, currentStoryID)
+	if !ok {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("story %q not found on plan (planning regression — Sarah output drifted from SortedStoryIDs)", currentStoryID))
+		return
+	}
+
+	dag, synthErr := synthesizeTaskDAGForStory(plan, story)
+	if synthErr != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("synthesize DAG for story %s failed: %v", currentStoryID, synthErr))
+		return
+	}
+
+	c.logger.Info("Dispatching story DAG",
 		"entity_id", exec.EntityID,
 		"requirement_id", exec.RequirementID,
+		"story_id", currentStoryID,
+		"story_idx", exec.CurrentStoryIdx+1,
+		"story_total", len(exec.SortedStoryIDs),
 		"node_count", len(dag.Nodes))
+
 	c.applyParsedDAGLocked(ctx, exec, dag, "stories-synthesis")
+}
+
+// findStoryByID returns the Story with the given ID from plan.Stories.
+// Returns the zero Story and false when not found.
+func findStoryByID(plan *workflow.Plan, storyID string) (workflow.Story, bool) {
+	if plan == nil {
+		return workflow.Story{}, false
+	}
+	for _, s := range plan.Stories {
+		if s.ID == storyID {
+			return s, true
+		}
+	}
+	return workflow.Story{}, false
 }
 
 // loadPlanScope reads the plan from PLAN_STATES KV and returns its scope.
@@ -1465,10 +1518,7 @@ func (c *Component) handleRequirementReviewerCompleteLocked(ctx context.Context,
 	exec.ScenarioVerdicts = result.ScenarioVerdicts
 
 	if result.Verdict == "approved" {
-		if c.handleApprovedClaimMismatchLocked(ctx, exec) {
-			return
-		}
-		c.markCompletedLocked(ctx, exec)
+		c.handleApprovedVerdictLocked(ctx, exec)
 		return
 	}
 
@@ -1706,10 +1756,14 @@ func (c *Component) buildRequirementReviewContext(exec *requirementExecution, re
 		NodeResults:   c.buildNodeSummaries(exec),
 	}
 
-	// Populate per-scenario specs for multi-scenario verdict tracking.
-	if len(exec.Scenarios) > 0 {
-		specs := make([]prompt.ScenarioSpec, len(exec.Scenarios))
-		for i, s := range exec.Scenarios {
+	// ADR-043 PR 4h: per-Story reviewer scope. Filter the requirement's
+	// scenarios down to the current Story's scenarios — that is the verdict
+	// surface for THIS reviewer dispatch. Other Stories' scenarios are out
+	// of scope (they'll get their own reviewer pass).
+	scoped := scopeScenariosToCurrentStory(exec)
+	if len(scoped) > 0 {
+		specs := make([]prompt.ScenarioSpec, len(scoped))
+		for i, s := range scoped {
 			specs[i] = prompt.ScenarioSpec{
 				ID:    s.ID,
 				Given: s.Given,
@@ -1736,6 +1790,98 @@ func (c *Component) buildRequirementReviewContext(exec *requirementExecution, re
 		Vocabulary:            prompt.GlobalPersonas().Vocabulary(),
 		HasResponseFormat:     terminal.EndpointSupportsResponseFormat(endpoint),
 	}
+}
+
+// handleApprovedVerdictLocked routes an approved reviewer verdict. ADR-043
+// PR 4h split this off handleRequirementReviewerCompleteLocked to keep the
+// outer function under the function-length lint cap and to localize the
+// per-Story advancement decision.
+//
+// Caller must hold exec.mu.
+func (c *Component) handleApprovedVerdictLocked(ctx context.Context, exec *requirementExecution) {
+	if c.handleApprovedClaimMismatchLocked(ctx, exec) {
+		return
+	}
+	// Per-Story reviewer: if more Stories remain, advance the cursor and
+	// dispatch the next Story's DAG; otherwise mark the whole requirement
+	// complete.
+	if exec.CurrentStoryIdx+1 < len(exec.SortedStoryIDs) {
+		c.advanceToNextStoryLocked(ctx, exec)
+		return
+	}
+	c.markCompletedLocked(ctx, exec)
+}
+
+// advanceToNextStoryLocked increments CurrentStoryIdx, clears per-Story
+// state (DAG / node bookkeeping / reviewer verdict / retry counters), and
+// dispatches the next Story's DAG. NodeResults accumulate across Stories
+// so the requirement-final aggregateFiles call still sees every node's
+// output for the merge-commit cross-check.
+//
+// Caller must hold exec.mu.
+func (c *Component) advanceToNextStoryLocked(ctx context.Context, exec *requirementExecution) {
+	exec.CurrentStoryIdx++
+
+	// Per-Story state reset. NodeResults intentionally NOT reset — they
+	// feed the requirement-level claim/observation cross-check at
+	// markCompletedLocked.
+	exec.DAG = nil
+	exec.SortedNodeIDs = nil
+	exec.NodeIndex = nil
+	exec.CurrentNodeIdx = -1
+	exec.CurrentNodeTaskID = ""
+	exec.VisitedNodes = make(map[string]bool)
+	exec.ReviewVerdict = ""
+	exec.ReviewFeedback = ""
+	exec.ReviewRetryCount = 0
+	exec.RetryCount = 0
+	exec.DirtyNodeIDs = nil
+	exec.ScenarioVerdicts = nil
+
+	nextStoryID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
+	c.logger.Info("Advancing to next Story",
+		"entity_id", exec.EntityID,
+		"requirement_id", exec.RequirementID,
+		"next_story_id", nextStoryID,
+		"story_idx", exec.CurrentStoryIdx+1,
+		"story_total", len(exec.SortedStoryIDs))
+
+	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
+	if err != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("load plan from KV failed mid-requirement: %v", err))
+		return
+	}
+	if plan == nil {
+		c.markFailedLocked(ctx, exec, "plan disappeared from PLAN_STATES mid-requirement")
+		return
+	}
+
+	c.dispatchCurrentStoryLocked(ctx, exec, plan)
+}
+
+// scopeScenariosToCurrentStory returns the subset of exec.Scenarios whose
+// StoryID matches the Story currently being executed (per CurrentStoryIdx).
+// When no Stories are tracked or the current Story ID can't be resolved,
+// falls back to all exec.Scenarios — preserves pre-ADR-043 behavior for
+// legacy plans that reach the reviewer without SortedStoryIDs populated.
+func scopeScenariosToCurrentStory(exec *requirementExecution) []workflow.Scenario {
+	if exec == nil {
+		return nil
+	}
+	if exec.CurrentStoryIdx < 0 || exec.CurrentStoryIdx >= len(exec.SortedStoryIDs) {
+		return exec.Scenarios
+	}
+	currentStoryID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
+	if currentStoryID == "" {
+		return exec.Scenarios
+	}
+	out := make([]workflow.Scenario, 0, len(exec.Scenarios))
+	for _, s := range exec.Scenarios {
+		if s.StoryID == currentStoryID {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // resolveProvider maps a model string to a prompt.Provider.

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -2077,3 +2077,158 @@ func TestRequirementCompletion_RejectsApprovalWithoutCommitObservation(t *testin
 		t.Errorf("requirementsFailed = %d, want 1 (claim/observation mismatch should fail the requirement)", c.requirementsFailed.Load())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ADR-043 PR 4h: per-Story dispatch — Story advancement on reviewer approval
+// ---------------------------------------------------------------------------
+
+// TestPerStoryReviewer_ApprovedAdvancesToNextStory pins the load-bearing
+// behavior of PR 4h: when the reviewer approves and more Stories remain
+// in SortedStoryIDs, the requirement does NOT terminate; instead the
+// CurrentStoryIdx cursor advances and per-Story state resets in
+// preparation for the next Story's DAG.
+func TestPerStoryReviewer_ApprovedAdvancesToNextStory(t *testing.T) {
+	c := newTestComponent(t)
+
+	exec := &requirementExecution{
+		EntityID:      "semspec.local.exec.req.run.test-multi-story",
+		Slug:          "test-plan",
+		RequirementID: "requirement.test-plan.1",
+		// Two Stories. Reviewer approval on Story 1 must advance to Story 2.
+		SortedStoryIDs:  []string{"story.test-plan.1.1", "story.test-plan.1.2"},
+		CurrentStoryIdx: 0,
+		VisitedNodes:    map[string]bool{"impl": true},
+		NodeResults: []NodeResult{
+			{NodeID: "impl", FilesModified: []string{"main.go"}, CommitSHA: "abc123"},
+		},
+	}
+
+	event := &agentic.LoopCompletedEvent{
+		Outcome:      agentic.OutcomeSuccess,
+		WorkflowSlug: "requirement-execution",
+		WorkflowStep: "requirement-review",
+		Result:       `{"verdict":"approved","feedback":"OK","scenario_verdicts":[]}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	// Requirement must NOT be marked completed — Story 2 still pending.
+	// (In unit-test mode, no NATS → loadPlanFromKV nil → markFailed fires
+	// from the synth-fail, so exec.terminated will be true. The load-
+	// bearing claim is the advancement decision: cursor moved, requirement
+	// did not complete.)
+	if c.requirementsCompleted.Load() != 0 {
+		t.Errorf("requirementsCompleted = %d, want 0 (Story 2 hasn't run yet)", c.requirementsCompleted.Load())
+	}
+	if exec.CurrentStoryIdx != 1 {
+		t.Errorf("CurrentStoryIdx = %d, want 1 (cursor advanced to Story 2)", exec.CurrentStoryIdx)
+	}
+}
+
+// TestPerStoryReviewer_ApprovedOnFinalStoryCompletesRequirement pins the
+// other side of the advancement decision: when the reviewer approves the
+// last Story (CurrentStoryIdx+1 == len(SortedStoryIDs)), markCompletedLocked
+// fires and the requirement terminates.
+func TestPerStoryReviewer_ApprovedOnFinalStoryCompletesRequirement(t *testing.T) {
+	c := newTestComponent(t)
+	gateOff := false
+	c.config.RequireCommitObservation = &gateOff // simplify — no claim/observation gate
+
+	exec := &requirementExecution{
+		EntityID:        "semspec.local.exec.req.run.test-final-story",
+		Slug:            "test-plan",
+		RequirementID:   "requirement.test-plan.1",
+		SortedStoryIDs:  []string{"story.test-plan.1.1"},
+		CurrentStoryIdx: 0, // 0 + 1 == 1 == len → final
+		VisitedNodes:    map[string]bool{"impl": true},
+	}
+
+	event := &agentic.LoopCompletedEvent{
+		Outcome: agentic.OutcomeSuccess,
+		Result:  `{"verdict":"approved","feedback":"OK","scenario_verdicts":[]}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	if c.requirementsCompleted.Load() != 1 {
+		t.Errorf("requirementsCompleted = %d, want 1 (final Story approved → requirement complete)", c.requirementsCompleted.Load())
+	}
+	if !exec.terminated {
+		t.Error("exec.terminated should be true after final Story approval")
+	}
+}
+
+// TestPerStoryReviewer_LegacyExecWithoutSortedStoryIDsCompletes pins the
+// backwards-compat path: an exec that never populated SortedStoryIDs
+// (CurrentStoryIdx+1 < len(SortedStoryIDs) is trivially false since
+// len==0). Such a requirement still terminates on approval via the
+// existing markCompletedLocked branch.
+func TestPerStoryReviewer_LegacyExecWithoutSortedStoryIDsCompletes(t *testing.T) {
+	c := newTestComponent(t)
+	gateOff := false
+	c.config.RequireCommitObservation = &gateOff
+
+	exec := &requirementExecution{
+		EntityID:      "semspec.local.exec.req.run.test-legacy",
+		Slug:          "test-plan",
+		RequirementID: "requirement.test-plan.1",
+		// SortedStoryIDs zero-len simulates a pre-PR-4h exec.
+		VisitedNodes: map[string]bool{"impl": true},
+	}
+
+	event := &agentic.LoopCompletedEvent{
+		Outcome: agentic.OutcomeSuccess,
+		Result:  `{"verdict":"approved","feedback":"OK","scenario_verdicts":[]}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	if c.requirementsCompleted.Load() != 1 {
+		t.Errorf("requirementsCompleted = %d, want 1", c.requirementsCompleted.Load())
+	}
+}
+
+// TestScopeScenariosToCurrentStory pins the reviewer-context scoping:
+// only scenarios whose StoryID matches the current Story make it into
+// the reviewer's prompt.
+func TestScopeScenariosToCurrentStory(t *testing.T) {
+	exec := &requirementExecution{
+		SortedStoryIDs:  []string{"story.x.1.1", "story.x.1.2"},
+		CurrentStoryIdx: 1, // Story 2
+		Scenarios: []workflow.Scenario{
+			{ID: "s1", StoryID: "story.x.1.1"},
+			{ID: "s2", StoryID: "story.x.1.2"},
+			{ID: "s3", StoryID: "story.x.1.2"},
+			{ID: "s4", StoryID: "story.x.1.3"}, // belongs to a different requirement; should not pass the filter
+		},
+	}
+	got := scopeScenariosToCurrentStory(exec)
+	if len(got) != 2 {
+		t.Fatalf("len(scoped) = %d, want 2", len(got))
+	}
+	if got[0].ID != "s2" || got[1].ID != "s3" {
+		t.Errorf("scoped IDs = %q,%q — want s2,s3", got[0].ID, got[1].ID)
+	}
+}
+
+// TestScopeScenariosToCurrentStory_LegacyExecFallsBackToAll pins the
+// backwards-compat fallback: when SortedStoryIDs is empty (legacy or
+// pre-init exec) the helper returns ALL scenarios so the reviewer still
+// sees a complete picture rather than nothing.
+func TestScopeScenariosToCurrentStory_LegacyExecFallsBackToAll(t *testing.T) {
+	exec := &requirementExecution{
+		Scenarios: []workflow.Scenario{
+			{ID: "s1"}, {ID: "s2"},
+		},
+	}
+	got := scopeScenariosToCurrentStory(exec)
+	if len(got) != 2 {
+		t.Errorf("legacy exec should return all scenarios; got len=%d", len(got))
+	}
+}

--- a/processor/requirement-executor/execution_state.go
+++ b/processor/requirement-executor/execution_state.go
@@ -76,16 +76,30 @@ type requirementExecution struct {
 	LoopID    string
 	RequestID string
 
-	// --- Decomposition output ---
+	// --- Story sequencing (ADR-043 PR 4h) ---
 
-	// DAG is the validated task DAG from the decomposer agent.
+	// SortedStoryIDs is the topologically sorted list of Story.IDs for
+	// this requirement. The executor dispatches one Story at a time in
+	// this order. Empty before initialization; populated from
+	// plan.StoriesForRequirement via topoSortStoryIDs.
+	SortedStoryIDs []string
+
+	// CurrentStoryIdx is the index into SortedStoryIDs of the Story
+	// currently being executed. -1 before the first Story is dispatched.
+	CurrentStoryIdx int
+
+	// --- Per-Story DAG (re-populated on each Story transition) ---
+
+	// DAG is the synthesized TaskDAG for the CURRENT Story. Reset between
+	// Stories — at any moment the DAG carries only the nodes Sarah authored
+	// for SortedStoryIDs[CurrentStoryIdx].
 	DAG *TaskDAG
 
-	// SortedNodeIDs is the topologically sorted list of node IDs.
-	// Execution proceeds serially through this list.
+	// SortedNodeIDs is the topologically sorted list of node IDs for the
+	// CURRENT Story's DAG.
 	SortedNodeIDs []string
 
-	// NodeIndex maps nodeID → TaskNode for quick lookup.
+	// NodeIndex maps nodeID → TaskNode for the CURRENT Story's DAG.
 	NodeIndex map[string]*TaskNode
 
 	// --- Serial execution tracking ---

--- a/processor/requirement-executor/synthesize_dag.go
+++ b/processor/requirement-executor/synthesize_dag.go
@@ -6,98 +6,50 @@ import (
 	"github.com/c360studio/semspec/workflow"
 )
 
-// synthesizeTaskDAGFromStories converts Sarah's Stories (ADR-043 Move 3 +
-// PR 4e positional shape, persisted by plan-manager from
-// StoriesGeneratedEvent) into a TaskDAG that the
-// requirement-executor's existing downstream consumes unchanged. This is
-// the PR 4f decomposer-bypass: when the plan carries Sarah-authored
-// Stories for the requirement, the LLM decomposer call is skipped — the
-// DAG comes directly from the structured Story.Tasks.
+// synthesizeTaskDAGForStory converts a single Sarah-prepared Story into a
+// TaskDAG. ADR-043 PR 4h: per-Story dispatch synthesizes one DAG per Story
+// (instead of combining every Story on a requirement into one flat DAG).
+// Sequencing of Stories within a requirement is handled by the caller via
+// Story.DependsOn topo-sort; the synthesized DAG carries only the Story's
+// own intra-Task ordering.
 //
 // Mapping:
-//   - Each Task in each Story for the requirement becomes one TaskNode.
+//   - Each Task in the Story becomes one TaskNode.
 //   - TaskNode.ID = Task.ID (canonical task.<slug>.<reqseq>.<storyseq>.<taskseq>).
-//   - TaskNode.Prompt = Task.Description (Sarah's 1-line intent).
-//   - TaskNode.Role = "developer" (matches the decomposer's default role
-//     for code-producing tasks; future ADR-043 work may differentiate
-//     review / qa nodes here).
-//   - TaskNode.DependsOn = intra-story Task.DependsOn (canonical IDs),
-//     extended on entry tasks (Tasks with empty DependsOn) with the exit
-//     tasks of cross-story prereqs from Story.DependsOn.
+//   - TaskNode.Prompt = Task.Description.
+//   - TaskNode.Role = "developer".
+//   - TaskNode.DependsOn = intra-story Task.DependsOn (canonical IDs).
 //   - TaskNode.FileScope = parent Story.FilesOwned.
-//   - TaskNode.ScenarioIDs = IDs of scenarios whose StoryID == this story
-//     (populated by Bob's attachStoryIDs in PR 4b; empty for legacy plans).
+//   - TaskNode.ScenarioIDs = IDs of scenarios whose StoryID == this story.
 //
-// Returns (nil, nil) when no Stories own the requirement — signals the
-// caller to fall back to the legacy decomposer-LLM dispatch path.
-// Returns (nil, err) when the synthesis produces a structurally invalid
-// DAG (caller surfaces as a parse-style failure).
-func synthesizeTaskDAGFromStories(plan *workflow.Plan, requirementID string) (*TaskDAG, error) {
-	if plan == nil || requirementID == "" {
-		return nil, nil
+// Returns (nil, err) on Sarah-readiness gate violations (no tasks / no
+// files_owned). Caller surfaces as a planning-phase failure.
+func synthesizeTaskDAGForStory(plan *workflow.Plan, story workflow.Story) (*TaskDAG, error) {
+	if len(story.Tasks) == 0 {
+		return nil, fmt.Errorf("story %q has no tasks; cannot synthesize DAG", story.ID)
 	}
-	stories := plan.StoriesForRequirement(requirementID)
-	if len(stories) == 0 {
-		return nil, nil
+	if len(story.FilesOwned) == 0 {
+		return nil, fmt.Errorf("story %q has empty files_owned; cannot synthesize DAG", story.ID)
 	}
 
-	// Pre-compute per-story exit tasks (tasks no other task in the same
-	// story depends on) so cross-story DependsOn can expand to concrete
-	// node-level prereqs.
-	exitTasksByStoryID := storyExitTasks(stories)
-
-	nodes := make([]TaskNode, 0)
-	for _, s := range stories {
-		if len(s.Tasks) == 0 {
-			// Empty Tasks on a story is a Sarah readiness-gate violation —
-			// caught upstream by workflow.ValidateStories. Surface as a
-			// synthesis error here so the caller knows the bypass can't
-			// proceed.
-			return nil, fmt.Errorf("story %q has no tasks; cannot synthesize DAG", s.ID)
-		}
-		if len(s.FilesOwned) == 0 {
-			return nil, fmt.Errorf("story %q has empty files_owned; cannot synthesize DAG (Sarah's gate should have caught this)", s.ID)
-		}
-
-		// Collect cross-story prereqs: exit tasks of every story this story
-		// depends on. Entry tasks (Task.DependsOn empty) inherit them.
-		var crossPrereqs []string
-		for _, depStoryID := range s.DependsOn {
-			crossPrereqs = append(crossPrereqs, exitTasksByStoryID[depStoryID]...)
-		}
-
-		// ScenarioIDs come from the plan's scenarios whose StoryID matches.
-		var scenarioIDs []string
-		for _, sc := range plan.ScenariosForStory(s.ID) {
+	var scenarioIDs []string
+	if plan != nil {
+		for _, sc := range plan.ScenariosForStory(story.ID) {
 			scenarioIDs = append(scenarioIDs, sc.ID)
 		}
-
-		// FileScope: clone Story.FilesOwned (each TaskNode gets the
-		// full story scope; per-task file partitioning is a refinement
-		// PR 4g+ may introduce).
-		files := append([]string(nil), s.FilesOwned...)
-
-		for _, t := range s.Tasks {
-			deps := append([]string(nil), t.DependsOn...)
-			if len(t.DependsOn) == 0 && len(crossPrereqs) > 0 {
-				// Entry task — inherit cross-story prereqs.
-				deps = append(deps, crossPrereqs...)
-			}
-			nodes = append(nodes, TaskNode{
-				ID:          t.ID,
-				Prompt:      t.Description,
-				Role:        "developer",
-				DependsOn:   deps,
-				FileScope:   files,
-				ScenarioIDs: append([]string(nil), scenarioIDs...),
-			})
-		}
 	}
 
-	if len(nodes) == 0 {
-		// Should be unreachable given the per-story empty-Tasks guard above,
-		// but defensive — the caller fallback path is well-tested.
-		return nil, nil
+	files := append([]string(nil), story.FilesOwned...)
+	nodes := make([]TaskNode, 0, len(story.Tasks))
+	for _, t := range story.Tasks {
+		nodes = append(nodes, TaskNode{
+			ID:          t.ID,
+			Prompt:      t.Description,
+			Role:        "developer",
+			DependsOn:   append([]string(nil), t.DependsOn...),
+			FileScope:   files,
+			ScenarioIDs: append([]string(nil), scenarioIDs...),
+		})
 	}
 
 	dag := &TaskDAG{Nodes: nodes}
@@ -107,32 +59,65 @@ func synthesizeTaskDAGFromStories(plan *workflow.Plan, requirementID string) (*T
 	return dag, nil
 }
 
-// storyExitTasks returns a map from Story.ID to the list of Task.IDs that
-// no other task in the same story depends on (the "exit" tasks). A
-// cross-story DependsOn edge expands to "the exit tasks of the prereq
-// story" so the consuming story waits on the actual terminal work, not
-// intermediate steps.
-func storyExitTasks(stories []workflow.Story) map[string][]string {
-	out := make(map[string][]string, len(stories))
-	for _, s := range stories {
-		if len(s.Tasks) == 0 {
-			continue
-		}
-		// Build a set of task IDs that ARE depended on by some other task
-		// in the same story.
-		dependedOn := make(map[string]struct{}, len(s.Tasks))
-		for _, t := range s.Tasks {
-			for _, dep := range t.DependsOn {
-				dependedOn[dep] = struct{}{}
-			}
-		}
-		var exits []string
-		for _, t := range s.Tasks {
-			if _, ok := dependedOn[t.ID]; !ok {
-				exits = append(exits, t.ID)
-			}
-		}
-		out[s.ID] = exits
+// topoSortStoryIDs returns the Story.IDs ordered so that every Story's
+// DependsOn entries appear before it. ADR-043 PR 4h: the requirement-
+// executor consumes this order to dispatch Stories sequentially.
+//
+// Cycles are an upstream planning bug (plan-reviewer R3
+// `story.depends_on_cycle` catches them); returning an error here is the
+// fail-loudly path that surfaces a planning regression as a synthesis
+// error rather than silently flattening into a non-deterministic order.
+func topoSortStoryIDs(stories []workflow.Story) ([]string, error) {
+	if len(stories) == 0 {
+		return nil, nil
 	}
-	return out
+
+	idIndex := make(map[string]struct{}, len(stories))
+	deps := make(map[string][]string, len(stories))
+	for _, s := range stories {
+		if _, dup := idIndex[s.ID]; dup {
+			return nil, fmt.Errorf("duplicate story ID %q in requirement", s.ID)
+		}
+		idIndex[s.ID] = struct{}{}
+		deps[s.ID] = append([]string(nil), s.DependsOn...)
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(stories))
+	var sorted []string
+
+	var visit func(id string) error
+	visit = func(id string) error {
+		switch color[id] {
+		case gray:
+			return fmt.Errorf("story dependency cycle involves %q", id)
+		case black:
+			return nil
+		}
+		color[id] = gray
+		for _, dep := range deps[id] {
+			if _, ok := idIndex[dep]; !ok {
+				return fmt.Errorf("story %q depends on unknown story %q", id, dep)
+			}
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		color[id] = black
+		sorted = append(sorted, id)
+		return nil
+	}
+
+	for _, s := range stories {
+		if color[s.ID] == white {
+			if err := visit(s.ID); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return sorted, nil
 }

--- a/processor/requirement-executor/synthesize_dag_test.go
+++ b/processor/requirement-executor/synthesize_dag_test.go
@@ -7,47 +7,24 @@ import (
 	"github.com/c360studio/semspec/workflow"
 )
 
-func TestSynthesizeTaskDAGFromStories_NoStoriesReturnsNil(t *testing.T) {
-	plan := &workflow.Plan{Slug: "x", Requirements: []workflow.Requirement{{ID: "req.x.1"}}}
-	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if dag != nil {
-		t.Errorf("expected nil DAG (fallthrough signal), got %+v", dag)
-	}
-}
-
-func TestSynthesizeTaskDAGFromStories_NilPlanReturnsNil(t *testing.T) {
-	dag, err := synthesizeTaskDAGFromStories(nil, "req.x.1")
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if dag != nil {
-		t.Errorf("expected nil DAG, got %+v", dag)
-	}
-}
-
-func TestSynthesizeTaskDAGFromStories_SingleStoryLinearTasks(t *testing.T) {
+func TestSynthesizeTaskDAGForStory_LinearTasks(t *testing.T) {
 	plan := &workflow.Plan{
 		Slug:         "x",
 		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
-		Stories: []workflow.Story{
-			{
-				ID: "story.x.1.1", RequirementID: "req.x.1",
-				FilesOwned: []string{"src/x.go"},
-				Tasks: []workflow.Task{
-					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "tests"},
-					{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "impl", DependsOn: []string{"task.x.1.1.1"}},
-					{ID: "task.x.1.1.3", StoryID: "story.x.1.1", Description: "verify", DependsOn: []string{"task.x.1.1.2"}},
-				},
-			},
-		},
 		Scenarios: []workflow.Scenario{
 			{ID: "scen.1", RequirementID: "req.x.1", StoryID: "story.x.1.1"},
 		},
 	}
-	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	story := workflow.Story{
+		ID: "story.x.1.1", RequirementID: "req.x.1",
+		FilesOwned: []string{"src/x.go"},
+		Tasks: []workflow.Task{
+			{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "tests"},
+			{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "impl", DependsOn: []string{"task.x.1.1.1"}},
+			{ID: "task.x.1.1.3", StoryID: "story.x.1.1", Description: "verify", DependsOn: []string{"task.x.1.1.2"}},
+		},
+	}
+	dag, err := synthesizeTaskDAGForStory(plan, story)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -57,96 +34,60 @@ func TestSynthesizeTaskDAGFromStories_SingleStoryLinearTasks(t *testing.T) {
 	if len(dag.Nodes) != 3 {
 		t.Fatalf("want 3 nodes, got %d", len(dag.Nodes))
 	}
-	// Node 0 is entry (no DependsOn).
 	if len(dag.Nodes[0].DependsOn) != 0 {
 		t.Errorf("entry task should have empty DependsOn, got %v", dag.Nodes[0].DependsOn)
 	}
-	// Node 1 depends on node 0.
 	if len(dag.Nodes[1].DependsOn) != 1 || dag.Nodes[1].DependsOn[0] != "task.x.1.1.1" {
 		t.Errorf("node[1].DependsOn = %v, want [task.x.1.1.1]", dag.Nodes[1].DependsOn)
 	}
-	// FileScope = Story.FilesOwned.
 	for i, n := range dag.Nodes {
 		if len(n.FileScope) != 1 || n.FileScope[0] != "src/x.go" {
 			t.Errorf("node[%d].FileScope = %v, want [src/x.go]", i, n.FileScope)
 		}
-	}
-	// ScenarioIDs from plan.ScenariosForStory.
-	for i, n := range dag.Nodes {
 		if len(n.ScenarioIDs) != 1 || n.ScenarioIDs[0] != "scen.1" {
 			t.Errorf("node[%d].ScenarioIDs = %v, want [scen.1]", i, n.ScenarioIDs)
 		}
-	}
-	// Role assigned to "developer".
-	if dag.Nodes[0].Role != "developer" {
-		t.Errorf("Role = %q, want developer", dag.Nodes[0].Role)
+		if n.Role != "developer" {
+			t.Errorf("node[%d].Role = %q, want developer", i, n.Role)
+		}
 	}
 }
 
-func TestSynthesizeTaskDAGFromStories_CrossStoryDependsOnExpansion(t *testing.T) {
-	// Story B depends on story A. The entry task(s) of B should inherit
-	// the exit task(s) of A as DependsOn.
+func TestSynthesizeTaskDAGForStory_PerStoryScopeNoCrossEdges(t *testing.T) {
+	// ADR-043 PR 4h: per-Story synthesis carries NO cross-Story DependsOn.
+	// Sequencing of Story B after Story A is the caller's job (topo-sort
+	// of Story.DependsOn). The DAG for B contains only B's own nodes.
 	plan := &workflow.Plan{
 		Slug:         "x",
 		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
-		Stories: []workflow.Story{
-			{
-				ID: "story.x.1.1", RequirementID: "req.x.1",
-				FilesOwned: []string{"src/a.go"},
-				Tasks: []workflow.Task{
-					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "A1"},
-					{ID: "task.x.1.1.2", StoryID: "story.x.1.1", Description: "A2", DependsOn: []string{"task.x.1.1.1"}},
-				},
-			},
-			{
-				ID: "story.x.1.2", RequirementID: "req.x.1",
-				FilesOwned: []string{"src/b.go"},
-				DependsOn:  []string{"story.x.1.1"},
-				Tasks: []workflow.Task{
-					{ID: "task.x.1.2.1", StoryID: "story.x.1.2", Description: "B1"},
-				},
-			},
+	}
+	storyB := workflow.Story{
+		ID: "story.x.1.2", RequirementID: "req.x.1",
+		FilesOwned: []string{"src/b.go"},
+		DependsOn:  []string{"story.x.1.1"}, // signals outer ordering — NOT a node edge
+		Tasks: []workflow.Task{
+			{ID: "task.x.1.2.1", StoryID: "story.x.1.2", Description: "B1"},
 		},
 	}
-	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	dag, err := synthesizeTaskDAGForStory(plan, storyB)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	// Find B1 node.
-	var b1 *struct {
-		ID, Prompt string
-		DependsOn  []string
+	if len(dag.Nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(dag.Nodes))
 	}
-	for _, n := range dag.Nodes {
-		if n.ID == "task.x.1.2.1" {
-			b1 = &struct {
-				ID, Prompt string
-				DependsOn  []string
-			}{n.ID, n.Prompt, n.DependsOn}
-		}
-	}
-	if b1 == nil {
-		t.Fatal("did not find task.x.1.2.1")
-	}
-	// B1 had no intra-story DependsOn; cross-story expansion adds A's exit (task.x.1.1.2, the last task in A's chain).
-	if len(b1.DependsOn) != 1 || b1.DependsOn[0] != "task.x.1.1.2" {
-		t.Errorf("B1.DependsOn = %v, want [task.x.1.1.2] (A's exit task)", b1.DependsOn)
+	if len(dag.Nodes[0].DependsOn) != 0 {
+		t.Errorf("entry task DependsOn must be empty — cross-Story edges live on Story.DependsOn, not on the synthesized DAG; got %v", dag.Nodes[0].DependsOn)
 	}
 }
 
-func TestSynthesizeTaskDAGFromStories_EmptyTasksReturnsError(t *testing.T) {
-	plan := &workflow.Plan{
-		Slug:         "x",
-		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
-		Stories: []workflow.Story{
-			{
-				ID: "story.x.1.1", RequirementID: "req.x.1",
-				FilesOwned: []string{"src/x.go"},
-				Tasks:      nil,
-			},
-		},
+func TestSynthesizeTaskDAGForStory_EmptyTasksReturnsError(t *testing.T) {
+	story := workflow.Story{
+		ID:         "story.x.1.1",
+		FilesOwned: []string{"src/x.go"},
+		Tasks:      nil,
 	}
-	_, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	_, err := synthesizeTaskDAGForStory(nil, story)
 	if err == nil {
 		t.Fatal("expected error for story with no tasks")
 	}
@@ -155,21 +96,15 @@ func TestSynthesizeTaskDAGFromStories_EmptyTasksReturnsError(t *testing.T) {
 	}
 }
 
-func TestSynthesizeTaskDAGFromStories_EmptyFilesOwnedReturnsError(t *testing.T) {
-	plan := &workflow.Plan{
-		Slug:         "x",
-		Requirements: []workflow.Requirement{{ID: "req.x.1"}},
-		Stories: []workflow.Story{
-			{
-				ID: "story.x.1.1", RequirementID: "req.x.1",
-				FilesOwned: nil,
-				Tasks: []workflow.Task{
-					{ID: "task.x.1.1.1", StoryID: "story.x.1.1", Description: "tests"},
-				},
-			},
+func TestSynthesizeTaskDAGForStory_EmptyFilesOwnedReturnsError(t *testing.T) {
+	story := workflow.Story{
+		ID:         "story.x.1.1",
+		FilesOwned: nil,
+		Tasks: []workflow.Task{
+			{ID: "task.x.1.1.1", Description: "tests"},
 		},
 	}
-	_, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	_, err := synthesizeTaskDAGForStory(nil, story)
 	if err == nil {
 		t.Fatal("expected error for story with empty files_owned")
 	}
@@ -178,58 +113,95 @@ func TestSynthesizeTaskDAGFromStories_EmptyFilesOwnedReturnsError(t *testing.T) 
 	}
 }
 
-func TestSynthesizeTaskDAGFromStories_OtherRequirementSkipped(t *testing.T) {
-	plan := &workflow.Plan{
-		Slug:         "x",
-		Requirements: []workflow.Requirement{{ID: "req.x.1"}, {ID: "req.x.2"}},
-		Stories: []workflow.Story{
-			{
-				ID: "story.x.2.1", RequirementID: "req.x.2", // belongs to req 2
-				FilesOwned: []string{"src/y.go"},
-				Tasks:      []workflow.Task{{ID: "task.x.2.1.1", StoryID: "story.x.2.1", Description: "y"}},
-			},
-		},
+func TestSynthesizeTaskDAGForStory_NilPlanOK(t *testing.T) {
+	// When plan is nil we can't look up scenarios — node.ScenarioIDs
+	// stays empty but synthesis still succeeds (the dispatcher would
+	// have already validated the plan exists).
+	story := workflow.Story{
+		ID:         "story.x.1.1",
+		FilesOwned: []string{"src/x.go"},
+		Tasks:      []workflow.Task{{ID: "task.x.1.1.1", Description: "tests"}},
 	}
-	dag, err := synthesizeTaskDAGFromStories(plan, "req.x.1")
+	dag, err := synthesizeTaskDAGForStory(nil, story)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if dag != nil {
-		t.Errorf("expected nil DAG (no stories for req.x.1), got %+v", dag)
+	if len(dag.Nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(dag.Nodes))
+	}
+	if len(dag.Nodes[0].ScenarioIDs) != 0 {
+		t.Errorf("nil plan should produce empty ScenarioIDs, got %v", dag.Nodes[0].ScenarioIDs)
 	}
 }
 
-func TestStoryExitTasks(t *testing.T) {
+func TestTopoSortStoryIDs_Linear(t *testing.T) {
 	stories := []workflow.Story{
-		{
-			ID: "s1",
-			Tasks: []workflow.Task{
-				{ID: "t1"},
-				{ID: "t2", DependsOn: []string{"t1"}},
-				{ID: "t3", DependsOn: []string{"t2"}},
-				// t3 is the exit (nothing depends on it).
-			},
-		},
-		{
-			ID: "s2",
-			Tasks: []workflow.Task{
-				{ID: "u1"},
-				// u1 has no dependents → exit.
-			},
-		},
-		{
-			ID:    "s3-empty",
-			Tasks: nil, // skipped entirely
-		},
+		{ID: "s2", DependsOn: []string{"s1"}},
+		{ID: "s1"},
+		{ID: "s3", DependsOn: []string{"s2"}},
 	}
-	got := storyExitTasks(stories)
-	if exits, ok := got["s1"]; !ok || len(exits) != 1 || exits[0] != "t3" {
-		t.Errorf("s1 exits = %v, want [t3]", exits)
+	sorted, err := topoSortStoryIDs(stories)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
-	if exits, ok := got["s2"]; !ok || len(exits) != 1 || exits[0] != "u1" {
-		t.Errorf("s2 exits = %v, want [u1]", exits)
+	want := []string{"s1", "s2", "s3"}
+	if len(sorted) != 3 {
+		t.Fatalf("len = %d, want 3", len(sorted))
 	}
-	if _, ok := got["s3-empty"]; ok {
-		t.Errorf("empty-tasks story s3-empty should not appear in exit map")
+	for i, w := range want {
+		if sorted[i] != w {
+			t.Errorf("sorted[%d] = %q, want %q", i, sorted[i], w)
+		}
+	}
+}
+
+func TestTopoSortStoryIDs_CycleErrors(t *testing.T) {
+	stories := []workflow.Story{
+		{ID: "s1", DependsOn: []string{"s2"}},
+		{ID: "s2", DependsOn: []string{"s1"}},
+	}
+	_, err := topoSortStoryIDs(stories)
+	if err == nil {
+		t.Fatal("expected cycle error")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error %q missing 'cycle'", err.Error())
+	}
+}
+
+func TestTopoSortStoryIDs_UnknownDependencyErrors(t *testing.T) {
+	stories := []workflow.Story{
+		{ID: "s1", DependsOn: []string{"ghost"}},
+	}
+	_, err := topoSortStoryIDs(stories)
+	if err == nil {
+		t.Fatal("expected unknown-dependency error")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error %q missing 'unknown'", err.Error())
+	}
+}
+
+func TestTopoSortStoryIDs_Empty(t *testing.T) {
+	sorted, err := topoSortStoryIDs(nil)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sorted != nil {
+		t.Errorf("expected nil sorted, got %v", sorted)
+	}
+}
+
+func TestTopoSortStoryIDs_DuplicateIDErrors(t *testing.T) {
+	stories := []workflow.Story{
+		{ID: "s1"},
+		{ID: "s1"},
+	}
+	_, err := topoSortStoryIDs(stories)
+	if err == nil {
+		t.Fatal("expected duplicate-ID error")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error %q missing 'duplicate'", err.Error())
 	}
 }

--- a/workflow/execution.go
+++ b/workflow/execution.go
@@ -139,7 +139,13 @@ type RequirementExecution struct {
 	Role       string          `json:"role,omitempty"`
 	PlanBranch string          `json:"plan_branch,omitempty"`
 
-	// DAG decomposition
+	// Story sequencing (ADR-043 PR 4h — per-Story dispatch)
+	SortedStoryIDs  []string `json:"sorted_story_ids,omitempty"`
+	CurrentStoryIdx int      `json:"current_story_idx,omitempty"`
+
+	// DAG decomposition — represents the CURRENT Story's DAG (per-Story
+	// dispatch; the value is replaced each time the executor advances to
+	// the next Story).
 	NodeCount      int             `json:"node_count,omitempty"`
 	CurrentNodeIdx int             `json:"current_node_idx"` // -1 before execution starts
 	DAGRaw         json.RawMessage `json:"dag,omitempty"`    // serialized TaskDAG


### PR DESCRIPTION
## Summary

- Splits requirement execution into per-Story dispatch: one TaskDAG per Story (Sarah-authored), one reviewer pass per Story, Stories sequenced via `Story.DependsOn` topo-sort. Faithful to ADR-043's "execution-manager dispatches per-Story" spec.
- Net delta: **+558 / −271** across 7 files.
- Builds on PR 4g (decomposer LLM retired); validated by the smoke 3 ground that synthesis-only dispatch works end-to-end.

## Behavior change

- Each Story's `Tasks` become their own TaskDAG. `Story.FilesOwned` → `TaskNode.FileScope`; `plan.ScenariosForStory(story.ID)` → `TaskNode.ScenarioIDs`.
- Stories execute in topo order via a new `SortedStoryIDs []string` + `CurrentStoryIdx int` cursor on `requirementExecution`.
- Reviewer scope tightens: only the current Story's scenarios feed the reviewer prompt (filtered via `scopeScenariosToCurrentStory`). Backward-compat fallback returns all scenarios when `SortedStoryIDs` is empty.
- Requirement is marked complete only after the LAST Story is reviewer-approved.

## Key files

- `processor/requirement-executor/synthesize_dag.go` — fully rewritten:
  - new `synthesizeTaskDAGForStory(plan, story)` — single-Story synthesis
  - new `topoSortStoryIDs(stories)` — outer ordering
  - old combined-DAG helpers removed
- `processor/requirement-executor/component.go`:
  - `dispatchDecomposerLocked` populates `SortedStoryIDs` and hands off to new `dispatchCurrentStoryLocked`
  - `handleRequirementReviewerCompleteLocked` approved branch extracted to `handleApprovedVerdictLocked` to stay under the function-length lint cap
  - new helpers: `advanceToNextStoryLocked`, `dispatchCurrentStoryLocked`, `findStoryByID`, `scopeScenariosToCurrentStory`
- `processor/requirement-executor/execution_state.go` — Story cursor fields
- `workflow/execution.go` + `processor/execution-manager/mutations.go` — persistence wiring (crash-recovery)

## Tests

- `synthesize_dag_test.go` fully rewritten (8 test cases): per-Story synthesis, topo-sort happy / cycle / duplicate / unknown-dep paths
- 4 new `component_test.go` cases: advancement on approval when more Stories remain, terminal on final Story, legacy-exec fallback, per-Story scenario scoping

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all green
- [x] `task lint` — clean (revive v1.5.1, function-length 50)
- [ ] CI green
- [ ] Real-LLM smoke under gemini @easy to verify multi-Story-per-Requirement plans run with the new per-Story reviewer cadence

## Up next

- **PR 4j** — Bob (scenario-generator) emits one scenario set per Story instead of per Requirement, completing the per-Story symmetry across plan and execution phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)