### PR TITLE
fix(#88): detect Story file-ownership overlap without DependsOn sequencing

### DIFF
--- a/workflow/plan_requirement.go
+++ b/workflow/plan_requirement.go
@@ -105,12 +105,14 @@ func ValidateRequirementDAG(requirements []Requirement) error {
 // file ownership now lives on Story (Sarah computes the union of selected
 // Components' implementation_files). The equivalent invariants for the
 // Story DAG live on workflow.ValidateStories + plan-reviewer R3 rules
-// (story.missing_files_owned, story.docs_only_files_owned).
+// (story.missing_files_owned, story.docs_only_files_owned), and the
+// overlap-without-depends_on check itself lives at
+// workflow.ValidateStoryFileOwnership (Mode 3 of ValidateStories) as of
+// issue #88 (2026-06-03), which fills in this function's explicit "moves
+// to ValidateStories in PR 4b" TODO.
 //
 // This function survives as a no-op so SaveRequirements still compiles
-// and existing callers don't fan out into the rest of the codebase. The
-// real partition validation moves to ValidateStories in PR 4b once
-// per-Story execution lands.
+// and existing callers don't fan out into the rest of the codebase.
 func ValidateFileOwnershipPartition(requirements []Requirement) error {
 	_ = requirements
 	return nil

--- a/workflow/plan_story.go
+++ b/workflow/plan_story.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -11,10 +12,11 @@ import (
 // the ErrInvalidRequirementDAG / ErrInvalidFileOwnership pattern from
 // plan_requirement.go.
 var (
-	ErrInvalidStoryDAG       = errors.New("invalid story DAG")
-	ErrInvalidStoryStructure = errors.New("invalid story structure")
-	ErrInvalidTaskDAG        = errors.New("invalid task DAG")
-	ErrInvalidTaskStructure  = errors.New("invalid task structure")
+	ErrInvalidStoryDAG           = errors.New("invalid story DAG")
+	ErrInvalidStoryStructure     = errors.New("invalid story structure")
+	ErrInvalidStoryFileOwnership = errors.New("invalid story file ownership")
+	ErrInvalidTaskDAG            = errors.New("invalid task DAG")
+	ErrInvalidTaskStructure      = errors.New("invalid task structure")
 )
 
 // ValidateStoryDAG validates that DependsOn references within the provided
@@ -141,9 +143,11 @@ func hasSourceFile(paths []string) bool {
 }
 
 // ValidateStories runs ValidateStory on each entry, ValidateStoryDAG across
-// the set, and additionally validates intra-Story task DAGs. Mode 1 (per-Story
-// structural invariants) runs first so callers see the most specific failure;
-// Mode 2 (cross-Story DAG) runs second; Mode 3 (per-Story task DAG) runs last.
+// the set, ValidateStoryFileOwnership across the set, and additionally
+// validates intra-Story task DAGs. Mode 1 (per-Story structural invariants)
+// runs first so callers see the most specific failure; Mode 2 (cross-Story
+// DAG) runs second; Mode 3 (cross-Story file-ownership / race prevention)
+// runs third; Mode 4 (per-Story task DAG) runs last.
 //
 // Plan-reviewer R3 invokes this on the preparing_stories → ready_for_execution
 // boundary; story-preparer (Sarah) invokes it inside her readiness gate.
@@ -154,6 +158,9 @@ func ValidateStories(stories []Story) error {
 		}
 	}
 	if err := ValidateStoryDAG(stories); err != nil {
+		return err
+	}
+	if err := ValidateStoryFileOwnership(stories); err != nil {
 		return err
 	}
 	for _, s := range stories {
@@ -167,6 +174,113 @@ func ValidateStories(stories []Story) error {
 		}
 	}
 	return nil
+}
+
+// ValidateStoryFileOwnership ensures that when two Stories share at least one
+// file in FilesOwned, the DependsOn DAG sequences one before the other so the
+// scenario-orchestrator's parallel dispatch (config max_concurrent=5) does NOT
+// race-write the shared files.
+//
+// ADR-043 Move 4 retired the requirement-level partition validator on the
+// premise that file-collision sequencing would move to Story.DependsOn after
+// Sarah shards. Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard) showed Sarah
+// declaring overlapping files_owned across sibling Stories under different
+// Requirements without the corresponding DependsOn edges — a latent
+// write-race that today is hidden by serial Requirement DAG execution but
+// would activate the moment parallel Requirement dispatch lands. This
+// validator fills in the explicitly-deferred TODO from plan_requirement.go
+// (ValidateFileOwnershipPartition no-op).
+//
+// The check is symmetric: for any pair (A, B) of distinct Stories sharing at
+// least one normalized FilesOwned path, A must be in B's transitive
+// DependsOn closure OR vice versa. Self-comparisons skipped. Empty FilesOwned
+// short-circuits. Files normalized via NormalizeFilePath so `src/x.go` and
+// `./src/x.go` compare equal.
+//
+// Returns ErrInvalidStoryFileOwnership wrapped with the offending Story IDs
+// and the shared file(s). plan-reviewer R3 and Sarah's readiness gate route
+// on errors.Is.
+func ValidateStoryFileOwnership(stories []Story) error {
+	if len(stories) < 2 {
+		return nil
+	}
+
+	// Build the transitive DependsOn closure for each Story. BFS from each
+	// Story over its direct DependsOn edges. O(n²) memory, O(n³) worst-case
+	// time — acceptable for plan-level Story counts (typically <20).
+	adj := make(map[string][]string, len(stories))
+	for _, s := range stories {
+		adj[s.ID] = s.DependsOn
+	}
+	closure := make(map[string]map[string]struct{}, len(stories))
+	for _, s := range stories {
+		seen := make(map[string]struct{})
+		queue := append([]string(nil), s.DependsOn...)
+		for len(queue) > 0 {
+			head := queue[0]
+			queue = queue[1:]
+			if _, ok := seen[head]; ok {
+				continue
+			}
+			seen[head] = struct{}{}
+			queue = append(queue, adj[head]...)
+		}
+		closure[s.ID] = seen
+	}
+
+	// Pre-normalize each Story's FilesOwned into a set so pair-wise checks
+	// don't re-normalize. Empty paths (NormalizeFilePath returns "" for
+	// escapes / "..") are dropped.
+	normalized := make(map[string]map[string]struct{}, len(stories))
+	for _, s := range stories {
+		set := make(map[string]struct{}, len(s.FilesOwned))
+		for _, f := range s.FilesOwned {
+			if n := NormalizeFilePath(f); n != "" {
+				set[n] = struct{}{}
+			}
+		}
+		normalized[s.ID] = set
+	}
+
+	for i := 0; i < len(stories); i++ {
+		a := stories[i]
+		for j := i + 1; j < len(stories); j++ {
+			b := stories[j]
+			shared := sharedFiles(normalized[a.ID], normalized[b.ID])
+			if len(shared) == 0 {
+				continue
+			}
+			_, aDependsOnB := closure[a.ID][b.ID]
+			_, bDependsOnA := closure[b.ID][a.ID]
+			if !aDependsOnB && !bDependsOnA {
+				return fmt.Errorf("%w: stories %q and %q share file(s) %v but neither depends on the other (transitively) — would race-write at parallel dispatch; add a depends_on edge from the later Story to the earlier one",
+					ErrInvalidStoryFileOwnership, a.ID, b.ID, shared)
+			}
+		}
+	}
+	return nil
+}
+
+// sharedFiles returns the sorted intersection of two normalized file sets.
+// Returns nil when there is no overlap. Sorted output makes test assertions
+// deterministic and the error message reproducible.
+func sharedFiles(a, b map[string]struct{}) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	// Iterate the smaller set for the membership test.
+	small, large := a, b
+	if len(b) < len(a) {
+		small, large = b, a
+	}
+	var out []string
+	for f := range small {
+		if _, ok := large[f]; ok {
+			out = append(out, f)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // ValidateTask checks structural invariants for a single Task:

--- a/workflow/plan_story_test.go
+++ b/workflow/plan_story_test.go
@@ -357,6 +357,184 @@ func TestValidateStoriesAggregate(t *testing.T) {
 	if err := ValidateStories(storyStructBad); !errors.Is(err, ErrInvalidStoryStructure) {
 		t.Errorf("story struct error not surfaced: %v", err)
 	}
+
+	// Aggregate hook for file-ownership: two stories share a file but neither
+	// depends on the other. ValidateStories must surface
+	// ErrInvalidStoryFileOwnership (not the per-Story / DAG error classes).
+	fileRace := []Story{
+		{ID: "s1", RequirementID: "r1", Title: "A", Status: StoryStatusReady,
+			FilesOwned: []string{"src/x.go"},
+			Tasks:      []Task{{ID: "t1", StoryID: "s1", Description: "tests"}}},
+		{ID: "s2", RequirementID: "r2", Title: "B", Status: StoryStatusReady,
+			FilesOwned: []string{"src/x.go"}, // same file, no depends_on edge
+			Tasks:      []Task{{ID: "t2", StoryID: "s2", Description: "tests"}}},
+	}
+	if err := ValidateStories(fileRace); !errors.Is(err, ErrInvalidStoryFileOwnership) {
+		t.Errorf("file-ownership race error not surfaced by ValidateStories: %v", err)
+	}
+}
+
+// TestValidateStoryFileOwnership covers ADR-043 issue #88: when two Stories
+// share a file in FilesOwned, the DependsOn DAG must sequence them — otherwise
+// the scenario-orchestrator's parallel dispatch races on the shared file.
+//
+// Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard, plan ebe27a10f9e4) had
+// stories 1.1, 2.1, 3.1 all owning the same 7-file MAVSDK driver set with
+// 2.1 and 3.1 both depending only on 1.1 — at dispatch time, 2.1 and 3.1
+// would race-write UnmannedSystem.java. The aborted run never reached that
+// point, but this validator now catches the shape at plan-time.
+func TestValidateStoryFileOwnership(t *testing.T) {
+	t.Run("empty input is valid", func(t *testing.T) {
+		if err := ValidateStoryFileOwnership(nil); err != nil {
+			t.Errorf("nil stories should validate: %v", err)
+		}
+		if err := ValidateStoryFileOwnership([]Story{}); err != nil {
+			t.Errorf("empty stories should validate: %v", err)
+		}
+	})
+
+	t.Run("single story validates", func(t *testing.T) {
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", Title: "A",
+				FilesOwned: []string{"src/x.go"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("single story should validate: %v", err)
+		}
+	})
+
+	t.Run("disjoint files validate", func(t *testing.T) {
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/a.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/b.go"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("disjoint files should validate: %v", err)
+		}
+	})
+
+	t.Run("shared file with direct dependency validates", func(t *testing.T) {
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/x.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/x.go"},
+				DependsOn: []string{"s1"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("shared file with direct dependency should validate: %v", err)
+		}
+	})
+
+	t.Run("shared file with transitive dependency validates", func(t *testing.T) {
+		// s1 → s2 → s3 ; s1 and s3 share a file but s3 transitively
+		// depends on s1 via s2. Safe to dispatch serially.
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/x.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/y.go"},
+				DependsOn: []string{"s1"}},
+			{ID: "s3", RequirementID: "r3", FilesOwned: []string{"src/x.go"},
+				DependsOn: []string{"s2"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("transitive dependency should validate: %v", err)
+		}
+	})
+
+	t.Run("shared file without dependency fails", func(t *testing.T) {
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/x.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/x.go"}},
+		}
+		err := ValidateStoryFileOwnership(stories)
+		if !errors.Is(err, ErrInvalidStoryFileOwnership) {
+			t.Fatalf("expected ErrInvalidStoryFileOwnership, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "src/x.go") {
+			t.Errorf("error should name the shared file: %v", err)
+		}
+		if !strings.Contains(err.Error(), "s1") || !strings.Contains(err.Error(), "s2") {
+			t.Errorf("error should name both stories: %v", err)
+		}
+	})
+
+	t.Run("siblings sharing files via same parent fail", func(t *testing.T) {
+		// This is the smoke-9 shape: s2 and s3 both depend_on s1, share a
+		// file, but do NOT depend on each other. Parallel dispatch would race.
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/base.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/shared.go"},
+				DependsOn: []string{"s1"}},
+			{ID: "s3", RequirementID: "r3", FilesOwned: []string{"src/shared.go"},
+				DependsOn: []string{"s1"}},
+		}
+		err := ValidateStoryFileOwnership(stories)
+		if !errors.Is(err, ErrInvalidStoryFileOwnership) {
+			t.Fatalf("expected smoke-9 shape to fail validation, got %v", err)
+		}
+	})
+
+	t.Run("multiple shared files all surface in error", func(t *testing.T) {
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1",
+				FilesOwned: []string{"src/x.go", "src/y.go", "src/z.go"}},
+			{ID: "s2", RequirementID: "r2",
+				FilesOwned: []string{"src/x.go", "src/y.go"}},
+		}
+		err := ValidateStoryFileOwnership(stories)
+		if !errors.Is(err, ErrInvalidStoryFileOwnership) {
+			t.Fatalf("expected error, got %v", err)
+		}
+		// Both shared files should appear in the message (sorted).
+		if !strings.Contains(err.Error(), "src/x.go") || !strings.Contains(err.Error(), "src/y.go") {
+			t.Errorf("error should list all shared files: %v", err)
+		}
+	})
+
+	t.Run("path normalization catches equivalent spellings", func(t *testing.T) {
+		// `src/x.go` and `./src/x.go` should normalize to the same path
+		// and the overlap should be detected.
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/x.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"./src/x.go"}},
+		}
+		err := ValidateStoryFileOwnership(stories)
+		if !errors.Is(err, ErrInvalidStoryFileOwnership) {
+			t.Fatalf("non-canonical paths should still detect overlap, got %v", err)
+		}
+	})
+
+	t.Run("diamond closure validates", func(t *testing.T) {
+		// Diamond:
+		//   s1 ──→ s2 ──→ s4
+		//    └──→ s3 ────┘
+		// s1 and s4 share a file; s4 transitively depends on s1 via both
+		// s2 and s3. Reachability through either path satisfies the check.
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: []string{"src/x.go"}},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/a.go"},
+				DependsOn: []string{"s1"}},
+			{ID: "s3", RequirementID: "r3", FilesOwned: []string{"src/b.go"},
+				DependsOn: []string{"s1"}},
+			{ID: "s4", RequirementID: "r4", FilesOwned: []string{"src/x.go"},
+				DependsOn: []string{"s2", "s3"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("diamond closure should validate s1↔s4 via s2 OR s3: %v", err)
+		}
+	})
+
+	t.Run("empty FilesOwned does not trip validation", func(t *testing.T) {
+		// ValidateStory enforces non-empty FilesOwned on signed-off Stories,
+		// but ValidateStoryFileOwnership is called with raw input — including
+		// possibly pending stories. Empty FilesOwned must be treated as "no
+		// overlap candidate" and pass through this validator silently.
+		stories := []Story{
+			{ID: "s1", RequirementID: "r1", FilesOwned: nil},
+			{ID: "s2", RequirementID: "r2", FilesOwned: []string{"src/x.go"}},
+		}
+		if err := ValidateStoryFileOwnership(stories); err != nil {
+			t.Errorf("empty FilesOwned should pass file-ownership check: %v", err)
+		}
+	})
 }
 
 func TestValidateCapabilityCoverage(t *testing.T) {


### PR DESCRIPTION
Closes #88.

## Summary

ADR-043 Move 4 retired `ValidateFileOwnershipPartition` in `workflow/plan_requirement.go` with the comment that "real partition validation moves to ValidateStories in PR 4b once per-Story execution lands." That migration never happened. Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard, plan `ebe27a10f9e4`) demonstrated the consequence:

- Stories 1.1, 2.1, 3.1 all owned the same 7-file MAVSDK driver set
- 2.1 and 3.1 both `depends_on: story.1.1` with **no edge between each other**
- `scenario-orchestrator.MaxConcurrent=5` means they would dispatch in parallel when 1.1 completes
- Today's serial Requirement DAG hides this; parallel Requirement dispatch would race-write `UnmannedSystem.java`

This PR fills in the deferred validator.

## Changes

- **`workflow/plan_story.go`**:
  - New sentinel `ErrInvalidStoryFileOwnership`
  - New `ValidateStoryFileOwnership(stories []Story) error` — pairwise file-overlap check; for any pair of stories sharing ≥1 normalized file path in `FilesOwned`, one must be in the other's transitive `DependsOn` closure. Returns wrapped sentinel + offending Story IDs + sorted shared files + remediation hint
  - `sharedFiles` helper — sorted intersection of two normalized file sets
  - `ValidateStories` now invokes the new check as Mode 3 between `ValidateStoryDAG` and per-Story task validation
- **`workflow/plan_requirement.go`**: updated `ValidateFileOwnershipPartition` doc-comment to point at the realized replacement (no behavior change)
- **`workflow/plan_story_test.go`**: 11 sub-tests + extended aggregate test

## Verification against actual smoke-9 data

Manual run of the validator against the actual smoke-9 KV state:

```
invalid story file ownership: stories "story.ebe27a10f9e4.2.1" and "story.ebe27a10f9e4.3.1"
share file(s) [src/main/java/.../UnmannedConfig.java src/main/java/.../UnmannedSystem.java]
but neither depends on the other (transitively) — would race-write at parallel dispatch;
add a depends_on edge from the later Story to the earlier one
```

Sarah's retry would receive this verbatim and could correct the missing edge.

## Test plan

- [x] `go test ./workflow/... -run TestValidateStoryFileOwnership -v` — 11/11 PASS
- [x] `go test ./workflow/...` full sweep — no regressions
- [x] `go test ./processor/story-preparer/... ./processor/plan-reviewer/...` — no regressions in callers
- [x] Manual smoke against smoke-9 KV state — catches the wild shape
- [x] go-reviewer pre-commit: APPROVE
- [ ] Re-run mavlink-hard with this + #91 merged to confirm validator fires before convergence cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)