### PR TITLE
fix(plan-manager): per-(Req, Story) scenario merge wire shape

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -56,10 +56,23 @@ type RequirementsMutationRequest struct {
 	TraceID      string                 `json:"trace_id,omitempty"`
 }
 
-// ScenariosMutationRequest is sent by the scenario-generator for a single requirement.
+// ScenariosMutationRequest is sent by the scenario-generator for a single
+// (Requirement, Story) batch.
+//
+// StoryID identifies the Story this batch belongs to and scopes the merge
+// semantics in handleScenariosMutation: when set, only scenarios for the
+// matching (RequirementID, StoryID) pair are wiped before appending — so
+// parallel per-Story dispatches under the same Requirement preserve each
+// other's batches.
+//
+// StoryID is omitempty for back-compat: pre-Sarah plans and mock fixtures
+// dispatch in legacy per-Requirement mode where Bob authors one batch for
+// the entire Requirement. The handler falls back to wipe-by-RequirementID
+// in that case, matching pre-ADR-043 behavior.
 type ScenariosMutationRequest struct {
 	Slug          string              `json:"slug"`
 	RequirementID string              `json:"requirement_id"`
+	StoryID       string              `json:"story_id,omitempty"`
 	Scenarios     []workflow.Scenario `json:"scenarios"`
 	TraceID       string              `json:"trace_id,omitempty"`
 }
@@ -431,6 +444,22 @@ func ensureScopeCreateCoversStories(scope workflow.Scope, stories []workflow.Sto
 	return scope
 }
 
+// scenarioMatchesMutationScope reports whether an existing scenario should be
+// wiped by the incoming mutation. Per-Story dispatch (StoryID non-empty) wipes
+// only scenarios matching BOTH (RequirementID, StoryID) so sibling Stories'
+// scenarios survive. Legacy per-Requirement dispatch (StoryID empty) wipes
+// every scenario under the RequirementID for back-compat with pre-Sarah
+// plans and mock fixtures.
+func scenarioMatchesMutationScope(existing workflow.Scenario, req ScenariosMutationRequest) bool {
+	if existing.RequirementID != req.RequirementID {
+		return false
+	}
+	if req.StoryID == "" {
+		return true
+	}
+	return existing.StoryID == req.StoryID
+}
+
 // handleScenariosMutation saves scenarios for a requirement inline on the plan and checks convergence.
 func (c *Component) handleScenariosMutation(ctx context.Context, data []byte) MutationResponse {
 	var req ScenariosMutationRequest
@@ -453,13 +482,28 @@ func (c *Component) handleScenariosMutation(ctx context.Context, data []byte) Mu
 		return MutationResponse{Success: false, Error: "plan not found"}
 	}
 
-	// Merge: replace scenarios for this requirement, keep others.
+	// Merge semantic depends on whether the dispatch identified a Story.
+	//
+	//  - StoryID set (per-Story dispatch, ADR-043 PR 4j): wipe only scenarios
+	//    matching BOTH (RequirementID, StoryID), keep everything else. Two
+	//    parallel Story dispatches under the same Requirement preserve each
+	//    other's batches.
+	//  - StoryID empty (legacy per-Requirement dispatch, pre-Sarah / mock):
+	//    wipe ALL scenarios for the RequirementID, matching pre-ADR-043
+	//    behavior. Sarah's per-Story chain is opt-in via the wire shape; the
+	//    fallback keeps mock fixtures and pre-Sarah plans working unchanged.
+	//
+	// Closes go-reviewer Pass-2 finding C2: pre-fix, parallel per-Story
+	// dispatches under the same Requirement silently dropped each other's
+	// batches because the merge keyed only on RequirementID. Smoke-6 didn't
+	// surface it because every fixture had exactly 1 Story per Requirement.
 	if len(req.Scenarios) > 0 {
 		var kept []workflow.Scenario
 		for _, s := range plan.Scenarios {
-			if s.RequirementID != req.RequirementID {
-				kept = append(kept, s)
+			if scenarioMatchesMutationScope(s, req) {
+				continue
 			}
+			kept = append(kept, s)
 		}
 		plan.Scenarios = append(kept, req.Scenarios...)
 	}
@@ -467,6 +511,7 @@ func (c *Component) handleScenariosMutation(ctx context.Context, data []byte) Mu
 	c.logger.Info("Scenarios saved via mutation",
 		"slug", req.Slug,
 		"requirement_id", req.RequirementID,
+		"story_id", req.StoryID,
 		"count", len(req.Scenarios))
 
 	// Check convergence: do all requirements have at least one scenario?

--- a/processor/plan-manager/stories_scenarios_mutation_test.go
+++ b/processor/plan-manager/stories_scenarios_mutation_test.go
@@ -268,7 +268,7 @@ func TestHandleScenariosMutation(t *testing.T) {
 			},
 		},
 		{
-			name: "wipe-by-RequirementID: second batch on same req replaces prior",
+			name: "legacy fallback (StoryID empty): second batch on same req replaces prior",
 			setup: func(t *testing.T) (*Component, string) {
 				c := setupTestComponent(t)
 				plan := setupTestPlan(t, c, "scen-wipe")
@@ -284,20 +284,140 @@ func TestHandleScenariosMutation(t *testing.T) {
 			req: ScenariosMutationRequest{
 				Slug:          "scen-wipe",
 				RequirementID: "req.scen-wipe.1",
+				// StoryID left empty → legacy per-Requirement dispatch fallback.
 				Scenarios: []workflow.Scenario{
 					{ID: "scen.new1", RequirementID: "req.scen-wipe.1"},
 				},
 			},
 			wantSuccess: true,
-			// Pins Pass-2 C2 current behavior: prior scenarios for this RequirementID
-			// are wiped. Pinning this lets us catch the change of shape when we move
-			// to per-(Req,Story) wipe-replace in a follow-up PR.
+			// Pre-Sarah plans and mock fixtures dispatch without StoryID; the
+			// handler wipes ALL prior scenarios under the RequirementID to
+			// match pre-ADR-043 behavior. Pinned so subsequent producer
+			// migrations that drop the legacy mode flag this as a regression.
 			checkPlan: func(t *testing.T, plan *workflow.Plan) {
 				if len(plan.Scenarios) != 1 {
 					t.Errorf("Scenarios = %d, want 1 (old batch wiped, new batch kept)", len(plan.Scenarios))
 				}
 				if plan.Scenarios[0].ID != "scen.new1" {
 					t.Errorf("Scenarios[0].ID = %q, want scen.new1", plan.Scenarios[0].ID)
+				}
+			},
+		},
+		{
+			name: "per-Story merge: two Stories under same Req each persist their scenarios",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-per-story")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{{ID: "req.scen-per-story.1", Title: "R1"}}
+				// Story A already landed its scenarios.
+				plan.Scenarios = []workflow.Scenario{
+					{ID: "scen.A.1", RequirementID: "req.scen-per-story.1", StoryID: "story.A"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-per-story"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-per-story",
+				RequirementID: "req.scen-per-story.1",
+				StoryID:       "story.B",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.B.1", RequirementID: "req.scen-per-story.1", StoryID: "story.B"},
+				},
+			},
+			wantSuccess: true,
+			// Closes Pass-2 C2: Story B's mutation must not wipe Story A's
+			// scenarios on the same Requirement.
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scenarios) != 2 {
+					t.Fatalf("Scenarios = %d, want 2 (Story A preserved + Story B added)", len(plan.Scenarios))
+				}
+				ids := map[string]bool{}
+				for _, s := range plan.Scenarios {
+					ids[s.ID] = true
+				}
+				if !ids["scen.A.1"] || !ids["scen.B.1"] {
+					t.Errorf("Scenarios IDs = %v, want both scen.A.1 and scen.B.1", ids)
+				}
+			},
+		},
+		{
+			name: "per-Story re-dispatch (same StoryID) wipes only that Story's prior scenarios",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-redispatch")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{{ID: "req.scen-redispatch.1", Title: "R1"}}
+				// Both Stories already landed; Story B is going to re-dispatch.
+				plan.Scenarios = []workflow.Scenario{
+					{ID: "scen.A.1", RequirementID: "req.scen-redispatch.1", StoryID: "story.A"},
+					{ID: "scen.B.old1", RequirementID: "req.scen-redispatch.1", StoryID: "story.B"},
+					{ID: "scen.B.old2", RequirementID: "req.scen-redispatch.1", StoryID: "story.B"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-redispatch"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-redispatch",
+				RequirementID: "req.scen-redispatch.1",
+				StoryID:       "story.B",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.B.new", RequirementID: "req.scen-redispatch.1", StoryID: "story.B"},
+				},
+			},
+			wantSuccess: true,
+			// Pinned: Story B's old scenarios are wiped (same StoryID),
+			// Story A's scenario survives (different StoryID).
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scenarios) != 2 {
+					t.Fatalf("Scenarios = %d, want 2 (Story A preserved + Story B's new batch)", len(plan.Scenarios))
+				}
+				ids := map[string]bool{}
+				for _, s := range plan.Scenarios {
+					ids[s.ID] = true
+				}
+				if !ids["scen.A.1"] {
+					t.Errorf("Story A's scen.A.1 should survive sibling-Story re-dispatch")
+				}
+				if !ids["scen.B.new"] {
+					t.Errorf("Story B's new batch (scen.B.new) should be present")
+				}
+				if ids["scen.B.old1"] || ids["scen.B.old2"] {
+					t.Errorf("Story B's old scenarios should be wiped on same-StoryID re-dispatch")
+				}
+			},
+		},
+		{
+			name: "per-Story dispatch with StoryID set does NOT wipe legacy (StoryID empty) scenarios on same Req",
+			setup: func(t *testing.T) (*Component, string) {
+				c := setupTestComponent(t)
+				plan := setupTestPlan(t, c, "scen-mixed")
+				plan.Status = workflow.StatusGeneratingScenarios
+				plan.Requirements = []workflow.Requirement{{ID: "req.scen-mixed.1", Title: "R1"}}
+				// A legacy scenario (no StoryID) is already attached to this Req.
+				plan.Scenarios = []workflow.Scenario{
+					{ID: "scen.legacy", RequirementID: "req.scen-mixed.1"},
+				}
+				_ = c.plans.save(ctx, plan)
+				return c, "scen-mixed"
+			},
+			req: ScenariosMutationRequest{
+				Slug:          "scen-mixed",
+				RequirementID: "req.scen-mixed.1",
+				StoryID:       "story.X",
+				Scenarios: []workflow.Scenario{
+					{ID: "scen.X.1", RequirementID: "req.scen-mixed.1", StoryID: "story.X"},
+				},
+			},
+			wantSuccess: true,
+			// Per-Story mutation must not wipe sibling scenarios with empty
+			// StoryID — they belong to "no Story / legacy" and would only be
+			// touched by another empty-StoryID dispatch. Documents the
+			// mixed-state shape; production plans should converge to one mode
+			// per Req but the merge must be safe during the transition.
+			checkPlan: func(t *testing.T, plan *workflow.Plan) {
+				if len(plan.Scenarios) != 2 {
+					t.Errorf("Scenarios = %d, want 2 (legacy preserved + new Story.X added)", len(plan.Scenarios))
 				}
 			},
 		},

--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -602,10 +602,13 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 	}
 
 	// Build a synthetic trigger for publishResults — it only needs Slug,
-	// RequirementID, and TraceID (which we leave empty for agentic-dispatch path).
+	// RequirementID, StoryID, and TraceID (TraceID is left empty for the
+	// agentic-dispatch path). StoryID identifies the (Req, Story) merge
+	// scope plan-manager uses to avoid wiping sibling Stories' scenarios.
 	trigger := &payloads.ScenarioGeneratorRequest{
 		Slug:          slug,
 		RequirementID: requirementID,
+		StoryID:       storyID,
 	}
 
 	if err := c.publishResults(ctx, trigger, scenarios); err != nil {
@@ -915,6 +918,36 @@ func extractJSONObject(s string) string {
 // Event publication
 // ---------------------------------------------------------------------------
 
+// scenariosMutationPayload mirrors plan-manager's ScenariosMutationRequest
+// wire shape. Defined here so scenario-generator does not import plan-
+// manager (avoids a producer→consumer package cycle).
+//
+// StoryID is omitempty: empty for legacy per-Requirement dispatch (pre-Sarah
+// plans, mock fixtures), populated for per-Story dispatch (ADR-043 PR 4j).
+// The consumer (handleScenariosMutation) uses StoryID to scope its merge
+// wipe so parallel Stories under one Requirement preserve each other's
+// scenarios. Closes go-reviewer Pass-2 C2.
+type scenariosMutationPayload struct {
+	Slug          string              `json:"slug"`
+	RequirementID string              `json:"requirement_id"`
+	StoryID       string              `json:"story_id,omitempty"`
+	Scenarios     []workflow.Scenario `json:"scenarios"`
+	TraceID       string              `json:"trace_id,omitempty"`
+}
+
+// buildScenariosMutationPayload marshals the wire payload plan-manager's
+// scenarios mutation handler consumes. Extracted from publishResults so
+// the wire-shape contract is unit-testable without a NATS server.
+func buildScenariosMutationPayload(trigger *payloads.ScenarioGeneratorRequest, scenarios []workflow.Scenario) ([]byte, error) {
+	return json.Marshal(scenariosMutationPayload{
+		Slug:          trigger.Slug,
+		RequirementID: trigger.RequirementID,
+		StoryID:       trigger.StoryID,
+		Scenarios:     scenarios,
+		TraceID:       trigger.TraceID,
+	})
+}
+
 // publishResults publishes a ScenariosForRequirementGeneratedEvent carrying
 // the full scenario data. Plan-manager (the single writer) handles persistence,
 // convergence checking, and status transitions.
@@ -923,20 +956,9 @@ func (c *Component) publishResults(ctx context.Context, trigger *payloads.Scenar
 		return fmt.Errorf("context cancelled: %w", err)
 	}
 
-	// Send results to plan-manager via request/reply (KV twofer — manager writes, watchers react).
-	mutationReq := struct {
-		Slug          string              `json:"slug"`
-		RequirementID string              `json:"requirement_id"`
-		Scenarios     []workflow.Scenario `json:"scenarios"`
-		TraceID       string              `json:"trace_id,omitempty"`
-	}{
-		Slug:          trigger.Slug,
-		RequirementID: trigger.RequirementID,
-		Scenarios:     scenarios,
-		TraceID:       trigger.TraceID,
-	}
-
-	data, err := json.Marshal(mutationReq)
+	// Send results to plan-manager via request/reply (KV twofer — manager writes,
+	// watchers react).
+	data, err := buildScenariosMutationPayload(trigger, scenarios)
 	if err != nil {
 		return fmt.Errorf("marshal scenarios mutation: %w", err)
 	}
@@ -967,6 +989,7 @@ func (c *Component) publishResults(ctx context.Context, trigger *payloads.Scenar
 	c.logger.Info("Scenarios sent to plan-manager via mutation",
 		"slug", trigger.Slug,
 		"requirement_id", trigger.RequirementID,
+		"story_id", trigger.StoryID,
 		"scenario_count", len(scenarios))
 
 	return nil

--- a/processor/scenario-generator/wire_payload_test.go
+++ b/processor/scenario-generator/wire_payload_test.go
@@ -1,0 +1,86 @@
+package scenariogenerator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestBuildScenariosMutationPayload_PerStoryCarriesStoryID pins that when
+// the trigger carries a StoryID (ADR-043 PR 4j per-Story dispatch), the
+// JSON-encoded mutation payload sent to plan-manager includes the
+// story_id field. Plan-manager's handleScenariosMutation uses this field
+// to scope its merge wipe so concurrent Stories' scenarios do not clobber
+// each other. Closes go-reviewer Pass-2 C2 (producer side).
+func TestBuildScenariosMutationPayload_PerStoryCarriesStoryID(t *testing.T) {
+	trigger := &payloads.ScenarioGeneratorRequest{
+		Slug:          "demo",
+		RequirementID: "req.demo.1",
+		StoryID:       "story.demo.1.1",
+		TraceID:       "trace-xyz",
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+	}
+
+	data, err := buildScenariosMutationPayload(trigger, scenarios)
+	if err != nil {
+		t.Fatalf("buildScenariosMutationPayload: %v", err)
+	}
+
+	var got scenariosMutationPayload
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Slug != "demo" {
+		t.Errorf("Slug = %q, want demo", got.Slug)
+	}
+	if got.RequirementID != "req.demo.1" {
+		t.Errorf("RequirementID = %q, want req.demo.1", got.RequirementID)
+	}
+	if got.StoryID != "story.demo.1.1" {
+		t.Errorf("StoryID = %q, want story.demo.1.1", got.StoryID)
+	}
+	if len(got.Scenarios) != 1 {
+		t.Errorf("Scenarios = %d, want 1", len(got.Scenarios))
+	}
+	if got.TraceID != "trace-xyz" {
+		t.Errorf("TraceID = %q, want trace-xyz", got.TraceID)
+	}
+}
+
+// TestBuildScenariosMutationPayload_LegacyOmitsStoryID pins back-compat:
+// when the trigger has no StoryID (pre-Sarah plans, mock fixtures), the
+// wire JSON OMITS the story_id field entirely — plan-manager's handler
+// then falls through to wipe-by-RequirementID, preserving pre-ADR-043
+// behavior for those callers.
+func TestBuildScenariosMutationPayload_LegacyOmitsStoryID(t *testing.T) {
+	trigger := &payloads.ScenarioGeneratorRequest{
+		Slug:          "legacy",
+		RequirementID: "req.legacy.1",
+		// StoryID intentionally empty — legacy per-Requirement dispatch.
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.legacy.1", RequirementID: "req.legacy.1"},
+	}
+
+	data, err := buildScenariosMutationPayload(trigger, scenarios)
+	if err != nil {
+		t.Fatalf("buildScenariosMutationPayload: %v", err)
+	}
+
+	// Verify the field is omitted from the wire bytes (not just zero-valued).
+	// The omitempty contract is load-bearing: plan-manager treats absent and
+	// empty identically, but operator/log readability prefers omission so
+	// legacy dispatches don't carry an empty `story_id:""` noise field.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, present := raw["story_id"]; present {
+		t.Errorf("story_id should be omitted from wire JSON when empty; got bytes: %s", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

- Closes go-reviewer Pass-2 finding **C2**: `handleScenariosMutation` wiped all scenarios for a `RequirementID` on every mutation, so two parallel per-Story dispatches under the same Requirement silently dropped each other's batches. Smoke 6 had exactly 1 Story per Requirement everywhere, so convergence still passed and the bug stayed invisible.
- Wire change is **additive**: `StoryID` added as `omitempty` on the mutation request. Per-Story dispatch wipes only `(RequirementID, StoryID)`; empty StoryID falls through to the legacy wipe-by-RequirementID path for pre-Sarah plans and mock fixtures.

## What changed

**plan-manager/mutations.go**
- `ScenariosMutationRequest` gains `StoryID string \`json:"story_id,omitempty\"\``.
- `handleScenariosMutation` merge logic now consults a new `scenarioMatchesMutationScope` helper: same-Req + (matching StoryID OR mutation-StoryID-empty) ⇒ wipe; otherwise keep.

**scenario-generator/component.go**
- Synthetic trigger built in `handleLoopCompletion` now carries `storyID` through to `publishResults`. Per-Story dispatch was already setting `Scenario.StoryID` on the inline batch (PR 4j); this PR closes the wire-shape gap so plan-manager actually uses it.
- Wire-payload construction extracted into `buildScenariosMutationPayload` + `scenariosMutationPayload` type — keeps the producer testable without a NATS server.

## Tests added

- **plan-manager** `stories_scenarios_mutation_test.go` (4 new + 1 renamed case):
  - `per-Story merge: two Stories under same Req each persist their scenarios` (the headline P2-C2 case)
  - `per-Story re-dispatch (same StoryID) wipes only that Story's prior scenarios`
  - `per-Story dispatch with StoryID set does NOT wipe legacy (StoryID empty) scenarios on same Req`
  - `legacy fallback (StoryID empty): second batch on same req replaces prior` — renamed from the older misleading name
- **scenario-generator** `wire_payload_test.go` (2 new cases): pins StoryID present when non-empty, omitted when empty.

## Train B progress

- ✅ Step 1: per-slug mutex (PR #72, merged)
- ✅ Step 2: this PR — per-(Req, Story) merge
- Step 3 (next): scenario ID with storyseq (Pass-2 C3) — currently `scenario.<slug>.<reqseq>.<i+1>` collides across Stories under the same Req. Train B step 2 (this PR) makes the collision survivable in the wire shape; step 3 makes the IDs unique.
- Step 4 (independent): retry-key alignment in scenario-generator (Pass-2 C1).

After Train B completes, Train A (Pass-1's 7-PR per-Story persistence chain) becomes safe to land — without the single-writer lock + per-(Req, Story) merge in place, Train A fixes would still race under multi-Story dispatch.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `revive -config revive.toml ./processor/plan-manager/... ./processor/scenario-generator/...` clean
- [x] New per-Story merge tests pass; renamed legacy-fallback test still passes
- [x] New producer wire-payload tests verify omitempty contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)