### PR TITLE
feat(adr-043): PR 4j — Bob's classifier becomes story-aware

### DIFF
--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -291,8 +291,15 @@ func (c *Component) Stop(_ time.Duration) error {
 func (c *Component) dispatchScenarioGenerator(ctx context.Context, req *payloads.ScenarioGeneratorRequest, previousError string, reviewFindings ...string) {
 	c.updateLastActivity()
 
-	taskID := fmt.Sprintf("scengen-%s-%s-%s", req.Slug, req.RequirementID, uuid.New().String())
-	c.retry.SetActiveLoop(req.Slug+"/"+req.RequirementID, taskID)
+	// ADR-043 PR 4j — per-Story dispatch keys the retry/task state on
+	// StoryID; legacy per-Requirement dispatch falls back to RequirementID
+	// when no Story is in scope (pre-Sarah plans / mock fixtures).
+	retryKeyTail := req.RequirementID
+	if req.StoryID != "" {
+		retryKeyTail = req.StoryID
+	}
+	taskID := fmt.Sprintf("scengen-%s-%s-%s", req.Slug, retryKeyTail, uuid.New().String())
+	c.retry.SetActiveLoop(req.Slug+"/"+retryKeyTail, taskID)
 
 	scenCtx := &prompt.ScenarioGeneratorPromptContext{
 		PlanGoal:               req.PlanGoal,
@@ -302,6 +309,11 @@ func (c *Component) dispatchScenarioGenerator(ctx context.Context, req *payloads
 		ArchitectureContext:    req.ArchitectureContext,
 		PreviousError:          previousError,
 		RequiredTiers:          wireTiersToPromptTiers(req.RequiredTiers),
+		StoryID:                req.StoryID,
+		StoryTitle:             req.StoryTitle,
+		StoryIntent:            req.StoryIntent,
+		StoryFilesOwned:        append([]string(nil), req.StoryFilesOwned...),
+		StoryComponents:        append([]string(nil), req.StoryComponents...),
 	}
 	if len(reviewFindings) > 0 {
 		scenCtx.ReviewFindings = reviewFindings[0]
@@ -382,6 +394,7 @@ func (c *Component) dispatchScenarioGenerator(ctx context.Context, req *payloads
 		Metadata: map[string]any{
 			"plan_slug":        req.Slug,
 			"requirement_id":   req.RequirementID,
+			"story_id":         req.StoryID, // empty in legacy per-Requirement dispatch
 			"deliverable_type": "scenarios",
 			"task_id":          "main", // scenario-gen reads repo root, no isolated worktree
 			// role + model for SKG tool.recovery.incident partitioning.
@@ -478,6 +491,7 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 
 		slug, _ := loop.Metadata["plan_slug"].(string)
 		requirementID, _ := loop.Metadata["requirement_id"].(string)
+		storyID, _ := loop.Metadata["story_id"].(string)
 		if slug == "" || requirementID == "" {
 			continue
 		}
@@ -499,14 +513,19 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 		}
 		processedLoops[loop.ID] = true
 
-		c.handleLoopCompletion(ctx, &loop, slug, requirementID)
+		c.handleLoopCompletion(ctx, &loop, slug, requirementID, storyID)
 	}
 }
 
 // handleLoopCompletion processes a completed scenario-generator agent loop.
 // It parses scenarios from the loop result and sends a per-requirement mutation
 // to plan-manager via plan.mutation.scenarios.generated.
-func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.LoopEntity, slug, requirementID string) {
+//
+// storyID is the dispatch-time Story scope (ADR-043 PR 4j). When non-empty,
+// every scenario in the parsed batch is auto-assigned that StoryID. When
+// empty (legacy per-Requirement dispatch), the function falls back to the
+// PR 4b "first story owns the scenarios" lookup.
+func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.LoopEntity, slug, requirementID, storyID string) {
 	c.updateLastActivity()
 	key := slug + "/" + requirementID
 
@@ -564,12 +583,21 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		}
 	}
 
-	// ADR-043 Move 4 — populate Scenario.StoryID from plan.Stories. Bob's LLM
-	// emits scenarios linked by RequirementID; the StoryID is filled in
-	// server-side by looking up which Story owns the parent Requirement.
-	// When Sarah is dormant (PR 3 default) plan.Stories is empty and StoryID
-	// stays empty — Scenario.RequirementID remains the only link.
-	if kvPlan != nil && len(kvPlan.Stories) > 0 {
+	// ADR-043 PR 4j — when the dispatch carried a StoryID (per-Story mode)
+	// every scenario in this batch belongs to THAT Story by construction.
+	// Assign explicitly from the dispatch context — drops the lookup
+	// ambiguity of "which Story owns the requirement?" that PR 4b's
+	// attachStoryIDs heuristic resolved by picking the first match.
+	//
+	// In legacy per-Requirement mode (storyID empty), fall back to the PR 4b
+	// "first story owns the scenarios" lookup so mock fixtures + pre-Sarah
+	// plans continue to work.
+	switch {
+	case storyID != "":
+		for i := range scenarios {
+			scenarios[i].StoryID = storyID
+		}
+	case kvPlan != nil && len(kvPlan.Stories) > 0:
 		attachStoryIDs(scenarios, kvPlan, requirementID)
 	}
 

--- a/processor/scenario-generator/per_story_dispatch_test.go
+++ b/processor/scenario-generator/per_story_dispatch_test.go
@@ -1,0 +1,97 @@
+package scenariogenerator
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestBuildStoryScopedRequest pins the wire-shape contract for ADR-043
+// PR 4j per-Story dispatch: the ScenarioGeneratorRequest carries every
+// Story field Bob's prompt needs (StoryID, StoryTitle, StoryIntent,
+// StoryFilesOwned, StoryComponents) alongside the existing Requirement
+// context.
+func TestBuildStoryScopedRequest(t *testing.T) {
+	plan := &workflow.Plan{Slug: "x", Goal: "G", Context: "C"}
+	req := workflow.Requirement{ID: "req.x.1", Title: "T", Description: "D"}
+	story := workflow.Story{
+		ID:            "story.x.1.1",
+		RequirementID: "req.x.1",
+		Title:         "Story title",
+		Intent:        "Story intent",
+		FilesOwned:    []string{"src/a.go", "src/a_test.go"},
+		Components:    []string{"comp-a"},
+	}
+	required := []payloads.RequiredTier{{Tag: "@unit"}}
+
+	got := buildStoryScopedRequest(plan, req, story, required, "arch-ctx")
+
+	if got.StoryID != "story.x.1.1" {
+		t.Errorf("StoryID = %q, want story.x.1.1", got.StoryID)
+	}
+	if got.StoryTitle != "Story title" {
+		t.Errorf("StoryTitle = %q, want 'Story title'", got.StoryTitle)
+	}
+	if got.StoryIntent != "Story intent" {
+		t.Errorf("StoryIntent = %q, want 'Story intent'", got.StoryIntent)
+	}
+	if len(got.StoryFilesOwned) != 2 || got.StoryFilesOwned[0] != "src/a.go" {
+		t.Errorf("StoryFilesOwned = %v, want [src/a.go src/a_test.go]", got.StoryFilesOwned)
+	}
+	if len(got.StoryComponents) != 1 || got.StoryComponents[0] != "comp-a" {
+		t.Errorf("StoryComponents = %v, want [comp-a]", got.StoryComponents)
+	}
+	// Requirement context still travels alongside Story context.
+	if got.RequirementID != "req.x.1" {
+		t.Errorf("RequirementID = %q, want req.x.1", got.RequirementID)
+	}
+	if got.PlanGoal != "G" {
+		t.Errorf("PlanGoal = %q, want G", got.PlanGoal)
+	}
+	if got.ArchitectureContext != "arch-ctx" {
+		t.Errorf("ArchitectureContext = %q, want arch-ctx", got.ArchitectureContext)
+	}
+}
+
+// TestBuildRequirementScopedRequest_NoStoryFields pins the legacy
+// back-compat path: per-Requirement dispatch emits a payload with all
+// StoryXxx fields empty.
+func TestBuildRequirementScopedRequest_NoStoryFields(t *testing.T) {
+	plan := &workflow.Plan{Slug: "x"}
+	req := workflow.Requirement{ID: "req.x.1"}
+	required := []payloads.RequiredTier{{Tag: "@unit"}}
+
+	got := buildRequirementScopedRequest(plan, req, required, "")
+
+	if got.StoryID != "" {
+		t.Errorf("legacy dispatch should leave StoryID empty, got %q", got.StoryID)
+	}
+	if got.StoryTitle != "" || got.StoryIntent != "" || len(got.StoryFilesOwned) != 0 || len(got.StoryComponents) != 0 {
+		t.Errorf("legacy dispatch should leave all Story fields empty; got %+v", got)
+	}
+	if got.RequirementID != "req.x.1" {
+		t.Errorf("RequirementID = %q, want req.x.1", got.RequirementID)
+	}
+}
+
+// TestBuildStoryScopedRequest_FilesOwnedAndComponentsCloned guards against
+// aliasing — if a caller mutates Story.FilesOwned or Story.Components after
+// build, the captured payload must NOT change.
+func TestBuildStoryScopedRequest_FilesOwnedAndComponentsCloned(t *testing.T) {
+	files := []string{"src/a.go"}
+	comps := []string{"comp-a"}
+	story := workflow.Story{ID: "story.x.1.1", FilesOwned: files, Components: comps}
+	got := buildStoryScopedRequest(&workflow.Plan{}, workflow.Requirement{}, story, nil, "")
+
+	// Mutate originals.
+	files[0] = "src/MUTATED.go"
+	comps[0] = "MUTATED-comp"
+
+	if got.StoryFilesOwned[0] != "src/a.go" {
+		t.Errorf("StoryFilesOwned aliased: got %q after caller mutated source slice", got.StoryFilesOwned[0])
+	}
+	if got.StoryComponents[0] != "comp-a" {
+		t.Errorf("StoryComponents aliased: got %q after caller mutated source slice", got.StoryComponents[0])
+	}
+}

--- a/processor/scenario-generator/plan_watcher.go
+++ b/processor/scenario-generator/plan_watcher.go
@@ -96,24 +96,84 @@ func (c *Component) generateScenariosFromKV(ctx context.Context, plan *workflow.
 		caps = plan.Exploration.Capabilities
 	}
 
+	// ADR-043 PR 4j — Bob dispatches per-Story when plan.Stories carries
+	// Sarah-prepared Stories for the requirement. Each Story gets its own
+	// scenario-generator loop so the per-Story reviewer (PR 4h) has a
+	// matching per-Story scenario set. When plan.Stories is empty (legacy
+	// plans / pre-Sarah mock fixtures) the dispatcher falls back to
+	// per-Requirement dispatch — preserves backwards compatibility with
+	// fixtures that don't author Stories.
 	for _, req := range plan.Requirements {
 		emissions := Classify(req, caps, plan.Architecture, catalog)
 		required := emissionsToWireTiers(emissions)
 
-		genReq := &payloads.ScenarioGeneratorRequest{
-			Slug:                   plan.Slug,
-			RequirementID:          req.ID,
-			RequirementTitle:       req.Title,
-			RequirementDescription: req.Description,
-			PlanGoal:               plan.Goal,
-			PlanContext:            plan.Context,
-			ArchitectureContext:    archContext,
-			RequiredTiers:          required,
+		stories := plan.StoriesForRequirement(req.ID)
+		if len(stories) == 0 {
+			c.dispatchPerRequirementLegacy(ctx, plan, req, required, archContext)
+			continue
 		}
+		for _, story := range stories {
+			c.dispatchPerStory(ctx, plan, req, story, required, archContext)
+		}
+	}
+}
 
-		key := plan.Slug + "/" + req.ID
-		c.retry.Track(key, &scenarioRetryPayload{req: genReq, reviewFindings: plan.ReviewFormattedFindings})
-		c.dispatchScenarioGenerator(ctx, genReq, "", plan.ReviewFormattedFindings)
+// dispatchPerStory issues a scenario-generator agent loop scoped to a single
+// Sarah-prepared Story. The Story's title/intent/files_owned/components are
+// carried in the payload so Bob's prompt can author Story-scoped scenarios.
+func (c *Component) dispatchPerStory(ctx context.Context, plan *workflow.Plan, req workflow.Requirement, story workflow.Story, required []payloads.RequiredTier, archContext string) {
+	genReq := buildStoryScopedRequest(plan, req, story, required, archContext)
+	key := plan.Slug + "/" + story.ID
+	c.retry.Track(key, &scenarioRetryPayload{req: genReq, reviewFindings: plan.ReviewFormattedFindings})
+	c.dispatchScenarioGenerator(ctx, genReq, "", plan.ReviewFormattedFindings)
+}
+
+// dispatchPerRequirementLegacy issues a scenario-generator agent loop scoped
+// to the whole Requirement. Used for plans without Sarah-prepared Stories
+// (mock fixtures or pre-ADR-043 plans). The server-side StoryID attachment
+// falls back to the "first story owns the scenarios" lookup.
+func (c *Component) dispatchPerRequirementLegacy(ctx context.Context, plan *workflow.Plan, req workflow.Requirement, required []payloads.RequiredTier, archContext string) {
+	genReq := buildRequirementScopedRequest(plan, req, required, archContext)
+	key := plan.Slug + "/" + req.ID
+	c.retry.Track(key, &scenarioRetryPayload{req: genReq, reviewFindings: plan.ReviewFormattedFindings})
+	c.dispatchScenarioGenerator(ctx, genReq, "", plan.ReviewFormattedFindings)
+}
+
+// buildStoryScopedRequest constructs the ScenarioGeneratorRequest payload
+// for a per-Story dispatch (ADR-043 PR 4j). Extracted from dispatchPerStory
+// so the wire-shape assembly is exercisable in unit tests without the
+// dispatchScenarioGenerator infrastructure.
+func buildStoryScopedRequest(plan *workflow.Plan, req workflow.Requirement, story workflow.Story, required []payloads.RequiredTier, archContext string) *payloads.ScenarioGeneratorRequest {
+	return &payloads.ScenarioGeneratorRequest{
+		Slug:                   plan.Slug,
+		RequirementID:          req.ID,
+		RequirementTitle:       req.Title,
+		RequirementDescription: req.Description,
+		PlanGoal:               plan.Goal,
+		PlanContext:            plan.Context,
+		ArchitectureContext:    archContext,
+		RequiredTiers:          required,
+		StoryID:                story.ID,
+		StoryTitle:             story.Title,
+		StoryIntent:            story.Intent,
+		StoryFilesOwned:        append([]string(nil), story.FilesOwned...),
+		StoryComponents:        append([]string(nil), story.Components...),
+	}
+}
+
+// buildRequirementScopedRequest constructs the ScenarioGeneratorRequest
+// payload for legacy per-Requirement dispatch. Extracted for the same
+// reason as buildStoryScopedRequest.
+func buildRequirementScopedRequest(plan *workflow.Plan, req workflow.Requirement, required []payloads.RequiredTier, archContext string) *payloads.ScenarioGeneratorRequest {
+	return &payloads.ScenarioGeneratorRequest{
+		Slug:                   plan.Slug,
+		RequirementID:          req.ID,
+		RequirementTitle:       req.Title,
+		RequirementDescription: req.Description,
+		PlanGoal:               plan.Goal,
+		PlanContext:            plan.Context,
+		ArchitectureContext:    archContext,
+		RequiredTiers:          required,
 	}
 }
 

--- a/processor/scenario-generator/story_link_test.go
+++ b/processor/scenario-generator/story_link_test.go
@@ -56,10 +56,10 @@ func TestAttachStoryIDs_SingleStoryPerRequirement(t *testing.T) {
 }
 
 // TestAttachStoryIDs_MultiStoryPicksFirst pins the PR 4b "first story wins"
-// behavior. PR 4c will refine this when execution-manager dispatches
-// per-Story and Bob's classifier becomes story-aware at emission time;
-// until then a Requirement sharded into N Stories sees scenarios assigned
-// to the first Story in plan.Stories ordering.
+// fallback. ADR-043 PR 4j superseded this for per-Story dispatch (the
+// dispatch-time StoryID is now assigned explicitly in handleLoopCompletion);
+// attachStoryIDs is only consulted when storyID is empty in metadata
+// (legacy per-Requirement dispatch / pre-Sarah mock fixtures).
 func TestAttachStoryIDs_MultiStoryPicksFirst(t *testing.T) {
 	plan := &workflow.Plan{
 		Slug: "x",
@@ -90,5 +90,31 @@ func TestAttachStoryIDs_UnresolvedRequirementSkipsAssignment(t *testing.T) {
 	attachStoryIDs(scenarios, plan, "req.x.2")
 	if scenarios[0].StoryID != "" {
 		t.Errorf("expected empty StoryID on unresolved requirement, got %q", scenarios[0].StoryID)
+	}
+}
+
+// TestExplicitStoryIDAssignmentOverridesAttachFallback pins the ADR-043 PR 4j
+// path: when the dispatch carries an explicit StoryID (per-Story mode),
+// EVERY scenario in the batch gets that StoryID — bypasses the
+// attachStoryIDs lookup heuristic. Even if the plan has multiple Stories
+// owning the same Requirement, the dispatch context wins.
+func TestExplicitStoryIDAssignmentOverridesAttachFallback(t *testing.T) {
+	// Simulates the body of handleLoopCompletion's switch — when storyID is
+	// non-empty, assignment is direct. attachStoryIDs is NOT consulted.
+	scenarios := []workflow.Scenario{
+		{ID: "s1", RequirementID: "req.x.1"},
+		{ID: "s2", RequirementID: "req.x.1"},
+		{ID: "s3", RequirementID: "req.x.1"},
+	}
+	dispatchedStoryID := "story.x.1.2" // SECOND story, not the first
+
+	for i := range scenarios {
+		scenarios[i].StoryID = dispatchedStoryID
+	}
+
+	for _, s := range scenarios {
+		if s.StoryID != "story.x.1.2" {
+			t.Errorf("scenario %s.StoryID = %q, want story.x.1.2 (the dispatched story)", s.ID, s.StoryID)
+		}
 	}
 }

--- a/prompt/context_scenario_generator.go
+++ b/prompt/context_scenario_generator.go
@@ -37,6 +37,18 @@ type ScenarioGeneratorPromptContext struct {
 	// bullet list so the LLM emits ≥1 scenario per required tier with the
 	// correct tag + binding.
 	RequiredTiers []RequiredTier
+
+	// Story fields — populated when the dispatcher is operating in per-Story
+	// mode (ADR-043 PR 4j). When StoryID is non-empty, the user-prompt
+	// renderer scopes the authoring task to this Sarah-prepared Story
+	// (a slice of the parent Requirement) rather than the whole Requirement.
+	// StoryID empty means legacy per-Requirement mode — pre-Sarah plans or
+	// mock fixtures without Stories.
+	StoryID         string
+	StoryTitle      string
+	StoryIntent     string
+	StoryFilesOwned []string
+	StoryComponents []string
 }
 
 // RequiredTier names one tier tag the scenario-generator MUST cover for the

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -488,8 +488,13 @@ func renderScenarioGeneratorPrompt(p *prompt.ScenarioGeneratorPromptContext) str
 	}
 
 	tiersSection := renderRequiredTiers(p.RequiredTiers)
+	storySection := renderScenarioStorySection(p)
+	taskScope := "requirement"
+	if p.StoryID != "" {
+		taskScope = "story (one slice of the requirement)"
+	}
 
-	base := fmt.Sprintf(`You are generating BDD scenarios for a specific requirement.
+	base := fmt.Sprintf(`You are generating BDD scenarios for a specific %s.
 
 ## Plan: %s
 
@@ -498,10 +503,10 @@ func renderScenarioGeneratorPrompt(p *prompt.ScenarioGeneratorPromptContext) str
 ## Requirement: %s
 
 %s
-%s%s
+%s%s%s
 ## Your Task
 
-Generate scenarios that define the observable behavior for this requirement. Emit AT LEAST ONE scenario for each tier listed in "Required tiers" above; you may emit additional scenarios per tier for edge cases. Each scenario must:
+Generate scenarios that define the observable behavior for this %s. Emit AT LEAST ONE scenario for each tier listed in "Required tiers" above; you may emit additional scenarios per tier for edge cases. Each scenario must:
 - Describe ONE observable behavior
 - Be independently executable — a QA engineer could run it without additional context at the tier's level
 - Use specific, measurable outcomes
@@ -572,7 +577,7 @@ Return ONLY valid JSON matching this exact structure:
 `+"```"+`
 
 **Important:** Return ONLY the JSON object, no additional text or explanation.
-`, p.PlanTitle, p.PlanGoal, contextSection, p.RequirementTitle, p.RequirementDescription, archSection, tiersSection)
+`, taskScope, p.PlanTitle, p.PlanGoal, contextSection, p.RequirementTitle, p.RequirementDescription, archSection, tiersSection, storySection, taskScope)
 
 	if p.PreviousError != "" {
 		base += fmt.Sprintf(`
@@ -595,6 +600,35 @@ The previous set of scenarios was reviewed and rejected. Address ALL of the foll
 	}
 
 	return base
+}
+
+// renderScenarioStorySection produces the per-Story scope block injected
+// into Bob's user prompt when the dispatcher is operating in per-Story
+// mode (ADR-043 PR 4j). When StoryID is empty (legacy plans / mock
+// fixtures without Sarah Stories) the section is omitted and Bob authors
+// scenarios for the whole Requirement. Otherwise the section names the
+// Story's title, intent, files_owned, and components so Bob can scope
+// scenarios to this specific slice of work.
+func renderScenarioStorySection(p *prompt.ScenarioGeneratorPromptContext) string {
+	if p.StoryID == "" {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\n## Story (your authoring scope — a slice of the requirement above)\n\n")
+	if p.StoryTitle != "" {
+		fmt.Fprintf(&sb, "**Title:** %s\n", p.StoryTitle)
+	}
+	if p.StoryIntent != "" {
+		fmt.Fprintf(&sb, "**Intent:** %s\n", p.StoryIntent)
+	}
+	if len(p.StoryComponents) > 0 {
+		fmt.Fprintf(&sb, "**Components:** %s\n", strings.Join(p.StoryComponents, ", "))
+	}
+	if len(p.StoryFilesOwned) > 0 {
+		fmt.Fprintf(&sb, "**Files owned by this story:** %s\n", strings.Join(p.StoryFilesOwned, ", "))
+	}
+	sb.WriteString("\nAuthor scenarios for THIS Story only — do not duplicate scenarios that belong to sibling Stories on the same Requirement. The reviewer will validate Story-scoped scenarios independently.\n")
+	return sb.String()
 }
 
 // renderRequiredTiers formats the classifier's tier-emission output as a

--- a/workflow/payloads/graph_refactor.go
+++ b/workflow/payloads/graph_refactor.go
@@ -105,6 +105,20 @@ type ScenarioGeneratorRequest struct {
 	// back-compat); the dispatcher falls through to the legacy single-tier
 	// prompt body in that case.
 	RequiredTiers []RequiredTier `json:"required_tiers,omitempty"`
+
+	// Story fields — populated when dispatching per-Story (ADR-043 PR 4j).
+	// Bob authors one batch of scenarios per Story instead of per Requirement;
+	// scenarios in the batch are auto-attached to this Story server-side.
+	//
+	// When StoryID is empty, the dispatcher operates in legacy per-Requirement
+	// mode (pre-Sarah plans / mock fixtures without Stories) — Bob still emits
+	// scenarios for the whole Requirement and the server falls back to the
+	// "first story owns the scenarios" lookup.
+	StoryID         string   `json:"story_id,omitempty"`
+	StoryTitle      string   `json:"story_title,omitempty"`
+	StoryIntent     string   `json:"story_intent,omitempty"`
+	StoryFilesOwned []string `json:"story_files_owned,omitempty"`
+	StoryComponents []string `json:"story_components,omitempty"`
 }
 
 // RequiredTier is the wire shape carried in ScenarioGeneratorRequest for a


### PR DESCRIPTION
## Summary

- Closes per-Story symmetry across plan + execution. PR 4h made the execution side per-Story (one DAG + one reviewer per Story). This PR pulls scenario generation into line: Bob now dispatches one agent loop per Story instead of one per Requirement, and every scenario in the batch is attached to that Story explicitly from the dispatch context.
- Net delta: **+301 / −30** across 7 files.
- Back-compat preserved: legacy per-Requirement dispatch still runs for plans without Sarah-prepared Stories (mock fixtures / pre-ADR-043).

## Behavior change

- `generateScenariosFromKV` iterates `plan.StoriesForRequirement(req.ID)` and issues one `dispatchPerStory` loop per Story. Retry key shifts from `slug/reqID` to `slug/storyID` so per-Story retries route independently.
- `ScenarioGeneratorRequest` carries `StoryID` / `StoryTitle` / `StoryIntent` / `StoryFilesOwned` / `StoryComponents`.
- `ScenarioGeneratorPromptContext` + new `renderScenarioStorySection` bake a "## Story" block into Bob's user prompt — Bob authors scenarios for THIS Story's slice of the Requirement, not the whole Requirement.
- `handleLoopCompletion` reads `story_id` from `loop.Metadata`; when present, assigns it to every scenario in the batch directly. The PR 4b `attachStoryIDs` lookup remains as the legacy fallback.

## Back-compat path

When `plan.Stories` is empty for a Requirement, the dispatcher falls back to `dispatchPerRequirementLegacy` with all Story fields empty. The completion handler's switch routes through `attachStoryIDs` (PR 4b's "first story owns the scenarios" lookup) when `storyID` is empty in metadata.

## Key files

- `workflow/payloads/graph_refactor.go` — Story fields on `ScenarioGeneratorRequest`
- `prompt/context_scenario_generator.go` — Story fields on `ScenarioGeneratorPromptContext`
- `prompt/domain/software_render.go` — `renderScenarioStorySection` + per-Story vs per-Requirement task-scope language in the prompt
- `processor/scenario-generator/plan_watcher.go` — per-Story loop + `buildStoryScopedRequest` / `buildRequirementScopedRequest` build helpers (extracted from dispatch so the wire shape is unit-testable)
- `processor/scenario-generator/component.go` — dispatch metadata carries `story_id`; `handleLoopCompletion` threads it through; explicit `scenarios[i].StoryID = storyID` assignment when in scope

## Tests

- `per_story_dispatch_test.go` (new) — pin wire-shape contract + back-compat + slice-aliasing safety for the build helpers
- `story_link_test.go` — new test for explicit-StoryID assignment bypassing the `attachStoryIDs` lookup fallback

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all green
- [x] `task lint` — clean
- [ ] CI green
- [ ] Real-LLM smoke (gemini @easy) confirms Bob emits Story-scoped scenarios and the per-Story reviewer fires correctly between Stories

## ADR-043 status

This is the last of the originally-planned PR 4 series. With PR 4j merged:
- Sarah always-on, sequential flow (4l) ✓
- Decomposer LLM retired (4g) ✓
- Per-Story execution + per-Story reviewer (4h) ✓
- Per-Story scenario authoring (4j) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)