### PR TITLE
Train D: Sarah readiness gate + R2 story-phase routing (P4-C3/C4/C5 + Pass-3 S-C1/S-C2)

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1704,16 +1704,26 @@ func (c *Component) resetRequirementExecutionsByID(ctx context.Context, slug str
 // point for Round 2. When findings carry phase markers, the plan can retry only
 // the affected phase instead of clearing everything.
 //
-// Priority (highest first): plan > requirements > architecture > scenarios.
+// Priority (highest first): plan > requirements > architecture > stories > scenarios.
 // If ANY error finding targets an earlier phase, re-entry cascades from there.
 // Without phase markers, falls back to StatusApproved (clear everything).
+//
+// The "stories" phase case closes go-reviewer Pass-4 finding P4-C3.
+// Pre-fix, story_rules.go emitted findings with Phase:"stories" but the
+// switch had no matching case, so the cascade fell through to default and
+// nuked Requirements + Architecture + Scenarios to re-run req-gen.
+// Sarah's defective Story output survived the regen because the plan
+// re-traversed the requirements path that didn't fail. With this case
+// in place, story-phase findings clear only Stories + Scenarios and
+// return to StatusArchitectureGenerated — Sarah's watcher claim point.
 func (c *Component) determineR2ReentryPoint(plan *workflow.Plan, findingsJSON json.RawMessage) workflow.Status {
 	var findings []workflow.PlanReviewFinding
 	if err := json.Unmarshal(findingsJSON, &findings); err != nil {
 		// Can't parse findings — fall back to clear everything.
 		plan.Requirements = nil
-		plan.Scenarios = nil
 		plan.Architecture = nil
+		plan.Stories = nil
+		plan.Scenarios = nil
 		return workflow.StatusApproved
 	}
 
@@ -1731,10 +1741,13 @@ func (c *Component) determineR2ReentryPoint(plan *workflow.Plan, findingsJSON js
 	}
 
 	if !hasPhaseMarker {
-		// No phase markers — fall back to clear everything.
+		// No phase markers — fall back to clear everything (including Stories;
+		// pre-fix the Stories slice survived this branch, which on a Sarah-
+		// authored plan would leave stale Stories pinned to wiped Requirements).
 		plan.Requirements = nil
-		plan.Scenarios = nil
 		plan.Architecture = nil
+		plan.Stories = nil
+		plan.Scenarios = nil
 		return workflow.StatusApproved
 	}
 
@@ -1743,33 +1756,47 @@ func (c *Component) determineR2ReentryPoint(plan *workflow.Plan, findingsJSON js
 	case phaseHit["plan"]:
 		// Re-draft from scratch.
 		plan.Requirements = nil
-		plan.Scenarios = nil
 		plan.Architecture = nil
+		plan.Stories = nil
+		plan.Scenarios = nil
 		return workflow.StatusCreated
 
 	case phaseHit["requirements"]:
-		// Re-generate requirements (and downstream).
+		// Re-generate requirements (and downstream architecture / stories / scenarios).
 		plan.Requirements = nil
-		plan.Scenarios = nil
 		plan.Architecture = nil
+		plan.Stories = nil
+		plan.Scenarios = nil
 		return workflow.StatusApproved
 
 	case phaseHit["architecture"]:
-		// Re-generate architecture (and downstream scenarios).
+		// Re-generate architecture (and downstream stories + scenarios).
 		plan.Architecture = nil
+		plan.Stories = nil
 		plan.Scenarios = nil
 		return workflow.StatusRequirementsGenerated
 
+	case phaseHit["stories"]:
+		// Re-run Sarah only; preserve Requirements + Architecture. Closes
+		// Pass-4 P4-C3 — pre-fix this case was missing and story findings
+		// fell to default, nuking everything.
+		plan.Stories = nil
+		plan.Scenarios = nil
+		return workflow.StatusArchitectureGenerated
+
 	case phaseHit["scenarios"]:
-		// Re-generate scenarios only, preserve requirements and architecture.
+		// Re-generate scenarios only, preserve requirements + architecture +
+		// stories. The architect's Sarah-prepared Stories stay; only Bob's
+		// scenario emission is re-run.
 		plan.Scenarios = nil
 		return workflow.StatusArchitectureGenerated
 
 	default:
 		// Unknown phase values — fall back to clear everything.
 		plan.Requirements = nil
-		plan.Scenarios = nil
 		plan.Architecture = nil
+		plan.Stories = nil
+		plan.Scenarios = nil
 		return workflow.StatusApproved
 	}
 }

--- a/processor/plan-manager/r2_reentry_test.go
+++ b/processor/plan-manager/r2_reentry_test.go
@@ -1,0 +1,139 @@
+package planmanager
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestDetermineR2ReentryPoint_StoriesPhaseRoutesToArchitectureGenerated is
+// the headline regression test for go-reviewer Pass-4 finding P4-C3.
+//
+// Pre-fix, story_rules.go emitted findings with `Phase: "stories"` but
+// determineR2ReentryPoint's switch had no matching case, so the cascade
+// fell through to the default branch — which nuked Requirements +
+// Architecture + Scenarios and returned StatusApproved (rewind to
+// requirements-gen). Sarah's defective Story output survived the regen
+// because the plan re-traversed the requirements path that didn't fail.
+//
+// Post-fix, story-phase findings clear only Stories + Scenarios and
+// return StatusArchitectureGenerated — Sarah's watcher claim point,
+// triggering a re-prep of Stories from the (still-valid) architecture.
+func TestDetermineR2ReentryPoint_StoriesPhaseRoutesToArchitectureGenerated(t *testing.T) {
+	c := setupTestComponent(t)
+	plan := &workflow.Plan{
+		Slug:         "demo",
+		Requirements: []workflow.Requirement{{ID: "req.demo.1", Title: "R"}},
+		Architecture: &workflow.ArchitectureDocument{Decisions: []workflow.ArchDecision{{Title: "use Go"}}},
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "broken"},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.demo.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		},
+	}
+	findings, _ := json.Marshal([]workflow.PlanReviewFinding{
+		{Severity: "error", Status: "violation", Phase: "stories", SOPID: "story.missing_files_owned"},
+	})
+
+	target := c.determineR2ReentryPoint(plan, findings)
+
+	if target != workflow.StatusArchitectureGenerated {
+		t.Errorf("target = %s, want %s (pre-fix P4-C3 would fall to default → StatusApproved, nuking Architecture too)", target, workflow.StatusArchitectureGenerated)
+	}
+
+	// Stories + Scenarios cleared (Sarah re-prep + Bob re-gen).
+	if plan.Stories != nil {
+		t.Errorf("plan.Stories = %v, want nil (Sarah re-prep required)", plan.Stories)
+	}
+	if plan.Scenarios != nil {
+		t.Errorf("plan.Scenarios = %v, want nil (Bob re-gen required after Sarah re-preps)", plan.Scenarios)
+	}
+
+	// Requirements + Architecture preserved — they're upstream of Sarah and
+	// passed review.
+	if len(plan.Requirements) != 1 {
+		t.Errorf("plan.Requirements wiped (len=%d), want preserved", len(plan.Requirements))
+	}
+	if plan.Architecture == nil {
+		t.Errorf("plan.Architecture wiped, want preserved")
+	}
+}
+
+// TestDetermineR2ReentryPoint_ScenariosCasePreservesStories pins the
+// minimal-blast-radius semantic for scenarios-phase findings: when only
+// Bob's output is at fault, Sarah's Stories survive. Pre-Train-D the
+// scenarios case did NOT explicitly preserve Stories (the field hadn't
+// existed yet at the time the function was written); the post-fix
+// version makes that contract explicit.
+func TestDetermineR2ReentryPoint_ScenariosCasePreservesStories(t *testing.T) {
+	c := setupTestComponent(t)
+	plan := &workflow.Plan{
+		Slug: "demo",
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "ok"},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.demo.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		},
+	}
+	findings, _ := json.Marshal([]workflow.PlanReviewFinding{
+		{Severity: "error", Status: "violation", Phase: "scenarios", SOPID: "scenario.missing_tier_tag"},
+	})
+
+	target := c.determineR2ReentryPoint(plan, findings)
+
+	if target != workflow.StatusArchitectureGenerated {
+		t.Errorf("target = %s, want StatusArchitectureGenerated", target)
+	}
+	if len(plan.Stories) != 1 {
+		t.Errorf("plan.Stories wiped, want preserved (only scenarios at fault)")
+	}
+	if plan.Scenarios != nil {
+		t.Errorf("plan.Scenarios = %v, want nil (Bob re-gen)", plan.Scenarios)
+	}
+}
+
+// TestDetermineR2ReentryPoint_UpstreamPhasesNukeStoriesToo pins that
+// every cascade case that wipes upstream artifacts (plan / requirements /
+// architecture) also wipes Stories — pre-fix the plan / requirements
+// branches left Stories pinned to wiped Requirements, which would fail
+// validation on Sarah's next dispatch.
+func TestDetermineR2ReentryPoint_UpstreamPhasesNukeStoriesToo(t *testing.T) {
+	c := setupTestComponent(t)
+	cases := []struct {
+		name  string
+		phase string
+		want  workflow.Status
+	}{
+		{"plan phase nukes Stories", "plan", workflow.StatusCreated},
+		{"requirements phase nukes Stories", "requirements", workflow.StatusApproved},
+		{"architecture phase nukes Stories", "architecture", workflow.StatusRequirementsGenerated},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := &workflow.Plan{
+				Slug:         "demo",
+				Requirements: []workflow.Requirement{{ID: "req.demo.1", Title: "R"}},
+				Architecture: &workflow.ArchitectureDocument{Decisions: []workflow.ArchDecision{{Title: "use Go"}}},
+				Stories:      []workflow.Story{{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "should be wiped"}},
+				Scenarios:    []workflow.Scenario{{ID: "scen.demo.1", RequirementID: "req.demo.1"}},
+			}
+			findings, _ := json.Marshal([]workflow.PlanReviewFinding{
+				{Severity: "error", Status: "violation", Phase: tc.phase, SOPID: "test.case"},
+			})
+			target := c.determineR2ReentryPoint(plan, findings)
+			if target != tc.want {
+				t.Errorf("target = %s, want %s", target, tc.want)
+			}
+			if plan.Stories != nil {
+				t.Errorf("%s: plan.Stories = %v, want nil (upstream phase invalidates Stories)", tc.phase, plan.Stories)
+			}
+			if plan.Scenarios != nil {
+				t.Errorf("%s: plan.Scenarios = %v, want nil", tc.phase, plan.Scenarios)
+			}
+		})
+	}
+}

--- a/processor/plan-manager/stories_scenarios_mutation_test.go
+++ b/processor/plan-manager/stories_scenarios_mutation_test.go
@@ -25,14 +25,20 @@ func marshalJSON(t *testing.T, v any) []byte {
 	return data
 }
 
-// validStory returns a minimal Story that passes workflow.ValidateStory. No
-// Status set — matches Sarah's emission shape, which the empty-Status branch
-// in ValidateStory accepts without running readiness invariants.
+// validStory returns a minimal Story that passes workflow.ValidateStory.
+// Status is left empty — matches Sarah's omitempty emission shape. Post-
+// Train-D, the readiness invariants apply on empty Status, so the helper
+// supplies one source file and one task. Callers that need to test the
+// invariant failures should build a Story inline with the missing field.
 func validStory(id, reqID, title string) workflow.Story {
 	return workflow.Story{
 		ID:            id,
 		RequirementID: reqID,
 		Title:         title,
+		FilesOwned:    []string{"src/" + id + ".go"},
+		Tasks: []workflow.Task{
+			{ID: "task." + id + ".1", StoryID: id, Description: "implement"},
+		},
 	}
 }
 
@@ -161,6 +167,9 @@ func TestHandleStoriesMutation(t *testing.T) {
 						RequirementID: "req.story-scope.1",
 						Title:         "T",
 						FilesOwned:    []string{"src/new.go"},
+						Tasks: []workflow.Task{
+							{ID: "task.story.story-scope.1.1.1", StoryID: "story.story-scope.1.1", Description: "implement"},
+						},
 					},
 				},
 			},

--- a/processor/plan-reviewer/component.go
+++ b/processor/plan-reviewer/component.go
@@ -343,6 +343,30 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 	// @integration for a services-class harness; the structural rules
 	// don't. NormalizeVerdict in each merge bumps "approved" to
 	// "needs_changes" when any error finding lands.
+	//
+	// R3 co-fire shape (P4-C5): plan-reviewer claims only StatusDrafted
+	// (R1) and StatusScenariosGenerated (R2). The story-phase rules in
+	// mergeStoryFindings DO NOT have a dedicated R3 round; they co-fire
+	// with R2 here. The reviewer agent's LLM prompt for R2 is scenario-
+	// shaped, but the structural rules in this file run on plan state,
+	// not on the LLM verdict — so the rules ARE correctly evaluated
+	// against the post-R2 plan even though the LLM's own verdict is on
+	// the wrong subject. Verdict alignment happens via NormalizeVerdict.
+	//
+	// End-to-end story-phase routing in the co-fire shape:
+	//   1. Rule emits finding with Phase:"stories" (story_rules.go).
+	//   2. determineR2ReentryPoint's stories case clears Stories +
+	//      Scenarios and returns StatusArchitectureGenerated → Sarah
+	//      re-prep claim point (Train D step 3 / P4-C3).
+	//   3. phaseToRole maps "stories" → "story-preparer" so the
+	//      lesson-learning counts roll up to Sarah's role correctly
+	//      (Train D step 4).
+	//
+	// A dedicated R3 round (its own claim path, story-shaped LLM prompt)
+	// is the longer-term shape but materially larger: separate ADR + new
+	// transition + prompt context. Tracked as P4-C5 (full implementation)
+	// in [[go-reviewer-cross-pass-synthesis-adr043]]; the co-fire shape
+	// here is the interim contract.
 	if planForRules, loadErr := c.loadPlanForRules(ctx, slug); loadErr == nil {
 		mergeCapabilityFindings(planForRules, result)
 		mergeArchitectureFindings(planForRules, result)
@@ -878,6 +902,8 @@ func phaseToRole(phase string) string {
 		return "requirement-generator"
 	case "architecture":
 		return "architect"
+	case "stories":
+		return "story-preparer"
 	case "scenarios":
 		return "scenario-generator"
 	default:

--- a/processor/plan-reviewer/phase_to_role_test.go
+++ b/processor/plan-reviewer/phase_to_role_test.go
@@ -1,0 +1,31 @@
+package planreviewer
+
+import "testing"
+
+// TestPhaseToRole pins the mapping that routes plan-review findings to
+// the pipeline role responsible for the offending phase. Lesson-learning
+// counts roll up by role, so a missing phase silently misattributes
+// failures to "planner" (the default) and the wrong role gets the
+// lesson update.
+//
+// The "stories" case was added with Train D step 3 (P4-C3 — new R2
+// re-entry case). Pre-this-commit, story-phase findings landed in the
+// default branch and credited Sarah's bugs to the planner role. Caught
+// by the pre-commit reviewer of Train D step 4 — same shape as P4-C3.
+func TestPhaseToRole(t *testing.T) {
+	cases := map[string]string{
+		"plan":         "planner",
+		"requirements": "requirement-generator",
+		"architecture": "architect",
+		"stories":      "story-preparer",
+		"scenarios":    "scenario-generator",
+		"":             "planner", // empty phase falls to default
+		"unknown":      "planner", // unrecognized phase falls to default
+	}
+	for phase, want := range cases {
+		got := phaseToRole(phase)
+		if got != want {
+			t.Errorf("phaseToRole(%q) = %q, want %q", phase, got, want)
+		}
+	}
+}

--- a/processor/plan-reviewer/story_rules.go
+++ b/processor/plan-reviewer/story_rules.go
@@ -110,10 +110,12 @@ func storyStructuralFindings(plan *workflow.Plan) []workflow.PlanReviewFinding {
 		}
 
 		// Readiness-gated invariants fire when Sarah's gate should have run.
-		// Empty status (the b7r50o9ov omitempty pattern for freshly-emitted
-		// stories) is treated as "Sarah signed off" because the story-preparer
-		// emits stories that have completed the gate; persistence has not yet
-		// set the runtime status.
+		// Empty Status is Sarah's omitempty emission shape after sign-off
+		// (b7r50o9ov) — workflow.ValidateStory enforces the same invariants
+		// at the mutation boundary post Train-D step 1 (Pass-3 S-C1), so
+		// by the time R3 runs here those defects are already caught. R3
+		// remains the defensive backstop layer: pending stories (Sarah
+		// explicitly mid-flight) are exempt, every other shape is checked.
 		if s.Status == workflow.StoryStatusPending {
 			continue
 		}

--- a/processor/story-preparer/component.go
+++ b/processor/story-preparer/component.go
@@ -840,6 +840,27 @@ func resolveStoryLabels(input []positionalStoryInput, plan *workflow.Plan, slug 
 			Tasks:         tasks,
 		}
 	}
+
+	// Per-Requirement coverage gate: every plan.Requirements entry MUST have
+	// at least one Story. Pre-fix, Sarah could omit a Requirement entirely;
+	// the parser passed, scenario-generator's legacy fallback engaged for
+	// the uncovered Req, and execution-manager later hard-failed with "no
+	// Stories on plan for requirement %s." Closes go-reviewer Pass-3 S-C2
+	// (also closes Pass-2 C5 from the producer side).
+	covered := make(map[string]struct{}, len(canonicalReqIDs))
+	for _, id := range canonicalReqIDs {
+		covered[id] = struct{}{}
+	}
+	var uncovered []string
+	for _, req := range plan.Requirements {
+		if _, ok := covered[req.ID]; !ok {
+			uncovered = append(uncovered, req.ID)
+		}
+	}
+	if len(uncovered) > 0 {
+		return nil, fmt.Errorf("Sarah must emit at least one story per requirement; uncovered: %v", uncovered)
+	}
+
 	return out, nil
 }
 

--- a/processor/story-preparer/component_test.go
+++ b/processor/story-preparer/component_test.go
@@ -43,9 +43,21 @@ func TestParseStoriesFromResult(t *testing.T) {
 			wantErr: "stories list is empty",
 		},
 		{
-			name:      "single story with positional shape parses cleanly",
-			input:     `{"stories":[{"label":"l1","requirement_index":0,"title":"T","intent":"i","components":["c"],"files_owned":["src/x.go"],"depends_on_labels":[],"tasks":[{"label":"t1","description":"d","depends_on_labels":[]}]}]}`,
-			wantCount: 1,
+			name:      "stories covering every requirement parse cleanly",
+			input:     `{"stories":[{"label":"l1","requirement_index":0,"title":"T1","intent":"i","components":["c"],"files_owned":["src/x.go"],"depends_on_labels":[],"tasks":[{"label":"t1","description":"d","depends_on_labels":[]}]},{"label":"l2","requirement_index":1,"title":"T2","intent":"i","components":["c"],"files_owned":["src/y.go"],"depends_on_labels":[],"tasks":[{"label":"t2","description":"d","depends_on_labels":[]}]}]}`,
+			wantCount: 2,
+		},
+		{
+			// Pass-3 S-C2 / Pass-2 C5: Sarah must emit at least one story
+			// per requirement. Pre-fix the parser passed on partial output,
+			// scenario-generator's legacy fallback engaged for the
+			// uncovered req, and execution-manager hard-failed later with
+			// "no Stories on plan for requirement %s". The error message
+			// names the uncovered requirement so Sarah's retry prompt
+			// pinpoints the gap.
+			name:    "partial coverage (2 reqs, 1 story) rejected — Pass-3 S-C2",
+			input:   `{"stories":[{"label":"l1","requirement_index":0,"title":"T","intent":"i","components":["c"],"files_owned":["src/x.go"],"depends_on_labels":[],"tasks":[{"label":"t1","description":"d","depends_on_labels":[]}]}]}`,
+			wantErr: "uncovered: [requirement.x.2]",
 		},
 		{
 			name:    "requirement_index out of range rejected",

--- a/workflow/plan_review_result.go
+++ b/workflow/plan_review_result.go
@@ -32,7 +32,7 @@ type PlanReviewFinding struct {
 	Severity string `json:"severity"`
 	Status   string `json:"status"`
 	Category string `json:"category,omitempty"`  // "sop" or "completeness" (ADR-029)
-	Phase    string `json:"phase,omitempty"`     // "plan", "requirements", "architecture", "scenarios"
+	Phase    string `json:"phase,omitempty"`     // "plan", "requirements", "architecture", "stories", "scenarios"
 	TargetID string `json:"target_id,omitempty"` // specific entity ID (e.g., "REQ-2", "SCEN-3")
 	// Action is the imperative remediation verb. Required on every error-
 	// severity violation when verdict=needs_changes. Allowed values: "add",

--- a/workflow/plan_story.go
+++ b/workflow/plan_story.go
@@ -78,15 +78,22 @@ func ValidateStoryDAG(stories []Story) error {
 
 // ValidateStory checks structural invariants for a single Story:
 //   - ID and RequirementID and Title non-empty
-//   - FilesOwned non-empty when Sarah has signed off (Status != pending)
+//   - FilesOwned non-empty when Sarah has signed off (Status empty OR != pending)
 //   - FilesOwned has at least one source-code file when sign-off requires
 //     it (docs-only is rejected by Sarah's readiness gate)
 //   - At least one Task present when Sarah has signed off
 //
+// Empty Status is Sarah's emission shape — `omitempty` on the wire elides
+// the field after she's signed off (b7r50o9ov 2026-05-08). The readiness
+// invariants apply to empty AND non-pending statuses; only StoryStatusPending
+// (Sarah explicitly mid-flight) is exempt. Pre-fix the empty-Status branch
+// ALSO bypassed the gate, which meant Sarah's primary readiness layer was
+// silently disabled — every defect rode through to plan-reviewer R3.
+//
 // Plan-reviewer R3 rules (story.missing_files_owned, story.docs_only_files_owned,
-// task.missing_within_story) wrap this as the defensive backstop layer.
-// Sarah's readiness gate is the primary layer (fails fast on the
-// architect's side).
+// task.missing_within_story) remain the defensive backstop layer. Now Sarah's
+// readiness gate actually fires first, matching the doc contract at
+// workflow/story_task.go:88. Closes go-reviewer Pass-3 S-C1 / Pass-4 P4-C4.
 func ValidateStory(s Story) error {
 	if s.ID == "" {
 		return fmt.Errorf("%w: story missing ID", ErrInvalidStoryStructure)
@@ -99,22 +106,23 @@ func ValidateStory(s Story) error {
 	}
 
 	// Pending stories are in-flight by Sarah and may not yet have files /
-	// tasks populated. The readiness invariants apply only on sign-off.
-	if s.Status == StoryStatusPending || s.Status == "" {
+	// tasks populated. The readiness invariants apply on every other shape,
+	// including the empty-Status emission Sarah produces post-sign-off.
+	if s.Status == StoryStatusPending {
 		return nil
 	}
 
 	if len(s.FilesOwned) == 0 {
-		return fmt.Errorf("%w: story %q has empty files_owned but status %q indicates Sarah signed off — readiness gate requires at least one workspace-relative path",
-			ErrInvalidStoryStructure, s.ID, s.Status)
+		return fmt.Errorf("%w: story %q has empty files_owned — readiness gate requires at least one workspace-relative path",
+			ErrInvalidStoryStructure, s.ID)
 	}
 	if !hasSourceFile(s.FilesOwned) {
 		return fmt.Errorf("%w: story %q files_owned %v contains only documentation files — readiness gate requires at least one source-code file",
 			ErrInvalidStoryStructure, s.ID, s.FilesOwned)
 	}
 	if len(s.Tasks) == 0 {
-		return fmt.Errorf("%w: story %q has empty tasks but status %q indicates Sarah signed off — readiness gate requires at least one task",
-			ErrInvalidStoryStructure, s.ID, s.Status)
+		return fmt.Errorf("%w: story %q has empty tasks — readiness gate requires at least one task",
+			ErrInvalidStoryStructure, s.ID)
 	}
 	return nil
 }

--- a/workflow/plan_story_test.go
+++ b/workflow/plan_story_test.go
@@ -88,8 +88,37 @@ func TestValidateStory(t *testing.T) {
 			story: Story{ID: "s1", RequirementID: "r1", Title: "T", Status: StoryStatusPending},
 		},
 		{
-			name:  "empty status (freshly generated) is treated as pending",
-			story: Story{ID: "s1", RequirementID: "r1", Title: "T"},
+			name: "empty status (Sarah signed off via omitempty) — readiness invariants apply",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T",
+				FilesOwned: []string{"src/a.go"},
+				Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "impl"}},
+			},
+		},
+		{
+			name:      "empty status + empty files_owned rejected (Train D — Pass-3 S-C1 / Pass-4 P4-C4)",
+			story:     Story{ID: "s1", RequirementID: "r1", Title: "T"},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "empty files_owned",
+		},
+		{
+			name: "empty status + empty tasks rejected (Train D — Pass-3 S-C1 / Pass-4 P4-C4)",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T",
+				FilesOwned: []string{"src/a.go"},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "empty tasks",
+		},
+		{
+			name: "empty status + docs-only files_owned rejected (Train D — Pass-3 S-C1 / Pass-4 P4-C4)",
+			story: Story{
+				ID: "s1", RequirementID: "r1", Title: "T",
+				FilesOwned: []string{"docs/notes.md"},
+				Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "impl"}},
+			},
+			wantErr:   ErrInvalidStoryStructure,
+			errPhrase: "only documentation files",
 		},
 		{
 			name:      "missing ID rejected",


### PR DESCRIPTION
## Summary

Stacked PR closing the **Pass-3 / Pass-4 findings around Sarah's readiness gate and R2 re-entry routing**. These bugs would affect smoke-6-shape single-Story runs as much as multi-Story (which Trains A + B already closed). Train D makes plan-reviewer R3 actually work end-to-end on Sarah's output.

| Commit | Closes | What |
|---|---|---|
| `7c367d0` | **P4-C4 / Pass-3 S-C1** | Flip `ValidateStory` empty-Status semantic so Sarah's omitempty emissions actually get gated on readiness (files_owned, source-file, tasks). Pre-fix the gate was silently disabled. |
| `dd91089` | **Pass-3 S-C2 / Pass-2 C5** | Sarah's `parseStoriesFromResult` now rejects partial Requirement coverage with the uncovered req IDs named — error flows through retryOrFail → Sarah's regen prompt verbatim. |
| `a19a149` | **P4-C3** | `determineR2ReentryPoint` gains the missing `"stories"` case: story-phase findings clear only Stories + Scenarios and return StatusArchitectureGenerated (Sarah re-prep). Also fixes a latent bug — pre-fix every other cascade branch left `plan.Stories` pinned to wiped Requirements. |
| `a7f893f` | **P4-C5 (interim)** + 2 doc-drift cleanups | `phaseToRole` gains `"stories" → "story-preparer"` so Sarah's lesson-learning counts route correctly (BLOCKER caught by the pre-commit reviewer of this commit). R3 co-fire shape documented at the mergeStoryFindings call site. `workflow/plan_review_result.go` Phase enum + `story_rules.go` empty-Status comment refreshed to match post-Train-D layering. |

## Why these bugs matter for smoke 6 / real-LLM

Smoke 6's failure modes had nothing to do with Train A/B (which only matter for multi-Story plans). Train D directly addresses the smoke-6-shape path:

- `ValidateStory` silently passed every defective Sarah emission — every docs-only / empty-files Story rode through to plan-reviewer R3 instead of failing fast → retry cycles wasted.
- `parseStoriesFromResult` accepted partial coverage → scenario-generator legacy fallback engaged for the uncovered Req → execution-manager hard-failed late with `"no Stories on plan for requirement %s"`.
- Story-phase R3 rejections fell to the default case → nuked Architecture + Requirements → rewound past Sarah → Sarah's defective output survived the regen.
- Story lessons misattributed to planner role → role-scoped lesson recall returned irrelevant lessons to future Sarah dispatches.

## Cadence note

Six commits across two PRs (#76 + #77 + this) were developed with pre-commit `go-reviewer` runs on each staged diff. Reviewer caught two BLOCKER follow-ons (H4b in Train A; P4-C5 sibling `phaseToRole` bug in this stack) that would have shipped silently with PR-only review. See `feedback_go_reviewer_before_each_commit.md` in user memory.

## What's NOT in this PR (deferred)

- **P4-C5 full implementation** — a dedicated `stories_generated → reviewing_stories` claim path with a story-shaped LLM prompt. Materially larger: separate ADR + new transition + prompt context. The co-fire interim shape (LLM verdict on scenarios, structural rules on plan state) is documented in this PR.
- **Train C decision** — `story_reprepare` implement vs retire still pending.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `gofmt -l processor/ workflow/` clean
- [x] `revive -config revive.toml ./processor/... ./workflow/...` clean
- [x] 9 new tests across the stack (ValidateStory empty-status cases, per-Req coverage gate, determineR2ReentryPoint three cases, phaseToRole table)
- [x] Pre-commit `go-reviewer` ship-it verdict on each of 4 commits (one BLOCKER caught + fixed mid-stack)

## After this lands

Real-LLM smoke preflight per `feedback_preflight_endpoint_before_paid_burn.md`. Target: `task e2e:watch:llm -- gemini easy` (8.7min baseline per `real-llm-expectations.md`) to validate the Train A/B/D cumulative chain on a known fixture before tackling harder tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)