### PR TITLE
fix(render): compact H1 + new stories.md artifact

### DIFF
--- a/output/workflow-documents/architecture_renderer.go
+++ b/output/workflow-documents/architecture_renderer.go
@@ -40,10 +40,7 @@ func RenderArchitecture(plan *workflow.Plan) string {
 }
 
 func renderArchitectureHeader(b *strings.Builder, plan *workflow.Plan) {
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# Architecture: %s\n\n", title))
 	b.WriteString("*Generated from the architect role's structured deliverable. The architecture is the bridge between the goal and the implementation.*\n\n")
 }

--- a/output/workflow-documents/component.go
+++ b/output/workflow-documents/component.go
@@ -206,6 +206,7 @@ var phaseArtifacts = []phaseArtifact{
 	{"plan.md", RenderPlan},
 	{"architecture.md", RenderArchitecture},
 	{"requirements.md", RenderRequirements},
+	{"stories.md", RenderStories},
 	{"scenarios.md", RenderScenarios},
 	{"qa-summary.md", RenderQASummary},
 	{"run-summary.md", RenderRunSummary},

--- a/output/workflow-documents/display_title.go
+++ b/output/workflow-documents/display_title.go
@@ -1,0 +1,32 @@
+package workflowdocuments
+
+import "github.com/c360studio/semspec/workflow"
+
+// maxDisplayTitleChars caps the H1 title length across every rendered
+// document. The original plan.Title can be the full user prompt (the
+// HTTP API falls back title=description when only description is
+// provided — see plan-manager/http.go:633-643). That makes the H1 a
+// multi-paragraph blob in every .md artifact. Smoke 6 (2026-06-02)
+// produced ~600-char H1s on plan.md / architecture.md / requirements.md /
+// scenarios.md / proposal.md / design.md / tasks.md.
+//
+// 100 chars is the conservative compromise: a real human-authored
+// title fits; a prompt-blob does not. The slug is used as fallback
+// because it's deterministic, unique, and already in the path.
+const maxDisplayTitleChars = 100
+
+// displayTitle returns the human-presentable plan title for use in
+// document H1 headings. When plan.Title is empty or longer than
+// maxDisplayTitleChars (typically because the API filled it from a
+// verbose description), the slug is used instead. plan.Goal stays
+// intact downstream — only the H1 changes.
+func displayTitle(plan *workflow.Plan) string {
+	if plan == nil {
+		return ""
+	}
+	t := plan.Title
+	if t == "" || len([]rune(t)) > maxDisplayTitleChars {
+		return plan.Slug
+	}
+	return t
+}

--- a/output/workflow-documents/display_title_test.go
+++ b/output/workflow-documents/display_title_test.go
@@ -1,0 +1,53 @@
+package workflowdocuments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestDisplayTitle_NormalLengthTitleUsedAsIs(t *testing.T) {
+	plan := &workflow.Plan{Slug: "my-plan", Title: "Add /health endpoint"}
+	got := displayTitle(plan)
+	if got != "Add /health endpoint" {
+		t.Errorf("got %q, want unchanged title", got)
+	}
+}
+
+func TestDisplayTitle_EmptyTitleFallsBackToSlug(t *testing.T) {
+	plan := &workflow.Plan{Slug: "my-plan"}
+	got := displayTitle(plan)
+	if got != "my-plan" {
+		t.Errorf("got %q, want slug fallback", got)
+	}
+}
+
+// TestDisplayTitle_OverlongTitleFallsBackToSlug pins the smoke 6 fix.
+// The plan-manager HTTP API falls back title=description when only
+// description is provided in the create request, so a verbose prompt
+// becomes a multi-paragraph H1 on every rendered doc. Render time we
+// substitute the slug to keep the heading scannable.
+func TestDisplayTitle_OverlongTitleFallsBackToSlug(t *testing.T) {
+	verbose := strings.Repeat("a", maxDisplayTitleChars+1)
+	plan := &workflow.Plan{Slug: "my-plan", Title: verbose}
+	got := displayTitle(plan)
+	if got != "my-plan" {
+		t.Errorf("got %q, want slug fallback when title > %d chars", got, maxDisplayTitleChars)
+	}
+}
+
+func TestDisplayTitle_BoundaryExactMaxStillUsesTitle(t *testing.T) {
+	atMax := strings.Repeat("x", maxDisplayTitleChars)
+	plan := &workflow.Plan{Slug: "p", Title: atMax}
+	got := displayTitle(plan)
+	if got != atMax {
+		t.Errorf("got %q, exactly maxDisplayTitleChars should still use the title", got)
+	}
+}
+
+func TestDisplayTitle_NilPlanReturnsEmpty(t *testing.T) {
+	if got := displayTitle(nil); got != "" {
+		t.Errorf("got %q, want empty for nil plan", got)
+	}
+}

--- a/output/workflow-documents/openspec/design.go
+++ b/output/workflow-documents/openspec/design.go
@@ -44,10 +44,7 @@ func RenderDesign(plan *workflow.Plan) string {
 	arch := plan.Architecture
 
 	var sb strings.Builder
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayPlanTitle(plan)
 	fmt.Fprintf(&sb, "# Design: %s\n\n", title)
 
 	if len(arch.TechnologyChoices) > 0 {

--- a/output/workflow-documents/openspec/display_title.go
+++ b/output/workflow-documents/openspec/display_title.go
@@ -1,0 +1,29 @@
+package openspec
+
+import "github.com/c360studio/semspec/workflow"
+
+// maxDisplayPlanTitleChars caps the H1 title length across every
+// OpenSpec document. Mirrors workflowdocuments.maxDisplayTitleChars
+// in the parent package — see that constant for the rationale (smoke 6
+// produced ~600-char H1s when plan.Title was filled from a verbose
+// API description).
+const maxDisplayPlanTitleChars = 100
+
+// displayPlanTitle returns the human-presentable plan title for use in
+// OpenSpec document H1 headings. When plan.Title is empty or longer
+// than maxDisplayPlanTitleChars, the slug is used as fallback. plan.Goal
+// stays intact in the body — only the H1 changes.
+//
+// Kept package-local rather than imported from workflow-documents
+// (openspec is a sibling subpackage; the helper is small and
+// well-contained, so duplication is cheaper than the import path).
+func displayPlanTitle(plan *workflow.Plan) string {
+	if plan == nil {
+		return ""
+	}
+	t := plan.Title
+	if t == "" || len([]rune(t)) > maxDisplayPlanTitleChars {
+		return plan.Slug
+	}
+	return t
+}

--- a/output/workflow-documents/openspec/proposal.go
+++ b/output/workflow-documents/openspec/proposal.go
@@ -37,10 +37,7 @@ func RenderProposal(plan *workflow.Plan) string {
 	}
 	var sb strings.Builder
 
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayPlanTitle(plan)
 	fmt.Fprintf(&sb, "# Proposal: %s\n\n", title)
 
 	if plan.Goal != "" {

--- a/output/workflow-documents/openspec/tasks.go
+++ b/output/workflow-documents/openspec/tasks.go
@@ -28,10 +28,7 @@ func RenderTasks(plan *workflow.Plan, execs map[string]workflow.RequirementExecu
 		return ""
 	}
 	var sb strings.Builder
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayPlanTitle(plan)
 	fmt.Fprintf(&sb, "# Tasks: %s\n\n", title)
 
 	for _, c := range plan.Exploration.Capabilities {

--- a/output/workflow-documents/plan_renderer.go
+++ b/output/workflow-documents/plan_renderer.go
@@ -43,10 +43,7 @@ func RenderPlan(plan *workflow.Plan) string {
 }
 
 func renderHeader(b *strings.Builder, plan *workflow.Plan) {
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# %s\n\n", title))
 
 	b.WriteString(fmt.Sprintf("**Status:** %s", plan.EffectiveStatus()))

--- a/output/workflow-documents/qa_summary_renderer.go
+++ b/output/workflow-documents/qa_summary_renderer.go
@@ -22,10 +22,7 @@ func RenderQASummary(plan *workflow.Plan) string {
 	}
 	var b strings.Builder
 
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# QA Summary: %s\n\n", title))
 	b.WriteString(fmt.Sprintf("*Generated from the qa-reviewer verdict, the QA phase's executor result, and any plan-decisions the qa-reviewer raised. QA level for this plan: `%s`.*\n\n",
 		plan.EffectiveQALevel()))

--- a/output/workflow-documents/requirements_renderer.go
+++ b/output/workflow-documents/requirements_renderer.go
@@ -21,10 +21,7 @@ func RenderRequirements(plan *workflow.Plan) string {
 	}
 	var b strings.Builder
 
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# Requirements: %s\n\n", title))
 	b.WriteString(fmt.Sprintf("*Generated from the requirement-generator role's output. **%d requirements** partition the implementation work.*\n\n",
 		len(plan.Requirements)))

--- a/output/workflow-documents/run_summary_renderer.go
+++ b/output/workflow-documents/run_summary_renderer.go
@@ -30,10 +30,7 @@ func RenderRunSummary(plan *workflow.Plan) string {
 
 	var b strings.Builder
 
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# Run summary: %s\n\n", title))
 	b.WriteString(fmt.Sprintf("**Slug:** `%s` | **Terminal status:** `%s` | **QA level:** `%s`\n\n",
 		plan.Slug, status, plan.EffectiveQALevel()))

--- a/output/workflow-documents/scenarios_renderer.go
+++ b/output/workflow-documents/scenarios_renderer.go
@@ -20,10 +20,7 @@ func RenderScenarios(plan *workflow.Plan) string {
 	}
 	var b strings.Builder
 
-	title := plan.Title
-	if title == "" {
-		title = plan.Slug
-	}
+	title := displayTitle(plan)
 	b.WriteString(fmt.Sprintf("# Scenarios: %s\n\n", title))
 	b.WriteString(fmt.Sprintf("*Generated from the scenario-generator role's output. **%d scenarios** verify the implementation, grouped by the requirement they cover.*\n\n",
 		len(plan.Scenarios)))

--- a/output/workflow-documents/stories_renderer.go
+++ b/output/workflow-documents/stories_renderer.go
@@ -1,0 +1,113 @@
+package workflowdocuments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// RenderStories produces a markdown view of Sarah's per-Story narratives,
+// grouped by the parent Requirement. ADR-043 added Stories as the unit of
+// dev work between Requirements and Tasks; until this renderer landed
+// (smoke 6 follow-up, 2026-06-02) Story data was only visible via
+// plan.json and the "Applies To" section of OpenSpec spec.md. The
+// stories.md artifact makes Sarah's contribution legible alongside the
+// other persona outputs in `.semspec/plans/<slug>/`.
+//
+// Returns "" when the plan has no Stories — the file is skipped on
+// pre-Sarah plans (mock fixtures, ADR-043 PR-3 dormant runs).
+func RenderStories(plan *workflow.Plan) string {
+	if plan == nil || len(plan.Stories) == 0 {
+		return ""
+	}
+	var b strings.Builder
+
+	title := displayTitle(plan)
+	b.WriteString(fmt.Sprintf("# Stories: %s\n\n", title))
+	b.WriteString(fmt.Sprintf("*Generated from the story-preparer role (Sarah). **%d stories** ready the per-Requirement work for the executor pipeline, each carrying its own Tasks checklist and FilesOwned scope.*\n\n",
+		len(plan.Stories)))
+
+	// Group stories by requirement ID, preserving requirement order.
+	byReq := make(map[string][]workflow.Story)
+	var orphans []workflow.Story
+	for _, s := range plan.Stories {
+		if s.RequirementID == "" {
+			orphans = append(orphans, s)
+			continue
+		}
+		byReq[s.RequirementID] = append(byReq[s.RequirementID], s)
+	}
+
+	for _, req := range plan.Requirements {
+		stories := byReq[req.ID]
+		if len(stories) == 0 {
+			continue
+		}
+		reqLabel := req.Title
+		if reqLabel == "" {
+			reqLabel = req.ID
+		}
+		fmt.Fprintf(&b, "## %s\n\n", reqLabel)
+		if req.ID != "" {
+			fmt.Fprintf(&b, "*Requirement `%s` — %d story(ies)*\n\n", req.ID, len(stories))
+		}
+		for _, s := range stories {
+			writeStory(&b, s)
+		}
+	}
+
+	if len(orphans) > 0 {
+		b.WriteString("## Unassigned stories\n\n")
+		b.WriteString("*These stories have no parent Requirement — investigate, the plan-reviewer R3 round should have rejected them.*\n\n")
+		for _, s := range orphans {
+			writeStory(&b, s)
+		}
+	}
+
+	return b.String()
+}
+
+// writeStory emits a single Story block: title, intent, components,
+// files_owned, depends_on, and the Task checklist.
+func writeStory(b *strings.Builder, s workflow.Story) {
+	heading := s.Title
+	if heading == "" {
+		heading = s.ID
+	}
+	fmt.Fprintf(b, "### %s\n\n", heading)
+	if s.ID != "" {
+		fmt.Fprintf(b, "*`%s`*\n\n", s.ID)
+	}
+	if s.Intent != "" {
+		fmt.Fprintf(b, "%s\n\n", s.Intent)
+	}
+	if len(s.Components) > 0 {
+		fmt.Fprintf(b, "**Components:** %s\n\n", strings.Join(s.Components, ", "))
+	}
+	if len(s.FilesOwned) > 0 {
+		b.WriteString("**Files owned:**\n\n")
+		for _, f := range s.FilesOwned {
+			fmt.Fprintf(b, "- `%s`\n", f)
+		}
+		b.WriteString("\n")
+	}
+	if len(s.DependsOn) > 0 {
+		b.WriteString("**Depends on:**\n\n")
+		for _, d := range s.DependsOn {
+			fmt.Fprintf(b, "- `%s`\n", d)
+		}
+		b.WriteString("\n")
+	}
+	if len(s.Tasks) > 0 {
+		b.WriteString("**Tasks:**\n\n")
+		for _, t := range s.Tasks {
+			desc := t.Description
+			if desc == "" {
+				desc = t.ID
+			}
+			fmt.Fprintf(b, "- `%s` — %s\n", t.ID, desc)
+		}
+		b.WriteString("\n")
+	}
+}

--- a/output/workflow-documents/stories_renderer_test.go
+++ b/output/workflow-documents/stories_renderer_test.go
@@ -1,0 +1,121 @@
+package workflowdocuments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestRenderStories_EmptyPlanReturnsEmpty(t *testing.T) {
+	if got := RenderStories(nil); got != "" {
+		t.Errorf("nil plan: got %q, want empty", got)
+	}
+	if got := RenderStories(&workflow.Plan{Slug: "p"}); got != "" {
+		t.Errorf("plan without stories: got %q, want empty", got)
+	}
+}
+
+// TestRenderStories_GroupsByRequirement pins the structural shape:
+// stories are listed under H2 headings keyed to their parent
+// Requirement; each Story block includes title, ID, intent, components,
+// files_owned, and tasks. Mirrors RenderScenarios's grouping.
+func TestRenderStories_GroupsByRequirement(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:  "p",
+		Title: "Short title",
+		Requirements: []workflow.Requirement{
+			{ID: "req.p.1", Title: "Auth"},
+			{ID: "req.p.2", Title: "Session"},
+		},
+		Stories: []workflow.Story{
+			{
+				ID: "story.p.1.1", RequirementID: "req.p.1",
+				Title:      "Lifecycle",
+				Intent:     "Set up the auth lifecycle component.",
+				Components: []string{"auth-service"},
+				FilesOwned: []string{"src/auth.go", "src/auth_test.go"},
+				Tasks: []workflow.Task{
+					{ID: "task.p.1.1.1", Description: "write failing test"},
+					{ID: "task.p.1.1.2", Description: "implement to pass", DependsOn: []string{"task.p.1.1.1"}},
+				},
+			},
+			{
+				ID: "story.p.2.1", RequirementID: "req.p.2",
+				Title:      "Wire-up",
+				DependsOn:  []string{"story.p.1.1"},
+				FilesOwned: []string{"src/session.go"},
+				Tasks: []workflow.Task{
+					{ID: "task.p.2.1.1", Description: "wire session"},
+				},
+			},
+		},
+	}
+	got := RenderStories(plan)
+	if got == "" {
+		t.Fatal("got empty render output for non-empty stories")
+	}
+	mustContain := []string{
+		"# Stories: Short title",
+		"**2 stories**",
+		"## Auth",
+		"`req.p.1` — 1 story(ies)",
+		"### Lifecycle",
+		"`story.p.1.1`",
+		"Set up the auth lifecycle component.",
+		"**Components:** auth-service",
+		"**Files owned:**",
+		"`src/auth.go`",
+		"**Tasks:**",
+		"`task.p.1.1.1` — write failing test",
+		"## Session",
+		"### Wire-up",
+		"**Depends on:**",
+		"`story.p.1.1`",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in render output", want)
+		}
+	}
+}
+
+// TestRenderStories_OrphanStoriesGetSeparateSection guards the
+// defensive fallback. Plan-reviewer R3 should reject Stories with
+// empty RequirementID; if one slips through the renderer surfaces it
+// under a dedicated heading rather than hiding it.
+func TestRenderStories_OrphanStoriesGetSeparateSection(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "p",
+		Stories: []workflow.Story{
+			{ID: "story.p.x.1", Title: "Orphan"}, // no RequirementID
+		},
+	}
+	got := RenderStories(plan)
+	if !strings.Contains(got, "## Unassigned stories") {
+		t.Error("orphan story should land under 'Unassigned stories' heading")
+	}
+}
+
+// TestRenderStories_OverlongTitleFallsBackToSlug pins the smoke 6
+// overlong-title behavior — same as the other renderers via the
+// shared displayTitle helper.
+func TestRenderStories_OverlongTitleFallsBackToSlug(t *testing.T) {
+	verbose := strings.Repeat("x", maxDisplayTitleChars+1)
+	plan := &workflow.Plan{
+		Slug:    "compact-slug",
+		Title:   verbose,
+		Stories: []workflow.Story{{ID: "s1", RequirementID: "r1"}},
+		Requirements: []workflow.Requirement{
+			{ID: "r1", Title: "R1"},
+		},
+	}
+	got := RenderStories(plan)
+	if !strings.HasPrefix(got, "# Stories: compact-slug\n") {
+		clip := 80
+		if len(got) < clip {
+			clip = len(got)
+		}
+		t.Errorf("overlong title should fall back to slug; got first %d chars: %q", clip, got[:clip])
+	}
+}


### PR DESCRIPTION
## Summary

Smoke 6 (2026-06-02) exposed two cosmetic issues in the rendered planning docs:

1. **Verbose H1s** — Every `.md` artifact (plan, requirements, architecture, scenarios, proposal, design, tasks) had ~600-char H1 headings. Root cause: \`plan-manager/http.go:633-643\` falls back \`title=description\` when only description is provided in a create request. With long user prompts (mavlink-hard's goal is multi-paragraph), the title becomes the prompt itself.

2. **Missing stories.md** — ADR-043 made Stories the unit of dev work between Requirements and Tasks, but Sarah's per-Story narrative had no dedicated render. Story data lived only in plan.json and the \"Applies To\" section of OpenSpec spec.md.

This PR fixes both at the render layer — data shape unchanged, only the cosmetic outputs adjust.

## Changes

### Compact H1 across all renderers

- New helper \`displayTitle(plan)\` in \`workflow-documents/\` (and sibling \`displayPlanTitle\` in \`workflow-documents/openspec/\` — subpackages don't share). Returns the slug when \`plan.Title\` is empty OR longer than 100 chars; otherwise returns the title verbatim.
- Every renderer migrated to the helper (plan / requirements / architecture / scenarios / qa-summary / run-summary + openspec proposal / design / tasks).
- \`plan.Goal\` stays intact in the document body — only the H1 line gets the slug fallback.

### New stories.md artifact

- \`RenderStories(plan)\` mirrors \`RenderScenarios\` structurally. H2 per Requirement, H3 per Story showing intent, components, files_owned, depends_on, and the Tasks checklist.
- Wired into \`phaseArtifacts\` so the file emits on every Sarah-completed write. Returns \"\" on pre-Sarah plans (mock fixtures, ADR-043 PR-3 dormant runs) → file simply doesn't appear.
- Orphan stories (no parent RequirementID — should be rejected by plan-reviewer R3 but render fails open) surface under a dedicated \"Unassigned stories\" heading.

## Tests

\`display_title_test.go\` (5 cases): normal-length, empty title, **overlong-title-falls-back-to-slug** (smoke 6 regression), boundary at max, nil plan.

\`stories_renderer_test.go\` (4 cases): empty plan returns empty, group-by-requirement structural shape, orphan stories under separate heading, overlong title falls back to slug.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all green
- [x] \`task lint\` — clean
- [ ] CI green
- [ ] Re-smoke after merge produces shorter H1s + stories.md alongside scenarios.md

Net **+358 / -36** across 15 files (9 modified, 4 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)