### PR TITLE
fix(adr-043): topoSortStoryIDs tolerates cross-requirement Story.DependsOn

### DIFF
--- a/processor/requirement-executor/synthesize_dag.go
+++ b/processor/requirement-executor/synthesize_dag.go
@@ -63,10 +63,27 @@ func synthesizeTaskDAGForStory(plan *workflow.Plan, story workflow.Story) (*Task
 // DependsOn entries appear before it. ADR-043 PR 4h: the requirement-
 // executor consumes this order to dispatch Stories sequentially.
 //
-// Cycles are an upstream planning bug (plan-reviewer R3
-// `story.depends_on_cycle` catches them); returning an error here is the
-// fail-loudly path that surfaces a planning regression as a synthesis
-// error rather than silently flattening into a non-deterministic order.
+// Scope: this function operates on a single requirement's Stories. Cross-
+// requirement Story.DependsOn entries (Sarah-authored references to
+// Stories on OTHER requirements) are intentionally ignored — that
+// ordering is enforced upstream by Requirement.DependsOn at the
+// scenario-orchestrator level, which already serializes requirement
+// dispatch on the inter-requirement graph. Smoke 6 (2026-06-01
+// mavlink-hard) surfaced this when Sarah produced Story.DependsOn that
+// mirrored the Requirement.DependsOn graph — semantically redundant but
+// the early implementation treated every unknown ID as a fatal error,
+// rejecting 3 of 5 requirements.
+//
+// Cycles within the local set are still an upstream planning bug
+// (plan-reviewer R3 catches them); returning an error here is the
+// fail-loudly path that surfaces a regression as a synthesis error
+// rather than silently flattening into non-deterministic order.
+//
+// Typo'd Story.DependsOn references (story IDs that don't exist anywhere
+// in the plan) are caught upstream by `workflow.ValidateStoryDAG`, which
+// runs against the full plan Stories list before persistence. We can
+// therefore trust that any DependsOn id absent from the local slice is
+// a legitimate cross-requirement reference, not a typo.
 func topoSortStoryIDs(stories []workflow.Story) ([]string, error) {
 	if len(stories) == 0 {
 		return nil, nil
@@ -101,7 +118,9 @@ func topoSortStoryIDs(stories []workflow.Story) ([]string, error) {
 		color[id] = gray
 		for _, dep := range deps[id] {
 			if _, ok := idIndex[dep]; !ok {
-				return fmt.Errorf("story %q depends on unknown story %q", id, dep)
+				// Cross-requirement reference. Skip — Requirement.DependsOn
+				// already serializes inter-requirement dispatch upstream.
+				continue
 			}
 			if err := visit(dep); err != nil {
 				return err

--- a/processor/requirement-executor/synthesize_dag_test.go
+++ b/processor/requirement-executor/synthesize_dag_test.go
@@ -169,16 +169,50 @@ func TestTopoSortStoryIDs_CycleErrors(t *testing.T) {
 	}
 }
 
-func TestTopoSortStoryIDs_UnknownDependencyErrors(t *testing.T) {
+// TestTopoSortStoryIDs_CrossRequirementDependsOnSilentlyDropped pins the
+// smoke-6 regression: when Sarah authors Story.DependsOn referencing a
+// Story on another requirement (e.g. story.x.2.1 depends_on=[story.x.1.1]
+// where story.x.1.1 belongs to req 1), the topo-sort over req 2's
+// Stories must NOT treat that cross-requirement reference as a fatal
+// "unknown story" error. Cross-requirement ordering is enforced upstream
+// by Requirement.DependsOn at the scenario-orchestrator; the topo-sort's
+// job is intra-requirement ordering only.
+//
+// Smoke 6 (2026-06-01 mavlink-hard) hit this when Sarah produced
+// Story.DependsOn that exactly mirrored the Requirement.DependsOn graph
+// — semantically redundant. Pre-fix, this rejected 3 of 5 requirements
+// with "topo-sort stories failed: story ... depends on unknown story ...".
+func TestTopoSortStoryIDs_CrossRequirementDependsOnSilentlyDropped(t *testing.T) {
+	// Simulate req 2's story slice. The lone story has a DependsOn that
+	// points at a story belonging to req 1 (not in this slice).
 	stories := []workflow.Story{
-		{ID: "s1", DependsOn: []string{"ghost"}},
+		{ID: "story.x.2.1", DependsOn: []string{"story.x.1.1"}},
 	}
-	_, err := topoSortStoryIDs(stories)
-	if err == nil {
-		t.Fatal("expected unknown-dependency error")
+	got, err := topoSortStoryIDs(stories)
+	if err != nil {
+		t.Fatalf("cross-requirement DependsOn must NOT error; got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown") {
-		t.Errorf("error %q missing 'unknown'", err.Error())
+	if len(got) != 1 || got[0] != "story.x.2.1" {
+		t.Errorf("got %v, want [story.x.2.1]", got)
+	}
+}
+
+// TestTopoSortStoryIDs_MixedLocalAndCrossReqDepsRetainsLocalOrder pins
+// that local DependsOn is still honored when cross-req refs are mixed
+// in. The local ordering wins; cross-req refs are dropped silently.
+func TestTopoSortStoryIDs_MixedLocalAndCrossReqDepsRetainsLocalOrder(t *testing.T) {
+	stories := []workflow.Story{
+		{ID: "story.x.2.2", DependsOn: []string{"story.x.2.1", "story.x.1.1"}}, // local + cross-req
+		{ID: "story.x.2.1", DependsOn: []string{"story.x.1.1"}},                // cross-req only
+	}
+	got, err := topoSortStoryIDs(stories)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// Local dep wins: 2.1 must precede 2.2. Cross-req refs ignored.
+	want := []string{"story.x.2.1", "story.x.2.2"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Smoke 6 (mavlink-hard, 2026-06-02) reached \`implementing\` but rejected 3 of 5 requirements with:

\`\`\`
topo-sort stories failed: story \"story.X.2.1\" depends on unknown story \"story.X.1.1\"
\`\`\`

Sarah authored Story.DependsOn referencing stories on OTHER requirements. The pattern **exactly mirrored** Requirement.DependsOn — semantically redundant since cross-requirement ordering is already enforced at the scenario-orchestrator level.

The bug: \`topoSortStoryIDs\` (PR 4h) treated any DependsOn id absent from the local requirement's story slice as a fatal \"unknown story\" error. That fired on every cross-req reference.

The fix is one case: silently skip such refs in the DFS visit since their ordering is handled upstream by Requirement.DependsOn.

## Why this is safe

\`workflow.ValidateStoryDAG\` runs against the FULL plan stories list before persistence. It catches typo'd Story.DependsOn references that don't exist anywhere in the plan. By the time \`topoSortStoryIDs\` runs over a single requirement's slice, any absent id is a legitimate cross-requirement reference, not a typo.

## How we missed it in PR 4h review

1. The original test \`TestTopoSortStoryIDs_UnknownDependencyErrors\` **pinned the wrong assumption** — it asserted that unknown refs MUST error. A reviewer reading that test sees pinned behavior, not a missing case.

2. Easy fixture has 1 story per requirement → cross-req Story.DependsOn is impossible. Smoke 4 couldn't have surfaced this even with multi-Story coverage.

3. mavlink-hard is the FIRST multi-requirement multi-story fixture. Sarah's natural reasoning produces cross-req Story.DependsOn when the design demands prerequisite work in another req.

4. ADR-043 doc never explicitly stated the scope of Story.DependsOn. \`workflow.ValidateStoryDAG\` operates over the FULL plan slice (so accepts cross-req refs) while \`topoSortStoryIDs\` operated over the single-req slice (so rejected them). The two validators disagreed on what \"valid\" means.

## How execution still produced value despite plan-rejection

- Req 1 had no DependsOn → dispatched first
- Req 1 ran 90 min with **2 successful ADR-037 recovery cycles** (03:01:04 and 04:01:49) — autonomous recovery chain worked exactly as designed
- Req 1 produced 15 commits / 25 Java files (real MAVSDK driver)
- Reqs 2/3/5 only dispatched at 04:24:02 AFTER req 1 completed (scenario-orchestrator correctly serialized on Requirement.DependsOn)
- Their synthesis failed instantly on the cross-req bug
- Plan auto-rejected on convergence

## Tests

- \`TestTopoSortStoryIDs_UnknownDependencyErrors\` **REMOVED** (encoded wrong assumption)
- \`TestTopoSortStoryIDs_CrossRequirementDependsOnSilentlyDropped\` added — pins the smoke-6 regression
- \`TestTopoSortStoryIDs_MixedLocalAndCrossReqDepsRetainsLocalOrder\` added — local intra-req DependsOn still honored, only cross-req refs dropped

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all green
- [x] \`task lint\` — clean
- [ ] CI green
- [ ] Re-smoke mavlink-hard once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)