### PR TITLE
fix(e2e): per-tier timeout overlay + active-polling sidecar (smoke 8 post-mortem)

### DIFF
--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -637,7 +637,7 @@
         "stream_name": "WORKFLOW",
         "consumer_name": "scenario-orchestrator",
         "trigger_subject": "scenario.orchestrate.*",
-        "execution_timeout": "3600s"
+        "execution_timeout": "${SEMSPEC_SCENARIO_ORCH_TIMEOUT:-3600s}"
       }
     },
     "question-manager": {
@@ -651,12 +651,12 @@
       "type": "processor",
       "enabled": true,
       "config": {
-        "timeout_seconds": 3600,
+        "timeout_seconds": ${SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
         "max_requirement_retries": 2,
         "max_decomposer_retries": 2,
         "defer_terminal_on_recovery": true,
-        "recovery_timeout_seconds": 60,
+        "recovery_timeout_seconds": ${SEMSPEC_RECOVERY_TIMEOUT_SECONDS:-60},
         "max_recovery_restarts": 2
       }
     },
@@ -679,7 +679,7 @@
       "enabled": true,
       "config": {
         "max_tdd_cycles": 7,
-        "timeout_seconds": 3600,
+        "timeout_seconds": ${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
         "graph_gateway_url": "http://localhost:8082",
         "indexing_budget": "60s",

--- a/docker/compose/e2e-llm.yml
+++ b/docker/compose/e2e-llm.yml
@@ -36,3 +36,14 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - OPENROUTER_SITE_URL=${OPENROUTER_SITE_URL:-https://semspec.dev}
       - OPENROUTER_SITE_NAME=${OPENROUTER_SITE_NAME:-semspec}
+      # Per-tier timeout overlay (option B). Defaults baked into the config
+      # files (3600s req-executor / 60s recovery / 3600s exec-manager / 3600s
+      # scenario-orchestrator) suit easy/medium tiers; the watch:llm task
+      # exports larger values for hard/mavlink-hard before invoking compose.
+      # Avoids editing the shared config for one tier and silently bloating
+      # the easy CI signal. See memory feedback_recovery_budget_match_playwright_cycles
+      # — these MUST stay aligned with Playwright EXECUTION_TIMEOUT.
+      - SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS=${SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS:-}
+      - SEMSPEC_RECOVERY_TIMEOUT_SECONDS=${SEMSPEC_RECOVERY_TIMEOUT_SECONDS:-}
+      - SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS=${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-}
+      - SEMSPEC_SCENARIO_ORCH_TIMEOUT=${SEMSPEC_SCENARIO_ORCH_TIMEOUT:-}

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -522,6 +522,23 @@ tasks:
           else
             echo '0'
           fi
+      # Per-tier backend timeout overlay — see watch:llm below for full
+      # rationale. Mirrored here so `task e2e:ui:test:llm` inherits the same
+      # alignment when invoked directly (without the watch sidecar).
+      REQ_EXECUTOR_TIMEOUT_SECONDS:
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard|mavlink-hard)  echo '7200' ;;
+            mavlink-decode)     echo '4800' ;;
+            *)                  echo '3600' ;;
+          esac
+      RECOVERY_TIMEOUT_SECONDS:
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard|mavlink-hard)  echo '600' ;;
+            mavlink-decode)     echo '300' ;;
+            *)                  echo '60' ;;
+          esac
     # E2E_FIXTURE feeds docker-compose's ${E2E_FIXTURE:-go-project} workspace
     # mount substitution. WITH_EPIC is re-exported with the resolved default
     # so the Playwright spec (ui/e2e/epic-meshtastic-llm.spec.ts) sees the
@@ -530,6 +547,10 @@ tasks:
     env:
       E2E_FIXTURE: "{{.FIXTURE_DIR}}"
       WITH_EPIC: "{{.EPIC_ON}}"
+      SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}"
+      SEMSPEC_RECOVERY_TIMEOUT_SECONDS: "{{.RECOVERY_TIMEOUT_SECONDS}}"
+      SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}"
+      SEMSPEC_SCENARIO_ORCH_TIMEOUT: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}s"
     cmds:
       - |
         if [ ! -f "configs/{{.E2E_CONFIG}}" ]; then
@@ -538,7 +559,7 @@ tasks:
           ls configs/e2e-*.json | sed 's|configs/e2e-||;s|\.json||' | grep -v mock | sed 's/^/  /'
           exit 1
         fi
-      - echo "[UI:TEST:LLM] Provider={{.PROVIDER}} Tier=@{{.TIER}} Config={{.E2E_CONFIG}} Fixture={{.FIXTURE_DIR}} Epic={{if .EPIC_OVERLAY}}on{{else}}off{{end}} Debug=${DEBUG:-off}"
+      - echo "[UI:TEST:LLM] Provider={{.PROVIDER}} Tier=@{{.TIER}} Config={{.E2E_CONFIG}} Fixture={{.FIXTURE_DIR}} Epic={{if .EPIC_OVERLAY}}on{{else}}off{{end}} Backend-req-timeout={{.REQ_EXECUTOR_TIMEOUT_SECONDS}}s Debug=${DEBUG:-off}"
       - echo "[UI:TEST:LLM] Resetting fixture to initial commit..."
       - task: reset-fixtures
       - echo "[UI:TEST:LLM] Building and starting real LLM stack..."
@@ -671,6 +692,29 @@ tasks:
       RUN_TS:
         sh: date +%Y%m%d-%H%M%S
       OUT_DIR: "/tmp/semspec-watch-{{.PROVIDER}}-{{.TIER}}-{{.RUN_TS}}"
+      # Per-tier backend timeout overlay (option B, smoke-8 mavlink-hard
+      # post-mortem 2026-06-02). The shared e2e-gemini.json bakes 3600s
+      # req-executor / 60s recovery / 3600s exec-manager which fit easy/
+      # medium but not hard tiers — smoke 8 hit the 60min req-executor
+      # ceiling while restructure retry #1 still had ~30min of useful work.
+      # Per memory feedback_recovery_budget_match_playwright_cycles these
+      # three knobs are conceptually ONE budget; the Playwright EXECUTION_
+      # TIMEOUT below stays the per-tier wallclock. Easy stays tight so
+      # CI signal is fast on the trivial-change case.
+      REQ_EXECUTOR_TIMEOUT_SECONDS:
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard|mavlink-hard)  echo '7200' ;;  # 2h/req — covers 1 initial + 2 restructure cycles
+            mavlink-decode)     echo '4800' ;;  # 80min/req — pairs with allowRecoveryCycles=2
+            *)                  echo '3600' ;;  # 1h/req — easy/medium default
+          esac
+      RECOVERY_TIMEOUT_SECONDS:
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard|mavlink-hard)  echo '600' ;;   # 10min — fits one recovery-agent dispatch
+            mavlink-decode)     echo '300' ;;
+            *)                  echo '60' ;;
+          esac
     # Export E2E_FIXTURE to docker-compose env so semspec's /workspace mount
     # ($E2E_FIXTURE:-go-project in ui/docker-compose.e2e.yml) matches what the
     # epic overlay hardcodes for sandbox + workspace semsource. Without this
@@ -685,6 +729,12 @@ tasks:
     env:
       E2E_FIXTURE: "{{.FIXTURE_DIR}}"
       WITH_EPIC: "{{.EPIC_ON}}"
+      # Backend timeout overlay — read by configs/e2e-gemini.json env-expansion
+      # at process startup. Compose passes these through via e2e-llm.yml.
+      SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}"
+      SEMSPEC_RECOVERY_TIMEOUT_SECONDS: "{{.RECOVERY_TIMEOUT_SECONDS}}"
+      SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}"
+      SEMSPEC_SCENARIO_ORCH_TIMEOUT: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}s"
     cmds:
       - |
         if [ ! -f "configs/{{.E2E_CONFIG}}" ]; then
@@ -693,7 +743,7 @@ tasks:
           ls configs/e2e-*.json | sed 's|configs/e2e-||;s|\.json||' | grep -v mock | sed 's/^/  /'
           exit 1
         fi
-      - echo "[WATCH:LLM] Provider={{.PROVIDER}} Tier=@{{.TIER}} Config={{.E2E_CONFIG}} Epic={{if .EPIC_OVERLAY}}on{{else}}off{{end}}"
+      - echo "[WATCH:LLM] Provider={{.PROVIDER}} Tier=@{{.TIER}} Config={{.E2E_CONFIG}} Epic={{if .EPIC_OVERLAY}}on{{else}}off{{end}} Backend-req-timeout={{.REQ_EXECUTOR_TIMEOUT_SECONDS}}s Recovery-timeout={{.RECOVERY_TIMEOUT_SECONDS}}s"
       - mkdir -p {{.OUT_DIR}}
       - echo "[WATCH:LLM] Artifacts will land in {{.OUT_DIR}}"
       # Build the host-side semspec binary that runs the watch sidecar.

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -651,6 +651,29 @@ tasks:
       - defer: { task: ui:cleanup:llm }
       - echo "[UI:TEST:LLM] Complete"
 
+  poll:llm:
+    desc: "Attach active-polling sidecar to an already-running UI E2E stack — usage: task e2e:poll:llm [-- out_dir]"
+    vars:
+      RUN_TS:
+        sh: date +%Y%m%d-%H%M%S
+      OUT_DIR:
+        sh: |
+          ARG="$(echo '{{.CLI_ARGS}}' | awk '{print $1}')"
+          if [ -n "$ARG" ]; then
+            echo "$ARG"
+          else
+            echo "/tmp/semspec-poll-{{.RUN_TS}}"
+          fi
+    cmds:
+      - mkdir -p {{.OUT_DIR}}
+      - |
+        echo "[POLL:LLM] Output -> {{.OUT_DIR}}/poll.log"
+        echo "[POLL:LLM] Tail it: tail -F {{.OUT_DIR}}/poll.log"
+        echo "[POLL:LLM] Stop with Ctrl+C"
+        # Foreground run so Ctrl+C cleanly stops the loop. The background
+        # wiring belongs in watch:llm — this task is for ad-hoc attach.
+        exec bash taskfiles/scripts/active-poll.sh {{.OUT_DIR}} http://localhost:3000 ui-semspec-1
+
   watch:llm:
     desc: "Real-LLM run with semspec watch sidecar (live alerts + final bundle) — usage: task e2e:watch:llm -- <provider> [tier]"
     deps: [check-ports:ui]
@@ -797,6 +820,20 @@ tasks:
         docker logs -f ui-semspec-1 > {{.OUT_DIR}}/semspec.log 2>&1 &
         echo $! > {{.OUT_DIR}}/semspec-log.pid
         echo "[WATCH:LLM] semspec log tail PID $(cat {{.OUT_DIR}}/semspec-log.pid) → {{.OUT_DIR}}/semspec.log"
+        # Active-polling sidecar — emits one-line wedge-shape events every
+        # POLL_INTERVAL (default 30s) by curl'ing /plan-manager/plans and
+        # scanning recent docker logs. Pairs with watch.log (crash-shaped
+        # signal) by surfacing INFO-shaped state changes the passive grep
+        # misses: stage progression, req-reviewer rejections, recovery
+        # dispatches, plan-decision lifecycle, and wedge-detect when a
+        # stage stalls past WEDGE_WARN_SECONDS. Designed for `tail -F
+        # {{.OUT_DIR}}/poll.log` as a primary monitor during the run.
+        # See memory: feedback_monitors_are_backstops_active_polling_primary.
+        bash taskfiles/scripts/active-poll.sh {{.OUT_DIR}} http://localhost:3000 ui-semspec-1 \
+          > {{.OUT_DIR}}/active-poll.stdout 2>&1 &
+        echo $! > {{.OUT_DIR}}/active-poll.pid
+        echo "[WATCH:LLM] active-poll PID $(cat {{.OUT_DIR}}/active-poll.pid) → {{.OUT_DIR}}/poll.log"
+        echo "[WATCH:LLM]   Tail it:  tail -F {{.OUT_DIR}}/poll.log"
       - defer: |
           if [ -f {{.OUT_DIR}}/watch.pid ]; then
             PID=$(cat {{.OUT_DIR}}/watch.pid)
@@ -822,6 +859,16 @@ tasks:
             PID=$(cat {{.OUT_DIR}}/semspec-log.pid)
             kill "$PID" 2>/dev/null || true
             rm -f {{.OUT_DIR}}/semspec-log.pid
+          fi
+          # Stop the active-polling sidecar. SIGTERM lets it flush the
+          # POLL_EXIT line via its EXIT trap; SIGKILL after a beat in
+          # case the curl is mid-flight against a torn-down stack.
+          if [ -f {{.OUT_DIR}}/active-poll.pid ]; then
+            PID=$(cat {{.OUT_DIR}}/active-poll.pid)
+            kill "$PID" 2>/dev/null || true
+            sleep 1
+            kill -9 "$PID" 2>/dev/null || true
+            rm -f {{.OUT_DIR}}/active-poll.pid
           fi
       - echo "[WATCH:LLM] Running @{{.TIER}} Playwright tests..."
       - cmd: |

--- a/taskfiles/scripts/active-poll.sh
+++ b/taskfiles/scripts/active-poll.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# active-poll.sh — emit one-line wedge-shape events during a paid e2e run.
+#
+# Pairs with the semspec watch sidecar (watch.log). The watch sidecar greps
+# for crash-shaped signal (errors=N counter, RepeatToolFailure ALERTs). It
+# stays SILENT through INFO-shaped events that nonetheless wedge a paid run:
+# req-reviewer rejections, recovery dispatches, plan-decision auto-accepts,
+# stage advances that stall. Smoke 8 (mavlink-hard 2026-06-02) burned ~75min
+# because the operator polled every ~20min while the backend's per-req
+# timeout was ticking down silently.
+#
+# This script polls authoritative state every POLL_INTERVAL seconds and
+# emits one line per event into poll.log. Line-oriented so `tail -F poll.log`
+# is a viable primary monitor.
+#
+# Emit shapes (single line, prefix = "[POLL <iso-ts>]"):
+#   STAGE_CHANGE       slug=<slug> from=<old> to=<new>
+#   WEDGE_DETECT       slug=<slug> stage=<stage> stuck_for=<sec>
+#   REVIEWER_REJECT    slug=<slug>? line="<grep snippet>"
+#   RECOVERY_DISPATCH  line="<grep snippet>"
+#   PLAN_DECISION      line="<grep snippet>"
+#   ERROR              line="<grep snippet>"
+#   HEARTBEAT          plans=<n> active=<slug:stage,...>
+#
+# Usage: active-poll.sh <out_dir> [http] [container]
+#   out_dir   — where to write poll.log + .poll-state/
+#   http      — defaults to http://localhost:3000
+#   container — defaults to ui-semspec-1
+#
+# Env: POLL_INTERVAL (default 30s), WEDGE_WARN_SECONDS (default 600).
+
+set -u
+
+OUT_DIR="${1:?usage: active-poll.sh out_dir [http] [container]}"
+HTTP="${2:-http://localhost:3000}"
+CONTAINER="${3:-ui-semspec-1}"
+POLL="${POLL_INTERVAL:-30}"
+WEDGE_WARN="${WEDGE_WARN_SECONDS:-600}"
+
+mkdir -p "$OUT_DIR/.poll-state"
+LOG="$OUT_DIR/poll.log"
+
+now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
+now_epoch() { date -u +%s; }
+emit() { printf '[POLL %s] %s\n' "$(now_iso)" "$*" >> "$LOG"; }
+
+# Track when we last scraped docker logs so we never re-emit a line.
+LAST_LOG_TS_FILE="$OUT_DIR/.poll-state/last-log-epoch"
+echo "$(now_epoch)" > "$LAST_LOG_TS_FILE"
+
+trap 'emit "POLL_EXIT signal=$?"' EXIT
+
+emit "POLL_START interval=${POLL}s http=$HTTP container=$CONTAINER wedge_warn=${WEDGE_WARN}s"
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+# Plan list → emit STAGE_CHANGE for any slug whose stage differs from
+# the per-slug state file. Update state file. Also detect wedge (stage
+# unchanged for >WEDGE_WARN seconds) and emit once per WEDGE_WARN window.
+poll_plan_stages() {
+	local plans_json
+	plans_json="$(curl -fsS --max-time 5 "$HTTP/plan-manager/plans" 2>/dev/null || echo '[]')"
+
+	# jq output: one line per plan, "slug|stage"
+	local entries
+	entries="$(echo "$plans_json" | jq -r '.[] | "\(.slug)|\(.stage)"' 2>/dev/null || true)"
+
+	local active=""
+	local n=0
+	local epoch
+	epoch="$(now_epoch)"
+
+	while IFS='|' read -r slug stage; do
+		[ -z "$slug" ] && continue
+		n=$((n + 1))
+		[ -z "$active" ] && active="$slug:$stage" || active="$active,$slug:$stage"
+
+		local state_file="$OUT_DIR/.poll-state/stage-$slug"
+		local since_file="$OUT_DIR/.poll-state/since-$slug"
+		local prev_stage=""
+		local since="$epoch"
+		[ -f "$state_file" ] && prev_stage="$(cat "$state_file")"
+		[ -f "$since_file" ] && since="$(cat "$since_file")"
+
+		if [ "$prev_stage" != "$stage" ]; then
+			emit "STAGE_CHANGE slug=$slug from=${prev_stage:-<new>} to=$stage"
+			echo "$stage" > "$state_file"
+			echo "$epoch" > "$since_file"
+		else
+			local elapsed=$((epoch - since))
+			if [ "$elapsed" -gt "$WEDGE_WARN" ]; then
+				# Emit once per WEDGE_WARN window to avoid log spam.
+				local window=$((elapsed / WEDGE_WARN))
+				local marker="$OUT_DIR/.poll-state/wedge-$slug-$stage-$window"
+				if [ ! -f "$marker" ]; then
+					touch "$marker"
+					emit "WEDGE_DETECT slug=$slug stage=$stage stuck_for=${elapsed}s"
+				fi
+			fi
+		fi
+	done <<< "$entries"
+
+	# Heartbeat once per poll so silence is provably silence, not a dead
+	# script. Lower-volume than per-event lines but still line-oriented.
+	emit "HEARTBEAT plans=$n active=${active:-<none>}"
+}
+
+# Scan docker logs since last poll for wedge-shape signals. Emits one line
+# per match. --since takes a duration so we use the saved epoch to compute.
+poll_docker_logs() {
+	local last_epoch now_epoch since_seconds
+	last_epoch="$(cat "$LAST_LOG_TS_FILE" 2>/dev/null || now_epoch)"
+	now_epoch="$(now_epoch)"
+	since_seconds=$((now_epoch - last_epoch + 5))  # +5s overlap to avoid gap
+	[ "$since_seconds" -lt 10 ] && since_seconds=10
+
+	# `docker logs --since=<seconds>s` is the post-25.0 syntax. The grep
+	# alternation MUST stay broad — silence is not success. We're hunting
+	# for any of: reviewer rejection, recovery emit, plan-decision lifecycle,
+	# explicit error/failure markers.
+	#
+	# Filter is per-line and the output is forwarded verbatim. Truncate to
+	# 240 chars per line so a runaway log doesn't blow up poll.log.
+	local out
+	out="$(docker logs --since="${since_seconds}s" "$CONTAINER" 2>&1 \
+		| grep -iE '(reject|fixable_rejection|needs_changes|recovery.requested|recovery.complete|plan-decision|plan_decision|wedged|exhausted|terminal_failure|context deadline exceeded|level=error|"level":"error")' \
+		| sed 's/[[:space:]]\+/ /g' \
+		| cut -c1-240 \
+		2>/dev/null || true)"
+
+	if [ -n "$out" ]; then
+		while IFS= read -r line; do
+			[ -z "$line" ] && continue
+			# Coarse classification — same line emits ONE category so we don't
+			# double-count. Order matters: most specific first.
+			if echo "$line" | grep -qiE 'recovery.requested|recovery.complete'; then
+				emit "RECOVERY_DISPATCH line=\"$line\""
+			elif echo "$line" | grep -qiE 'plan-decision|plan_decision'; then
+				emit "PLAN_DECISION line=\"$line\""
+			elif echo "$line" | grep -qiE 'reject|fixable_rejection|needs_changes'; then
+				emit "REVIEWER_REJECT line=\"$line\""
+			elif echo "$line" | grep -qiE 'wedged|exhausted|terminal_failure|context deadline exceeded'; then
+				emit "WEDGE_SIGNAL line=\"$line\""
+			else
+				emit "ERROR line=\"$line\""
+			fi
+		done <<< "$out"
+	fi
+
+	echo "$now_epoch" > "$LAST_LOG_TS_FILE"
+}
+
+# ── Main loop ────────────────────────────────────────────────────────────
+
+while true; do
+	poll_plan_stages
+	poll_docker_logs
+	sleep "$POLL"
+done


### PR DESCRIPTION
## Summary

Two fixes from the smoke 8 (mavlink-hard 2026-06-02) post-mortem, both addressing root causes of the ~75min wasted paid run:

1. **Backend `requirement-executor.timeout_seconds` was silently 1h** in the shared `e2e-gemini.json` while Playwright `EXECUTION_TIMEOUT` was 3h. Restructure retry started at min 28 and hit the 60min ceiling mid-cycle. Per-tier env overlay (option B) keeps easy fast and gives hard tiers 2h/req.
2. **Watch sidecar greps for crash-shaped signal only** — silent through req-reviewer rejections, recovery dispatches, plan-decision lifecycle. New `active-poll.sh` polls `/plan-manager/plans` + recent docker logs every 30s and emits line-oriented events for primary monitoring.

## Why option B

The shared `e2e-gemini.json` is used by easy / medium / hard / mavlink-hard tiers. Bumping the file globally to 7200s would silently double-budget the easy CI signal too. Per-tier env overlay keeps the easy path tight while giving hard tiers the budget the Playwright spec already grants.

## The four knobs

Per `feedback_recovery_budget_match_playwright_cycles`, the Playwright `EXECUTION_TIMEOUT`, `allowRecoveryCycles`, and backend `max_recovery_restarts` are conceptually one budget. Today's wedge revealed a FOURTH: backend `requirement-executor.timeout_seconds` is an independent per-req wall clock that fires first when undersized.

Smoke 8 today:
- Playwright `EXECUTION_TIMEOUT` = 10,800,000 ms (3h) ✓
- backend `max_recovery_restarts` = 2 ✓
- spec `allowRecoveryCycles` = 2 ✓
- backend `requirement-executor.timeout_seconds` = 3600 (1h) ✗ ← fired at 60min

## Per-tier values shipped

| Tier | req-executor timeout | recovery timeout |
|---|---|---|
| `easy` (default) | 3600s (1h) | 60s |
| `medium` (default) | 3600s (1h) | 60s |
| `mavlink-decode` | 4800s (80min) | 300s (5min) |
| `hard` | 7200s (2h) | 600s (10min) |
| `mavlink-hard` | 7200s (2h) | 600s (10min) |

## Active-polling sidecar

`taskfiles/scripts/active-poll.sh` — emits one-line events into `poll.log` every 30s:

- `STAGE_CHANGE slug=<slug> from=<old> to=<new>`
- `WEDGE_DETECT slug=<slug> stage=<stage> stuck_for=<sec>` (after 10min stall, dedup per window)
- `REVIEWER_REJECT line="<grep snippet>"`
- `RECOVERY_DISPATCH line="<grep snippet>"`
- `PLAN_DECISION line="<grep snippet>"`
- `WEDGE_SIGNAL line="<grep snippet>"`
- `HEARTBEAT plans=<n> active=<slug:stage,...>` (every poll so silence is provably silence)

Auto-launched from `watch:llm` as a third background sidecar alongside `watch.log` + `semspec.log`. Also exposed as standalone `task e2e:poll:llm` for ad-hoc attach to an already-running stack.

Operator workflow next paid run:
```
task e2e:watch:llm -- gemini mavlink-hard
tail -F /tmp/semspec-watch-gemini-mavlink-hard-*/poll.log   # primary
tail -F /tmp/semspec-watch-gemini-mavlink-hard-*/watch.log  # backstop
```

## Test plan

- [x] `go test ./cmd/semspec/...` — config env-expansion tests pass
- [x] `go build ./...` — clean
- [x] `go test ./workflow/cascade/... ./processor/requirement-executor/...` — pass
- [x] Smoke-test JSON parses both with and without the env overrides set
- [x] Smoke-test `active-poll.sh` against a missing endpoint — emits HEARTBEAT and POLL_EXIT cleanly
- [x] `bash -n` syntax check on the script
- [x] `task --list` parses Taskfile and shows new `e2e:poll:llm` task
- [ ] Rerun mavlink-hard with `task e2e:watch:llm -- gemini mavlink-hard` to verify the 2h/req budget converges req-1 within retries AND verify the poll.log surfaces the req-reviewer reject + restructure retry as line events
- [ ] Verify easy-tier defaults unchanged by `task e2e:watch:llm -- gemini easy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)