### PR TITLE
fix(scenario-generator): align retry key across producer + consumer

### DIFF
--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -53,7 +53,9 @@ const (
 // scenarioRetryPayload is the per-key context retryOrFail needs to re-dispatch
 // scenario generation: the original request and reviewFindings (preserved
 // across error retries per ADR-029 H1). Stored as the Payload field of a
-// dispatchretry.Entry under the composite "slug/requirementID" key.
+// dispatchretry.Entry under the composite key built by retryKey — that is
+// "slug/storyID" for per-Story dispatch (ADR-043 PR 4j) and "slug/requirementID"
+// for legacy per-Requirement dispatch.
 type scenarioRetryPayload struct {
 	req            *payloads.ScenarioGeneratorRequest
 	reviewFindings string
@@ -294,12 +296,12 @@ func (c *Component) dispatchScenarioGenerator(ctx context.Context, req *payloads
 	// ADR-043 PR 4j — per-Story dispatch keys the retry/task state on
 	// StoryID; legacy per-Requirement dispatch falls back to RequirementID
 	// when no Story is in scope (pre-Sarah plans / mock fixtures).
-	retryKeyTail := req.RequirementID
+	taskIDSegment := req.RequirementID
 	if req.StoryID != "" {
-		retryKeyTail = req.StoryID
+		taskIDSegment = req.StoryID
 	}
-	taskID := fmt.Sprintf("scengen-%s-%s-%s", req.Slug, retryKeyTail, uuid.New().String())
-	c.retry.SetActiveLoop(req.Slug+"/"+retryKeyTail, taskID)
+	taskID := fmt.Sprintf("scengen-%s-%s-%s", req.Slug, taskIDSegment, uuid.New().String())
+	c.retry.SetActiveLoop(retryKey(req.Slug, req.RequirementID, req.StoryID), taskID)
 
 	scenCtx := &prompt.ScenarioGeneratorPromptContext{
 		PlanGoal:               req.PlanGoal,
@@ -527,12 +529,12 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 // PR 4b "first story owns the scenarios" lookup.
 func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.LoopEntity, slug, requirementID, storyID string) {
 	c.updateLastActivity()
-	key := slug + "/" + requirementID
+	key := retryKey(slug, requirementID, storyID)
 
 	// Stale loop guard: drop completions from older dispatches that race a retry.
 	if c.retry.IsStaleLoop(key, loop.TaskID) {
 		c.logger.Debug("Dropping stale scenario loop completion (task ID mismatch)",
-			"slug", slug, "requirement_id", requirementID,
+			"slug", slug, "requirement_id", requirementID, "story_id", storyID,
 			"loop_task_id", loop.TaskID, "loop_id", loop.ID)
 		return
 	}
@@ -546,10 +548,11 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		c.logger.Error("Scenario generator agent loop failed",
 			"slug", slug,
 			"requirement_id", requirementID,
+			"story_id", storyID,
 			"loop_id", loop.ID,
 			"outcome", loop.Outcome,
 			"error", loopErrorMsg)
-		c.retryOrFail(ctx, slug, requirementID, loopErrorMsg)
+		c.retryOrFail(ctx, slug, requirementID, storyID, loopErrorMsg)
 		return
 	}
 
@@ -560,9 +563,10 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		c.logger.Error("Failed to parse scenarios from agent result",
 			"slug", slug,
 			"requirement_id", requirementID,
+			"story_id", storyID,
 			"loop_id", loop.ID,
 			"error", err)
-		c.retryOrFail(ctx, slug, requirementID, parseErrorMsg)
+		c.retryOrFail(ctx, slug, requirementID, storyID, parseErrorMsg)
 		return
 	}
 
@@ -652,12 +656,12 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 // recovery path — the dispatch payload (request + reviewFindings) cannot be
 // reconstructed from the plan alone (we'd lose architecture context, etc.).
 // If the entry is missing on retry, fail-closed.
-func (c *Component) retryOrFail(ctx context.Context, slug, requirementID, errorMsg string) {
-	key := slug + "/" + requirementID
+func (c *Component) retryOrFail(ctx context.Context, slug, requirementID, storyID, errorMsg string) {
+	key := retryKey(slug, requirementID, storyID)
 
 	if _, ok := c.retry.Snapshot(key); !ok {
 		c.logger.Warn("retryOrFail: no retry state found, failing immediately",
-			"slug", slug, "requirement_id", requirementID)
+			"slug", slug, "requirement_id", requirementID, "story_id", storyID)
 		c.sendGenerationFailed(ctx, slug, errorMsg)
 		return
 	}
@@ -666,11 +670,11 @@ func (c *Component) retryOrFail(ctx context.Context, slug, requirementID, errorM
 	if entry == nil {
 		if ctx.Err() != nil {
 			c.logger.Debug("retryOrFail aborted during backoff",
-				"slug", slug, "requirement_id", requirementID, "error", ctx.Err())
+				"slug", slug, "requirement_id", requirementID, "story_id", storyID, "error", ctx.Err())
 			return
 		}
 		c.logger.Warn("retryOrFail: lost retry context, failing immediately",
-			"slug", slug, "requirement_id", requirementID)
+			"slug", slug, "requirement_id", requirementID, "story_id", storyID)
 		c.sendGenerationFailed(ctx, slug, errorMsg)
 		return
 	}
@@ -864,6 +868,26 @@ func attachStoryIDs(scenarios []workflow.Scenario, plan *workflow.Plan, requirem
 	for i := range scenarios {
 		scenarios[i].StoryID = firstStoryID
 	}
+}
+
+// retryKey returns the dispatchretry.State key for a scenario-generator
+// dispatch. Per-Story dispatch (storyID non-empty) keys by storyID so two
+// Stories under one Requirement get distinct retry registry entries;
+// legacy per-Requirement dispatch keys by requirementID for back-compat
+// with pre-Sarah plans and mock fixtures.
+//
+// Closes go-reviewer Pass-2 finding C1: pre-fix, the producer
+// (dispatchPerStory / SetActiveLoop) keyed by storyID while the consumer
+// (handleLoopCompletion / retryOrFail / IsStaleLoop / Clear) keyed by
+// requirementID, so per-Story Track entries were written and never
+// looked up. The result was a silent disablement of the retry registry
+// in per-Story mode — a single Bob parse glitch hard-failed the entire
+// plan with zero retries despite MaxGenerationRetries.
+func retryKey(slug, requirementID, storyID string) string {
+	if storyID != "" {
+		return slug + "/" + storyID
+	}
+	return slug + "/" + requirementID
 }
 
 // requirementSequence extracts the trailing sequence suffix from a requirement ID.

--- a/processor/scenario-generator/plan_watcher.go
+++ b/processor/scenario-generator/plan_watcher.go
@@ -123,7 +123,7 @@ func (c *Component) generateScenariosFromKV(ctx context.Context, plan *workflow.
 // carried in the payload so Bob's prompt can author Story-scoped scenarios.
 func (c *Component) dispatchPerStory(ctx context.Context, plan *workflow.Plan, req workflow.Requirement, story workflow.Story, required []payloads.RequiredTier, archContext string) {
 	genReq := buildStoryScopedRequest(plan, req, story, required, archContext)
-	key := plan.Slug + "/" + story.ID
+	key := retryKey(plan.Slug, req.ID, story.ID)
 	c.retry.Track(key, &scenarioRetryPayload{req: genReq, reviewFindings: plan.ReviewFormattedFindings})
 	c.dispatchScenarioGenerator(ctx, genReq, "", plan.ReviewFormattedFindings)
 }
@@ -134,7 +134,7 @@ func (c *Component) dispatchPerStory(ctx context.Context, plan *workflow.Plan, r
 // falls back to the "first story owns the scenarios" lookup.
 func (c *Component) dispatchPerRequirementLegacy(ctx context.Context, plan *workflow.Plan, req workflow.Requirement, required []payloads.RequiredTier, archContext string) {
 	genReq := buildRequirementScopedRequest(plan, req, required, archContext)
-	key := plan.Slug + "/" + req.ID
+	key := retryKey(plan.Slug, req.ID, "")
 	c.retry.Track(key, &scenarioRetryPayload{req: genReq, reviewFindings: plan.ReviewFormattedFindings})
 	c.dispatchScenarioGenerator(ctx, genReq, "", plan.ReviewFormattedFindings)
 }

--- a/processor/scenario-generator/retry_key_test.go
+++ b/processor/scenario-generator/retry_key_test.go
@@ -1,0 +1,110 @@
+package scenariogenerator
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow/dispatchretry"
+)
+
+// TestRetryKey_PerStoryUsesStoryIDSuffix pins the per-Story retry key
+// shape. The dispatcher (dispatchPerStory) and consumer
+// (handleLoopCompletion / retryOrFail / IsStaleLoop / Clear) must use the
+// same key for the same (slug, requirement, story) tuple — otherwise the
+// retry registry is silently bypassed in per-Story dispatch.
+func TestRetryKey_PerStoryUsesStoryIDSuffix(t *testing.T) {
+	got := retryKey("demo", "req.demo.1", "story.demo.1.1")
+	want := "demo/story.demo.1.1"
+	if got != want {
+		t.Errorf("retryKey(per-Story) = %q, want %q", got, want)
+	}
+}
+
+// TestRetryKey_LegacyUsesRequirementIDSuffix pins the legacy
+// per-Requirement key shape kept for pre-Sarah plans and mock fixtures.
+func TestRetryKey_LegacyUsesRequirementIDSuffix(t *testing.T) {
+	got := retryKey("demo", "req.demo.1", "")
+	want := "demo/req.demo.1"
+	if got != want {
+		t.Errorf("retryKey(legacy) = %q, want %q", got, want)
+	}
+}
+
+// TestRetryKey_DistinctKeysForDifferentStoriesUnderSameRequirement is the
+// headline regression test for go-reviewer Pass-2 finding C1.
+//
+// Pre-fix, the dispatcher wrote retry state under "slug/storyID" but the
+// consumer (handleLoopCompletion / retryOrFail) looked it up under
+// "slug/requirementID" — so per-Story dispatches silently bypassed the
+// entire retry registry. A single Bob parse glitch hard-failed the plan
+// with zero retries, despite MaxGenerationRetries being configured.
+//
+// This test pins that two Stories under one Requirement produce distinct
+// keys (so the dispatcher Tracks them separately) AND that the consumer
+// can recover the same key from (slug, requirementID, storyID) — the
+// underlying contract that closes C1.
+func TestRetryKey_DistinctKeysForDifferentStoriesUnderSameRequirement(t *testing.T) {
+	keyA := retryKey("demo", "req.demo.1", "story.demo.1.1")
+	keyB := retryKey("demo", "req.demo.1", "story.demo.1.2")
+	if keyA == keyB {
+		t.Errorf("two Stories under same Requirement produced the SAME retry key (%q) — pre-fix shape would silently bypass the retry registry", keyA)
+	}
+}
+
+// TestRetryKey_PerStoryProducerConsumerRoundTrip simulates the load-bearing
+// flow: dispatcher Tracks under the per-Story key, consumer's Snapshot
+// finds the entry under the same key. Demonstrates the bug pre-fix would
+// produce: a Snapshot lookup keyed by requirementID returns nothing
+// because the entry was stored under storyID.
+func TestRetryKey_PerStoryProducerConsumerRoundTrip(t *testing.T) {
+	const slug = "demo"
+	const reqID = "req.demo.1"
+	const storyID = "story.demo.1.1"
+
+	producerKey := retryKey(slug, reqID, storyID)
+	consumerKey := retryKey(slug, reqID, storyID)
+
+	if producerKey != consumerKey {
+		t.Errorf("producer key %q ≠ consumer key %q — symmetric retryKey call is the contract that closes Pass-2 C1", producerKey, consumerKey)
+	}
+}
+
+// TestRetryRegistry_PerStoryTrackAndSnapshotRoundTrip exercises the real
+// dispatchretry.State the way the producer and consumer use it: Track
+// under the per-Story key, then Snapshot from the same (slug, req, story)
+// tuple. Pre-fix, the consumer's "slug + / + requirementID" lookup
+// returned (nil, false) because the entry was stored under storyID — and
+// retryOrFail's `if _, ok := Snapshot(key); !ok { sendGenerationFailed }`
+// hard-rejected the plan with zero retries. Post-fix, the symmetric
+// retryKey call recovers the entry.
+func TestRetryRegistry_PerStoryTrackAndSnapshotRoundTrip(t *testing.T) {
+	state := dispatchretry.New(dispatchretry.Config{MaxRetries: 3})
+
+	const slug = "demo"
+	const reqID = "req.demo.1"
+	const storyA = "story.demo.1.1"
+	const storyB = "story.demo.1.2"
+
+	// Producer side: dispatcher Tracks two Story entries under one Req.
+	state.Track(retryKey(slug, reqID, storyA), &scenarioRetryPayload{})
+	state.Track(retryKey(slug, reqID, storyB), &scenarioRetryPayload{})
+
+	// Consumer side: handleLoopCompletion for Story A must find Story A's
+	// entry, NOT Story B's. Pre-fix, the consumer key (slug/requirementID)
+	// would collide across A and B — and would even be MISSING since the
+	// entries were stored under storyID-keyed strings.
+	if _, ok := state.Snapshot(retryKey(slug, reqID, storyA)); !ok {
+		t.Errorf("consumer Snapshot for Story A returned no entry — retry registry bypassed; Pass-2 C1 not closed")
+	}
+	if _, ok := state.Snapshot(retryKey(slug, reqID, storyB)); !ok {
+		t.Errorf("consumer Snapshot for Story B returned no entry — retry registry bypassed; Pass-2 C1 not closed")
+	}
+
+	// Clearing one Story's entry must not affect the other's.
+	state.Clear(retryKey(slug, reqID, storyA))
+	if _, ok := state.Snapshot(retryKey(slug, reqID, storyA)); ok {
+		t.Errorf("Story A's entry should be cleared")
+	}
+	if _, ok := state.Snapshot(retryKey(slug, reqID, storyB)); !ok {
+		t.Errorf("Story B's entry should survive Story A's Clear")
+	}
+}


### PR DESCRIPTION
## Summary

- Closes go-reviewer Pass-2 finding **C1**: producer dispatch sites keyed the retry registry by `slug/storyID` but consumer sites keyed by `slug/requirementID` — per-Story Track entries were written and never looked up. The retry registry was silently disabled in per-Story mode.
- Smoke 6 ran with retry permanently disabled and no one noticed because no retries fired during that run (the easy + mavlink-hard fixtures had exactly 1 Story per Requirement).

## Bug effects (pre-fix)

Three downstream effects per the Pass-2 finding:

- **Stale-loop guard always passed** — a retry's stale completion was not dropped.
- **Single Bob parse glitch hard-killed the plan** — `retryOrFail`'s `Snapshot` lookup returned no entry → `"no retry state found, failing immediately"` → `sendGenerationFailed` → entire plan rejected, despite `MaxGenerationRetries` being configured.
- **Memory leak** — `retry.Clear` was a no-op so the story-keyed entry stayed in the registry forever.

## Fix

- New `retryKey(slug, requirementID, storyID)` helper returns `slug/storyID` when storyID is non-empty, `slug/requirementID` otherwise. Mirrors the `scenarioIDFor` / `storySequence` patterns introduced in #74.
- All producer call sites use `retryKey`: `plan_watcher.go::dispatchPerStory`, `dispatchPerRequirementLegacy`; `component.go::dispatchScenarioGenerator::SetActiveLoop`.
- All consumer call sites use `retryKey`: `handleLoopCompletion`'s `key` var; `retryOrFail`'s `key` var. `retryOrFail` signature gains `storyID` so the consumer can compute the right key.
- Log lines on both sides include `story_id` so operators can correlate per-Story retry state.

## Tests added (5 cases in `retry_key_test.go`)

- `TestRetryKey_PerStoryUsesStoryIDSuffix` + `TestRetryKey_LegacyUsesRequirementIDSuffix` — pin both branches in isolation.
- `TestRetryKey_DistinctKeysForDifferentStoriesUnderSameRequirement` — the headline P2-C1 contract.
- `TestRetryKey_PerStoryProducerConsumerRoundTrip` — symmetric call returns the same key for the same tuple.
- `TestRetryRegistry_PerStoryTrackAndSnapshotRoundTrip` — end-to-end with real `dispatchretry.State`: `Track` under per-Story key, `Snapshot` from same tuple recovers entry, `Clear` of one Story does not affect the other.

## Train B status

- ✅ Step 1: per-slug mutex (PR #72)
- ✅ Step 2: per-(Req, Story) merge (PR #73)
- ✅ Step 3: scenario ID with storyseq (PR #74)
- ✅ Step 4: this PR — retry-key alignment

**Train B is complete.** The C1/C2/C3/C4 cluster is closed. **Train A** (Pass-1's 7-PR per-Story persistence chain in requirement-executor) becomes safe to start after #75 lands — the per-slug mutex (#72) protects mutation handlers, the per-(Req, Story) merge (#73) preserves parallel Story scenarios, distinct scenario IDs (#74) make collisions observable, and now per-Story retries actually fire.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `gofmt -l processor/scenario-generator/` clean
- [x] `revive -config revive.toml ./processor/scenario-generator/...` clean
- [x] 5 new tests added; all existing scenario-generator tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)