### PR TITLE
Train C: story_reprepare end-to-end (ADR-043 PR 4i completion)

### DIFF
--- a/processor/plan-decision-handler/component.go
+++ b/processor/plan-decision-handler/component.go
@@ -287,8 +287,11 @@ func (c *Component) handleCascadeRequest(ctx context.Context, req *payloads.Plan
 		return nil, fmt.Errorf("proposal %q not found in slug %q", req.ProposalID, req.Slug)
 	}
 
-	// Run the cascade: pure business logic, no I/O.
-	result, err := cascade.PlanDecision(target, plan.Scenarios)
+	// Run the cascade: pure business logic, no I/O. Stories are passed in
+	// so the cascade can branch on Kind=story_reprepare (Train C) — the
+	// existing requirement_change path ignores stories and stays
+	// behavior-identical.
+	result, err := cascade.PlanDecision(target, plan.Stories, plan.Scenarios)
 	if err != nil {
 		return nil, fmt.Errorf("cascade change proposal: %w", err)
 	}

--- a/processor/plan-decision-handler/recovery_autoaccept.go
+++ b/processor/plan-decision-handler/recovery_autoaccept.go
@@ -122,11 +122,22 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 }
 
 // shouldAutoAcceptRecovery is the gated filter — narrow on purpose.
-// Returns true iff the proposal is a recovery-agent-emitted
-// requirement_change proposal in proposed status with at least one
-// affected req to target. Everything else (qa-reviewer proposals,
-// execution_exhausted terminal records, human proposals) is left for
-// human review.
+// Returns true iff the proposal is a recovery-agent-emitted decision in
+// proposed status with at least one affected req to target AND its Kind
+// is in the auto-acceptable set:
+//
+//   - PlanDecisionKindRequirementChange — refine_prompt / narrow_scope /
+//     split_req recovery actions (the existing path).
+//   - PlanDecisionKindStoryReprepare — story_reprepare action (Train C
+//     step 4). The cascade dirty-marks Stories + scenarios; plan-manager
+//     drives stories_generated → preparing_stories so Sarah re-runs with
+//     the diagnosis as Story.RecoveryHint.
+//
+// Other kinds (execution_exhausted terminal records, qa-reviewer
+// proposals, human proposals) stay human-gated. AffectedReqIDs is the
+// load-bearing predicate for both auto-acceptable kinds: it scopes the
+// cascade target, and an empty list signals "the wedge isn't scoped to
+// specific work — needs human triage."
 func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	if dec == nil {
 		return false
@@ -137,7 +148,11 @@ func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	if dec.Status != workflow.PlanDecisionStatusProposed {
 		return false
 	}
-	if dec.Kind != workflow.PlanDecisionKindRequirementChange {
+	switch dec.Kind {
+	case workflow.PlanDecisionKindRequirementChange,
+		workflow.PlanDecisionKindStoryReprepare:
+		// auto-acceptable
+	default:
 		return false
 	}
 	if len(dec.AffectedReqIDs) == 0 {

--- a/processor/plan-decision-handler/should_auto_accept_test.go
+++ b/processor/plan-decision-handler/should_auto_accept_test.go
@@ -1,0 +1,102 @@
+package changeproposalhandler
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestShouldAutoAcceptRecovery_WidenedForStoryReprepare pins the Train C
+// step 4 widening: recovery-agent-emitted story_reprepare proposals are
+// now auto-acceptable alongside requirement_change. Pre-fix the filter
+// only matched requirement_change → story_reprepare proposals sat in
+// `proposed` forever waiting for a human click, defeating the whole
+// autonomous-recovery shape.
+func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
+	cases := []struct {
+		name    string
+		dec     *workflow.PlanDecision
+		wantOK  bool
+		comment string
+	}{
+		{
+			name: "story_reprepare is auto-acceptable",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindStoryReprepare,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  true,
+			comment: "Train C step 4: widened from requirement_change-only",
+		},
+		{
+			name: "requirement_change still auto-acceptable",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindRequirementChange,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  true,
+			comment: "pre-existing path unchanged",
+		},
+		{
+			name: "execution_exhausted stays human-gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindExecutionExhausted,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  false,
+			comment: "terminal kind requires human ack",
+		},
+		{
+			name: "non-recovery-agent proposer stays human-gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "qa-reviewer",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindStoryReprepare,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  false,
+			comment: "filter is recovery-agent-only by design",
+		},
+		{
+			name: "non-proposed status stays human-gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusAccepted,
+				Kind:           workflow.PlanDecisionKindStoryReprepare,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  false,
+			comment: "already-decided proposals aren't re-accepted",
+		},
+		{
+			name: "empty AffectedReqIDs stays human-gated (story_reprepare)",
+			dec: &workflow.PlanDecision{
+				ProposedBy: "recovery-agent",
+				Status:     workflow.PlanDecisionStatusProposed,
+				Kind:       workflow.PlanDecisionKindStoryReprepare,
+			},
+			wantOK:  false,
+			comment: "no scope to target — needs human triage",
+		},
+		{
+			name:   "nil proposal stays human-gated",
+			dec:    nil,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldAutoAcceptRecovery(tc.dec)
+			if got != tc.wantOK {
+				t.Errorf("shouldAutoAcceptRecovery = %v, want %v (%s)", got, tc.wantOK, tc.comment)
+			}
+		})
+	}
+}

--- a/processor/plan-manager/http_plan_decision.go
+++ b/processor/plan-manager/http_plan_decision.go
@@ -493,15 +493,38 @@ func (c *Component) handleAcceptPlanDecision(w http.ResponseWriter, r *http.Requ
 	proposal.DecidedAt = &now
 
 	// ADR-037 stage-1 (a3): when accepting a recovery PlanDecision, apply
-	// the rationale as supplementary feedback on the affected req(s) via
-	// req.RecoveryHint. Execution-manager prepends this onto exec.Feedback
-	// at next-cycle developer dispatch so the manager-role agent's
-	// recommendation reaches the wedged role through the existing
-	// retry-feedback channel. No new prompt fragment, no new wire shape.
-	// Gated by ProposedBy="recovery-agent" so qa-reviewer + req-executor
-	// proposals (which use the same wire) don't get hint application.
+	// the rationale as supplementary feedback on the affected entity(ies)
+	// via RecoveryHint. Execution-manager prepends Req.RecoveryHint onto
+	// exec.Feedback at next-cycle developer dispatch; Sarah reads
+	// Story.RecoveryHint at re-prep time (Train C step 4) so the
+	// manager-role agent's recommendation reaches the wedged role through
+	// the existing retry-feedback channel. No new prompt fragment, no new
+	// wire shape. Gated by ProposedBy="recovery-agent" so qa-reviewer +
+	// req-executor proposals (which use the same wire) don't get hint
+	// application.
 	if proposal.ProposedBy == "recovery-agent" && proposal.Rationale != "" {
 		applyRecoveryHint(plan, proposal)
+	}
+
+	// Train C step 4: when a story_reprepare PlanDecision is accepted,
+	// drive the back-transition stories_generated → preparing_stories so
+	// Sarah's watcher claims and re-preps. Cascade has already dirty-
+	// marked the affected Stories at the cache level; this clears them
+	// from plan.Stories so Sarah's gate sees them as needing fresh work
+	// rather than treating stale content as already-done. Only the named
+	// Stories (or, if AffectedStoryIDs empty, every Story under
+	// AffectedReqIDs — matches the cascade fallback) are removed; sibling
+	// Stories survive.
+	//
+	// Transition validation happens in setPlanStatusCached; an invalid
+	// transition (e.g., plan moved past stories_generated while the human
+	// review window was open) leaves the plan in place + logs a warning.
+	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
+		clearStoriesForReprepare(plan, proposal)
+		if err := c.setPlanStatusCached(r.Context(), plan, workflow.StatusPreparingStories); err != nil {
+			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
+				"slug", slug, "proposal_id", proposalID, "current_status", plan.EffectiveStatus(), "error", err)
+		}
 	}
 
 	if err := c.plans.save(r.Context(), plan); err != nil {
@@ -587,32 +610,128 @@ func (c *Component) handleRejectPlanDecision(w http.ResponseWriter, r *http.Requ
 }
 
 // applyRecoveryHint writes the recovery agent's diagnosis onto each
-// affected requirement's RecoveryHint field. Execution-manager reads
+// affected entity's RecoveryHint field. Execution-manager reads
 // req.RecoveryHint at developer dispatch time and prepends it to
 // exec.Feedback so the agent sees the manager-role recommendation in
-// the same channel as prior reviewer feedback.
+// the same channel as prior reviewer feedback; Sarah reads
+// Story.RecoveryHint at re-prep time for the same purpose.
+//
+// Branches on proposal.Kind:
+//
+//   - Kind=story_reprepare: write proposal.Rationale onto every Story
+//     in proposal.AffectedStoryIDs (Train C step 4). If
+//     AffectedStoryIDs is empty, fall back to "every Story under
+//     proposal.AffectedReqIDs" — matches the cascade's whole-
+//     Requirement re-prep fallback so Sarah sees the diagnosis on every
+//     Story she's about to re-author.
+//   - Kind=requirement_change OR unset (back-compat): write
+//     proposal.Rationale onto every Requirement in
+//     proposal.AffectedReqIDs (the pre-Train-C contract).
 //
 // Idempotent: repeated accepts of the same proposal overwrite the hint
 // with the same content. The hint is cleared on req completion (the next
 // cycle of a different req doesn't carry stale recovery context).
 //
-// Best-effort: a missing affected req (deleted between propose + accept)
-// is logged and skipped, not an error — the cascade re-run will surface
-// the missing-req case through the existing dirty-mark machinery.
+// Best-effort: a missing affected entity (deleted between propose +
+// accept) is logged and skipped, not an error — the cascade re-run will
+// surface the missing-entity case through the existing dirty-mark
+// machinery.
 func applyRecoveryHint(plan *workflow.Plan, proposal *workflow.PlanDecision) {
 	if proposal == nil || proposal.Rationale == "" {
 		return
 	}
+	now := time.Now()
+
+	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
+		applyRecoveryHintToStories(plan, proposal, now)
+		return
+	}
+
 	affected := make(map[string]bool, len(proposal.AffectedReqIDs))
 	for _, id := range proposal.AffectedReqIDs {
 		affected[id] = true
 	}
-	now := time.Now()
 	for i := range plan.Requirements {
 		if !affected[plan.Requirements[i].ID] {
 			continue
 		}
 		plan.Requirements[i].RecoveryHint = proposal.Rationale
 		plan.Requirements[i].UpdatedAt = now
+	}
+}
+
+// clearStoriesForReprepare removes the Stories named in
+// proposal.AffectedStoryIDs from plan.Stories (or, when AffectedStoryIDs
+// is empty, every Story under proposal.AffectedReqIDs — matches the
+// cascade.storiesForReprepare fallback). Sibling Stories survive.
+//
+// Removing the Stories from plan.Stories is the "dirty mark" that Sarah's
+// re-prep relies on: workflow.ValidateStories runs on Sarah's emission at
+// the next mutation boundary, and Sarah's prompt context iterates
+// plan.Stories to see what's already authored. Stale-Story content
+// passing through would silently overwrite the diagnosis-shaped re-prep.
+func clearStoriesForReprepare(plan *workflow.Plan, proposal *workflow.PlanDecision) {
+	if len(plan.Stories) == 0 {
+		return
+	}
+	target := make(map[string]bool, len(proposal.AffectedStoryIDs))
+	for _, id := range proposal.AffectedStoryIDs {
+		target[id] = true
+	}
+	if len(target) == 0 {
+		reqs := make(map[string]bool, len(proposal.AffectedReqIDs))
+		for _, id := range proposal.AffectedReqIDs {
+			reqs[id] = true
+		}
+		kept := plan.Stories[:0]
+		for _, s := range plan.Stories {
+			if !reqs[s.RequirementID] {
+				kept = append(kept, s)
+			}
+		}
+		plan.Stories = kept
+		return
+	}
+	kept := plan.Stories[:0]
+	for _, s := range plan.Stories {
+		if !target[s.ID] {
+			kept = append(kept, s)
+		}
+	}
+	plan.Stories = kept
+}
+
+// applyRecoveryHintToStories writes proposal.Rationale onto every Story
+// in proposal.AffectedStoryIDs (or, if empty, every Story under
+// proposal.AffectedReqIDs). Mirrors the cascade.storiesForReprepare
+// fallback so applyRecoveryHint and cascade agree on which Stories are
+// in scope.
+func applyRecoveryHintToStories(plan *workflow.Plan, proposal *workflow.PlanDecision, now time.Time) {
+	target := make(map[string]bool, len(proposal.AffectedStoryIDs))
+	for _, id := range proposal.AffectedStoryIDs {
+		target[id] = true
+	}
+
+	if len(target) == 0 {
+		// Fallback: every Story under any affected Requirement.
+		reqs := make(map[string]bool, len(proposal.AffectedReqIDs))
+		for _, id := range proposal.AffectedReqIDs {
+			reqs[id] = true
+		}
+		for i := range plan.Stories {
+			if reqs[plan.Stories[i].RequirementID] {
+				plan.Stories[i].RecoveryHint = proposal.Rationale
+				plan.Stories[i].UpdatedAt = now
+			}
+		}
+		return
+	}
+
+	for i := range plan.Stories {
+		if !target[plan.Stories[i].ID] {
+			continue
+		}
+		plan.Stories[i].RecoveryHint = proposal.Rationale
+		plan.Stories[i].UpdatedAt = now
 	}
 }

--- a/processor/plan-manager/http_plan_decision.go
+++ b/processor/plan-manager/http_plan_decision.go
@@ -508,22 +508,28 @@ func (c *Component) handleAcceptPlanDecision(w http.ResponseWriter, r *http.Requ
 
 	// Train C step 4: when a story_reprepare PlanDecision is accepted,
 	// drive the back-transition stories_generated → preparing_stories so
-	// Sarah's watcher claims and re-preps. Cascade has already dirty-
-	// marked the affected Stories at the cache level; this clears them
-	// from plan.Stories so Sarah's gate sees them as needing fresh work
-	// rather than treating stale content as already-done. Only the named
-	// Stories (or, if AffectedStoryIDs empty, every Story under
-	// AffectedReqIDs — matches the cascade fallback) are removed; sibling
-	// Stories survive.
+	// Sarah's watcher claims and re-preps. The affected Stories STAY in
+	// plan.Stories with their RecoveryHint set (written by
+	// applyRecoveryHint above) so Sarah's prompt iterates the full Story
+	// set and sees which entries need re-authoring; her emission then
+	// REPLACES plan.Stories per the existing handleStoriesMutation
+	// wipe-and-replace contract.
 	//
-	// Transition validation happens in setPlanStatusCached; an invalid
-	// transition (e.g., plan moved past stories_generated while the human
-	// review window was open) leaves the plan in place + logs a warning.
+	// In-place transition check (NOT setPlanStatusCached) avoids a double
+	// KV put: setPlanStatusCached would save, then the trailing ps.save
+	// below would save again — both putting status=preparing_stories. The
+	// watcher would see two identical events and dispatch Sarah twice. The
+	// inline check + mutation lets the existing trailing save be the sole
+	// persist point. An invalid transition (plan moved past
+	// stories_generated while the human review window was open) leaves the
+	// plan in place + logs a warning.
 	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
-		clearStoriesForReprepare(plan, proposal)
-		if err := c.setPlanStatusCached(r.Context(), plan, workflow.StatusPreparingStories); err != nil {
+		current := plan.EffectiveStatus()
+		if current.CanTransitionTo(workflow.StatusPreparingStories) {
+			plan.Status = workflow.StatusPreparingStories
+		} else {
 			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
-				"slug", slug, "proposal_id", proposalID, "current_status", plan.EffectiveStatus(), "error", err)
+				"slug", slug, "proposal_id", proposalID, "current_status", current)
 		}
 	}
 
@@ -658,47 +664,6 @@ func applyRecoveryHint(plan *workflow.Plan, proposal *workflow.PlanDecision) {
 		plan.Requirements[i].RecoveryHint = proposal.Rationale
 		plan.Requirements[i].UpdatedAt = now
 	}
-}
-
-// clearStoriesForReprepare removes the Stories named in
-// proposal.AffectedStoryIDs from plan.Stories (or, when AffectedStoryIDs
-// is empty, every Story under proposal.AffectedReqIDs — matches the
-// cascade.storiesForReprepare fallback). Sibling Stories survive.
-//
-// Removing the Stories from plan.Stories is the "dirty mark" that Sarah's
-// re-prep relies on: workflow.ValidateStories runs on Sarah's emission at
-// the next mutation boundary, and Sarah's prompt context iterates
-// plan.Stories to see what's already authored. Stale-Story content
-// passing through would silently overwrite the diagnosis-shaped re-prep.
-func clearStoriesForReprepare(plan *workflow.Plan, proposal *workflow.PlanDecision) {
-	if len(plan.Stories) == 0 {
-		return
-	}
-	target := make(map[string]bool, len(proposal.AffectedStoryIDs))
-	for _, id := range proposal.AffectedStoryIDs {
-		target[id] = true
-	}
-	if len(target) == 0 {
-		reqs := make(map[string]bool, len(proposal.AffectedReqIDs))
-		for _, id := range proposal.AffectedReqIDs {
-			reqs[id] = true
-		}
-		kept := plan.Stories[:0]
-		for _, s := range plan.Stories {
-			if !reqs[s.RequirementID] {
-				kept = append(kept, s)
-			}
-		}
-		plan.Stories = kept
-		return
-	}
-	kept := plan.Stories[:0]
-	for _, s := range plan.Stories {
-		if !target[s.ID] {
-			kept = append(kept, s)
-		}
-	}
-	plan.Stories = kept
 }
 
 // applyRecoveryHintToStories writes proposal.Rationale onto every Story

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1952,6 +1952,18 @@ func (c *Component) handlePlanDecisionAcceptMutation(ctx context.Context, data [
 		applyRecoveryHint(plan, proposal)
 	}
 
+	// Mirror HTTP path: drive the stories_generated → preparing_stories
+	// back-transition when a story_reprepare PlanDecision is accepted.
+	// Clearing Stories matching the proposal scope is the "dirty mark"
+	// that makes Sarah's re-prep land on a clean slate. Train C step 4.
+	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
+		clearStoriesForReprepare(plan, proposal)
+		if err := c.setPlanStatusCached(ctx, plan, workflow.StatusPreparingStories); err != nil {
+			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
+				"slug", req.Slug, "proposal_id", req.ProposalID, "current_status", plan.EffectiveStatus(), "error", err)
+		}
+	}
+
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save plan after auto-accepting plan_decision",
 			"slug", req.Slug, "proposal_id", req.ProposalID, "error", err)

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1954,13 +1954,22 @@ func (c *Component) handlePlanDecisionAcceptMutation(ctx context.Context, data [
 
 	// Mirror HTTP path: drive the stories_generated → preparing_stories
 	// back-transition when a story_reprepare PlanDecision is accepted.
-	// Clearing Stories matching the proposal scope is the "dirty mark"
-	// that makes Sarah's re-prep land on a clean slate. Train C step 4.
+	// The affected Stories stay in plan.Stories with their RecoveryHint
+	// set (applyRecoveryHint above); Sarah's prompt iterates the full
+	// Story set on re-prep and her emission replaces plan.Stories per
+	// the existing handleStoriesMutation wipe-and-replace contract.
+	// Train C step 4.
+	//
+	// In-place transition check (NOT setPlanStatusCached) avoids a
+	// double-save / double-event — see the matching block in
+	// handleAcceptPlanDecision for the explanation.
 	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
-		clearStoriesForReprepare(plan, proposal)
-		if err := c.setPlanStatusCached(ctx, plan, workflow.StatusPreparingStories); err != nil {
+		current := plan.EffectiveStatus()
+		if current.CanTransitionTo(workflow.StatusPreparingStories) {
+			plan.Status = workflow.StatusPreparingStories
+		} else {
 			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
-				"slug", req.Slug, "proposal_id", req.ProposalID, "current_status", plan.EffectiveStatus(), "error", err)
+				"slug", req.Slug, "proposal_id", req.ProposalID, "current_status", current)
 		}
 	}
 

--- a/processor/plan-manager/story_reprepare_apply_test.go
+++ b/processor/plan-manager/story_reprepare_apply_test.go
@@ -103,61 +103,6 @@ func TestApplyRecoveryHint_RequirementChangePreservesBackCompat(t *testing.T) {
 	}
 }
 
-// TestClearStoriesForReprepare_NamedStoriesRemoved pins the dirty-mark
-// semantic: clearStoriesForReprepare drops the named Stories from
-// plan.Stories so Sarah's re-prep starts from a clean slate. Sibling
-// Stories survive.
-func TestClearStoriesForReprepare_NamedStoriesRemoved(t *testing.T) {
-	plan := &workflow.Plan{
-		Stories: []workflow.Story{
-			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
-			{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
-			{ID: "story.demo.1.3", RequirementID: "req.demo.1"},
-		},
-	}
-	proposal := &workflow.PlanDecision{
-		Kind:             workflow.PlanDecisionKindStoryReprepare,
-		AffectedStoryIDs: []string{"story.demo.1.2"},
-	}
-
-	clearStoriesForReprepare(plan, proposal)
-
-	if len(plan.Stories) != 2 {
-		t.Fatalf("plan.Stories len = %d, want 2 (story 2 removed)", len(plan.Stories))
-	}
-	for _, s := range plan.Stories {
-		if s.ID == "story.demo.1.2" {
-			t.Errorf("story.demo.1.2 should have been removed; still present")
-		}
-	}
-}
-
-// TestClearStoriesForReprepare_FallbackRemovesByReqScope pins the
-// fallback: empty AffectedStoryIDs → remove every Story under
-// AffectedReqIDs. Matches the cascade + applyRecoveryHint fallback.
-func TestClearStoriesForReprepare_FallbackRemovesByReqScope(t *testing.T) {
-	plan := &workflow.Plan{
-		Stories: []workflow.Story{
-			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
-			{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
-			{ID: "story.demo.2.1", RequirementID: "req.demo.2"},
-		},
-	}
-	proposal := &workflow.PlanDecision{
-		Kind:           workflow.PlanDecisionKindStoryReprepare,
-		AffectedReqIDs: []string{"req.demo.1"},
-	}
-
-	clearStoriesForReprepare(plan, proposal)
-
-	if len(plan.Stories) != 1 {
-		t.Fatalf("plan.Stories len = %d, want 1 (req.demo.1 Stories all removed)", len(plan.Stories))
-	}
-	if plan.Stories[0].ID != "story.demo.2.1" {
-		t.Errorf("plan.Stories[0].ID = %q, want story.demo.2.1 (different req survives)", plan.Stories[0].ID)
-	}
-}
-
 // TestApplyRecoveryHint_StoryUpdatedAtSet pins that Story.UpdatedAt is
 // bumped on hint write so downstream consumers (UI badges, graph
 // observers) see the freshness.

--- a/processor/plan-manager/story_reprepare_apply_test.go
+++ b/processor/plan-manager/story_reprepare_apply_test.go
@@ -1,0 +1,182 @@
+package planmanager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestApplyRecoveryHint_StoryReprepare_NamedStoriesOnly is the headline
+// Train C step 4 regression for the Story-scoped hint write: only the
+// Stories in proposal.AffectedStoryIDs gain the RecoveryHint; sibling
+// Stories on the same Requirement are untouched. Pre-fix the function
+// only wrote Requirement.RecoveryHint regardless of Kind, so Sarah's
+// re-prep prompt never saw the diagnosis.
+func TestApplyRecoveryHint_StoryReprepare_NamedStoriesOnly(t *testing.T) {
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "untouched"},
+			{ID: "story.demo.1.2", RequirementID: "req.demo.1", Title: "targeted"},
+			{ID: "story.demo.1.3", RequirementID: "req.demo.1", Title: "untouched"},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		ID:               "plan-decision.demo.recovery.abc12345",
+		Kind:             workflow.PlanDecisionKindStoryReprepare,
+		Rationale:        "Story 2's files_owned missed src/x.go; re-shard including the X module.",
+		AffectedReqIDs:   []string{"req.demo.1"},
+		AffectedStoryIDs: []string{"story.demo.1.2"},
+	}
+
+	applyRecoveryHint(plan, proposal)
+
+	if got := plan.Stories[0].RecoveryHint; got != "" {
+		t.Errorf("Stories[0].RecoveryHint = %q, want empty (sibling untouched)", got)
+	}
+	if got := plan.Stories[1].RecoveryHint; got != proposal.Rationale {
+		t.Errorf("Stories[1].RecoveryHint = %q, want %q", got, proposal.Rationale)
+	}
+	if got := plan.Stories[2].RecoveryHint; got != "" {
+		t.Errorf("Stories[2].RecoveryHint = %q, want empty (sibling untouched)", got)
+	}
+}
+
+// TestApplyRecoveryHint_StoryReprepare_FallbackToReqScope pins the
+// fallback path: when proposal.AffectedStoryIDs is empty,
+// applyRecoveryHint writes onto every Story under proposal.AffectedReqIDs.
+// Mirrors cascade.storiesForReprepare's fallback so the two functions
+// agree on scope.
+func TestApplyRecoveryHint_StoryReprepare_FallbackToReqScope(t *testing.T) {
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+			{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
+			{ID: "story.demo.2.1", RequirementID: "req.demo.2"}, // different req
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		Kind:           workflow.PlanDecisionKindStoryReprepare,
+		Rationale:      "Re-shard req.demo.1 with the X module in scope.",
+		AffectedReqIDs: []string{"req.demo.1"},
+		// AffectedStoryIDs intentionally empty
+	}
+
+	applyRecoveryHint(plan, proposal)
+
+	if got := plan.Stories[0].RecoveryHint; got != proposal.Rationale {
+		t.Errorf("Stories[0].RecoveryHint = %q, want %q (in req scope)", got, proposal.Rationale)
+	}
+	if got := plan.Stories[1].RecoveryHint; got != proposal.Rationale {
+		t.Errorf("Stories[1].RecoveryHint = %q, want %q (in req scope)", got, proposal.Rationale)
+	}
+	if got := plan.Stories[2].RecoveryHint; got != "" {
+		t.Errorf("Stories[2].RecoveryHint = %q, want empty (different req)", got)
+	}
+}
+
+// TestApplyRecoveryHint_RequirementChangePreservesBackCompat pins the
+// pre-Train-C behavior: Kind=requirement_change still writes onto
+// Requirement.RecoveryHint and does NOT touch Story.RecoveryHint.
+func TestApplyRecoveryHint_RequirementChangePreservesBackCompat(t *testing.T) {
+	plan := &workflow.Plan{
+		Requirements: []workflow.Requirement{
+			{ID: "req.demo.1"},
+		},
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		Kind:           workflow.PlanDecisionKindRequirementChange,
+		Rationale:      "Refine the prompt with explicit X reference.",
+		AffectedReqIDs: []string{"req.demo.1"},
+	}
+
+	applyRecoveryHint(plan, proposal)
+
+	if got := plan.Requirements[0].RecoveryHint; got != proposal.Rationale {
+		t.Errorf("Requirements[0].RecoveryHint = %q, want %q (requirement_change writes here)", got, proposal.Rationale)
+	}
+	if got := plan.Stories[0].RecoveryHint; got != "" {
+		t.Errorf("Stories[0].RecoveryHint = %q, want empty (requirement_change does NOT touch Stories)", got)
+	}
+}
+
+// TestClearStoriesForReprepare_NamedStoriesRemoved pins the dirty-mark
+// semantic: clearStoriesForReprepare drops the named Stories from
+// plan.Stories so Sarah's re-prep starts from a clean slate. Sibling
+// Stories survive.
+func TestClearStoriesForReprepare_NamedStoriesRemoved(t *testing.T) {
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+			{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
+			{ID: "story.demo.1.3", RequirementID: "req.demo.1"},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		Kind:             workflow.PlanDecisionKindStoryReprepare,
+		AffectedStoryIDs: []string{"story.demo.1.2"},
+	}
+
+	clearStoriesForReprepare(plan, proposal)
+
+	if len(plan.Stories) != 2 {
+		t.Fatalf("plan.Stories len = %d, want 2 (story 2 removed)", len(plan.Stories))
+	}
+	for _, s := range plan.Stories {
+		if s.ID == "story.demo.1.2" {
+			t.Errorf("story.demo.1.2 should have been removed; still present")
+		}
+	}
+}
+
+// TestClearStoriesForReprepare_FallbackRemovesByReqScope pins the
+// fallback: empty AffectedStoryIDs → remove every Story under
+// AffectedReqIDs. Matches the cascade + applyRecoveryHint fallback.
+func TestClearStoriesForReprepare_FallbackRemovesByReqScope(t *testing.T) {
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+			{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
+			{ID: "story.demo.2.1", RequirementID: "req.demo.2"},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		Kind:           workflow.PlanDecisionKindStoryReprepare,
+		AffectedReqIDs: []string{"req.demo.1"},
+	}
+
+	clearStoriesForReprepare(plan, proposal)
+
+	if len(plan.Stories) != 1 {
+		t.Fatalf("plan.Stories len = %d, want 1 (req.demo.1 Stories all removed)", len(plan.Stories))
+	}
+	if plan.Stories[0].ID != "story.demo.2.1" {
+		t.Errorf("plan.Stories[0].ID = %q, want story.demo.2.1 (different req survives)", plan.Stories[0].ID)
+	}
+}
+
+// TestApplyRecoveryHint_StoryUpdatedAtSet pins that Story.UpdatedAt is
+// bumped on hint write so downstream consumers (UI badges, graph
+// observers) see the freshness.
+func TestApplyRecoveryHint_StoryUpdatedAtSet(t *testing.T) {
+	stale := time.Now().Add(-time.Hour)
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1", UpdatedAt: stale},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		Kind:             workflow.PlanDecisionKindStoryReprepare,
+		Rationale:        "test",
+		AffectedStoryIDs: []string{"story.demo.1.1"},
+	}
+
+	applyRecoveryHint(plan, proposal)
+
+	if !plan.Stories[0].UpdatedAt.After(stale) {
+		t.Errorf("Stories[0].UpdatedAt not bumped; was %v, still %v", stale, plan.Stories[0].UpdatedAt)
+	}
+}

--- a/processor/plan-manager/story_reprepare_end_to_end_test.go
+++ b/processor/plan-manager/story_reprepare_end_to_end_test.go
@@ -1,0 +1,146 @@
+package planmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/cascade"
+)
+
+// TestStoryReprepare_EndToEnd_AcceptPathTransitionsPlanAndAppliesHints
+// is the cross-cutting Train C regression. It walks the wire shape
+// the recovery cascade depends on, asserting that:
+//
+//  1. applyRecoveryHint writes Story.RecoveryHint onto the affected
+//     Stories (Train C step 4 — Story-level hint write).
+//  2. The same applyRecoveryHint call leaves the rest of plan.Stories
+//     intact (so Sarah's prompt context can iterate the full set in
+//     step 5).
+//  3. The accept-path's inline CanTransitionTo + plan.Status mutation
+//     produces a SINGLE save at the trailing ps.save (Train C step 5 —
+//     B1 fix; double-save would emit two preparing_stories watcher
+//     events and double-dispatch Sarah).
+//  4. The cascade dirty-marks only the named Stories + their scenarios
+//     (Train C step 3 — story-shape cascade).
+//
+// Together, these pin the contract that an accepted story_reprepare
+// PlanDecision drives the plan into preparing_stories with the
+// affected Stories carrying RecoveryHint, sibling Stories untouched,
+// and a per-(Req,Story) cascade scope ready for Sarah's re-emit.
+//
+// This is a pure-function integration: we don't drive the NATS path
+// because that requires a test NATS server. The accept handler's
+// in-memory mutation contract is the load-bearing piece — the wire
+// glue is tested separately in the per-step commits.
+func TestStoryReprepare_EndToEnd_AcceptPathTransitionsPlanAndAppliesHints(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	const slug = "demo-train-c-e2e"
+
+	// Seed plan at stories_generated with 3 Stories under 1 Req + their
+	// scenarios.
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusStoriesGenerated
+	plan.Requirements = []workflow.Requirement{
+		{ID: "req.demo.1", Title: "the requirement"},
+	}
+	plan.Stories = []workflow.Story{
+		{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "Sibling 1"},
+		{ID: "story.demo.1.2", RequirementID: "req.demo.1", Title: "Targeted"},
+		{ID: "story.demo.1.3", RequirementID: "req.demo.1", Title: "Sibling 3"},
+	}
+	plan.Scenarios = []workflow.Scenario{
+		{ID: "scen.demo.1.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		{ID: "scen.demo.1.2", RequirementID: "req.demo.1", StoryID: "story.demo.1.2"},
+		{ID: "scen.demo.1.3", RequirementID: "req.demo.1", StoryID: "story.demo.1.3"},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// Build a story_reprepare PlanDecision targeting only Story 2.
+	proposal := workflow.PlanDecision{
+		ID:               "plan-decision.demo.recovery.abcd1234",
+		PlanID:           workflow.PlanEntityID(slug),
+		Kind:             workflow.PlanDecisionKindStoryReprepare,
+		Title:            "Recovery: story_reprepare for req.demo.1",
+		Rationale:        "Story 2's files_owned missed src/x.go; re-shard to include the X module.",
+		Status:           workflow.PlanDecisionStatusProposed,
+		ProposedBy:       "recovery-agent",
+		AffectedReqIDs:   []string{"req.demo.1"},
+		AffectedStoryIDs: []string{"story.demo.1.2"},
+		CreatedAt:        time.Now(),
+	}
+	plan.PlanDecisions = []workflow.PlanDecision{proposal}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("seed proposal save: %v", err)
+	}
+
+	// --- Phase 1: applyRecoveryHint writes Story.RecoveryHint onto
+	// Story 2 only; siblings untouched. ---
+	loaded, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan not in store after seed")
+	}
+	applyRecoveryHint(loaded, &proposal)
+	if got := loaded.Stories[0].RecoveryHint; got != "" {
+		t.Errorf("Story 1 RecoveryHint = %q, want empty (sibling untouched)", got)
+	}
+	if got := loaded.Stories[1].RecoveryHint; got != proposal.Rationale {
+		t.Errorf("Story 2 RecoveryHint = %q, want %q", got, proposal.Rationale)
+	}
+	if got := loaded.Stories[2].RecoveryHint; got != "" {
+		t.Errorf("Story 3 RecoveryHint = %q, want empty (sibling untouched)", got)
+	}
+	// Phase 1 invariant: ALL 3 Stories still in plan.Stories — sibling
+	// Stories must survive so Sarah's prompt context can iterate them.
+	if len(loaded.Stories) != 3 {
+		t.Errorf("len(plan.Stories) = %d, want 3 (sibling Stories MUST survive)", len(loaded.Stories))
+	}
+
+	// --- Phase 2: inline transition check + direct mutation drives
+	// plan.Status without an intermediate save. ---
+	current := loaded.EffectiveStatus()
+	if !current.CanTransitionTo(workflow.StatusPreparingStories) {
+		t.Fatalf("transition stories_generated → preparing_stories rejected: current = %s", current)
+	}
+	loaded.Status = workflow.StatusPreparingStories
+
+	// Single trailing save captures: proposal accepted + RecoveryHint
+	// applied + plan.Status transitioned. One KV put → one watcher
+	// event → Sarah dispatches ONCE. Pre-B1-fix the setPlanStatusCached
+	// path would have saved twice here.
+	if err := c.plans.save(ctx, loaded); err != nil {
+		t.Fatalf("final save: %v", err)
+	}
+
+	// --- Phase 3: cascade.PlanDecision runs the story-shape cascade. ---
+	cascadeResult, err := cascade.PlanDecision(&proposal, loaded.Stories, loaded.Scenarios)
+	if err != nil {
+		t.Fatalf("cascade: %v", err)
+	}
+	if len(cascadeResult.AffectedStoryIDs) != 1 || cascadeResult.AffectedStoryIDs[0] != "story.demo.1.2" {
+		t.Errorf("cascade AffectedStoryIDs = %v, want [story.demo.1.2]", cascadeResult.AffectedStoryIDs)
+	}
+	if len(cascadeResult.AffectedScenarioIDs) != 1 || cascadeResult.AffectedScenarioIDs[0] != "scen.demo.1.2" {
+		t.Errorf("cascade AffectedScenarioIDs = %v, want [scen.demo.1.2] (only Story 2's scenarios dirty)", cascadeResult.AffectedScenarioIDs)
+	}
+
+	// --- Phase 4: re-read the saved plan; assert the post-accept state
+	// is durable and ready for Sarah's re-prep claim. ---
+	final, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan disappeared after final save")
+	}
+	if final.EffectiveStatus() != workflow.StatusPreparingStories {
+		t.Errorf("final plan.Status = %s, want preparing_stories (Sarah's watcher claim point)", final.EffectiveStatus())
+	}
+	if final.Stories[1].RecoveryHint != proposal.Rationale {
+		t.Errorf("RecoveryHint did not survive save round-trip: %q", final.Stories[1].RecoveryHint)
+	}
+	if len(final.Stories) != 3 {
+		t.Errorf("final len(Stories) = %d, want 3 (Sarah sees the full set on re-prep)", len(final.Stories))
+	}
+}

--- a/processor/recovery-agent/affected_story_ids_test.go
+++ b/processor/recovery-agent/affected_story_ids_test.go
@@ -1,0 +1,56 @@
+package recoveryagent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestBuildRecoveryPlanDecision_ThreadsAffectedStoryIDsThrough is the
+// Train C step 2 wire-shape contract: RecoveryRequested.AffectedStoryIDs
+// (populated by requirement-executor from the wedged exec's Story
+// cursor) MUST propagate through buildRecoveryPlanDecision into
+// PlanDecision.AffectedStoryIDs. plan-manager downstream consumes that
+// list to scope the story_reprepare cascade + applyRecoveryHint to the
+// specific Stories rather than the whole Requirement.
+func TestBuildRecoveryPlanDecision_ThreadsAffectedStoryIDsThrough(t *testing.T) {
+	req := &payloads.RecoveryRequested{
+		RecoveryID:       "12345678-aaaa-bbbb-cccc-dddddddddddd",
+		Slug:             "demo",
+		Layer:            payloads.RecoveryLayerPhaseLocal,
+		RequirementID:    "req.demo.1",
+		AffectedStoryIDs: []string{"story.demo.1.1", "story.demo.1.2"},
+		EscalationReason: "wedge analysis points at Sarah's story-shaping",
+	}
+
+	dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionStoryReprepare, "Story 2's files_owned missed src/x.go", true, time.Now())
+
+	want := []string{"story.demo.1.1", "story.demo.1.2"}
+	if !reflect.DeepEqual(dec.AffectedStoryIDs, want) {
+		t.Errorf("AffectedStoryIDs = %v, want %v", dec.AffectedStoryIDs, want)
+	}
+}
+
+// TestBuildRecoveryPlanDecision_EmptyAffectedStoryIDsOmitsField pins the
+// omitempty contract: legacy / single-Story / pre-ADR-043 wedges leave
+// AffectedStoryIDs nil. The downstream cascade interprets nil/empty
+// as "operate at Requirement granularity"; setting an empty slice
+// explicitly here would be indistinguishable but is wasteful.
+func TestBuildRecoveryPlanDecision_EmptyAffectedStoryIDsOmitsField(t *testing.T) {
+	req := &payloads.RecoveryRequested{
+		RecoveryID:       "12345678-aaaa-bbbb-cccc-dddddddddddd",
+		Slug:             "legacy",
+		Layer:            payloads.RecoveryLayerPhaseLocal,
+		RequirementID:    "req.legacy.1",
+		EscalationReason: "legacy req without Stories",
+		// AffectedStoryIDs intentionally empty
+	}
+
+	dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionRefinePrompt, "refine the prompt", true, time.Now())
+
+	if dec.AffectedStoryIDs != nil {
+		t.Errorf("AffectedStoryIDs = %v, want nil (legacy wedge has no Stories in scope)", dec.AffectedStoryIDs)
+	}
+}

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -764,16 +764,32 @@ func buildRecoveryPlanDecision(req *payloads.RecoveryRequested, loop *agentic.Lo
 
 	decisionID := fmt.Sprintf("plan-decision.%s.recovery.%s", req.Slug, req.RecoveryID[:8])
 
+	// Story IDs are passed through unconditionally. They're only
+	// load-bearing when Kind=story_reprepare (cascade + applyRecoveryHint
+	// look here); for other kinds the field is omitempty on the wire and
+	// harmless to set. Pre-ADR-043-Train-C consumers ignore the unknown
+	// field, so the wire shape is back-compat.
+	//
+	// The explicit nil-vs-empty distinction is preserved: empty input
+	// leaves affectedStories nil so the JSON omitempty drops the field
+	// entirely (legacy / single-Story wedges), while populated input
+	// forces explicit serialization.
+	var affectedStories []string
+	if len(req.AffectedStoryIDs) > 0 {
+		affectedStories = append(affectedStories, req.AffectedStoryIDs...)
+	}
+
 	return workflow.PlanDecision{
-		ID:             decisionID,
-		PlanID:         workflow.PlanEntityID(req.Slug),
-		Kind:           kind,
-		Title:          title,
-		Rationale:      rationale,
-		Status:         workflow.PlanDecisionStatusProposed,
-		ProposedBy:     componentName,
-		AffectedReqIDs: affectedReqs,
-		CreatedAt:      now,
+		ID:               decisionID,
+		PlanID:           workflow.PlanEntityID(req.Slug),
+		Kind:             kind,
+		Title:            title,
+		Rationale:        rationale,
+		Status:           workflow.PlanDecisionStatusProposed,
+		ProposedBy:       componentName,
+		AffectedReqIDs:   affectedReqs,
+		AffectedStoryIDs: affectedStories,
+		CreatedAt:        now,
 	}
 }
 

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -697,26 +697,29 @@ func (c *Component) deriveDecision(loop *agentic.LoopEntity, escalationReason st
 }
 
 // recoveryActionToPlanDecisionKind maps a RecoveryAction to the
-// PlanDecision kind that drives the cascade. Recoverable actions go
-// through requirement_change so the cascade dirty-marks the req for
-// re-run; terminal actions go through execution_exhausted so plan-manager
-// auto-archives when the subject req reaches a non-failed terminal state.
+// PlanDecision kind that drives the cascade.
 //
-// story_reprepare (ADR-043 PR 4i) maps to requirement_change because the
-// cascade target is the same: dirty-mark the parent requirement so the
-// downstream chain (Sarah's preparing_stories → ready_for_execution)
-// re-runs. The distinction between story_reprepare and the other
-// requirement_change actions surfaces in the PlanDecision rationale text,
-// which plan-manager threads into Sarah's RecoveryHint on the next
-// dispatch — Sarah sees "the wedge happened because <X>; re-shard with
-// <Y> in mind."
+//   - refine_prompt / narrow_scope / split_req → requirement_change.
+//     Cascade dirty-marks scenarios for the affected requirement; the
+//     executor re-runs with the same Story DAG.
+//   - story_reprepare → story_reprepare. Distinct from requirement_change
+//     because the cascade target is Stories + Scenarios (not just
+//     Scenarios) AND plan-manager drives stories_generated →
+//     preparing_stories on accept so Sarah actually re-runs with
+//     Story.RecoveryHint set. Pre-Train-C, story_reprepare mapped to
+//     requirement_change, which silently degraded into a scenarios-only
+//     cascade that left Sarah's stories unchanged.
+//   - escalate_human / mark_unrecoverable → execution_exhausted. Terminal;
+//     plan-manager auto-archives when the subject req reaches a non-failed
+//     terminal state.
 func recoveryActionToPlanDecisionKind(action payloads.RecoveryActionKind) workflow.PlanDecisionKind {
 	switch action {
 	case payloads.RecoveryActionRefinePrompt,
 		payloads.RecoveryActionNarrowScope,
-		payloads.RecoveryActionSplitReq,
-		payloads.RecoveryActionStoryReprepare:
+		payloads.RecoveryActionSplitReq:
 		return workflow.PlanDecisionKindRequirementChange
+	case payloads.RecoveryActionStoryReprepare:
+		return workflow.PlanDecisionKindStoryReprepare
 	case payloads.RecoveryActionEscalateHuman, payloads.RecoveryActionMarkUnrecoverable:
 		return workflow.PlanDecisionKindExecutionExhausted
 	default:

--- a/processor/recovery-agent/plan_decision_kind_mapping_test.go
+++ b/processor/recovery-agent/plan_decision_kind_mapping_test.go
@@ -1,0 +1,52 @@
+package recoveryagent
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestRecoveryActionToPlanDecisionKind pins the mapping that determines
+// which PlanDecisionKind a given RecoveryActionKind escalates into. The
+// kind drives the downstream cascade shape:
+//
+//   - requirement_change → cascade dirty-marks Scenarios for affected reqs;
+//     executor re-runs the same Story DAG.
+//   - story_reprepare → cascade dirty-marks Stories + Scenarios; plan-manager
+//     drives stories_generated → preparing_stories so Sarah re-runs.
+//   - execution_exhausted → terminal; plan-manager auto-archives when subject
+//     reaches a non-failed terminal state.
+//
+// Train C step 1: split story_reprepare out of requirement_change so the
+// cascade can actually do something different for Story-shaped wedges.
+// Pre-fix, story_reprepare returned requirement_change and the wedge
+// silently degraded into a scenarios-only cascade that didn't re-run Sarah.
+func TestRecoveryActionToPlanDecisionKind(t *testing.T) {
+	// MAINTENANCE: when adding a RecoveryActionKind constant in
+	// workflow/payloads/recovery.go, ALSO update the switch in
+	// recoveryActionToPlanDecisionKind AND this table. The defensive
+	// default falls to execution_exhausted (terminal), so an unrecognized
+	// action will route to "terminal" without test failure — silent.
+	cases := map[payloads.RecoveryActionKind]workflow.PlanDecisionKind{
+		payloads.RecoveryActionRefinePrompt:      workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionNarrowScope:       workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionSplitReq:          workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionStoryReprepare:    workflow.PlanDecisionKindStoryReprepare,
+		payloads.RecoveryActionEscalateHuman:     workflow.PlanDecisionKindExecutionExhausted,
+		payloads.RecoveryActionMarkUnrecoverable: workflow.PlanDecisionKindExecutionExhausted,
+	}
+	for action, want := range cases {
+		got := recoveryActionToPlanDecisionKind(action)
+		if got != want {
+			t.Errorf("recoveryActionToPlanDecisionKind(%q) = %q, want %q", action, got, want)
+		}
+	}
+
+	// Defensive: unknown action falls to execution_exhausted (terminal — safer
+	// than running an unintended cascade).
+	got := recoveryActionToPlanDecisionKind("definitely-not-a-real-action")
+	if got != workflow.PlanDecisionKindExecutionExhausted {
+		t.Errorf("unknown action: got %q, want execution_exhausted (defensive fallback)", got)
+	}
+}

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -2137,11 +2137,22 @@ func (c *Component) emitExhaustionDecision(ctx context.Context, exec *requiremen
 	// signal landed in the proposed PlanDecision and stopped. Wiring this
 	// publish gives the recovery agent the same chance to dispatch a
 	// manager-role diagnosis here as on the other two routes.
+	// Forward the exec's Story cursor so the recovery-agent can reach back
+	// to Sarah's layer when its diagnosis points at story-shaping (ADR-043
+	// PR 4i + Train C). Empty in legacy / single-Story plans, which is
+	// fine — recovery-agent won't propose story_reprepare without Stories
+	// in scope.
+	var affectedStories []string
+	if len(exec.SortedStoryIDs) > 0 {
+		affectedStories = append(affectedStories, exec.SortedStoryIDs...)
+	}
+
 	c.publishRecoveryRequested(ctx, &payloads.RecoveryRequested{
 		RecoveryID:          uuid.New().String(),
 		Layer:               payloads.RecoveryLayerPhaseLocal,
 		Slug:                exec.Slug,
 		RequirementID:       exec.RequirementID,
+		AffectedStoryIDs:    affectedStories,
 		LoopID:              exec.LoopID,
 		EscalationReason:    fmt.Sprintf("requirement retries exhausted (%d/%d); last verdict=%q", exec.RetryCount, exec.MaxRetries, verdict),
 		LastFailureFeedback: feedback,

--- a/processor/story-preparer/component.go
+++ b/processor/story-preparer/component.go
@@ -77,6 +77,15 @@ type Component struct {
 
 	retry *dispatchretry.State
 
+	// claimedSlugs records slugs whose preparing_stories status this
+	// watcher's own ClaimPlanStatus call just produced. The watcher will
+	// observe the corresponding KV-put event next (because plan-manager
+	// echoes the status change back), and without this dedup it would
+	// treat the echo as a back-transition (Train C step 5) and double-
+	// dispatch. Entries are removed once the echo is consumed.
+	claimedSlugsMu sync.Mutex
+	claimedSlugs   map[string]bool
+
 	triggersProcessed atomic.Int64
 	generationsFailed atomic.Int64
 	lastActivityMu    sync.RWMutex
@@ -138,6 +147,7 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 		toolRegistry:  deps.ToolRegistry,
 		assembler:     assembler,
 		lessonWriter:  &lessons.Writer{TW: tw, Logger: logger},
+		claimedSlugs:  make(map[string]bool),
 		retry: dispatchretry.New(dispatchretry.Config{
 			MaxRetries: config.MaxGenerationRetries,
 			BackoffMs:  config.RetryBackoffMs,
@@ -250,7 +260,7 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 	}
 	defer watcher.Stop()
 
-	c.logger.Info("Watching PLAN_STATES for architecture_generated")
+	c.logger.Info("Watching PLAN_STATES for architecture_generated / preparing_stories")
 
 	for entry := range watcher.Updates() {
 		if entry == nil {
@@ -264,15 +274,37 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 		if json.Unmarshal(entry.Value(), &plan) != nil {
 			continue
 		}
-		if plan.Status != workflow.StatusArchitectureGenerated {
-			continue
-		}
-
-		// Claim the plan to prevent re-trigger on watcher restarts. If the
-		// claim fails another watcher already advanced — usually because
-		// PR 3 ships dormant and scenario-generator claims generating_scenarios
-		// first.
-		if !workflow.ClaimPlanStatus(ctx, c.natsClient, plan.Slug, workflow.StatusPreparingStories, c.logger) {
+		// Two claim points for Sarah's dispatch:
+		//   (A) architecture_generated → preparing_stories: forward flow
+		//       on a freshly architected plan. ClaimPlanStatus does an
+		//       atomic CAS via plan-manager so only one replica wins.
+		//   (B) preparing_stories already set: back-transition driven by
+		//       plan-manager when a story_reprepare PlanDecision is
+		//       accepted (Train C step 4). plan-manager has already
+		//       cleared the affected Stories + written Story.RecoveryHint;
+		//       Sarah's re-prep reads those hints via the prompt context.
+		//       Already-in-target-state means ClaimPlanStatus rejects (a
+		//       → a is not a valid transition), so we don't claim — the
+		//       transition is already done; we just need to dispatch and
+		//       dedup against the echo from path (A) below.
+		switch plan.Status {
+		case workflow.StatusArchitectureGenerated:
+			if !workflow.ClaimPlanStatus(ctx, c.natsClient, plan.Slug, workflow.StatusPreparingStories, c.logger) {
+				continue
+			}
+			// Track the claim so the corresponding preparing_stories echo
+			// the watcher sees next does NOT trigger a second dispatch.
+			c.markClaimedSlug(plan.Slug)
+			plan.Status = workflow.StatusPreparingStories
+		case workflow.StatusPreparingStories:
+			// Was THIS watcher's claim the cause of this echo? If yes, the
+			// dispatch already happened in path (A) — drop the echo and
+			// clear the flag. If no, plan-manager drove the back-
+			// transition and we dispatch now.
+			if c.consumeClaimedSlug(plan.Slug) {
+				continue
+			}
+		default:
 			continue
 		}
 
@@ -281,6 +313,33 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 
 		go c.processStoryPhase(ctx, &plan)
 	}
+}
+
+// markClaimedSlug records that THIS watcher just produced a
+// preparing_stories status for the named slug via ClaimPlanStatus. The
+// next preparing_stories KV-put echo this watcher observes for the slug
+// will be the corresponding self-echo (the status mutation plan-manager
+// performed in response to our claim) and should be skipped, not
+// treated as a back-transition.
+func (c *Component) markClaimedSlug(slug string) {
+	c.claimedSlugsMu.Lock()
+	defer c.claimedSlugsMu.Unlock()
+	c.claimedSlugs[slug] = true
+}
+
+// consumeClaimedSlug reports whether THIS watcher had a pending claim
+// for the slug and clears the flag. Returns true when the caller should
+// SKIP processing the current event (it's the self-echo); false when
+// the event came from elsewhere (e.g., plan-manager back-transition)
+// and the caller should dispatch.
+func (c *Component) consumeClaimedSlug(slug string) bool {
+	c.claimedSlugsMu.Lock()
+	defer c.claimedSlugsMu.Unlock()
+	if c.claimedSlugs[slug] {
+		delete(c.claimedSlugs, slug)
+		return true
+	}
+	return false
 }
 
 // processStoryPhase handles the story-preparation phase for a single plan.
@@ -447,6 +506,25 @@ func buildPromptContext(plan *workflow.Plan, previousError string) *prompt.Story
 		}
 	}
 
+	// Train C step 5: surface Story.RecoveryHint values onto the prompt
+	// context. plan-manager wrote these onto the affected Stories at
+	// PlanDecision-accept time (Train C step 4 applyRecoveryHint); the
+	// Stories themselves stay in plan.Stories so Sarah's emission
+	// replaces the whole set per the existing handleStoriesMutation
+	// wipe-and-replace contract. Empty on the forward flow
+	// (architecture_generated → preparing_stories); populated on the
+	// back-transition flow where Sarah is being asked to re-prep.
+	var recoveryHints []prompt.StoryRecoveryHint
+	for _, s := range plan.Stories {
+		if s.RecoveryHint == "" {
+			continue
+		}
+		recoveryHints = append(recoveryHints, prompt.StoryRecoveryHint{
+			StoryID: s.ID,
+			Hint:    s.RecoveryHint,
+		})
+	}
+
 	return &prompt.StoryPreparerPromptContext{
 		PlanTitle:              plan.Title,
 		PlanGoal:               plan.Goal,
@@ -455,6 +533,7 @@ func buildPromptContext(plan *workflow.Plan, previousError string) *prompt.Story
 		ArchitectureComponents: components,
 		Requirements:           reqs,
 		PreviousError:          previousError,
+		StoryRecoveryHints:     recoveryHints,
 	}
 }
 

--- a/processor/story-preparer/recovery_hint_prompt_test.go
+++ b/processor/story-preparer/recovery_hint_prompt_test.go
@@ -1,0 +1,98 @@
+package storypreparer
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestBuildPromptContext_PopulatesStoryRecoveryHints pins the Train C
+// step 5 contract: plan.Stories carrying Story.RecoveryHint values
+// (written by plan-manager at story_reprepare PlanDecision accept time)
+// flow into the prompt context as StoryRecoveryHint entries. Sarah's
+// re-prep prompt then surfaces those diagnoses so she re-authors the
+// affected Stories with the wedge context in scope.
+func TestBuildPromptContext_PopulatesStoryRecoveryHints(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:  "demo",
+		Title: "demo",
+		Stories: []workflow.Story{
+			{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "untouched"},
+			{ID: "story.demo.1.2", RequirementID: "req.demo.1", Title: "flagged", RecoveryHint: "missed src/x.go"},
+			{ID: "story.demo.1.3", RequirementID: "req.demo.1", Title: "untouched"},
+		},
+	}
+
+	ctx := buildPromptContext(plan, "")
+
+	if len(ctx.StoryRecoveryHints) != 1 {
+		t.Fatalf("StoryRecoveryHints len = %d, want 1 (only Story 2 has a hint)", len(ctx.StoryRecoveryHints))
+	}
+	if ctx.StoryRecoveryHints[0].StoryID != "story.demo.1.2" {
+		t.Errorf("StoryRecoveryHints[0].StoryID = %q, want story.demo.1.2", ctx.StoryRecoveryHints[0].StoryID)
+	}
+	if ctx.StoryRecoveryHints[0].Hint != "missed src/x.go" {
+		t.Errorf("StoryRecoveryHints[0].Hint = %q, want %q", ctx.StoryRecoveryHints[0].Hint, "missed src/x.go")
+	}
+}
+
+// TestBuildPromptContext_NoHintsForForwardFlow pins the back-compat path:
+// on the architecture_generated → preparing_stories forward flow, no
+// Story has a RecoveryHint set (Sarah is preparing for the first time),
+// so StoryRecoveryHints comes out empty. The prompt render's hints block
+// won't fire and Sarah's prompt looks like the pre-Train-C shape.
+func TestBuildPromptContext_NoHintsForForwardFlow(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:  "demo",
+		Title: "demo",
+		// No Stories yet — typical forward-flow state at preparing_stories
+		// claim time. Even if Stories were present, none would have
+		// RecoveryHint set on the forward flow.
+	}
+
+	ctx := buildPromptContext(plan, "")
+
+	if len(ctx.StoryRecoveryHints) != 0 {
+		t.Errorf("StoryRecoveryHints = %v, want empty (forward flow has no recovery context)", ctx.StoryRecoveryHints)
+	}
+}
+
+// TestClaimedSlugDedup_RoundTripsAndConsumes pins the in-process dedup
+// that prevents the watcher from double-dispatching when its own
+// ClaimPlanStatus echoes back as a preparing_stories KV event.
+func TestClaimedSlugDedup_RoundTripsAndConsumes(t *testing.T) {
+	c := &Component{claimedSlugs: make(map[string]bool)}
+
+	// First-time mark + consume returns true (skip the echo).
+	c.markClaimedSlug("demo")
+	if !c.consumeClaimedSlug("demo") {
+		t.Errorf("first consume after mark returned false; want true (skip self-echo)")
+	}
+
+	// Second consume returns false (no pending claim → external trigger
+	// like plan-manager's back-transition).
+	if c.consumeClaimedSlug("demo") {
+		t.Errorf("second consume returned true; want false (no pending claim)")
+	}
+
+	// Unmarked slug always returns false.
+	if c.consumeClaimedSlug("other") {
+		t.Errorf("consume on unmarked slug returned true; want false")
+	}
+}
+
+// TestClaimedSlugDedup_PerSlugIndependent pins that the dedup is
+// slug-scoped — marking slug A doesn't affect slug B.
+func TestClaimedSlugDedup_PerSlugIndependent(t *testing.T) {
+	c := &Component{claimedSlugs: make(map[string]bool)}
+
+	c.markClaimedSlug("a")
+	c.markClaimedSlug("b")
+
+	if !c.consumeClaimedSlug("a") {
+		t.Errorf("consume(a) after mark(a) returned false; want true")
+	}
+	if !c.consumeClaimedSlug("b") {
+		t.Errorf("consume(b) after mark(b) returned false; want true (independent of a)")
+	}
+}

--- a/prompt/context_story_preparer.go
+++ b/prompt/context_story_preparer.go
@@ -43,6 +43,27 @@ type StoryPreparerPromptContext struct {
 	// ReviewFindings carries plan-reviewer R3 findings from a prior
 	// review round, injected so Sarah can address them on regen.
 	ReviewFindings string
+
+	// StoryRecoveryHints carries Story.RecoveryHint values written by
+	// plan-manager when a story_reprepare PlanDecision was accepted
+	// (Train C step 4). Populated only on back-transition dispatches
+	// (stories_generated → preparing_stories); empty on the forward
+	// flow. Each entry pairs the original Story ID + the recovery
+	// agent's diagnosis so Sarah's re-prep prompt sees "Story X failed
+	// because Y; re-shard with Z in mind."
+	StoryRecoveryHints []StoryRecoveryHint
+}
+
+// StoryRecoveryHint pairs a Story ID with the recovery-agent diagnosis
+// that triggered Sarah's re-prep. Train C re-prep KEEPS the Story in
+// plan.Stories with its RecoveryHint set so the (StoryID, Hint) pairs
+// can be projected onto the prompt context; Sarah's emission replaces
+// plan.Stories wholesale per the handleStoriesMutation wipe-and-replace
+// contract, so the prior Story content survives only long enough to
+// guide the next emission.
+type StoryRecoveryHint struct {
+	StoryID string
+	Hint    string
 }
 
 // StoryPreparerCapability is the projection of workflow.Capability into the

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -467,6 +467,26 @@ func renderStoryPreparerPrompt(p *prompt.StoryPreparerPromptContext) string {
 			p.ReviewFindings, reviewFindingsActionDirective())
 	}
 
+	// Train C step 5: surface recovery diagnoses on Stories that wedged.
+	// plan-manager writes Story.RecoveryHint at PlanDecision-accept time
+	// when a story_reprepare proposal is approved; Sarah re-shapes the
+	// Story set from scratch, accounting for each diagnosis.
+	//
+	// Note: the prompt does NOT carry the prior Stories' content (only
+	// the IDs the recovery-agent flagged). Sarah re-derives the full
+	// Story set from the Requirements + Architecture inputs above, so
+	// her emission is fresh — story IDs may change across re-preps.
+	// Downstream consumers (Bob's scenarios) re-key on Sarah's new IDs
+	// via the handleStoriesMutation wipe-and-replace contract.
+	if len(p.StoryRecoveryHints) > 0 {
+		sb.WriteString("## Recovery Diagnoses for Previously Wedged Stories\n\n")
+		sb.WriteString("Each entry below identifies a Story whose prior execution wedged, plus the recovery-agent's diagnosis of WHY. Re-shape the Story set from scratch using the Requirements + Architecture above, accounting for each diagnosis as you re-author. The prior Story IDs are reference points only — your new emission may use different IDs.\n\n")
+		for _, h := range p.StoryRecoveryHints {
+			fmt.Fprintf(&sb, "- **%s**: %s\n", h.StoryID, h.Hint)
+		}
+		sb.WriteString("\n")
+	}
+
 	return sb.String()
 }
 

--- a/workflow/cascade/cascade.go
+++ b/workflow/cascade/cascade.go
@@ -1,5 +1,6 @@
 // Package cascade implements the dirty-cascade logic applied when a
-// PlanDecision is accepted, marking affected scenarios for re-execution.
+// PlanDecision is accepted, marking affected scenarios + stories for
+// re-execution / re-prep.
 package cascade
 
 import (
@@ -11,48 +12,121 @@ import (
 // Result summarizes the effect of accepting a PlanDecision.
 type Result struct {
 	AffectedRequirementIDs []string
-	AffectedScenarioIDs    []string
+	// AffectedStoryIDs lists Story IDs the cascade dirty-marked. Populated
+	// for Kind=story_reprepare (the cascade target is Stories + Scenarios)
+	// or, in back-compat mode, when the proposal's AffectedReqIDs match
+	// Stories under those Requirements. Empty for requirement_change /
+	// execution_exhausted cascades that don't touch Sarah's layer.
+	AffectedStoryIDs    []string
+	AffectedScenarioIDs []string
 }
 
 // PlanDecision executes the dirty cascade when a PlanDecision is accepted.
 //
-// Steps:
-//  1. Filter scenarios to those whose RequirementID is in proposal.AffectedReqIDs.
-//  2. Return a Result describing what changed.
+// Cascade shape branches on proposal.Kind:
 //
-// The function is pure business logic — it performs no I/O and can be tested
-// without any infrastructure. The caller is responsible for loading the plan
-// from KV and passing the current scenario list.
-func PlanDecision(proposal *workflow.PlanDecision, scenarios []workflow.Scenario) (*Result, error) {
+//   - Kind=story_reprepare: dirty-mark the Stories named in
+//     proposal.AffectedStoryIDs (Train C — Story-level granularity),
+//     PLUS every scenario whose StoryID matches. If AffectedStoryIDs is
+//     empty, falls back to "all Stories under AffectedReqIDs" so the
+//     cascade still reaches Sarah's layer.
+//   - Kind=requirement_change (or unset for back-compat): the existing
+//     scenarios-only cascade — filter scenarios to those whose
+//     RequirementID is in proposal.AffectedReqIDs. Stories untouched.
+//   - Kind=execution_exhausted: terminal acknowledgement; cascade is a
+//     no-op (callers shouldn't invoke PlanDecision for this kind, but
+//     the function returns empty Result safely if they do).
+//
+// Pure business logic — no I/O. Caller loads the plan from KV and passes
+// stories + scenarios. Returns the IDs that were dirty-marked so
+// downstream consumers (plan-manager status transition, executor reset)
+// can scope their actions.
+func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, scenarios []workflow.Scenario) (*Result, error) {
 	if proposal == nil {
 		return nil, fmt.Errorf("proposal is nil")
 	}
 
 	result := &Result{
 		AffectedRequirementIDs: make([]string, 0, len(proposal.AffectedReqIDs)),
+		AffectedStoryIDs:       make([]string, 0),
 		AffectedScenarioIDs:    make([]string, 0),
 	}
 
-	// Copy affected requirement IDs into result and build a lookup set.
-	// Scenario RequirementIDs in the KV plan match the raw (non-hashed) IDs stored
-	// in the plan's Scenarios slice, so no hashing is needed here.
+	// Always record the Requirement IDs the proposal targets — they're
+	// the entry-point context for downstream consumers regardless of Kind.
 	affectedReqs := make(map[string]bool, len(proposal.AffectedReqIDs))
 	for _, id := range proposal.AffectedReqIDs {
 		affectedReqs[id] = true
 		result.AffectedRequirementIDs = append(result.AffectedRequirementIDs, id)
 	}
 
-	if len(affectedReqs) == 0 {
-		// No requirements affected — nothing to cascade.
-		return result, nil
-	}
+	switch proposal.Kind {
+	case workflow.PlanDecisionKindStoryReprepare:
+		affectedStories := storiesForReprepare(proposal, stories, affectedReqs)
+		result.AffectedStoryIDs = append(result.AffectedStoryIDs, affectedStories...)
 
-	// Find scenarios belonging to affected requirements.
-	for _, sc := range scenarios {
-		if affectedReqs[sc.RequirementID] {
-			result.AffectedScenarioIDs = append(result.AffectedScenarioIDs, sc.ID)
+		affectedStorySet := make(map[string]bool, len(affectedStories))
+		for _, id := range affectedStories {
+			affectedStorySet[id] = true
+		}
+		// Scenarios are dirty when their parent Story is dirty. Falls back
+		// to "scenarios for affected reqs" when no Story IDs were resolved
+		// (e.g. legacy plan with empty plan.Stories but Kind=story_reprepare
+		// — should be rare; preserves a useful cascade rather than no-op).
+		for _, sc := range scenarios {
+			switch {
+			case len(affectedStorySet) > 0 && affectedStorySet[sc.StoryID]:
+				result.AffectedScenarioIDs = append(result.AffectedScenarioIDs, sc.ID)
+			case len(affectedStorySet) == 0 && affectedReqs[sc.RequirementID]:
+				result.AffectedScenarioIDs = append(result.AffectedScenarioIDs, sc.ID)
+			}
+		}
+
+	case workflow.PlanDecisionKindExecutionExhausted:
+		// Terminal kind — cascade is a no-op beyond recording the
+		// AffectedRequirementIDs already populated above for caller
+		// telemetry. Stories + Scenarios stay empty.
+
+	default:
+		// Kind=requirement_change OR unset (back-compat with pre-Kind records).
+		// Scenarios-only cascade matching pre-Train-C behavior.
+		if len(affectedReqs) == 0 {
+			return result, nil
+		}
+		for _, sc := range scenarios {
+			if affectedReqs[sc.RequirementID] {
+				result.AffectedScenarioIDs = append(result.AffectedScenarioIDs, sc.ID)
+			}
 		}
 	}
 
 	return result, nil
+}
+
+// storiesForReprepare resolves the Story IDs the cascade should dirty-mark
+// for a story_reprepare proposal. Three input shapes:
+//
+//   - proposal.AffectedStoryIDs populated → use those directly (the
+//     recovery-agent threaded them through from the wedged exec's cursor).
+//   - proposal.AffectedStoryIDs empty AND AffectedReqIDs populated → walk
+//     plan.Stories and select every Story whose RequirementID is in scope.
+//     Whole-Requirement re-prep — coarser but still reaches Sarah.
+//   - Both empty → return nil. Caller's downstream behavior is "no-op
+//     cascade"; plan-manager treats that as human-review territory.
+func storiesForReprepare(proposal *workflow.PlanDecision, stories []workflow.Story, affectedReqs map[string]bool) []string {
+	if len(proposal.AffectedStoryIDs) > 0 {
+		out := make([]string, 0, len(proposal.AffectedStoryIDs))
+		out = append(out, proposal.AffectedStoryIDs...)
+		return out
+	}
+	if len(affectedReqs) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(stories))
+	for _, s := range stories {
+		if affectedReqs[s.RequirementID] {
+			out = append(out, s.ID)
+		}
+	}
+	return out
 }

--- a/workflow/cascade/cascade_test.go
+++ b/workflow/cascade/cascade_test.go
@@ -9,7 +9,7 @@ import (
 // TestPlanDecision_NilProposal verifies that a nil proposal returns an error
 // immediately, before any scenario filtering.
 func TestPlanDecision_NilProposal(t *testing.T) {
-	_, err := PlanDecision(nil, nil)
+	_, err := PlanDecision(nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for nil proposal")
 	}
@@ -23,7 +23,7 @@ func TestPlanDecision_NoAffectedRequirements(t *testing.T) {
 		AffectedReqIDs: []string{}, // empty — returns before filtering scenarios
 	}
 
-	result, err := PlanDecision(proposal, nil)
+	result, err := PlanDecision(proposal, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/workflow/cascade/story_reprepare_test.go
+++ b/workflow/cascade/story_reprepare_test.go
@@ -1,0 +1,171 @@
+package cascade
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestPlanDecision_StoryReprepare_ExplicitStoryIDs is the headline Train C
+// step 3 contract: when proposal.Kind=story_reprepare AND
+// proposal.AffectedStoryIDs is populated, the cascade dirty-marks ONLY
+// those Stories + scenarios attached to them. Sibling Stories on the same
+// Requirement are NOT touched.
+func TestPlanDecision_StoryReprepare_ExplicitStoryIDs(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:               "plan-decision.demo.recovery.abc12345",
+		Kind:             workflow.PlanDecisionKindStoryReprepare,
+		AffectedReqIDs:   []string{"req.demo.1"},
+		AffectedStoryIDs: []string{"story.demo.1.2"}, // only Story 2
+	}
+	stories := []workflow.Story{
+		{ID: "story.demo.1.1", RequirementID: "req.demo.1", Title: "Story 1 (untouched)"},
+		{ID: "story.demo.1.2", RequirementID: "req.demo.1", Title: "Story 2 (targeted)"},
+		{ID: "story.demo.1.3", RequirementID: "req.demo.1", Title: "Story 3 (untouched)"},
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.demo.1.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		{ID: "scen.demo.1.2", RequirementID: "req.demo.1", StoryID: "story.demo.1.2"},
+		{ID: "scen.demo.1.3", RequirementID: "req.demo.1", StoryID: "story.demo.1.3"},
+	}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("PlanDecision: %v", err)
+	}
+
+	if want := []string{"story.demo.1.2"}; !reflect.DeepEqual(result.AffectedStoryIDs, want) {
+		t.Errorf("AffectedStoryIDs = %v, want %v", result.AffectedStoryIDs, want)
+	}
+	if want := []string{"scen.demo.1.2"}; !reflect.DeepEqual(result.AffectedScenarioIDs, want) {
+		t.Errorf("AffectedScenarioIDs = %v, want %v (sibling Stories' scenarios must NOT be dirty)", result.AffectedScenarioIDs, want)
+	}
+}
+
+// TestPlanDecision_StoryReprepare_FallbackToReqScope pins the back-compat
+// path: when proposal.AffectedStoryIDs is empty but Kind=story_reprepare
+// AND AffectedReqIDs is populated, the cascade dirty-marks every Story
+// under those Requirements. Whole-Requirement re-prep — coarser but still
+// reaches Sarah.
+func TestPlanDecision_StoryReprepare_FallbackToReqScope(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.demo.recovery.def67890",
+		Kind:           workflow.PlanDecisionKindStoryReprepare,
+		AffectedReqIDs: []string{"req.demo.1"},
+		// AffectedStoryIDs intentionally empty
+	}
+	stories := []workflow.Story{
+		{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+		{ID: "story.demo.1.2", RequirementID: "req.demo.1"},
+		{ID: "story.demo.2.1", RequirementID: "req.demo.2"}, // different req — must NOT match
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.demo.1.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		{ID: "scen.demo.1.2", RequirementID: "req.demo.1", StoryID: "story.demo.1.2"},
+		{ID: "scen.demo.2.1", RequirementID: "req.demo.2", StoryID: "story.demo.2.1"},
+	}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("PlanDecision: %v", err)
+	}
+
+	sort.Strings(result.AffectedStoryIDs)
+	sort.Strings(result.AffectedScenarioIDs)
+	wantStories := []string{"story.demo.1.1", "story.demo.1.2"}
+	wantScenarios := []string{"scen.demo.1.1", "scen.demo.1.2"}
+	if !reflect.DeepEqual(result.AffectedStoryIDs, wantStories) {
+		t.Errorf("AffectedStoryIDs = %v, want %v", result.AffectedStoryIDs, wantStories)
+	}
+	if !reflect.DeepEqual(result.AffectedScenarioIDs, wantScenarios) {
+		t.Errorf("AffectedScenarioIDs = %v, want %v (different-req scenarios must NOT cascade)", result.AffectedScenarioIDs, wantScenarios)
+	}
+}
+
+// TestPlanDecision_RequirementChangePreservesBackCompat pins the existing
+// scenarios-only cascade for Kind=requirement_change (the pre-Train-C
+// contract). Stories are passed in but must NOT be dirty-marked by this
+// kind — that's story_reprepare's job. Pre-Train-C behavior preserved.
+func TestPlanDecision_RequirementChangePreservesBackCompat(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.demo.qa.abc12345",
+		Kind:           workflow.PlanDecisionKindRequirementChange,
+		AffectedReqIDs: []string{"req.demo.1"},
+	}
+	stories := []workflow.Story{
+		{ID: "story.demo.1.1", RequirementID: "req.demo.1"},
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.demo.1.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"},
+		{ID: "scen.demo.2.1", RequirementID: "req.demo.2", StoryID: "story.demo.2.1"},
+	}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("PlanDecision: %v", err)
+	}
+
+	if len(result.AffectedStoryIDs) != 0 {
+		t.Errorf("AffectedStoryIDs = %v, want empty (requirement_change does not dirty-mark Stories)", result.AffectedStoryIDs)
+	}
+	if want := []string{"scen.demo.1.1"}; !reflect.DeepEqual(result.AffectedScenarioIDs, want) {
+		t.Errorf("AffectedScenarioIDs = %v, want %v (scenarios-only cascade)", result.AffectedScenarioIDs, want)
+	}
+}
+
+// TestPlanDecision_UnsetKindPreservesBackCompat pins that legacy
+// PlanDecision records without a Kind field (pre-Kind enum, default
+// zero-value) get the same scenarios-only cascade as
+// Kind=requirement_change. plan-manager's wire-shape default is
+// requirement_change but cascade.go itself must tolerate the empty case
+// too.
+func TestPlanDecision_UnsetKindPreservesBackCompat(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID: "plan-decision.legacy.1",
+		// Kind intentionally unset (zero-value "")
+		AffectedReqIDs: []string{"req.legacy.1"},
+	}
+	scenarios := []workflow.Scenario{
+		{ID: "scen.legacy.1", RequirementID: "req.legacy.1"},
+	}
+
+	result, err := PlanDecision(proposal, nil, scenarios)
+	if err != nil {
+		t.Fatalf("PlanDecision: %v", err)
+	}
+
+	if want := []string{"scen.legacy.1"}; !reflect.DeepEqual(result.AffectedScenarioIDs, want) {
+		t.Errorf("AffectedScenarioIDs = %v, want %v (legacy unset-Kind ⇒ scenarios-only)", result.AffectedScenarioIDs, want)
+	}
+}
+
+// TestPlanDecision_ExecutionExhaustedIsNoOp pins that the terminal kind
+// produces an empty cascade. Callers don't typically invoke PlanDecision
+// for execution_exhausted (the auto-archive path is separate), but the
+// function must tolerate it as a defensive no-op.
+func TestPlanDecision_ExecutionExhaustedIsNoOp(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.demo.exhausted.1",
+		Kind:           workflow.PlanDecisionKindExecutionExhausted,
+		AffectedReqIDs: []string{"req.demo.1"},
+	}
+	stories := []workflow.Story{{ID: "story.demo.1.1", RequirementID: "req.demo.1"}}
+	scenarios := []workflow.Scenario{{ID: "scen.demo.1.1", RequirementID: "req.demo.1", StoryID: "story.demo.1.1"}}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("PlanDecision: %v", err)
+	}
+
+	if len(result.AffectedStoryIDs) != 0 {
+		t.Errorf("AffectedStoryIDs = %v, want empty for execution_exhausted no-op", result.AffectedStoryIDs)
+	}
+	if len(result.AffectedScenarioIDs) != 0 {
+		t.Errorf("AffectedScenarioIDs = %v, want empty for execution_exhausted no-op", result.AffectedScenarioIDs)
+	}
+	if want := []string{"req.demo.1"}; !reflect.DeepEqual(result.AffectedRequirementIDs, want) {
+		t.Errorf("AffectedRequirementIDs = %v, want %v (telemetry context preserved)", result.AffectedRequirementIDs, want)
+	}
+}

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -144,6 +144,17 @@ type RecoveryRequested struct {
 	// outcome.
 	AffectedRequirementIDs []string `json:"affected_requirement_ids,omitempty"`
 
+	// AffectedStoryIDs lists Story IDs the wedge implicates when recovery
+	// reaches Sarah's layer (ADR-043). Populated by requirement-executor
+	// from the wedged exec's SortedStoryIDs at the time the
+	// RecoveryRequested fires. The recovery-agent threads this list into
+	// PlanDecision.AffectedStoryIDs so the cascade can dirty-mark the
+	// specific Stories rather than the whole Requirement. Empty for
+	// recovery requests whose wedge is requirement-scoped (refine_prompt,
+	// narrow_scope) — the absence signals the recovery-agent should not
+	// propose story_reprepare. Train C step 2.
+	AffectedStoryIDs []string `json:"affected_story_ids,omitempty"`
+
 	// TaskID identifies the specific TDD task that wedged. Empty for
 	// plan-phase wedges.
 	TaskID string `json:"task_id,omitempty"`

--- a/workflow/plan_decision_kind_test.go
+++ b/workflow/plan_decision_kind_test.go
@@ -1,0 +1,32 @@
+package workflow
+
+import "testing"
+
+// TestPlanDecisionKind_IsValid pins the closed enum. Train C step 1
+// added PlanDecisionKindStoryReprepare; the IsValid switch must accept
+// it so the wire parser at plan-manager/mutations.go's
+// handlePlanDecisionAddMutation doesn't reject incoming story_reprepare
+// decisions as malformed.
+func TestPlanDecisionKind_IsValid(t *testing.T) {
+	cases := map[PlanDecisionKind]bool{
+		PlanDecisionKindRequirementChange:  true,
+		PlanDecisionKindExecutionExhausted: true,
+		PlanDecisionKindStoryReprepare:     true,
+		"":                                 false,
+		"not-a-kind":                       false,
+		"requirement-change":               false, // hyphen not underscore
+	}
+	for k, want := range cases {
+		got := k.IsValid()
+		if got != want {
+			t.Errorf("PlanDecisionKind(%q).IsValid() = %v, want %v", k, got, want)
+		}
+	}
+}
+
+// TestPlanDecisionKind_String round-trips the enum's wire shape.
+func TestPlanDecisionKind_String(t *testing.T) {
+	if got := PlanDecisionKindStoryReprepare.String(); got != "story_reprepare" {
+		t.Errorf("PlanDecisionKindStoryReprepare.String() = %q, want story_reprepare", got)
+	}
+}

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -1638,14 +1638,21 @@ func (s PlanDecisionStatus) CanTransitionTo(target PlanDecisionStatus) bool {
 
 // PlanDecisionKind narrows the intent of a PlanDecision so downstream handlers
 // (cascade, UI, plan-manager auto-close) dispatch correctly. Same container,
-// two distinct semantics:
+// three distinct semantics:
 //
 //	requirement_change  — something proposes to mutate the plan's requirements
-//	                      (e.g. qa-reviewer needs_changes). Accept runs cascade.
+//	                      (e.g. qa-reviewer needs_changes). Accept runs cascade
+//	                      against scenarios for the affected requirement.
 //	execution_exhausted — a requirement exhausted its retry budget and needs a
 //	                      human to decide next step. Accept is acknowledgement
 //	                      only; the actual remedy is taken via existing retry /
 //	                      force-complete / reject endpoints.
+//	story_reprepare     — recovery analysis points at Sarah's story-shaping
+//	                      (ADR-043 Move 3) as the source of the wedge. Accept
+//	                      runs cascade against the affected Stories + scenarios,
+//	                      writes the diagnosis to Story.RecoveryHint, and drives
+//	                      stories_generated → preparing_stories so Sarah re-runs
+//	                      with the failure context.
 type PlanDecisionKind string
 
 const (
@@ -1658,6 +1665,20 @@ const (
 	// endpoints, and plan-manager auto-archives the decision when the
 	// subject requirement reaches a non-failed terminal state.
 	PlanDecisionKindExecutionExhausted PlanDecisionKind = "execution_exhausted"
+	// PlanDecisionKindStoryReprepare marks a decision proposing that Sarah
+	// re-prep the affected Stories. Distinct from requirement_change because
+	// the cascade target is Stories + Scenarios (not just Scenarios) AND
+	// accepting the decision drives the back-transition stories_generated →
+	// preparing_stories. Sarah's persona prompt consumes Story.RecoveryHint
+	// (written by applyRecoveryHint at accept time) so she sees the wedge
+	// diagnosis on re-prep.
+	//
+	// ADR-043 Move 3 introduced Story-level decomposition between
+	// requirements and execution; pre-this-kind the recovery vocabulary had
+	// no action targeting Sarah's layer, so wedges originating from
+	// story-shaping degraded into requirement_change cascades that didn't
+	// actually re-run Sarah. Closes the cross-pass synthesis Train C.
+	PlanDecisionKindStoryReprepare PlanDecisionKind = "story_reprepare"
 )
 
 // String returns the string representation of the plan decision kind.
@@ -1668,7 +1689,9 @@ func (k PlanDecisionKind) String() string {
 // IsValid reports whether the kind is a known value.
 func (k PlanDecisionKind) IsValid() bool {
 	switch k {
-	case PlanDecisionKindRequirementChange, PlanDecisionKindExecutionExhausted:
+	case PlanDecisionKindRequirementChange,
+		PlanDecisionKindExecutionExhausted,
+		PlanDecisionKindStoryReprepare:
 		return true
 	default:
 		return false

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -1719,13 +1719,20 @@ type PlanDecision struct {
 	PlanID string `json:"plan_id"`
 	// Kind narrows the intent. Defaults to requirement_change for back-compat
 	// with old records that predate the Kind field.
-	Kind             PlanDecisionKind   `json:"kind,omitempty"`
-	Title            string             `json:"title"`
-	Rationale        string             `json:"rationale"`
-	Status           PlanDecisionStatus `json:"status"`
-	ProposedBy       string             `json:"proposed_by"`
-	AffectedReqIDs   []string           `json:"affected_requirement_ids"`
-	RejectionReasons map[string]string  `json:"rejection_reasons,omitempty"`
+	Kind           PlanDecisionKind   `json:"kind,omitempty"`
+	Title          string             `json:"title"`
+	Rationale      string             `json:"rationale"`
+	Status         PlanDecisionStatus `json:"status"`
+	ProposedBy     string             `json:"proposed_by"`
+	AffectedReqIDs []string           `json:"affected_requirement_ids"`
+	// AffectedStoryIDs lists specific Story IDs the decision targets. Used
+	// by Kind=story_reprepare to scope the cascade + re-prep to just the
+	// affected Stories rather than the whole Requirement. Empty when
+	// Kind=requirement_change or execution_exhausted (those operate at the
+	// Requirement granularity). Populated by recovery-agent from the
+	// wedged exec's SortedStoryIDs at the time of diagnosis.
+	AffectedStoryIDs []string          `json:"affected_story_ids,omitempty"`
+	RejectionReasons map[string]string `json:"rejection_reasons,omitempty"`
 	// ArtifactReferences links artifacts (logs, screenshots, traces, trajectory
 	// steps) to this decision. Populated by qa-reviewer on needs_changes and
 	// by requirement-executor on retry exhaustion so the human reviewer can


### PR DESCRIPTION
## Summary

Finishes the wiring for `story_reprepare` — the recovery action that ADR-043 PR 4i shipped as "reserved infrastructure" but never completed end-to-end. Pre-this-PR, when the recovery agent diagnosed a wedge as Sarah's story-shaping fault, the emitted PlanDecision silently degraded into a scenarios-only cascade that left Sarah's Stories unchanged. Now the full chain works.

## End-to-end flow (post-this-PR)

```
recovery-agent emits PlanDecision{Kind: story_reprepare,
                                  AffectedStoryIDs: [...]}
→ plan-decision-handler auto-accepts (widened whitelist)
→ plan-manager applyRecoveryHint writes Story.RecoveryHint
→ plan-manager drives stories_generated → preparing_stories
→ cascade.PlanDecision dirty-marks named Stories + their scenarios
→ story-preparer watcher claims the back-transition
→ buildPromptContext projects Story.RecoveryHint into prompt context
→ Sarah's renderer surfaces "Recovery Diagnoses" section
→ Sarah re-shapes the Story set; her emission replaces plan.Stories
```

## Commits

| Commit | Closes | What |
|---|---|---|
| `dd68acf` | step 1 | New `PlanDecisionKindStoryReprepare`. Recovery-agent maps `RecoveryActionStoryReprepare` → this kind (was incorrectly mapping to `RequirementChange`). |
| `dc31afb` | step 2 | `PlanDecision.AffectedStoryIDs` + `RecoveryRequested.AffectedStoryIDs` wire shape. Requirement-executor populates from `exec.SortedStoryIDs` on exhaustion. |
| `2010deb` | step 3 | `cascade.PlanDecision` branches on Kind. `story_reprepare` dirty-marks Stories + scenarios; `requirement_change` keeps the existing scenarios-only cascade. |
| `7a0b175` | step 4 | `applyRecoveryHint` writes `Story.RecoveryHint` when Kind=story_reprepare; auto-accept whitelist widens; plan-manager drives the back-transition. |
| `bdc4d5a` | step 5 | Sarah's watcher accepts the back-transition with in-process dedup against self-claim echoes; prompt context + renderer surface `Story.RecoveryHint`. **Also fixes a B1 blocker** (double-save → double-dispatch) and reverts a step-4 design bug (`clearStoriesForReprepare` deleted Stories before their hints could be surfaced). |
| `7f14f71` | step 6 | Cross-cutting integration test asserting all invariants together. |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -count=1` — all packages pass
- [x] `gofmt -l processor/ workflow/ prompt/` clean
- [x] `revive -config revive.toml ./processor/... ./workflow/... ./prompt/...` clean
- [x] 20+ new tests across the stack (per-step unit tests + end-to-end integration in `processor/plan-manager/story_reprepare_end_to_end_test.go`)
- [x] Pre-commit `go-reviewer` ship-it on each of 6 commits (one BLOCKER caught + fixed mid-stack: B1 double-save)

## Known follow-ups (flagged by pre-commit reviewers; not blocking)

1. **Orphan scenarios on Sarah re-prep:** `handleStoriesMutation` wipes-and-replaces `plan.Stories` but does NOT wipe `plan.Scenarios` whose `StoryID` is no longer in the new Story set. Executor's `ScenariosForStory(id)` silently skips orphans so it's functionally invisible — memory/observability wart.
2. **execution-manager `markEscalatedLocked` emit site:** doesn't yet forward Story IDs to RecoveryRequested. The per-task exhaustion path could route through `story_reprepare` if the parent reqExecution's `SortedStoryIDs` is reachable; today it falls back to `requirement_change` safely.
3. **Watcher dedup is single-replica-only:** `claimedSlugs` is in-process. Multi-replica deployments would need plan-side dedup (e.g., a `claim_source` tag on the KV put).
4. **Doc-comment + test/e2e/client/http.go mirror struct:** these would need updates if e2e Playwright tests start asserting on `AffectedStoryIDs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)