### PR TITLE
fix(scenario-generator): include storyseq segment in per-Story scenario IDs

### DIFF
--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -553,7 +553,7 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		return
 	}
 
-	scenarios, err := c.parseScenariosFromResult(loop.Result, slug, requirementID)
+	scenarios, err := c.parseScenariosFromResult(loop.Result, slug, requirementID, storyID)
 	if err != nil {
 		c.generationsFailed.Add(1)
 		parseErrorMsg := fmt.Sprintf("failed to parse scenarios: %s", err.Error())
@@ -744,8 +744,24 @@ func (c *Component) sendGenerationFailed(ctx context.Context, slug, feedback str
 }
 
 // parseScenariosFromResult extracts and validates scenario JSON from an agent
-// loop result string, then assigns IDs based on the slug and requirement ID.
-func (c *Component) parseScenariosFromResult(result, slug, requirementID string) ([]workflow.Scenario, error) {
+// loop result string, then assigns IDs based on the slug, requirement ID, and
+// (when non-empty) story ID.
+//
+// Scenario ID format:
+//   - Per-Story dispatch (storyID non-empty): scenario.<slug>.<reqseq>.<storyseq>.<i+1>
+//     Mirrors Sarah's task ID convention (task.<slug>.<reqseq>.<storyseq>.<taskseq>).
+//   - Legacy per-Requirement dispatch (storyID empty): scenario.<slug>.<reqseq>.<i+1>
+//     Pre-ADR-043 shape, kept for mock fixtures and pre-Sarah plans.
+//
+// Pre-this-change, IDs collided across Stories under the same Requirement
+// because the storyseq segment was missing — Story A and Story B both
+// produced scenario.<slug>.<reqseq>.1, scenario.<slug>.<reqseq>.2, etc. The
+// collision was masked by Pass-2 C2 (the consumer wiped one batch on every
+// mutation), so the system "worked" by accidentally dropping duplicates. PR
+// #73 closed C2, which surfaces this collision — and this PR closes it.
+//
+// Closes go-reviewer Pass-2 finding C3.
+func (c *Component) parseScenariosFromResult(result, slug, requirementID, storyID string) ([]workflow.Scenario, error) {
 	if result == "" {
 		return nil, fmt.Errorf("empty result")
 	}
@@ -783,6 +799,7 @@ func (c *Component) parseScenariosFromResult(result, slug, requirementID string)
 	}
 
 	reqSeq := requirementSequence(requirementID)
+	storySeq := storySequence(storyID)
 
 	now := time.Now()
 	scenarios := make([]workflow.Scenario, len(raw))
@@ -797,7 +814,7 @@ func (c *Component) parseScenariosFromResult(result, slug, requirementID string)
 			return nil, fmt.Errorf("scenario %d missing 'then' field (must be non-empty array)", i+1)
 		}
 
-		scenarioID := fmt.Sprintf("scenario.%s.%s.%d", slug, reqSeq, i+1)
+		scenarioID := scenarioIDFor(slug, reqSeq, storySeq, i+1)
 		scenarios[i] = workflow.Scenario{
 			ID:                scenarioID,
 			RequirementID:     requirementID,
@@ -858,6 +875,33 @@ func requirementSequence(requirementID string) string {
 		return parts[len(parts)-1]
 	}
 	return requirementID
+}
+
+// storySequence extracts the storyseq suffix from a Story ID like
+// "story.<slug>.<reqseq>.<storyseq>". Returns "" for an empty input so the
+// scenario ID falls back to the legacy 3-segment shape — this is the
+// signal scenarioIDFor uses to switch between per-Story and legacy formats.
+func storySequence(storyID string) string {
+	if storyID == "" {
+		return ""
+	}
+	parts := strings.Split(storyID, ".")
+	if len(parts) > 0 {
+		return parts[len(parts)-1]
+	}
+	return storyID
+}
+
+// scenarioIDFor builds the canonical scenario ID. When storySeq is empty
+// the legacy shape scenario.<slug>.<reqseq>.<i> is emitted (pre-ADR-043 /
+// mock-fixture compatibility); otherwise the per-Story shape
+// scenario.<slug>.<reqseq>.<storyseq>.<i> is used so two Stories under one
+// Requirement produce distinct IDs.
+func scenarioIDFor(slug, reqSeq, storySeq string, index int) string {
+	if storySeq == "" {
+		return fmt.Sprintf("scenario.%s.%s.%d", slug, reqSeq, index)
+	}
+	return fmt.Sprintf("scenario.%s.%s.%s.%d", slug, reqSeq, storySeq, index)
 }
 
 // extractJSONArray returns the first JSON array found in s, or "".

--- a/processor/scenario-generator/scenario_id_test.go
+++ b/processor/scenario-generator/scenario_id_test.go
@@ -1,0 +1,141 @@
+package scenariogenerator
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestScenarioIDFor_LegacyShape pins the pre-ADR-043 scenario ID format
+// for back-compat with mock fixtures and pre-Sarah plans: when no story
+// sequence is supplied (empty string), the ID is the historical
+// `scenario.<slug>.<reqseq>.<i>` shape.
+func TestScenarioIDFor_LegacyShape(t *testing.T) {
+	got := scenarioIDFor("demo", "1", "", 2)
+	want := "scenario.demo.1.2"
+	if got != want {
+		t.Errorf("scenarioIDFor(\"demo\", \"1\", \"\", 2) = %q, want %q", got, want)
+	}
+}
+
+// TestScenarioIDFor_PerStoryShape pins the ADR-043 PR 4j scenario ID
+// format: when storyseq is non-empty, it's spliced between reqseq and the
+// per-batch index. This mirrors Sarah's task ID convention
+// (task.<slug>.<reqseq>.<storyseq>.<taskseq>).
+func TestScenarioIDFor_PerStoryShape(t *testing.T) {
+	got := scenarioIDFor("demo", "1", "2", 3)
+	want := "scenario.demo.1.2.3"
+	if got != want {
+		t.Errorf("scenarioIDFor(\"demo\", \"1\", \"2\", 3) = %q, want %q", got, want)
+	}
+}
+
+// TestStorySequence_ExtractsTrailingSeq pins the storyseq derivation. Story
+// IDs are `story.<slug>.<reqseq>.<storyseq>`; we want just the storyseq
+// segment so it composes with reqseq into the scenario ID.
+func TestStorySequence_ExtractsTrailingSeq(t *testing.T) {
+	cases := map[string]string{
+		"story.demo.1.1":   "1",
+		"story.demo.1.42":  "42",
+		"story.x.2.3":      "3",
+		"":                 "",
+		"story-without-dots": "story-without-dots",
+	}
+	for in, want := range cases {
+		got := storySequence(in)
+		if got != want {
+			t.Errorf("storySequence(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestParseScenariosFromResult_PerStoryProducesDistinctIDsAcrossStories is
+// the headline regression test for go-reviewer Pass-2 finding C3.
+//
+// Pre-fix, two Stories under the same Requirement produced colliding
+// scenario IDs (`scenario.demo.1.1`, `scenario.demo.1.2` from BOTH
+// dispatches). The collision was masked by Pass-2 C2 — the consumer wiped
+// one batch on every mutation, so duplicates never landed in plan.Scenarios
+// simultaneously. PR #73 fixed C2; running both dispatches now lands both
+// batches, and identical IDs would break every downstream lookup. This PR
+// closes C3 by including the storyseq segment in per-Story dispatch IDs.
+func TestParseScenariosFromResult_PerStoryProducesDistinctIDsAcrossStories(t *testing.T) {
+	c := &Component{logger: slog.Default()}
+
+	// The agent result is a minimal scenarios JSON wrapper with a single
+	// Given/When/Then so parsing succeeds without triggering tag validation.
+	result := `{"scenarios":[
+		{"title":"happy","given":"a precondition","when":"an action","then":["an assertion"],"tags":["@unit"]}
+	]}`
+
+	storyA, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	if err != nil {
+		t.Fatalf("parse storyA: %v", err)
+	}
+	storyB, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.2")
+	if err != nil {
+		t.Fatalf("parse storyB: %v", err)
+	}
+
+	if len(storyA) != 1 || len(storyB) != 1 {
+		t.Fatalf("expected one scenario per Story, got A=%d B=%d", len(storyA), len(storyB))
+	}
+	if storyA[0].ID == storyB[0].ID {
+		t.Errorf("Story A and Story B produced the SAME scenario ID (%q) under one Requirement — collision survives across the per-Story merge, which is the Pass-2 C3 bug", storyA[0].ID)
+	}
+	if !strings.HasPrefix(storyA[0].ID, "scenario.demo.1.1.") {
+		t.Errorf("Story A's scenario ID = %q, want prefix scenario.demo.1.1.", storyA[0].ID)
+	}
+	if !strings.HasPrefix(storyB[0].ID, "scenario.demo.1.2.") {
+		t.Errorf("Story B's scenario ID = %q, want prefix scenario.demo.1.2.", storyB[0].ID)
+	}
+}
+
+// TestParseScenariosFromResult_LegacyDispatchPreservesPreADR043IDs pins
+// the back-compat path: when storyID is empty (mock fixtures, pre-Sarah
+// plans), scenario IDs keep the historical `scenario.<slug>.<reqseq>.<i>`
+// format. Migrating downstream tooling to expect the 5-segment shape would
+// break legacy callers — this test catches that drift.
+func TestParseScenariosFromResult_LegacyDispatchPreservesPreADR043IDs(t *testing.T) {
+	c := &Component{logger: slog.Default()}
+	result := `{"scenarios":[
+		{"title":"happy","given":"a precondition","when":"an action","then":["an assertion"],"tags":["@unit"]}
+	]}`
+
+	scenarios, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(scenarios) != 1 {
+		t.Fatalf("expected 1 scenario, got %d", len(scenarios))
+	}
+	if scenarios[0].ID != "scenario.demo.1.1" {
+		t.Errorf("legacy ID = %q, want scenario.demo.1.1", scenarios[0].ID)
+	}
+}
+
+// TestParseScenariosFromResult_DeterministicAcrossReRuns pins that two
+// parses of the same input produce identical IDs — load-bearing for
+// idempotent retries (scenario-generator's retry loop) so the second
+// dispatch lands the same IDs in plan.Scenarios as the first would have.
+func TestParseScenariosFromResult_DeterministicAcrossReRuns(t *testing.T) {
+	c := &Component{logger: slog.Default()}
+	result := `{"scenarios":[
+		{"title":"a","given":"g","when":"w","then":["t"],"tags":["@unit"]},
+		{"title":"b","given":"g","when":"w","then":["t"],"tags":["@unit"]}
+	]}`
+
+	first, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	if err != nil {
+		t.Fatalf("first parse: %v", err)
+	}
+	second, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	if err != nil {
+		t.Fatalf("second parse: %v", err)
+	}
+	for i := range first {
+		if first[i].ID != second[i].ID {
+			t.Errorf("non-deterministic ID at index %d: first=%q second=%q", i, first[i].ID, second[i].ID)
+		}
+	}
+}

--- a/processor/scenario-generator/scenario_id_test.go
+++ b/processor/scenario-generator/scenario_id_test.go
@@ -35,10 +35,10 @@ func TestScenarioIDFor_PerStoryShape(t *testing.T) {
 // segment so it composes with reqseq into the scenario ID.
 func TestStorySequence_ExtractsTrailingSeq(t *testing.T) {
 	cases := map[string]string{
-		"story.demo.1.1":   "1",
-		"story.demo.1.42":  "42",
-		"story.x.2.3":      "3",
-		"":                 "",
+		"story.demo.1.1":     "1",
+		"story.demo.1.42":    "42",
+		"story.x.2.3":        "3",
+		"":                   "",
 		"story-without-dots": "story-without-dots",
 	}
 	for in, want := range cases {


### PR DESCRIPTION
## Summary

- Closes go-reviewer Pass-2 finding **C3**: scenario IDs collided across Stories under the same Requirement because the ID format was `scenario.<slug>.<reqseq>.<i>` with no Story awareness. The collision was masked by Pass-2 C2 (consumer wiped duplicates on every mutation). PR #73 closed C2; now both Stories' batches land, and identical IDs would break every downstream lookup. This PR makes them distinct.

## Format change

- **Per-Story dispatch** (`storyID` non-empty): `scenario.<slug>.<reqseq>.<storyseq>.<i>` — mirrors Sarah's task ID convention `task.<slug>.<reqseq>.<storyseq>.<taskseq>`.
- **Legacy per-Requirement dispatch** (`storyID` empty): `scenario.<slug>.<reqseq>.<i>` — pre-ADR-043 shape, kept for mock fixtures and pre-Sarah plans.

`storySequence(storyID)` is a new helper that extracts the trailing storyseq from a Story.ID (`story.<slug>.<reqseq>.<storyseq>`), mirroring the existing `requirementSequence` helper.

## Tests added

`parseScenariosFromResult` previously had **zero direct test coverage**. New tests in `scenario_id_test.go`:

- `TestParseScenariosFromResult_PerStoryProducesDistinctIDsAcrossStories` — the **headline P2-C3 regression**. Without this fix, two Stories under one Requirement emit identical scenario IDs.
- `TestParseScenariosFromResult_LegacyDispatchPreservesPreADR043IDs` — back-compat pin for mock fixtures + pre-Sarah plans.
- `TestParseScenariosFromResult_DeterministicAcrossReRuns` — idempotent retries land identical IDs.
- `TestScenarioIDFor_LegacyShape` + `TestScenarioIDFor_PerStoryShape` — pin the two ID format branches in isolation.
- `TestStorySequence_ExtractsTrailingSeq` — pin the storyseq extraction logic.

## Train B status

- ✅ Step 1: per-slug mutex (PR #72)
- ✅ Step 2: per-(Req, Story) merge (PR #73)
- ✅ Step 3: this PR — distinct scenario IDs per Story
- Step 4 (next, independent): retry-key alignment in scenario-generator (Pass-2 C4) — handler reads `slug/requirementID` while dispatcher writes `slug/storyID`, silently disabling retries in per-Story mode.

After this lands, the C1/C2/C3 cluster is closed. **Train A** (Pass-1's 7-PR per-Story persistence chain) becomes safe to start once C4 is in.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `revive -config revive.toml ./processor/scenario-generator/...` clean
- [x] 6 new tests added (4 for the new behavior, 2 for back-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)