### PR TITLE
fix(#94): active-poll.sh cleanup — DEBUG filter, dedup, per-stage wedge

### DIFF
--- a/taskfiles/scripts/active-poll.sh
+++ b/taskfiles/scripts/active-poll.sh
@@ -27,7 +27,14 @@
 #   http      — defaults to http://localhost:3000
 #   container — defaults to ui-semspec-1
 #
-# Env: POLL_INTERVAL (default 30s), WEDGE_WARN_SECONDS (default 600).
+# Env:
+#   POLL_INTERVAL (default 30s)
+#   WEDGE_WARN_SECONDS (default 600) — fallback stage threshold for stages
+#                                       not in the per-stage map
+#   WEDGE_THRESHOLD_IMPLEMENTING (default 1800)   — implementing legitimately
+#                                                     runs long; 30min before warn
+#   WEDGE_THRESHOLD_GENERATING (default 900)      — generating_*/reviewing_*; 15min
+#   WEDGE_THRESHOLD_DRAFTING (default 300)        — drafting; 5min
 
 set -u
 
@@ -44,9 +51,35 @@ now_iso() { date -u +'%Y-%m-%dT%H:%M:%SZ'; }
 now_epoch() { date -u +%s; }
 emit() { printf '[POLL %s] %s\n' "$(now_iso)" "$*" >> "$LOG"; }
 
+# wedge_threshold_for_stage returns the wedge-warn seconds for a given
+# plan stage. Per smoke 9 (2026-06-02): `implementing` legitimately
+# runs for an hour or more on hard fixtures, so the original universal
+# 600s threshold spammed false-positive wedge warnings. Per-stage map
+# keeps the signal honest — short stages get tighter thresholds, long
+# stages get more headroom. Unknown stages fall back to WEDGE_WARN.
+wedge_threshold_for_stage() {
+	case "$1" in
+		implementing)
+			echo "${WEDGE_THRESHOLD_IMPLEMENTING:-1800}" ;;
+		generating_*|reviewing_*|preparing_*)
+			echo "${WEDGE_THRESHOLD_GENERATING:-900}" ;;
+		drafting)
+			echo "${WEDGE_THRESHOLD_DRAFTING:-300}" ;;
+		*)
+			echo "$WEDGE_WARN" ;;
+	esac
+}
+
 # Track when we last scraped docker logs so we never re-emit a line.
 LAST_LOG_TS_FILE="$OUT_DIR/.poll-state/last-log-epoch"
 echo "$(now_epoch)" > "$LAST_LOG_TS_FILE"
+
+# Track the highest semspec log-line timestamp we've already emitted into
+# poll.log. Lines with timestamps <= this value are dropped on the next
+# poll, killing the duplicate-emission shape PR #86's overlap window
+# created. ISO-8601 timestamps sort correctly under bash string
+# comparison so no extra parsing needed.
+LAST_EMIT_TS_FILE="$OUT_DIR/.poll-state/last-emit-ts"
 
 trap 'emit "POLL_EXIT signal=$?"' EXIT
 
@@ -88,13 +121,15 @@ poll_plan_stages() {
 			echo "$epoch" > "$since_file"
 		else
 			local elapsed=$((epoch - since))
-			if [ "$elapsed" -gt "$WEDGE_WARN" ]; then
-				# Emit once per WEDGE_WARN window to avoid log spam.
-				local window=$((elapsed / WEDGE_WARN))
+			local threshold
+			threshold="$(wedge_threshold_for_stage "$stage")"
+			if [ "$elapsed" -gt "$threshold" ]; then
+				# Emit once per threshold window to avoid log spam.
+				local window=$((elapsed / threshold))
 				local marker="$OUT_DIR/.poll-state/wedge-$slug-$stage-$window"
 				if [ ! -f "$marker" ]; then
 					touch "$marker"
-					emit "WEDGE_DETECT slug=$slug stage=$stage stuck_for=${elapsed}s"
+					emit "WEDGE_DETECT slug=$slug stage=$stage stuck_for=${elapsed}s threshold=${threshold}s"
 				fi
 			fi
 		fi
@@ -107,6 +142,18 @@ poll_plan_stages() {
 
 # Scan docker logs since last poll for wedge-shape signals. Emits one line
 # per match. --since takes a duration so we use the saved epoch to compute.
+#
+# Two filters layered:
+#   1. LEVEL prefilter — only INFO/WARN/ERROR semspec log lines reach the
+#      wedge-shape grep. Pre-fix, DEBUG payload echoes (OpenAI API request
+#      payload contains the agent's PROMPT, which has words like "reject"
+#      and "exhausted") triggered hundreds of false-positive emits per
+#      poll. Caught smoke 9 2026-06-02. Now DEBUG lines are dropped before
+#      the wedge-shape regex even runs.
+#   2. Timestamp dedup — log lines carry `time=<iso8601>` at column 0;
+#      we track the highest emitted timestamp and drop any line at or
+#      below it. Kills the cross-poll-boundary duplicate-emission shape
+#      the +5s overlap window created in PR #86.
 poll_docker_logs() {
 	local last_epoch now_epoch since_seconds
 	last_epoch="$(cat "$LAST_LOG_TS_FILE" 2>/dev/null || now_epoch)"
@@ -114,23 +161,45 @@ poll_docker_logs() {
 	since_seconds=$((now_epoch - last_epoch + 5))  # +5s overlap to avoid gap
 	[ "$since_seconds" -lt 10 ] && since_seconds=10
 
-	# `docker logs --since=<seconds>s` is the post-25.0 syntax. The grep
-	# alternation MUST stay broad — silence is not success. We're hunting
-	# for any of: reviewer rejection, recovery emit, plan-decision lifecycle,
-	# explicit error/failure markers.
-	#
+	local last_emit_ts
+	last_emit_ts="$(cat "$LAST_EMIT_TS_FILE" 2>/dev/null || echo '')"
+
 	# Filter is per-line and the output is forwarded verbatim. Truncate to
 	# 240 chars per line so a runaway log doesn't blow up poll.log.
+	#
+	# LEVEL prefilter: keep only lines with level=(INFO|WARN|ERROR). The
+	# alternation list is exhaustive — level=DEBUG simply isn't in the
+	# set, so DEBUG lines are dropped. Case-insensitive (`-iE`) because
+	# the downstream wedge-shape grep also accepts lowercase
+	# `level=error` / `"level":"error"` — components or upstream
+	# semstreams that emit lowercase levels must still flow through.
+	# Silence is not success (per PR #86 design comment).
 	local out
 	out="$(docker logs --since="${since_seconds}s" "$CONTAINER" 2>&1 \
+		| grep -iE 'level=(INFO|WARN|ERROR)|"level":"(INFO|WARN|ERROR)"' \
 		| grep -iE '(reject|fixable_rejection|needs_changes|recovery.requested|recovery.complete|plan-decision|plan_decision|wedged|exhausted|terminal_failure|context deadline exceeded|level=error|"level":"error")' \
 		| sed 's/[[:space:]]\+/ /g' \
 		| cut -c1-240 \
 		2>/dev/null || true)"
 
+	local max_seen_ts="$last_emit_ts"
+
 	if [ -n "$out" ]; then
 		while IFS= read -r line; do
 			[ -z "$line" ] && continue
+
+			# Timestamp dedup: extract `time=<iso8601>` from the front of
+			# the line; skip if at or before the last emitted timestamp.
+			# ISO-8601 sorts lexicographically so plain bash [[ < ]] works.
+			local line_ts
+			line_ts="$(printf '%s' "$line" | grep -oE 'time=[^ ]+' | head -1 | sed 's/^time=//')"
+			if [ -n "$line_ts" ] && [ -n "$last_emit_ts" ]; then
+				# bash has no <= operator on strings, hence the negated >.
+				if [[ ! "$line_ts" > "$last_emit_ts" ]]; then
+					continue
+				fi
+			fi
+
 			# Coarse classification — same line emits ONE category so we don't
 			# double-count. Order matters: most specific first.
 			if echo "$line" | grep -qiE 'recovery.requested|recovery.complete'; then
@@ -144,7 +213,17 @@ poll_docker_logs() {
 			else
 				emit "ERROR line=\"$line\""
 			fi
+
+			# Track the highest log-line timestamp we've emitted this poll.
+			if [ -n "$line_ts" ] && [[ "$line_ts" > "$max_seen_ts" ]]; then
+				max_seen_ts="$line_ts"
+			fi
 		done <<< "$out"
+	fi
+
+	# Persist the high-water-mark for next poll's dedup.
+	if [ -n "$max_seen_ts" ]; then
+		printf '%s' "$max_seen_ts" > "$LAST_EMIT_TS_FILE"
 	fi
 
 	echo "$now_epoch" > "$LAST_LOG_TS_FILE"

--- a/test/plumbing/plumbing_discipline_test.go
+++ b/test/plumbing/plumbing_discipline_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	scenariogenerator "github.com/c360studio/semspec/processor/scenario-generator"
 	requirementexecutor "github.com/c360studio/semspec/processor/requirement-executor"
+	scenariogenerator "github.com/c360studio/semspec/processor/scenario-generator"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/harnesscatalog"
 )


### PR DESCRIPTION
Closes #94.

## Summary

PR #86 shipped the active-polling sidecar. Smoke 9 (2026-06-02 hybrid-gpt5 mavlink-hard) surfaced three rough edges on its first paid use:

1. **DEBUG-payload false positives** — the wedge-shape grep matched the agent's PROMPT content echoed in `level=DEBUG msg="OpenAI API request payload"` lines (the prompt contains domain words like "reject", "exhausted"). Every poll dumped 5-15 false ERROR lines.
2. **Cross-poll-boundary duplicate emission** — `--since=Ns + 5s overlap` window pulls cross-boundary log lines twice; same event emitted as two separate POLL lines.
3. **Stage-blind wedge thresholds** — WEDGE_DETECT fires at 600s for ALL stages; `implementing` legitimately runs for an hour on hard fixtures, so the operator gets a false-positive wedge warning every 10min during a healthy run.

## Fixes

| Issue | Fix |
|---|---|
| 1 | LEVEL prefilter (`grep -iE 'level=(INFO\|WARN\|ERROR)\|"level":"(INFO\|WARN\|ERROR)"'`) runs BEFORE the wedge-shape grep. DEBUG-payload echoes dropped entirely. Case-insensitive to keep lowercase `level=error` + JSON-shape lines flowing |
| 2 | Timestamp-based dedup. Each log line's `time=<iso8601>` extracted; highest emitted ts persisted to `.poll-state/last-emit-ts`; subsequent polls skip lines ≤ that. ISO-8601 lex-sorts so bash `[[ < ]]` works |
| 3 | New `wedge_threshold_for_stage` function. Per-stage map: `implementing` → 1800s; `generating_*` / `reviewing_*` / `preparing_*` → 900s; `drafting` → 300s; else 600s (fallback). All overridable via env vars. WEDGE_DETECT emit now includes `threshold=Ns` for operator visibility |

## Verified

- [x] `bash -n` syntax clean
- [x] Live 7s smoke against bogus endpoint: HEARTBEATs fire, EXIT trap fires cleanly
- [x] Targeted filter test: synthetic DEBUG line dropped; lowercase/uppercase/JSON-shape ERROR lines all flow through
- [x] go-reviewer pre-commit: REQUEST_CHANGES (caught a case-sensitivity regression in the first draft) → addressed → APPROVE

## Incidental

Includes the same 1-char gofmt fix on `test/plumbing/plumbing_discipline_test.go` that in-flight PR #111 ships separately — both branches were red on the same import-order issue post PR #110 merge. Identical change in both branches, will auto-resolve at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)