### PR TITLE
fix(requirement-executor): persist Story cursor + CommitSHA across restart

### DIFF
--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -527,7 +527,9 @@ func (c *Component) rebuildExecFromKV(key string, reqExec *workflow.RequirementE
 		}
 	}
 
-	// Rebuild VisitedNodes from NodeResults.
+	// Rebuild VisitedNodes from NodeResults. CommitSHA is round-tripped so the
+	// claim/observation gate (handleApprovedClaimMismatchLocked) sees the
+	// merge commit for nodes that completed before the restart.
 	exec.VisitedNodes = make(map[string]bool, len(reqExec.NodeResults))
 	exec.NodeResults = make([]NodeResult, 0, len(reqExec.NodeResults))
 	for _, nr := range reqExec.NodeResults {
@@ -536,6 +538,7 @@ func (c *Component) rebuildExecFromKV(key string, reqExec *workflow.RequirementE
 			NodeID:        nr.NodeID,
 			FilesModified: nr.FilesModified,
 			Summary:       nr.Summary,
+			CommitSHA:     nr.CommitSHA,
 		})
 	}
 
@@ -567,16 +570,30 @@ func (c *Component) applyParsedDAGLocked(ctx context.Context, exec *requirementE
 	}
 
 	// Persist DAG state to EXECUTION_STATES for crash recovery.
-	// The DAGRaw + SortedNodeIDs fields let reconcileFromKV rebuild the full
-	// execution state without re-running the decomposer.
+	// The DAGRaw + SortedNodeIDs + SortedStoryIDs + CurrentStoryIdx fields let
+	// reconcileFromKV rebuild the full execution state without re-running the
+	// decomposer AND without losing the per-Story cursor (Pass-1 C1/C2).
 	dagRaw, _ := json.Marshal(*dag)
 
 	nodeCount := len(sorted)
-	if err := c.sendReqPhase(ctx, exec.storeKey, phaseExecuting, map[string]any{
+	fields := map[string]any{
 		"node_count":      nodeCount,
 		"dag":             json.RawMessage(dagRaw),
 		"sorted_node_ids": sorted,
-	}); err != nil {
+	}
+	// Include the Story cursor when populated. dispatchDecomposerLocked seeds
+	// these the first time the requirement enters per-Story dispatch, and
+	// advanceToNextStoryLocked re-enters here after incrementing the cursor —
+	// so this single sendReqPhase site is the chokepoint for keeping KV in
+	// sync with the in-memory cursor.
+	if len(exec.SortedStoryIDs) > 0 {
+		fields["sorted_story_ids"] = exec.SortedStoryIDs
+		// Send as pointer to satisfy the *int wire shape — value 0 still
+		// distinguishes "set to 0" from "leave unchanged" on the consumer.
+		idx := exec.CurrentStoryIdx
+		fields["current_story_idx"] = &idx
+	}
+	if err := c.sendReqPhase(ctx, exec.storeKey, phaseExecuting, fields); err != nil {
 		c.logger.Warn("Failed to send req.phase mutation", "stage", phaseExecuting, "error", err)
 	}
 
@@ -882,6 +899,7 @@ func (c *Component) recordNodeSuccessLocked(ctx context.Context, exec *requireme
 		NodeID:        nodeResult.NodeID,
 		FilesModified: nodeResult.FilesModified,
 		Summary:       nodeResult.Summary,
+		CommitSHA:     nodeResult.CommitSHA,
 	}
 	if err := c.sendReqNode(ctx, exec.storeKey, exec.CurrentNodeIdx, "", wfResult); err != nil {
 		c.logger.Warn("Failed to send req.node mutation", "node_id", nodeID, "error", err)

--- a/processor/requirement-executor/rebuild_persistence_test.go
+++ b/processor/requirement-executor/rebuild_persistence_test.go
@@ -1,0 +1,164 @@
+package requirementexecutor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestRebuildExecFromKV_CommitSHARoundTrips pins the load-bearing
+// contract behind go-reviewer Pass-1 finding C4: after a process restart,
+// the requirement-executor rebuilds its in-memory state from
+// EXECUTION_STATES KV. NodeResults restored from KV MUST carry their
+// CommitSHA values so the RequireCommitObservation gate sees the merge
+// commit observation that produced them.
+//
+// Pre-fix, workflow.NodeResult had no CommitSHA field. The executor set
+// CommitSHA on its in-memory shadow type but dropped it at the wire
+// boundary when building the workflow.NodeResult for execution-manager's
+// KV. After a restart, rebuildExecFromKV reconstructed every NodeResult
+// with an empty CommitSHA, and the gate at handleApprovedClaimMismatchLocked
+// false-failed every requirement that had completed nodes claiming
+// FilesModified.
+func TestRebuildExecFromKV_CommitSHARoundTrips(t *testing.T) {
+	c := newTestComponent(t)
+	persisted := &workflow.RequirementExecution{
+		EntityID:      "entity-1",
+		Slug:          "demo",
+		RequirementID: "req.demo.1",
+		NodeResults: []workflow.NodeResult{
+			{NodeID: "node.A", FilesModified: []string{"src/a.go"}, CommitSHA: "abc123"},
+			{NodeID: "node.B", FilesModified: []string{"src/b.go"}, CommitSHA: "def456"},
+		},
+	}
+
+	exec := c.rebuildExecFromKV("req.demo.req.demo.1", persisted)
+
+	if len(exec.NodeResults) != 2 {
+		t.Fatalf("NodeResults = %d, want 2", len(exec.NodeResults))
+	}
+	if exec.NodeResults[0].CommitSHA != "abc123" {
+		t.Errorf("NodeResults[0].CommitSHA = %q, want abc123 (rebuilt from KV)", exec.NodeResults[0].CommitSHA)
+	}
+	if exec.NodeResults[1].CommitSHA != "def456" {
+		t.Errorf("NodeResults[1].CommitSHA = %q, want def456 (rebuilt from KV)", exec.NodeResults[1].CommitSHA)
+	}
+}
+
+// TestRebuildExecFromKV_StoryCursorRoundTrips pins go-reviewer Pass-1
+// findings C1 + C2: after restart, the per-Story cursor (SortedStoryIDs +
+// CurrentStoryIdx) MUST round-trip through KV. Pre-fix, no sendReqPhase
+// call sent these fields, so rebuildExecFromKV always reconstructed
+// SortedStoryIDs as nil and CurrentStoryIdx as 0. A 3-Story requirement
+// mid-Story-2 at restart would silently truncate to a single Story:
+//
+//	rebuilt cursor: SortedStoryIDs=[], CurrentStoryIdx=0
+//	handleApprovedVerdictLocked: 0+1 < 0 → false → markCompletedLocked
+//	Stories 2 and 3 silently never run; requirement claims success.
+func TestRebuildExecFromKV_StoryCursorRoundTrips(t *testing.T) {
+	c := newTestComponent(t)
+	persisted := &workflow.RequirementExecution{
+		EntityID:        "entity-1",
+		Slug:            "demo",
+		RequirementID:   "req.demo.1",
+		SortedStoryIDs:  []string{"story.demo.1.1", "story.demo.1.2", "story.demo.1.3"},
+		CurrentStoryIdx: 1,
+	}
+
+	exec := c.rebuildExecFromKV("req.demo.req.demo.1", persisted)
+
+	if len(exec.SortedStoryIDs) != 3 {
+		t.Errorf("SortedStoryIDs = %v (len=%d), want 3 entries", exec.SortedStoryIDs, len(exec.SortedStoryIDs))
+	}
+	if exec.CurrentStoryIdx != 1 {
+		t.Errorf("CurrentStoryIdx = %d, want 1 (rebuilt from KV)", exec.CurrentStoryIdx)
+	}
+}
+
+// TestRebuildExecFromKV_EmptyCommitSHAPreservesBackCompat documents that
+// the new CommitSHA field round-trips empty strings unchanged. KV records
+// written before this PR have no commit_sha field on their NodeResults;
+// after restart they restore as CommitSHA="", which the
+// RequireCommitObservation gate already treated as "unobserved." This is
+// the pre-existing semantic — not a regression introduced by the new field.
+//
+// In practice the gate's behavior for ALREADY-EMPTY-IN-KV records is
+// unchanged. The new field only PERSISTS values that were previously
+// dropped. Operators with old KV state will still see the gate fire on
+// pre-PR completions; the fix is forward-looking.
+func TestRebuildExecFromKV_EmptyCommitSHAPreservesBackCompat(t *testing.T) {
+	c := newTestComponent(t)
+	persisted := &workflow.RequirementExecution{
+		EntityID:      "entity-1",
+		Slug:          "demo",
+		RequirementID: "req.demo.1",
+		NodeResults: []workflow.NodeResult{
+			{NodeID: "node.A", FilesModified: []string{"src/a.go"}}, // legacy: no CommitSHA
+		},
+	}
+
+	exec := c.rebuildExecFromKV("req.demo.req.demo.1", persisted)
+
+	if len(exec.NodeResults) != 1 {
+		t.Fatalf("NodeResults = %d, want 1", len(exec.NodeResults))
+	}
+	if exec.NodeResults[0].CommitSHA != "" {
+		t.Errorf("NodeResults[0].CommitSHA = %q, want empty (legacy KV record had no CommitSHA)", exec.NodeResults[0].CommitSHA)
+	}
+}
+
+// TestHandleApprovedClaimMismatch_DoesNotFalseFailRestoredNodes is the
+// headline regression test for go-reviewer Pass-1 finding C4. Pre-fix,
+// every restored NodeResult carried an empty CommitSHA (because the wire
+// shape didn't have the field), so the gate at handleApprovedClaimMismatchLocked
+// false-failed every requirement that completed nodes before a restart.
+//
+// Post-fix, restored NodeResults retain their CommitSHA values, the gate
+// finds no unobserved nodes, and the requirement proceeds normally.
+func TestHandleApprovedClaimMismatch_DoesNotFalseFailRestoredNodes(t *testing.T) {
+	c := newTestComponent(t)
+	persisted := &workflow.RequirementExecution{
+		EntityID:      "entity-1",
+		Slug:          "demo",
+		RequirementID: "req.demo.1",
+		NodeResults: []workflow.NodeResult{
+			{NodeID: "node.A", FilesModified: []string{"src/a.go"}, CommitSHA: "abc123"},
+		},
+	}
+	exec := c.rebuildExecFromKV("req.demo.req.demo.1", persisted)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	fired := c.handleApprovedClaimMismatchLocked(context.Background(), exec)
+
+	if fired {
+		t.Errorf("claim/observation gate fired on restored NodeResult with CommitSHA — pre-fix shape would false-fail here; CommitSHA round-trip closes Pass-1 C4")
+	}
+}
+
+// TestHandleApprovedClaimMismatch_FiresWhenObservationGenuinelyMissing
+// pins the positive direction of the gate: a NodeResult that claims
+// FilesModified but truly has no CommitSHA (the bug-9 pattern this gate
+// was built for) still fails the requirement. The C4 fix narrows
+// false-positives without disabling the gate.
+func TestHandleApprovedClaimMismatch_FiresWhenObservationGenuinelyMissing(t *testing.T) {
+	c := newTestComponent(t)
+	persisted := &workflow.RequirementExecution{
+		EntityID:      "entity-1",
+		Slug:          "demo",
+		RequirementID: "req.demo.1",
+		NodeResults: []workflow.NodeResult{
+			{NodeID: "node.A", FilesModified: []string{"src/a.go"}}, // empty CommitSHA — bug-9 pattern
+		},
+	}
+	exec := c.rebuildExecFromKV("req.demo.req.demo.1", persisted)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	fired := c.handleApprovedClaimMismatchLocked(context.Background(), exec)
+
+	if !fired {
+		t.Errorf("claim/observation gate should fire when CommitSHA is genuinely empty on a node that claimed FilesModified — gate must still catch bug-9 patterns")
+	}
+}

--- a/workflow/execution.go
+++ b/workflow/execution.go
@@ -106,10 +106,22 @@ func IsTerminalTaskStage(phase string) bool {
 }
 
 // NodeResult tracks output from a completed DAG node.
+//
+// CommitSHA is the merge commit produced when the node's worktree was
+// folded back onto the requirement branch. It is the durable observation
+// of "this node really wrote the files it claimed." requirement-executor's
+// RequireCommitObservation gate compares NodeResult.CommitSHA against
+// NodeResult.FilesModified to catch the bug-9 pattern (node claims
+// files_modified without producing a commit). Pre-this-field, the SHA
+// was set in the in-memory shadow type but dropped at the wire boundary,
+// so after a process restart the gate found every restored NodeResult
+// with empty CommitSHA → false-failed every requirement that hit it.
+// Closes go-reviewer Pass-1 finding C4.
 type NodeResult struct {
 	NodeID        string   `json:"node_id"`
 	FilesModified []string `json:"files_modified,omitempty"`
 	Summary       string   `json:"summary,omitempty"`
+	CommitSHA     string   `json:"commit_sha,omitempty"`
 }
 
 // RequirementExecution is the KV-serializable state for a requirement execution.


### PR DESCRIPTION
## Summary

Closes go-reviewer Pass-1 findings **C1**, **C2**, and **C4**. Train A step 1 of 6.

- **C1+C2 (per-Story cursor never persisted):** the producer never sent `SortedStoryIDs`/`CurrentStoryIdx` in any `sendReqPhase` call, even though the type and execution-manager handler already accepted them. After a restart, the cursor reconstructed as zero values, and a multi-Story requirement mid-Story-2 silently truncated:
  ```
  rebuilt: SortedStoryIDs=[], CurrentStoryIdx=0
  handleApprovedVerdictLocked: 0+1 < 0 → false → markCompletedLocked
  Stories 2 and 3 silently never run; requirement claims success.
  ```
- **C4 (CommitSHA dropped at wire boundary):** the executor's in-memory shadow `NodeResult` had a `CommitSHA` field, but `workflow.NodeResult` did not. `recordNodeSuccessLocked` set it locally and dropped it building the wire payload. After restart, every restored `NodeResult` had `CommitSHA=""`, and the `RequireCommitObservation` gate (default on) false-failed every requirement that had completed nodes claiming `FilesModified`.

Smoke 6 hid all of this: easy + mavlink-hard fixtures had one Story per Requirement (cursor never advanced) AND no production restart fired mid-execution.

## Changes

- **`workflow/execution.go`** — `NodeResult` gains `CommitSHA \`json:"commit_sha,omitempty"\``.
- **`processor/requirement-executor/component.go`** —
  - `recordNodeSuccessLocked` forwards `CommitSHA` into the `workflow.NodeResult` it sends via `sendReqNode`.
  - `rebuildExecFromKV` restores `CommitSHA` on each restored `NodeResult`.
  - `applyParsedDAGLocked` (the chokepoint reached by both initial Story dispatch and advancement) sends `sorted_story_ids` + `current_story_idx` in its `sendReqPhase` mutation. `CurrentStoryIdx` is sent as `*int` (matches `ReqPhaseRequest` shape) so "set to 0" remains distinguishable from "leave unchanged."

## Tests (5 new cases)

`rebuild_persistence_test.go`:

- `TestRebuildExecFromKV_CommitSHARoundTrips` — pre-seed KV with `CommitSHA`; rebuild; assert preserved.
- `TestRebuildExecFromKV_StoryCursorRoundTrips` — pre-seed cursor; rebuild; assert `SortedStoryIDs` + `CurrentStoryIdx` preserved.
- `TestRebuildExecFromKV_EmptyCommitSHAPreservesBackCompat` — legacy KV records (no `commit_sha`) restore as empty.
- `TestHandleApprovedClaimMismatch_DoesNotFalseFailRestoredNodes` — the headline regression: gate no longer false-fails restored nodes carrying `CommitSHA`.
- `TestHandleApprovedClaimMismatch_FiresWhenObservationGenuinelyMissing` — negative pin: gate still catches bug-9 patterns.

## Train A status

| Step | What | PR |
|---|---|---|
| 1 | Persist Story cursor + CommitSHA (C1, C2, C4) | this PR |
| 2 | Reviewer scope consistency (C5) | next |
| 3 | VisitedNodes per-Story counter (C3) | — |
| 4 | Concurrency hardening (H1, H2) | — |
| 5 | NodeResults KV reset mutation (H4) | — |
| 6 | Test coverage sweep (H3) | — |

Train A becomes safe after Train B (PRs #72-75) closed the upstream preconditions: single-writer lock, per-(Req,Story) merge, distinct scenario IDs, retry-key alignment.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `gofmt -l processor/requirement-executor/ workflow/` clean
- [x] `revive` clean on both touched packages
- [x] 5 new tests pass; existing requirement-executor tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)