### PR TITLE
fix(prompt): explicit RoleStoryPreparer tool filter + coverage test

### DIFF
--- a/prompt/tool_filter.go
+++ b/prompt/tool_filter.go
@@ -53,6 +53,21 @@ func DefaultToolFilters() map[Role]*ToolFilter {
 		RoleScenarioGenerator: {
 			AllowExact: []string{"bash", "submit_work", "scratchpad"},
 		},
+		// Story-preparer (Sarah, ADR-043). Reads architecture +
+		// requirements and emits Stories with Tasks. Single-shot generator
+		// shape — same minimal palette as the other generators plus
+		// write_todos because Sarah's prompt instructs her to track
+		// readiness-gate progress across her own reasoning steps.
+		//
+		// Without this entry FilterTools falls through to "unknown role
+		// returns all tools," which today is invisible because story-
+		// preparer's own availableToolNames() returns only 4 tools — but
+		// the gap is a latent risk if that list ever broadens. Added 2026-
+		// 06-02 as defense-in-depth after the semteams 51-tools-leak
+		// investigation.
+		RoleStoryPreparer: {
+			AllowExact: []string{"bash", "submit_work", "write_todos", "scratchpad"},
+		},
 		// Recovery agent (manager-role wedge diagnosis) — closed action
 		// set is enforced at parse time; the palette here is "the tools
 		// you'll actually call." submit_work is the terminal commit;

--- a/prompt/tool_filter_test.go
+++ b/prompt/tool_filter_test.go
@@ -113,3 +113,58 @@ func TestFilterTools_UnknownRoleReturnsAll(t *testing.T) {
 		t.Errorf("unknown role should return all tools unchanged; got %v", got)
 	}
 }
+
+// TestFilterTools_StoryPreparerPalette pins Sarah's tight palette so a
+// future tool addition doesn't silently leak into the story-preparer
+// dispatch. Added 2026-06-02 alongside the explicit DefaultToolFilters
+// entry that closes the unknown-role fall-through gap for RoleStoryPreparer.
+func TestFilterTools_StoryPreparerPalette(t *testing.T) {
+	allTools := []string{
+		"bash", "submit_work", "ask_question", "answer_question",
+		"write_todos", "scratchpad", "web_search", "http_request",
+		"graph_search", "graph_query", "graph_summary",
+		"research", "answer_research", "spawn_agent",
+	}
+	allowed := FilterTools(allTools, RoleStoryPreparer)
+	want := []string{"bash", "submit_work", "write_todos", "scratchpad"}
+	if !slices.Equal(allowed, want) {
+		t.Errorf("RoleStoryPreparer palette = %v, want %v", allowed, want)
+	}
+}
+
+// TestFilterTools_AllDispatchRolesHaveExplicitEntry pins the contract
+// that every role used by an actual processor dispatcher has an
+// explicit entry in DefaultToolFilters — not a fall-through to "all
+// tools." Drift on this list = the semteams 51-tools-leak surface.
+//
+// Roles intentionally excluded (used only for telemetry tagging, NOT
+// dispatch):
+//   - RoleQA — qa-reviewer tags its loop with this string, but the
+//     actual FilterTools call uses RolePlanQAReviewer.
+//   - RoleCapabilities / RoleContext — sub-role labels used inside
+//     persona fragments, not standalone dispatch roles.
+func TestFilterTools_AllDispatchRolesHaveExplicitEntry(t *testing.T) {
+	filters := DefaultToolFilters()
+	dispatchRoles := []Role{
+		RolePlanner,
+		RoleArchitect,
+		RoleRequirementGenerator,
+		RoleScenarioGenerator,
+		RoleStoryPreparer,
+		RoleScenarioReviewer,
+		RolePlanReviewer,
+		RoleTaskReviewer,
+		RoleReviewer,
+		RoleValidator,
+		RoleDeveloper,
+		RolePlanQAReviewer,
+		RoleLessonDecomposer,
+		RoleRecoveryAgent,
+		RoleResearcher,
+	}
+	for _, role := range dispatchRoles {
+		if _, ok := filters[role]; !ok {
+			t.Errorf("dispatch role %q missing from DefaultToolFilters() — falls through to 'all tools' return and risks the 51-tool leak shape", role)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Investigating the semteams \"every agent sees 51 tools\" report (2026-06-02) surfaced that **\`RoleStoryPreparer\` was missing from \`DefaultToolFilters()\`**, so Sarah's \`FilterTools\` call fell through to the \"unknown roles get all tools\" return.

Today this is invisible because story-preparer's own \`availableToolNames()\` is hand-narrowed to 4 tools (\`bash, submit_work, write_todos, scratchpad\`). Both wire and prompt palettes therefore land at those 4. But the gap is a **latent risk** — if anyone broadens story-preparer's availableToolNames later, Sarah suddenly inherits everything the registry holds.

This PR closes the gap with defense-in-depth.

## Changes

1. **New \`RoleStoryPreparer\` entry** in \`DefaultToolFilters\` with the same \`AllowExact\` list Sarah actually uses today: \`bash, submit_work, write_todos, scratchpad\`.

2. **New test \`TestFilterTools_StoryPreparerPalette\`** pins Sarah's palette against a 14-tool universe — any future allow-list change becomes a compile-aware decision.

3. **New test \`TestFilterTools_AllDispatchRolesHaveExplicitEntry\`** pins the broader contract: every role used by an actual processor dispatcher must have an explicit \`DefaultToolFilters\` entry. **Drift on this list = the semteams 51-tool leak surface.**

   Telemetry-only roles documented as intentionally excluded:
   - \`RoleQA\` — qa-reviewer tags its loop with this string, but the actual \`FilterTools\` call uses \`RolePlanQAReviewer\`
   - \`RoleCapabilities\` / \`RoleContext\` — sub-role labels used inside persona fragments, not standalone dispatch roles

## What I verified

Active-checked the existing 13 dispatch roles. All other roles already have explicit filters:

| Role | AllowExact count |
|---|---|
| Developer, Architect, Planner | 6 each |
| Lesson-decomposer | 4 |
| **Story-preparer (this PR)** | **4** |
| Researcher | 4 |
| Reviewer, Plan-reviewer, Scenario-gen, Scenario-reviewer, Requirement-gen, QA-reviewer | 3 each |
| Validator, Recovery-agent | 2 each |

No role gets 51 tools. semspec does not have the semteams leak.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./...\` — all green
- [x] \`task lint\` — clean
- [ ] CI green
- [ ] Future smoke trajectories should continue showing 4 tools advertised to Sarah (regression guard via new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)