### PR TITLE
fix: gofmt import order in plumbing_discipline_test.go (unblocks main)

### DIFF
--- a/test/plumbing/plumbing_discipline_test.go
+++ b/test/plumbing/plumbing_discipline_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	scenariogenerator "github.com/c360studio/semspec/processor/scenario-generator"
 	requirementexecutor "github.com/c360studio/semspec/processor/requirement-executor"
+	scenariogenerator "github.com/c360studio/semspec/processor/scenario-generator"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/harnesscatalog"
 )


### PR DESCRIPTION
Tiny import-order fix to unblock main.

PR #110 (#92) merged with lint-and-test red — my Monitor's auto-merge check only inspected the `build` job and missed the gofmt failure. Lesson logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)