### PR TITLE
fix(adr-043): auto-derive plan.Scope.Create from Story.FilesOwned

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -366,6 +367,18 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 	plan.Stories = req.Stories
 	plan.Status = workflow.StatusStoriesGenerated
 
+	// ADR-043 follow-up — auto-derive plan.Scope.Create from the union of
+	// Story.FilesOwned. Sarah declares which files each Story will create,
+	// but pre-PR-4j the planner had to anticipate those paths in
+	// scope.create at plan-draft time. That created a consistency burden
+	// the planner reliably failed (smoke 5 / mavlink-hard 2026-06-01 saw
+	// plan-reviewer reject 3× because story.files_owned drifted from
+	// scope.create). Deriving here eliminates the drift: scope.create
+	// always reflects what stories actually intend to create. Files
+	// already in scope.include are excluded — they exist already, no
+	// creation intent needed.
+	plan.Scope = ensureScopeCreateCoversStories(plan.Scope, req.Stories)
+
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save stories via mutation", "slug", req.Slug, "error", err)
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save plan: %v", err)}
@@ -373,9 +386,43 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 
 	c.logger.Info("Stories saved via mutation",
 		"slug", req.Slug,
-		"count", len(req.Stories))
+		"count", len(req.Stories),
+		"scope_create_count", len(plan.Scope.Create))
 
 	return MutationResponse{Success: true}
+}
+
+// ensureScopeCreateCoversStories augments scope.Create with every
+// Story.FilesOwned path that is not already in scope.Include or scope.Create.
+// The returned Scope preserves the original Include / Exclude / DoNotTouch
+// fields; only Create may change. Result Create entries are sorted for
+// deterministic output.
+func ensureScopeCreateCoversStories(scope workflow.Scope, stories []workflow.Story) workflow.Scope {
+	have := make(map[string]struct{}, len(scope.Include)+len(scope.Create))
+	for _, p := range scope.Include {
+		have[p] = struct{}{}
+	}
+	for _, p := range scope.Create {
+		have[p] = struct{}{}
+	}
+	added := false
+	for _, s := range stories {
+		for _, p := range s.FilesOwned {
+			if p == "" {
+				continue
+			}
+			if _, ok := have[p]; ok {
+				continue
+			}
+			have[p] = struct{}{}
+			scope.Create = append(scope.Create, p)
+			added = true
+		}
+	}
+	if added {
+		sort.Strings(scope.Create)
+	}
+	return scope
 }
 
 // handleScenariosMutation saves scenarios for a requirement inline on the plan and checks convergence.

--- a/processor/plan-manager/scope_derive_test.go
+++ b/processor/plan-manager/scope_derive_test.go
@@ -1,0 +1,87 @@
+package planmanager
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestEnsureScopeCreateCoversStories_AddsMissingPaths pins the load-bearing
+// behavior: when a Story.FilesOwned path isn't already in scope.Include or
+// scope.Create, the helper appends it to Create. Result is sorted.
+func TestEnsureScopeCreateCoversStories_AddsMissingPaths(t *testing.T) {
+	scope := workflow.Scope{Include: []string{"existing.go"}}
+	stories := []workflow.Story{
+		{ID: "s1", FilesOwned: []string{"src/b.go", "src/a.go"}},
+		{ID: "s2", FilesOwned: []string{"src/c.go"}},
+	}
+	got := ensureScopeCreateCoversStories(scope, stories)
+	want := []string{"src/a.go", "src/b.go", "src/c.go"}
+	if !reflect.DeepEqual(got.Create, want) {
+		t.Errorf("Create = %v, want %v", got.Create, want)
+	}
+	// Include must be unchanged.
+	if !reflect.DeepEqual(got.Include, []string{"existing.go"}) {
+		t.Errorf("Include = %v, want [existing.go]", got.Include)
+	}
+}
+
+// TestEnsureScopeCreateCoversStories_SkipsPathsAlreadyInInclude pins the
+// "files that exist already don't need creation intent" semantic — the planner
+// can keep authoring scope.Include for existing-but-modified files; the
+// derivation must not duplicate them as Create entries.
+func TestEnsureScopeCreateCoversStories_SkipsPathsAlreadyInInclude(t *testing.T) {
+	scope := workflow.Scope{Include: []string{"src/main.go"}}
+	stories := []workflow.Story{
+		{ID: "s1", FilesOwned: []string{"src/main.go", "src/new.go"}},
+	}
+	got := ensureScopeCreateCoversStories(scope, stories)
+	want := []string{"src/new.go"}
+	if !reflect.DeepEqual(got.Create, want) {
+		t.Errorf("Create = %v, want %v — src/main.go was already in Include, must NOT be duplicated to Create", got.Create, want)
+	}
+}
+
+// TestEnsureScopeCreateCoversStories_PreservesExistingCreate pins
+// idempotency: re-running the derivation over a scope that already has
+// Create entries (from a prior Sarah pass or operator edit) doesn't drop
+// them. The function is union-style, not overwrite.
+func TestEnsureScopeCreateCoversStories_PreservesExistingCreate(t *testing.T) {
+	scope := workflow.Scope{Create: []string{"src/operator-added.go"}}
+	stories := []workflow.Story{
+		{ID: "s1", FilesOwned: []string{"src/sarah-new.go"}},
+	}
+	got := ensureScopeCreateCoversStories(scope, stories)
+	want := []string{"src/operator-added.go", "src/sarah-new.go"}
+	if !reflect.DeepEqual(got.Create, want) {
+		t.Errorf("Create = %v, want %v", got.Create, want)
+	}
+}
+
+// TestEnsureScopeCreateCoversStories_NoStoriesNoChange covers the empty
+// Story list case (e.g. mid-flight regen) — Create must stay as it was.
+func TestEnsureScopeCreateCoversStories_NoStoriesNoChange(t *testing.T) {
+	scope := workflow.Scope{Create: []string{"src/a.go"}}
+	got := ensureScopeCreateCoversStories(scope, nil)
+	want := []string{"src/a.go"}
+	if !reflect.DeepEqual(got.Create, want) {
+		t.Errorf("Create = %v, want %v", got.Create, want)
+	}
+}
+
+// TestEnsureScopeCreateCoversStories_DropsEmptyAndDeduplicates pins
+// defensive handling: empty path strings (legacy / drift) are skipped,
+// duplicates across stories collapse to one entry.
+func TestEnsureScopeCreateCoversStories_DropsEmptyAndDeduplicates(t *testing.T) {
+	scope := workflow.Scope{}
+	stories := []workflow.Story{
+		{ID: "s1", FilesOwned: []string{"src/shared.go", "", "src/a.go"}},
+		{ID: "s2", FilesOwned: []string{"src/shared.go"}}, // duplicate of s1
+	}
+	got := ensureScopeCreateCoversStories(scope, stories)
+	want := []string{"src/a.go", "src/shared.go"}
+	if !reflect.DeepEqual(got.Create, want) {
+		t.Errorf("Create = %v, want %v (empty path skipped, src/shared.go deduplicated)", got.Create, want)
+	}
+}


### PR DESCRIPTION
## Summary

Surfaced by smoke 5 (2026-06-01 EVE `hybrid-gpt5 mavlink-hard`). Plan blocked at R2 for 3 regen rounds on:

> story 1 files_owned includes MavsdkServerManager.java but scope.create does not.

Sarah authors per-Story \`FilesOwned\` (ADR-043), but \`plan.Scope.Create\` was never updated to reflect those paths. Mary the planner had to anticipate every file Sarah would later declare at plan-draft time — a consistency burden she reliably fails on multi-Story plans.

The reviewer classified the finding as \`phase: \"requirements\"\` and the architecture-findings won the phase-routing race, so the scope finding never got addressed in any regen round.

## Fix

In \`handleStoriesMutation\`, after persisting the new Stories, run \`ensureScopeCreateCoversStories\` to union every \`Story.FilesOwned\` path into \`plan.Scope.Create\`. Skips paths already in \`Scope.Include\` (those exist, no creation intent needed). Sorted for deterministic output and idempotency across Sarah retries.

Eliminates the consistency burden from Mary's persona — the planner authors \`scope.Include\` for existing-file modifications, and \`scope.Create\` just reflects what Stories actually intend to create.

## Tests

\`scope_derive_test.go\` (5 cases):
- adds-missing-paths happy path with sort
- skips-already-in-include (no Include/Create duplication)
- preserves-existing-Create (idempotent union)
- no-stories-no-change (mid-flight regen safety)
- drops-empty-and-deduplicates (defensive)

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all green
- [x] \`task lint\` — clean
- [ ] CI green
- [ ] Smoke retry on mavlink-hard once Bug 1 (Winston Rule 7a) is also fixed — the two failures compound

## Forensics

Watch dir: \`/tmp/semspec-watch-hybrid-gpt5-mavlink-hard-20260601-190913/\`. The exact finding that motivated this PR:

\`\`\`json
{
  \"category\": \"completeness\",
  \"evidence\": \"story 1 files_owned includes MavsdkServerManager.java but scope.create does not.\",
  \"issue\": \"Story 1 owns MavsdkServerManager.java but plan.scope.create lacks the file.\",
  \"phase\": \"requirements\",
  \"severity\": \"error\",
  \"sop_id\": \"completeness\",
  \"sop_title\": \"Scope Alignment\",
  \"status\": \"violation\",
  \"target_id\": \"story.054b9890f6c7.1.\"
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)