### PR TITLE
fix(#90): front-load ADR-041 binding requirements into dev task prompts

### DIFF
--- a/processor/requirement-executor/binding_context.go
+++ b/processor/requirement-executor/binding_context.go
@@ -1,0 +1,184 @@
+// binding_context.go implements issue #90: surface ADR-041 mechanical
+// binding requirements (tier tag, harness profile string, env var names,
+// required assertions) in the dev's task prompt so the dev can satisfy
+// them on the first cycle rather than discovering them via reviewer
+// feedback across multiple cycles.
+//
+// Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard) showed the dev was
+// substantively responsive to LLM reviewer feedback but burned cycles
+// re-discovering the same mechanical bindings each pass. Front-loading
+// the data Sarah already has access to (via scenarios denormalized in
+// issue #89) closes the gap.
+//
+// The binding context block is appended to TaskNode.Prompt at DAG
+// synthesis time. When scenarios carry no integration-tier binding
+// data the helper returns "" and the prompt stays unchanged — the
+// addition is purely additive for @unit / @e2e-only stories.
+
+package requirementexecutor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// maxAssertionsPerScenario caps how many RequiredAssertions render in a
+// single scenario's bullet block. Catalogs today carry ~3-5 assertions per
+// profile so the cap is generous; a future profile bloating past this
+// gets truncated with an explicit marker rather than blowing prompt token
+// budget. Per go-reviewer feedback on PR #90.
+const maxAssertionsPerScenario = 10
+
+// buildBindingContextBlock returns a formatted Markdown block listing
+// per-scenario integration-tier authoring requirements (tier tag,
+// harness profile string, env var names, required assertions). Returns
+// "" when no scenario in the slice carries binding-relevant data.
+//
+// Scenarios without HarnessProfileIDs and without a non-@unit tier tag
+// are skipped — they're @unit work where the dev doesn't need this
+// guidance. Only @integration / @smoke / @e2e scenarios are surfaced,
+// since those are the ones where structural-validator + the reviewer
+// enforce the mechanical bindings.
+func buildBindingContextBlock(scenarios []workflow.Scenario) string {
+	relevant := filterIntegrationTierScenarios(scenarios)
+	if len(relevant) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Integration Test Requirements\n\n")
+	b.WriteString("The scenarios below require integration-tier test authoring. ")
+	b.WriteString("Satisfy each bullet to avoid mechanical rejections on the first review cycle.\n\n")
+
+	for _, sc := range relevant {
+		b.WriteString(formatScenarioBinding(sc))
+	}
+
+	return b.String()
+}
+
+// filterIntegrationTierScenarios returns scenarios that carry at least
+// one non-@unit tier tag OR at least one harness profile binding.
+// Stable input order is preserved so the prompt is deterministic given
+// the same scenario set.
+func filterIntegrationTierScenarios(scenarios []workflow.Scenario) []workflow.Scenario {
+	out := make([]workflow.Scenario, 0, len(scenarios))
+	for _, sc := range scenarios {
+		if hasIntegrationTierSignal(sc) {
+			out = append(out, sc)
+		}
+	}
+	return out
+}
+
+// hasIntegrationTierSignal returns true when a scenario has either an
+// @integration / @smoke / @e2e tier tag OR a non-empty HarnessProfileIDs.
+// @unit-only scenarios with no harness binding return false — the dev
+// doesn't need the binding context for those.
+func hasIntegrationTierSignal(sc workflow.Scenario) bool {
+	if len(sc.HarnessProfileIDs) > 0 {
+		return true
+	}
+	for _, tag := range sc.Tags {
+		if tag == "@integration" || tag == "@smoke" || tag == "@e2e" {
+			return true
+		}
+	}
+	return false
+}
+
+// formatScenarioBinding renders one scenario's binding requirements as
+// a Markdown bullet block.
+func formatScenarioBinding(sc workflow.Scenario) string {
+	var b strings.Builder
+
+	// Scenario header with tags.
+	tagPart := ""
+	if len(sc.Tags) > 0 {
+		tagPart = " " + strings.Join(sc.Tags, " ")
+	}
+	fmt.Fprintf(&b, "- **%s**%s\n", sc.ID, tagPart)
+
+	// Tier-tag directive — frame language-agnostic per the
+	// feedback_no_colons_or_dots_in_bdd_tags convention. JUnit5 uses
+	// @Tag("integration"); pytest uses pytest.mark.integration. Go is
+	// omitted on purpose: //go:build integration is a file-level build
+	// constraint, not a per-test tag, and would exclude every test in
+	// the file. Go devs apply per-test conventions (subtest naming,
+	// test helper gating) which they'll pick up from the JUnit5/pytest
+	// patterns. Per go-reviewer feedback on PR #90.
+	if tag := pickTierTag(sc.Tags); tag != "" {
+		bare := strings.TrimPrefix(tag, "@")
+		fmt.Fprintf(&b, "  - Tag tests for the %s tier (e.g. JUnit5 `@Tag(%q)`, pytest `pytest.mark.%s`).\n",
+			tag, bare, bare)
+	}
+
+	// Harness profile string literals — structural-validator checks the
+	// test contents for these literal strings (ADR-041 Move 5 binding
+	// check). Quoting them in the prompt makes the literal explicit.
+	if len(sc.HarnessProfileIDs) > 0 {
+		fmt.Fprintf(&b, "  - Reference at least one of the bound harness profile ID(s) as a string literal in test source: %s.\n",
+			quotedJoined(sc.HarnessProfileIDs))
+	}
+
+	// Env var consumption — the catalog declares which env vars the
+	// qa-runner injects at test time. Tests must read from these rather
+	// than hardcoding values (catalog-grounded env keys per the memory
+	// note feedback_catalog_grounded_env_keys).
+	if len(sc.Env) > 0 {
+		keys := make([]string, 0, len(sc.Env))
+		for k := range sc.Env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		fmt.Fprintf(&b, "  - Read these env var(s) at test runtime (qa-runner injects values): %s.\n",
+			quotedJoined(keys))
+	}
+
+	// Required assertions — copy verbatim from catalog so the dev knows
+	// what the reviewer will demand. Capped at maxAssertionsPerScenario
+	// to guard prompt token budget against future bloated catalogs;
+	// truncation marker tells the dev to dig deeper if needed.
+	if len(sc.RequiredAssertions) > 0 {
+		b.WriteString("  - Required assertions:\n")
+		limit := len(sc.RequiredAssertions)
+		if limit > maxAssertionsPerScenario {
+			limit = maxAssertionsPerScenario
+		}
+		for i := 0; i < limit; i++ {
+			fmt.Fprintf(&b, "    * %s\n", sc.RequiredAssertions[i])
+		}
+		if dropped := len(sc.RequiredAssertions) - limit; dropped > 0 {
+			fmt.Fprintf(&b, "    * (+%d more — see harness catalog entry)\n", dropped)
+		}
+	}
+
+	b.WriteString("\n")
+	return b.String()
+}
+
+// pickTierTag returns the first tier tag found in the tags slice
+// (@integration / @smoke / @e2e), or "" when only @unit / facet tags
+// are present. ADR-041 guarantees exactly one tier tag per scenario via
+// ValidateScenarioTags, so the first match is the canonical one.
+func pickTierTag(tags []string) string {
+	for _, t := range tags {
+		if t == "@integration" || t == "@smoke" || t == "@e2e" {
+			return t
+		}
+	}
+	return ""
+}
+
+// quotedJoined renders a slice as `"a", "b", "c"`. Used for prompt
+// literals so the dev sees explicit string-literal form.
+func quotedJoined(items []string) string {
+	parts := make([]string, len(items))
+	for i, s := range items {
+		parts[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/processor/requirement-executor/binding_context_test.go
+++ b/processor/requirement-executor/binding_context_test.go
@@ -1,0 +1,290 @@
+package requirementexecutor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestBuildBindingContextBlock_Empty covers the no-op paths: empty
+// scenario slice, @unit-only scenarios, scenarios without any
+// integration-tier signal. The block must return "" so the dev prompt
+// stays unchanged for purely unit-tier work.
+func TestBuildBindingContextBlock_Empty(t *testing.T) {
+	cases := []struct {
+		name      string
+		scenarios []workflow.Scenario
+	}{
+		{name: "empty slice"},
+		{name: "nil slice", scenarios: nil},
+		{
+			name: "@unit only, no harness binding",
+			scenarios: []workflow.Scenario{
+				{ID: "s1", Tags: []string{"@unit"}},
+				{ID: "s2", Tags: []string{"@unit"}},
+			},
+		},
+		{
+			name: "untagged scenarios with no harness binding",
+			scenarios: []workflow.Scenario{
+				{ID: "s1"},
+				{ID: "s2"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildBindingContextBlock(tc.scenarios)
+			if got != "" {
+				t.Errorf("expected empty block, got:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestBuildBindingContextBlock_IntegrationScenario covers the smoke-9
+// shape: an @integration scenario with harness profile binding, env,
+// and required assertions. All four binding facets must surface.
+func TestBuildBindingContextBlock_IntegrationScenario(t *testing.T) {
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "scenario.ebe27a10f9e4.1.1.3",
+			Tags:              []string{"@integration"},
+			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+			Env:               map[string]string{"PX4_SIM_MODEL": "iris"},
+			RequiredAssertions: []string{
+				"Observe a MAVLink heartbeat from the SITL target.",
+				"Assert MAVSDK reports a connected vehicle before plugin calls run.",
+			},
+		},
+	}
+
+	got := buildBindingContextBlock(scenarios)
+	if got == "" {
+		t.Fatal("expected non-empty block, got empty")
+	}
+
+	mustContain(t, got, "## Integration Test Requirements")
+	mustContain(t, got, "scenario.ebe27a10f9e4.1.1.3")
+	mustContain(t, got, "@integration")
+	mustContain(t, got, `"integration"`) // JUnit5 tag literal
+	mustContain(t, got, "pytest.mark.integration")
+	// Go `//go:build integration` example intentionally omitted — it's
+	// file-level, not per-test, and would exclude unit tests in the
+	// same file (go-reviewer feedback on PR #90).
+	if strings.Contains(got, "//go:build") {
+		t.Errorf("Go build-tag example should not appear in tier directive:\n%s", got)
+	}
+	mustContain(t, got, `"mavlink.px4-sitl.mavsdk-smoke"`) // harness ID as string literal
+	mustContain(t, got, `"PX4_SIM_MODEL"`)                 // env var key as literal
+	mustContain(t, got, "Observe a MAVLink heartbeat from the SITL target.")
+	mustContain(t, got, "Assert MAVSDK reports a connected vehicle before plugin calls run.")
+}
+
+// TestBuildBindingContextBlock_HarnessOnlyNoTag covers a scenario that
+// has harness bindings but somehow lacks a tier tag. The block must
+// still render the harness/env/assertions so the dev sees them; the
+// tier directive is omitted when no tier tag is present.
+func TestBuildBindingContextBlock_HarnessOnlyNoTag(t *testing.T) {
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "s1",
+			HarnessProfileIDs: []string{"some.profile"},
+			Env:               map[string]string{"VAR": "val"},
+		},
+	}
+	got := buildBindingContextBlock(scenarios)
+	mustContain(t, got, "some.profile")
+	mustContain(t, got, `"VAR"`)
+	if strings.Contains(got, "pytest.mark.") {
+		t.Errorf("tier directive should be absent when no tier tag, got:\n%s", got)
+	}
+}
+
+// TestBuildBindingContextBlock_MultipleScenarios covers a story with
+// multiple integration-tier scenarios. Each must surface as its own
+// bullet block with its own bindings.
+func TestBuildBindingContextBlock_MultipleScenarios(t *testing.T) {
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "s1",
+			Tags:              []string{"@integration"},
+			HarnessProfileIDs: []string{"profile.a"},
+		},
+		{
+			ID:                "s2",
+			Tags:              []string{"@smoke"},
+			HarnessProfileIDs: []string{"profile.b"},
+		},
+		{
+			// @unit only — must be filtered out.
+			ID:   "s3",
+			Tags: []string{"@unit"},
+		},
+	}
+	got := buildBindingContextBlock(scenarios)
+	mustContain(t, got, "s1")
+	mustContain(t, got, "s2")
+	mustContain(t, got, "profile.a")
+	mustContain(t, got, "profile.b")
+	if strings.Contains(got, "- **s3**") {
+		t.Errorf("@unit-only scenario s3 should be filtered out, got:\n%s", got)
+	}
+}
+
+// TestBuildBindingContextBlock_MultipleEnvKeysSorted covers
+// determinism: when a scenario has multiple env keys, they must render
+// in sorted order so the prompt is byte-identical across runs.
+func TestBuildBindingContextBlock_MultipleEnvKeysSorted(t *testing.T) {
+	scenarios := []workflow.Scenario{
+		{
+			ID:                "s1",
+			Tags:              []string{"@integration"},
+			HarnessProfileIDs: []string{"p1"},
+			Env: map[string]string{
+				"ZEBRA":  "z",
+				"ALPHA":  "a",
+				"MIDDLE": "m",
+			},
+		},
+	}
+	got := buildBindingContextBlock(scenarios)
+	// Expect "ALPHA", "MIDDLE", "ZEBRA" in that order.
+	idxA := strings.Index(got, `"ALPHA"`)
+	idxM := strings.Index(got, `"MIDDLE"`)
+	idxZ := strings.Index(got, `"ZEBRA"`)
+	if idxA < 0 || idxM < 0 || idxZ < 0 {
+		t.Fatalf("missing env keys in output:\n%s", got)
+	}
+	if !(idxA < idxM && idxM < idxZ) {
+		t.Errorf("env keys not in sorted order: ALPHA@%d MIDDLE@%d ZEBRA@%d", idxA, idxM, idxZ)
+	}
+}
+
+func mustContain(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("output missing %q\n--- output ---\n%s", want, got)
+	}
+}
+
+// TestSynthesizeTaskDAGForStory_BindingBlockAppendedToPrompts pins the
+// integration: when a Story has @integration scenarios, every TaskNode
+// in the synthesized DAG gets the binding block appended to its Prompt
+// (after the original Task.Description, separated by ---).
+func TestSynthesizeTaskDAGForStory_BindingBlockAppendedToPrompts(t *testing.T) {
+	story := workflow.Story{
+		ID:            "story.demo.1.1",
+		RequirementID: "req.demo.1",
+		Title:         "Lifecycle",
+		FilesOwned:    []string{"src/x.go"},
+		Tasks: []workflow.Task{
+			{ID: "task.demo.1.1.1", StoryID: "story.demo.1.1", Description: "Write failing test for lifecycle."},
+			{ID: "task.demo.1.1.2", StoryID: "story.demo.1.1", Description: "Implement to pass."},
+		},
+	}
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{story},
+		Scenarios: []workflow.Scenario{
+			{
+				ID:                "scen.demo.1.1.1",
+				StoryID:           "story.demo.1.1",
+				RequirementID:     "req.demo.1",
+				Tags:              []string{"@integration"},
+				HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
+				Env:               map[string]string{"PX4_SIM_MODEL": "iris"},
+			},
+		},
+	}
+
+	dag, err := synthesizeTaskDAGForStory(plan, story)
+	if err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	if len(dag.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(dag.Nodes))
+	}
+	// Build a Task.ID → Description index so the prefix assertion isn't
+	// coupled to specific description strings (go-reviewer feedback).
+	descByID := make(map[string]string, len(story.Tasks))
+	for _, t := range story.Tasks {
+		descByID[t.ID] = t.Description
+	}
+	for _, n := range dag.Nodes {
+		if !strings.Contains(n.Prompt, "Integration Test Requirements") {
+			t.Errorf("node %s prompt missing binding block:\n%s", n.ID, n.Prompt)
+		}
+		if !strings.Contains(n.Prompt, "mavlink.px4-sitl.mavsdk-smoke") {
+			t.Errorf("node %s prompt missing harness profile literal:\n%s", n.ID, n.Prompt)
+		}
+		if want := descByID[n.ID]; !strings.HasPrefix(n.Prompt, want) {
+			t.Errorf("node %s prompt should start with original Task.Description %q, got:\n%s", n.ID, want, n.Prompt)
+		}
+	}
+}
+
+// TestBuildBindingContextBlock_AssertionCap pins the safety cap on
+// RequiredAssertions: a profile with more than maxAssertionsPerScenario
+// entries renders the first N + a truncation marker. Catalog authors
+// today stay well below this cap; the test guards against future bloat.
+func TestBuildBindingContextBlock_AssertionCap(t *testing.T) {
+	many := make([]string, 0, maxAssertionsPerScenario+5)
+	for i := 0; i < maxAssertionsPerScenario+5; i++ {
+		many = append(many, "Assertion XYZ-"+string(rune('A'+i)))
+	}
+	scenarios := []workflow.Scenario{
+		{
+			ID:                 "s1",
+			Tags:               []string{"@integration"},
+			HarnessProfileIDs:  []string{"p1"},
+			RequiredAssertions: many,
+		},
+	}
+	got := buildBindingContextBlock(scenarios)
+	// First N must render.
+	for i := 0; i < maxAssertionsPerScenario; i++ {
+		if !strings.Contains(got, many[i]) {
+			t.Errorf("expected assertion %d (%q) in output", i, many[i])
+		}
+	}
+	// (+N more) marker should appear with the correct overflow count.
+	if !strings.Contains(got, "(+5 more — see harness catalog entry)") {
+		t.Errorf("expected truncation marker '(+5 more — see harness catalog entry)' in output:\n%s", got)
+	}
+	// Last few assertions must NOT render verbatim.
+	for i := maxAssertionsPerScenario; i < len(many); i++ {
+		if strings.Contains(got, many[i]+"\n") {
+			t.Errorf("assertion %d (%q) should be truncated", i, many[i])
+		}
+	}
+}
+
+// TestSynthesizeTaskDAGForStory_NoBindingForUnitOnlyStory pins that
+// @unit-only stories don't get the binding block appended (no behavior
+// change for trivial scopes).
+func TestSynthesizeTaskDAGForStory_NoBindingForUnitOnlyStory(t *testing.T) {
+	story := workflow.Story{
+		ID:            "story.demo.1.1",
+		RequirementID: "req.demo.1",
+		Title:         "Simple",
+		FilesOwned:    []string{"src/x.go"},
+		Tasks: []workflow.Task{
+			{ID: "task.demo.1.1.1", StoryID: "story.demo.1.1", Description: "Write a test."},
+		},
+	}
+	plan := &workflow.Plan{
+		Stories: []workflow.Story{story},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.demo.1.1.1", StoryID: "story.demo.1.1", RequirementID: "req.demo.1", Tags: []string{"@unit"}},
+		},
+	}
+
+	dag, err := synthesizeTaskDAGForStory(plan, story)
+	if err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	if got := dag.Nodes[0].Prompt; got != "Write a test." {
+		t.Errorf("expected prompt unchanged for unit-only story, got:\n%s", got)
+	}
+}

--- a/processor/requirement-executor/synthesize_dag.go
+++ b/processor/requirement-executor/synthesize_dag.go
@@ -33,18 +33,34 @@ func synthesizeTaskDAGForStory(plan *workflow.Plan, story workflow.Story) (*Task
 	}
 
 	var scenarioIDs []string
+	var storyScenarios []workflow.Scenario
 	if plan != nil {
-		for _, sc := range plan.ScenariosForStory(story.ID) {
+		storyScenarios = plan.ScenariosForStory(story.ID)
+		for _, sc := range storyScenarios {
 			scenarioIDs = append(scenarioIDs, sc.ID)
 		}
 	}
 
+	// Issue #90: front-load ADR-041 mechanical binding requirements
+	// (tier tag, harness profile string literal, env var consumption,
+	// required assertions) into the dev's task prompt. Sarah's authored
+	// task description is intentionally short; smoke 9 showed the dev
+	// burned multiple TDD cycles re-discovering the bindings via reviewer
+	// feedback even though the data is already on the scenarios (after
+	// issue #89 denormalized it from the catalog). The binding block
+	// returns "" for @unit-only stories so this is purely additive.
+	bindingBlock := buildBindingContextBlock(storyScenarios)
+
 	files := append([]string(nil), story.FilesOwned...)
 	nodes := make([]TaskNode, 0, len(story.Tasks))
 	for _, t := range story.Tasks {
+		prompt := t.Description
+		if bindingBlock != "" {
+			prompt = prompt + "\n\n---\n\n" + bindingBlock
+		}
 		nodes = append(nodes, TaskNode{
 			ID:          t.ID,
-			Prompt:      t.Description,
+			Prompt:      prompt,
 			Role:        "developer",
 			DependsOn:   append([]string(nil), t.DependsOn...),
 			FileScope:   files,


### PR DESCRIPTION
Closes #90.

Builds on #89 (merged) which put `Env` and `RequiredAssertions` on the Scenario struct.

## Summary

Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard, plan `ebe27a10f9e4`) showed the dev was substantively responsive to LLM reviewer feedback but burned multiple TDD cycles re-discovering the same mechanical bindings: `@Tag` annotations, harness profile string literals, env var consumption, required assertions. The catalog has this data, scenarios now denormalize it (per #89), and this PR uses it to front-load the requirements in the dev's task prompt.

**Reframing:** Demoted from "blocker" to "cycle-rate optimization" per the smoke-9 post-mortem — `structural-validator`'s discipline check already catches these issues deterministically; this PR saves TDD cycles by surfacing the data upfront.

## Rendered example (smoke-9 shape)

The smoke-9 dev prompt was 801 chars:
```
Write failing test for mavsdk_server startup and shutdown lifecycle.

---

REVISION REQUEST: ...
```

After this PR, the dev's first-cycle prompt:
```
Write failing test for mavsdk_server startup and shutdown lifecycle.

---

## Integration Test Requirements

The scenarios below require integration-tier test authoring. Satisfy each bullet
to avoid mechanical rejections on the first review cycle.

- **scenario.ebe27a10f9e4.1.1.3** @integration
  - Tag tests for the @integration tier (e.g. JUnit5 `@Tag("integration")`, pytest `pytest.mark.integration`).
  - Reference at least one of the bound harness profile ID(s) as a string literal in test source: "mavlink.px4-sitl.mavsdk-smoke".
  - Read these env var(s) at test runtime (qa-runner injects values): "PX4_SIM_MODEL".
  - Required assertions:
    * Observe a MAVLink heartbeat from the SITL target.
    * Assert MAVSDK reports a connected vehicle before plugin calls run.
```

The structural-validator would have rejected smoke-9's first attempts on missing `@Tag` and missing env-var consumption. With this PR, the dev sees the requirements upfront.

## Changes

| File | Change |
|---|---|
| `processor/requirement-executor/binding_context.go` (new) | `buildBindingContextBlock` + helpers; per-scenario render with sorted env keys, quoted literals, assertion cap (10) with truncation marker |
| `processor/requirement-executor/synthesize_dag.go` | `synthesizeTaskDAGForStory` appends the block to every TaskNode.Prompt when non-empty; pure addition for @unit-only stories |
| `processor/requirement-executor/binding_context_test.go` (new) | 8 test functions covering all branches incl. assertion cap |

## Test plan

- [x] `go test ./processor/requirement-executor/... -run "TestBuildBindingContext|TestSynthesizeTaskDAGForStory_Binding|TestSynthesizeTaskDAGForStory_NoBinding"` — 12/12 PASS
- [x] Full sweep on workflow + requirement-executor + scenario-generator + story-preparer — no regressions
- [x] gofmt + visual render of smoke-9 prompt verified
- [x] go-reviewer pre-commit: APPROVE → addressed assertion cap, dropped Go `//go:build` example, fixed prefix coupling
- [ ] Re-run @mavlink-hard with this + #88 + #89 merged to confirm dev satisfies binding requirements on first cycle

## Design notes

- **Go `//go:build integration` deliberately omitted** from tier-tag examples — it's a file-level build constraint, not a per-test tag; would exclude unit tests in the same file. JUnit5 + pytest examples are per-test; Go devs apply their own per-test idiom
- **Block placement:** appended *after* Task.Description but *before* any revision-feedback block requirement-executor adds on retry — keeps the dev's task first, binding spec second, current-cycle feedback last
- **Determinism:** env keys sorted; HarnessProfileIDs / Tags / RequiredAssertions iterate in slice order (Sarah's emission order, deterministic per #89's dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)