### PR TITLE
fix(plan-manager): per-slug mutex serializes mutation handlers

### DIFF
--- a/processor/plan-manager/component.go
+++ b/processor/plan-manager/component.go
@@ -64,6 +64,40 @@ type Component struct {
 	// is no way to assert publishRecoveryRequested actually fires at the
 	// revision-cap / iteration-exhaustion / QA-rejection trigger points.
 	recoveryPublisher func(ctx context.Context, req *payloads.RecoveryRequested)
+
+	// slugMutexes serializes mutation handlers per plan slug. NATS dispatches
+	// each subscription's handler in its own goroutine, so two mutations for
+	// the same plan can interleave their get → mutate → save sequence and
+	// silently drop one update. Acquiring lockSlug(slug) at the top of every
+	// mutation handler bounds the read-modify-write to a single goroutine per
+	// slug. Mutations for distinct slugs continue to run in parallel.
+	//
+	// Lifecycle: lazy-create on first acquire via LoadOrStore; never deleted.
+	// Mutex memory is small and plan churn is low — leaving entries in place
+	// avoids the ABA issue of recreating a mutex while another goroutine still
+	// holds a reference to the old one. Closes go-reviewer Pass-4 P4-C1.
+	slugMutexes sync.Map
+}
+
+// lockSlug returns an unlock function that releases the per-slug mutex.
+// Empty slug returns a no-op unlock so the caller can still defer it; the
+// handler will fail validation on the empty slug separately. Lazy-creates
+// the mutex on first acquire — see slugMutexes godoc for the lifecycle
+// rationale.
+func (c *Component) lockSlug(slug string) func() {
+	if slug == "" {
+		return func() {}
+	}
+	v, _ := c.slugMutexes.LoadOrStore(slug, &sync.Mutex{})
+	m, ok := v.(*sync.Mutex)
+	if !ok {
+		// LoadOrStore stored or returned the *sync.Mutex we just initialized;
+		// the type assertion failing means another writer raced and stored a
+		// different type, which would be a bug. Defensive — should never fire.
+		return func() {}
+	}
+	m.Lock()
+	return m.Unlock
 }
 
 // loadPlanCached loads a plan from the store (cache → KV → graph fallback).

--- a/processor/plan-manager/concurrent_mutation_test.go
+++ b/processor/plan-manager/concurrent_mutation_test.go
@@ -1,0 +1,165 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestHandleScenariosMutation_ConcurrentDifferentRequirementsPreservesAll
+// pins the single-writer invariant for plan-manager: when N concurrent
+// handleScenariosMutation calls land on the same plan with distinct
+// RequirementIDs, ALL N scenario batches must persist.
+//
+// On the current (pre-fix) code this test FAILS because the
+// `c.mu.RLock(); ps := c.plans; c.mu.RUnlock(); plan, ok := ps.get(slug);
+// ...; ps.save(ctx, plan)` sequence in every mutation handler is not
+// serialized per slug. NATS dispatches each subscription's handler in its
+// own goroutine — two concurrent handlers read the same plan snapshot,
+// each appends its batch to a local copy, and whichever ps.save lands
+// second silently overwrites the first's append. The first batch is lost.
+//
+// Reference: go-reviewer Pass 4 finding P4-C1 and the cross-pass synthesis
+// memory note (project_go_reviewer_cross_pass_synthesis_adr043.md).
+//
+// After the per-slug-mutex fix this test PASSES because each handler
+// acquires the slug's mutex at entry and releases at exit, serializing
+// the get/mutate/save sequence.
+func TestHandleScenariosMutation_ConcurrentDifferentRequirementsPreservesAll(t *testing.T) {
+	const slug = "concurrent-scen"
+	const numReqs = 64
+
+	ctx := context.Background()
+	c := setupTestComponent(t)
+
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusGeneratingScenarios
+	plan.Requirements = make([]workflow.Requirement, numReqs)
+	for i := 0; i < numReqs; i++ {
+		plan.Requirements[i] = workflow.Requirement{
+			ID:    fmt.Sprintf("req.%s.%d", slug, i),
+			Title: fmt.Sprintf("R%d", i),
+		}
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save initial plan: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := 0; i < numReqs; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			reqID := fmt.Sprintf("req.%s.%d", slug, idx)
+			scenarioID := fmt.Sprintf("scen.%s.%d", slug, idx)
+			req := ScenariosMutationRequest{
+				Slug:          slug,
+				RequirementID: reqID,
+				Scenarios: []workflow.Scenario{
+					{ID: scenarioID, RequirementID: reqID},
+				},
+			}
+			data, err := json.Marshal(req)
+			if err != nil {
+				t.Errorf("marshal: %v", err)
+				return
+			}
+			<-start // wait for the green light
+			resp := c.handleScenariosMutation(ctx, data)
+			if !resp.Success {
+				t.Errorf("handler returned !success for req %d: %s", idx, resp.Error)
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan disappeared after concurrent mutations")
+	}
+
+	// Build a presence set so duplicate scenario IDs don't mask losses.
+	present := make(map[string]bool, len(got.Scenarios))
+	for _, s := range got.Scenarios {
+		present[s.ID] = true
+	}
+
+	var missing []string
+	for i := 0; i < numReqs; i++ {
+		want := fmt.Sprintf("scen.%s.%d", slug, i)
+		if !present[want] {
+			missing = append(missing, want)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("LOST UPDATE — %d of %d concurrent scenario batches missing from plan.Scenarios after handlers returned; this proves the read-modify-write race in handleScenariosMutation. First few missing: %v",
+			len(missing), numReqs, missing[:min(5, len(missing))])
+	}
+}
+
+// TestHandleStoriesMutation_ConcurrentSameSlugSerializeMonotonically pins
+// that two back-to-back handleStoriesMutation calls on the same plan
+// converge to a consistent terminal state. Today both would race to set
+// plan.Status=stories_generated and Stories=req.Stories — and either order
+// is acceptable, but if locking is broken the cache/KV/graph layers can
+// diverge (cache shows one set, KV shows another).
+//
+// This test mainly serves as a smoke test for "no panic, no deadlock,
+// consistent final state" once the per-slug lock is in place. Pre-fix it
+// can also expose the cache-vs-KV divergence under tighter timing windows.
+func TestHandleStoriesMutation_ConcurrentSameSlugSerializeMonotonically(t *testing.T) {
+	const slug = "concurrent-stories"
+
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusPreparingStories
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save initial plan: %v", err)
+	}
+
+	storyA := validStory(fmt.Sprintf("story.%s.A", slug), "req.x.1", "Story A")
+	storyB := validStory(fmt.Sprintf("story.%s.B", slug), "req.x.1", "Story B")
+
+	reqs := []storiesMutationRequest{
+		{Slug: slug, Stories: []workflow.Story{storyA}, StoryCount: 1},
+		{Slug: slug, Stories: []workflow.Story{storyB}, StoryCount: 1},
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for _, r := range reqs {
+		wg.Add(1)
+		go func(r storiesMutationRequest) {
+			defer wg.Done()
+			data, _ := json.Marshal(r)
+			<-start
+			// One will succeed (preparing_stories → stories_generated), the
+			// other will hit invalid transition (stories_generated →
+			// stories_generated). Both are acceptable outcomes; the test
+			// asserts no panic + a consistent terminal state.
+			_ = c.handleStoriesMutation(ctx, data)
+		}(r)
+	}
+	close(start)
+	wg.Wait()
+
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan disappeared")
+	}
+	if got.EffectiveStatus() != workflow.StatusStoriesGenerated {
+		t.Errorf("final status = %s, want stories_generated", got.EffectiveStatus())
+	}
+	if len(got.Stories) != 1 {
+		t.Errorf("Stories count = %d, want exactly 1 (the winning mutation's batch)", len(got.Stories))
+	}
+}

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -233,6 +233,8 @@ func (c *Component) handleRequirementsMutation(ctx context.Context, data []byte)
 		return MutationResponse{Success: false, Error: err.Error()}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -290,6 +292,8 @@ func (c *Component) handleArchitectureMutation(ctx context.Context, data []byte)
 	if req.Slug == "" {
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -349,6 +353,8 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 	if err := workflow.ValidateStories(req.Stories); err != nil {
 		return MutationResponse{Success: false, Error: fmt.Sprintf("validate stories: %v", err)}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -436,6 +442,8 @@ func (c *Component) handleScenariosMutation(ctx context.Context, data []byte) Mu
 		return MutationResponse{Success: false, Error: "slug and requirement_id required"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -515,6 +523,8 @@ func (c *Component) handleGenerationFailedMutation(ctx context.Context, data []b
 	c.logger.Error("Generation failed via mutation",
 		"slug", req.Slug, "phase", req.Phase, "error", req.Error)
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -561,6 +571,8 @@ func (c *Component) handleExploredMutation(ctx context.Context, data []byte) Mut
 		return MutationResponse{Success: false, Error: err.Error()}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -600,6 +612,8 @@ func (c *Component) handleDraftedMutation(ctx context.Context, data []byte) Muta
 	if req.Slug == "" || req.Goal == "" {
 		return MutationResponse{Success: false, Error: "slug and goal required"}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -645,6 +659,8 @@ func (c *Component) handleReviewedMutation(ctx context.Context, data []byte) Mut
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -682,6 +698,8 @@ func (c *Component) handleApprovedMutation(ctx context.Context, data []byte) Mut
 	if req.Slug == "" {
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -726,6 +744,8 @@ func (c *Component) handleClaimMutation(ctx context.Context, data []byte) Mutati
 		return MutationResponse{Success: false, Error: fmt.Sprintf("can only claim in-progress statuses, got %q", req.Status)}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -764,6 +784,8 @@ func (c *Component) handleScenariosReviewedMutation(ctx context.Context, data []
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -797,6 +819,8 @@ func (c *Component) handleReadyForExecutionMutation(ctx context.Context, data []
 	if req.Slug == "" {
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -974,6 +998,8 @@ func (c *Component) handleRevisionMutation(ctx context.Context, data []byte) Mut
 		return MutationResponse{Success: false, Error: "revision handler only accepts verdict=needs_changes"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -1076,6 +1102,8 @@ func (c *Component) handleQAStartMutation(ctx context.Context, data []byte) Muta
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -1130,6 +1158,8 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 	default:
 		return MutationResponse{Success: false, Error: fmt.Sprintf("verdict must be approved|needs_changes|rejected, got %q", req.Verdict)}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -1277,6 +1307,8 @@ func (c *Component) handleReviewApproveMutation(ctx context.Context, data []byte
 		return MutationResponse{Success: false, Error: "slug is required"}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -1330,11 +1362,14 @@ func (c *Component) handleGitHubPlanCreateMutation(ctx context.Context, data []b
 		return MutationResponse{Success: false, Error: fmt.Sprintf("validate: %v", err)}
 	}
 
+	// Slug must be computed before lockSlug — see slugMutexes godoc.
+	slug := fmt.Sprintf("%d-%s", req.IssueNumber, paths.Slugify(req.Title))
+	defer c.lockSlug(slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
 
-	slug := fmt.Sprintf("%d-%s", req.IssueNumber, paths.Slugify(req.Title))
 	if ps.exists(slug) {
 		c.logger.Info("GitHub plan already exists, skipping", "slug", slug, "issue", req.IssueNumber)
 		return MutationResponse{Success: true}
@@ -1395,6 +1430,8 @@ func (c *Component) handleGitHubPRFeedbackMutation(ctx context.Context, data []b
 		return MutationResponse{Success: false, Error: fmt.Sprintf("validate: %v", err)}
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -1436,25 +1473,7 @@ func (c *Component) handleGitHubPRFeedbackMutation(ctx context.Context, data []b
 	}
 
 	// Create PlanDecision(s) for audit trail.
-	now := time.Now()
-	for _, reqID := range affectedReqIDs {
-		proposalID := fmt.Sprintf("plan-decision.%s.pr-feedback.%d.%s", req.Slug, req.ReviewID, reqID)
-		rationale := fmt.Sprintf("PR review feedback from @%s (review %d)", req.Reviewer, req.ReviewID)
-		if req.Body != "" {
-			rationale += ": " + req.Body
-		}
-		plan.PlanDecisions = append(plan.PlanDecisions, workflow.PlanDecision{
-			ID:             proposalID,
-			PlanID:         workflow.PlanEntityID(req.Slug),
-			Title:          fmt.Sprintf("PR feedback round %d", plan.GitHub.PRRevision+1),
-			Rationale:      rationale,
-			Status:         workflow.PlanDecisionStatusAccepted,
-			ProposedBy:     "github-pr-review",
-			AffectedReqIDs: []string{reqID},
-			CreatedAt:      now,
-			DecidedAt:      &now,
-		})
-	}
+	appendPRFeedbackPlanDecisions(plan, &req, affectedReqIDs)
 
 	// Update GitHub metadata.
 	plan.GitHub.PRRevision++
@@ -1486,6 +1505,32 @@ func (c *Component) handleGitHubPRFeedbackMutation(ctx context.Context, data []b
 		"pr_revision", plan.GitHub.PRRevision)
 
 	return MutationResponse{Success: true}
+}
+
+// appendPRFeedbackPlanDecisions records one PlanDecision per affected
+// requirement so the PR review feedback round becomes part of the plan's
+// audit trail. Extracted from handleGitHubPRFeedbackMutation to keep that
+// handler within the per-function statement budget.
+func appendPRFeedbackPlanDecisions(plan *workflow.Plan, req *payloads.GitHubPRFeedbackRequest, affectedReqIDs []string) {
+	now := time.Now()
+	for _, reqID := range affectedReqIDs {
+		proposalID := fmt.Sprintf("plan-decision.%s.pr-feedback.%d.%s", req.Slug, req.ReviewID, reqID)
+		rationale := fmt.Sprintf("PR review feedback from @%s (review %d)", req.Reviewer, req.ReviewID)
+		if req.Body != "" {
+			rationale += ": " + req.Body
+		}
+		plan.PlanDecisions = append(plan.PlanDecisions, workflow.PlanDecision{
+			ID:             proposalID,
+			PlanID:         workflow.PlanEntityID(req.Slug),
+			Title:          fmt.Sprintf("PR feedback round %d", plan.GitHub.PRRevision+1),
+			Rationale:      rationale,
+			Status:         workflow.PlanDecisionStatusAccepted,
+			ProposedBy:     "github-pr-review",
+			AffectedReqIDs: []string{reqID},
+			CreatedAt:      now,
+			DecidedAt:      &now,
+		})
+	}
 }
 
 // buildFileToReqMap builds a file→requirementID reverse index from EXECUTION_STATES.
@@ -1564,6 +1609,8 @@ func (c *Component) handleGitHubPRMetadataMutation(ctx context.Context, data []b
 	if req.Slug == "" || req.PRNumber == 0 {
 		return MutationResponse{Success: false, Error: "slug and pr_number are required"}
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans
@@ -1723,6 +1770,8 @@ func (c *Component) handlePlanDecisionAddMutation(ctx context.Context, data []by
 		req.Decision.CreatedAt = time.Now()
 	}
 
+	defer c.lockSlug(req.Slug)()
+
 	c.mu.RLock()
 	ps := c.plans
 	c.mu.RUnlock()
@@ -1798,6 +1847,8 @@ func (c *Component) handlePlanDecisionAcceptMutation(ctx context.Context, data [
 	if acceptedBy == "" {
 		acceptedBy = "auto"
 	}
+
+	defer c.lockSlug(req.Slug)()
 
 	c.mu.RLock()
 	ps := c.plans

--- a/processor/plan-manager/stories_scenarios_mutation_test.go
+++ b/processor/plan-manager/stories_scenarios_mutation_test.go
@@ -1,0 +1,402 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// These tests close the coverage gap surfaced by the post-ADR-043 go-reviewer
+// passes (Pass 2 H4 + Pass 4 H4): handleStoriesMutation and
+// handleScenariosMutation had zero direct test coverage despite being the
+// load-bearing mutation handlers for the entire per-Story chain. They pin
+// current behavior so subsequent refactors (per-(Req,Story) wipe, scenario-ID
+// format change) are pinned by failing tests, not silent regressions.
+
+func marshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
+}
+
+// validStory returns a minimal Story that passes workflow.ValidateStory. No
+// Status set — matches Sarah's emission shape, which the empty-Status branch
+// in ValidateStory accepts without running readiness invariants.
+func validStory(id, reqID, title string) workflow.Story {
+	return workflow.Story{
+		ID:            id,
+		RequirementID: reqID,
+		Title:         title,
+	}
+}
+
+func TestHandleStoriesMutation(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// setup prepares the component + plan. Returns slug used by the test.
+		setup func(t *testing.T) (*Component, string)
+		req   storiesMutationRequest
+		// expected outcomes
+		wantSuccess     bool
+		wantErrorSubstr string
+		// post-condition assertions (only when wantSuccess)
+		checkPlan func(t *testing.T, plan *workflow.Plan)
+	}{
+		{
+			name: "happy path from preparing_stories",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "story-happy")
+				plan.Status = workflow.StatusPreparingStories
+				_ = c.plans.save(ctx, plan)
+				return c, "story-happy"
+			},
+			req: storiesMutationRequest{
+				Slug: "story-happy",
+				Stories: []workflow.Story{
+					validStory("story.story-happy.1.1", "req.story-happy.1", "Implement core"),
+				},
+				StoryCount: 1,
+			},
+			wantSuccess: true,
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if plan.EffectiveStatus() != workflow.StatusStoriesGenerated {
+					t.Errorf("status = %s, want stories_generated", plan.EffectiveStatus())
+				}
+				if len(plan.Stories) != 1 {
+					t.Errorf("Stories count = %d, want 1", len(plan.Stories))
+				}
+				if plan.Stories[0].ID != "story.story-happy.1.1" {
+					t.Errorf("Stories[0].ID = %q, want story.story-happy.1.1", plan.Stories[0].ID)
+				}
+			},
+		},
+		{
+			name: "empty slug rejected",
+			setup: func(t *testing.T) (*Component, string) {
+				return setupTestComponent(t), ""
+			},
+			req: storiesMutationRequest{
+				Slug: "",
+				Stories: []workflow.Story{
+					validStory("story.x.1.1", "req.x.1", "T"),
+				},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "slug required",
+		},
+		{
+			name: "plan not found",
+			setup: func(t *testing.T) (*Component, string) {
+				return setupTestComponent(t), "nonexistent"
+			},
+			req: storiesMutationRequest{
+				Slug: "nonexistent",
+				Stories: []workflow.Story{
+					validStory("story.x.1.1", "req.x.1", "T"),
+				},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "plan not found",
+		},
+		{
+			name: "validation failure propagated (missing requirement_id)",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "story-validate")
+				plan.Status = workflow.StatusPreparingStories
+				_ = c.plans.save(ctx, plan)
+				return c, "story-validate"
+			},
+			req: storiesMutationRequest{
+				Slug: "story-validate",
+				Stories: []workflow.Story{
+					{ID: "story.bad.1.1" /* RequirementID intentionally empty */, Title: "T"},
+				},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "validate stories",
+		},
+		{
+			name: "invalid transition from wrong status",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "story-wrong-status")
+				plan.Status = workflow.StatusCreated // not preparing_stories
+				_ = c.plans.save(ctx, plan)
+				return c, "story-wrong-status"
+			},
+			req: storiesMutationRequest{
+				Slug: "story-wrong-status",
+				Stories: []workflow.Story{
+					validStory("story.x.1.1", "req.x.1", "T"),
+				},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "invalid transition",
+		},
+		{
+			name: "scope auto-derived from Story.FilesOwned",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "story-scope")
+				plan.Status = workflow.StatusPreparingStories
+				plan.Scope = workflow.Scope{Include: []string{"existing.go"}}
+				_ = c.plans.save(ctx, plan)
+				return c, "story-scope"
+			},
+			req: storiesMutationRequest{
+				Slug: "story-scope",
+				Stories: []workflow.Story{
+					{
+						ID:            "story.story-scope.1.1",
+						RequirementID: "req.story-scope.1",
+						Title:         "T",
+						FilesOwned:    []string{"src/new.go"},
+					},
+				},
+			},
+			wantSuccess: true,
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scope.Create) != 1 || plan.Scope.Create[0] != "src/new.go" {
+					t.Errorf("Scope.Create = %v, want [src/new.go]", plan.Scope.Create)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := tt.setup(t)
+
+			data := marshalJSON(t, tt.req)
+			resp := c.handleStoriesMutation(ctx, data)
+
+			if resp.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error: %s)", resp.Success, tt.wantSuccess, resp.Error)
+			}
+			if !tt.wantSuccess && tt.wantErrorSubstr != "" {
+				if !strings.Contains(resp.Error, tt.wantErrorSubstr) {
+					t.Errorf("Error = %q, want substring %q", resp.Error, tt.wantErrorSubstr)
+				}
+			}
+			if tt.wantSuccess && tt.checkPlan != nil {
+				plan, ok := c.plans.get(tt.req.Slug)
+				if !ok {
+					t.Fatal("plan not found after mutation")
+				}
+				tt.checkPlan(t, plan)
+			}
+		})
+	}
+}
+
+func TestHandleScenariosMutation(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		setup           func(t *testing.T) (*Component, string)
+		req             ScenariosMutationRequest
+		wantSuccess     bool
+		wantErrorSubstr string
+		checkPlan       func(t *testing.T, plan *workflow.Plan)
+	}{
+		{
+			name: "happy path: single requirement, single scenario batch",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-happy")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{{ID: "req.scen-happy.1", Title: "R1"}}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-happy"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-happy",
+				RequirementID: "req.scen-happy.1",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.1", RequirementID: "req.scen-happy.1"},
+				},
+			},
+			wantSuccess: true,
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if plan.EffectiveStatus() != workflow.StatusScenariosGenerated {
+					t.Errorf("status = %s, want scenarios_generated (single req covered)", plan.EffectiveStatus())
+				}
+				if len(plan.Scenarios) != 1 {
+					t.Errorf("Scenarios = %d, want 1", len(plan.Scenarios))
+				}
+			},
+		},
+		{
+			name: "convergence holds when one of two requirements still uncovered",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-partial")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{
+					{ID: "req.scen-partial.1", Title: "R1"},
+					{ID: "req.scen-partial.2", Title: "R2"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-partial"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-partial",
+				RequirementID: "req.scen-partial.1",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.1", RequirementID: "req.scen-partial.1"},
+				},
+			},
+			wantSuccess: true,
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if plan.EffectiveStatus() != workflow.StatusGeneratingScenarios {
+					t.Errorf("status = %s, want generating_scenarios (req.2 still uncovered)", plan.EffectiveStatus())
+				}
+				if len(plan.Scenarios) != 1 {
+					t.Errorf("Scenarios = %d, want 1", len(plan.Scenarios))
+				}
+			},
+		},
+		{
+			name: "wipe-by-RequirementID: second batch on same req replaces prior",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-wipe")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{{ID: "req.scen-wipe.1", Title: "R1"}}
+				plan.Scenarios = []workflow.Scenario{
+					{ID: "scen.old1", RequirementID: "req.scen-wipe.1"},
+					{ID: "scen.old2", RequirementID: "req.scen-wipe.1"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-wipe"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-wipe",
+				RequirementID: "req.scen-wipe.1",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.new1", RequirementID: "req.scen-wipe.1"},
+				},
+			},
+			wantSuccess: true,
+			// Pins Pass-2 C2 current behavior: prior scenarios for this RequirementID
+			// are wiped. Pinning this lets us catch the change of shape when we move
+			// to per-(Req,Story) wipe-replace in a follow-up PR.
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scenarios) != 1 {
+					t.Errorf("Scenarios = %d, want 1 (old batch wiped, new batch kept)", len(plan.Scenarios))
+				}
+				if plan.Scenarios[0].ID != "scen.new1" {
+					t.Errorf("Scenarios[0].ID = %q, want scen.new1", plan.Scenarios[0].ID)
+				}
+			},
+		},
+		{
+			name: "merge keeps other requirements' scenarios",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-merge")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{
+					{ID: "req.scen-merge.1", Title: "R1"},
+					{ID: "req.scen-merge.2", Title: "R2"},
+				}
+				plan.Scenarios = []workflow.Scenario{
+					{ID: "scen.req2", RequirementID: "req.scen-merge.2"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-merge"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-merge",
+				RequirementID: "req.scen-merge.1",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.req1", RequirementID: "req.scen-merge.1"},
+				},
+			},
+			wantSuccess: true,
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scenarios) != 2 {
+					t.Errorf("Scenarios = %d, want 2 (req-2 scenario preserved + req-1 added)", len(plan.Scenarios))
+				}
+				if plan.EffectiveStatus() != workflow.StatusScenariosGenerated {
+					t.Errorf("status = %s, want scenarios_generated (both reqs now covered)", plan.EffectiveStatus())
+				}
+			},
+		},
+		{
+			name: "empty slug rejected",
+			setup: func(t *testing.T) (*Component, string) {
+				return setupTestComponent(t), ""
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "",
+				RequirementID: "req.x.1",
+				Scenarios:     []workflow.Scenario{{ID: "s1", RequirementID: "req.x.1"}},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "slug and requirement_id required",
+		},
+		{
+			name: "empty requirement_id rejected",
+			setup: func(t *testing.T) (*Component, string) {
+				return setupTestComponent(t), ""
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "anything",
+				RequirementID: "",
+				Scenarios:     []workflow.Scenario{{ID: "s1"}},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "slug and requirement_id required",
+		},
+		{
+			name: "plan not found",
+			setup: func(t *testing.T) (*Component, string) {
+				return setupTestComponent(t), "nonexistent"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "nonexistent",
+				RequirementID: "req.x.1",
+				Scenarios:     []workflow.Scenario{{ID: "s1", RequirementID: "req.x.1"}},
+			},
+			wantSuccess:     false,
+			wantErrorSubstr: "plan not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := tt.setup(t)
+
+			data := marshalJSON(t, tt.req)
+			resp := c.handleScenariosMutation(ctx, data)
+
+			if resp.Success != tt.wantSuccess {
+				t.Errorf("Success = %v, want %v (error: %s)", resp.Success, tt.wantSuccess, resp.Error)
+			}
+			if !tt.wantSuccess && tt.wantErrorSubstr != "" {
+				if !strings.Contains(resp.Error, tt.wantErrorSubstr) {
+					t.Errorf("Error = %q, want substring %q", resp.Error, tt.wantErrorSubstr)
+				}
+			}
+			if tt.wantSuccess && tt.checkPlan != nil {
+				plan, ok := c.plans.get(tt.req.Slug)
+				if !ok {
+					t.Fatal("plan not found after mutation")
+				}
+				tt.checkPlan(t, plan)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Closes go-reviewer Pass-4 finding **P4-C1**: plan-manager's 21 NATS mutation handlers were not serialized per slug. NATS dispatches each subscription's handler in its own goroutine; concurrent mutations on the same plan dropped writes because `ps.get → mutate → ps.save` ran unlocked.
- New regression test demonstrates the bug: 64 concurrent `handleScenariosMutation` calls on the same plan drop 56/64 batches on `main`. After the fix, all 64 persist and the plan transitions to `scenarios_generated`.
- Adds direct test coverage for `handleStoriesMutation` and `handleScenariosMutation` (Pass-2 H4 / Pass-4 H4 — both handlers previously had zero direct tests).

## What changed

- `processor/plan-manager/component.go` — new `slugMutexes sync.Map` field on `Component` + `lockSlug(slug) func()` helper (lazy-create on first acquire via `LoadOrStore`; never deleted).
- `processor/plan-manager/mutations.go` — `defer c.lockSlug(req.Slug)()` added to all 21 NATS mutation handlers. `handleGitHubPlanCreateMutation` (which computes slug from `IssueNumber + Title` rather than reading `req.Slug`) gets the lock immediately after slug computation.
- `processor/plan-manager/stories_scenarios_mutation_test.go` — 13 happy-path + error-path tests for the two load-bearing handlers. Pins **current** behavior including Pass-2 C2's wipe-by-RequirementID semantic — so future PRs that reshape the wire (per-(Req,Story) merge) will see clear test failures.
- `processor/plan-manager/concurrent_mutation_test.go` — the P4-C1 regression test (lost-update demonstration) and a serialize-monotonically smoke test.
- Tiny refactor: extracted `appendPRFeedbackPlanDecisions` helper to keep `handleGitHubPRFeedbackMutation` within revive's 50-statement budget.

## Scope

NATS mutation handlers only. HTTP handlers and `execution_events.go` watchers share the same race surface (~20 sites) — those are tracked as a follow-up; the highest-volume race is the NATS mutation path that smoke-6 would have triggered if its fixtures had emitted multi-Story parallelism.

## Cross-pass dependencies (Train B from the cross-pass synthesis)

This is the first PR of Train B. Coming next:

1. Per-(Req,Story) scenario merge wire shape (Pass-2 C2) — add `StoryID` to `ScenariosMutationRequest`; merge by `(RequirementID, StoryID)`
2. Scenario ID format with storyseq (Pass-2 C3) — depends on #1
3. Retry-key alignment in scenario-generator (Pass-2 C1) — independent

Pass-1's 7-PR persistence chain (Train A) is unblocked by this PR — without the per-slug mutex, every Train A fix would be racy under multi-Story dispatch.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `revive -config revive.toml ./processor/plan-manager/...` clean
- [x] New `TestHandleScenariosMutation_ConcurrentDifferentRequirementsPreservesAll` test demonstrates the bug pre-fix (56/64 batches lost) and verifies the fix post-fix (0 lost)
- [x] New direct happy-path / error-path tests for `handleStoriesMutation` (6 cases) and `handleScenariosMutation` (7 cases) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)