### PR TITLE
fix(#113): retire structural-validator literal-substring sub-checks (Option A)

### DIFF
--- a/docs/adr/ADR-041-test-evidence-ladder-and-scenario-tags.md
+++ b/docs/adr/ADR-041-test-evidence-ladder-and-scenario-tags.md
@@ -147,6 +147,19 @@ For every `@integration` scenario, the dev's tagged test file (matching the scen
 
 This extends the existing `CheckHarnessProfileDiscipline` (in `processor/structural-validator/testcontainers_discipline.go`) — the assertions check is already there. The additions are (1) the harness-binding string presence and (2) the env-var consumption pattern. The check name (`harness-profile-discipline`) stays as the stable operator identifier; the messaging and behavior expand.
 
+#### Amendment (2026-06-03, issue #113): Move 5 retired
+
+The three literal-substring sub-checks above were retired. They were goodhart-able: any check that grades on "did you write this exact string" can be passed with a dead string literal. PR #109 (#90) made the attack surface visible by surfacing the expected literals to the dev's first-cycle prompt — turning a latent footgun into an active invitation.
+
+**What replaced them.** `CheckHarnessProfileDiscipline` now does one thing: verify the architect's `harness_profile_selections` resolve in the catalog (a plan-time validity check, not a behavioral one). Binding correctness is enforced by:
+
+- **LLM reviewer** — judges whether the test actually exercises the bound harness. Smoke 9 (2026-06-02) demonstrated this works in practice: the reviewer caught "UDP heartbeat probe facade is not real `mavsdk_server` lifecycle management" — the exact stub shape a literal check cannot distinguish.
+- **qa-runner runtime** — actually starts the bound service stack and runs the `@integration` test against it. A test that references the literal but doesn't open the service fails at runtime.
+
+**Prompt language reframed.** The dev-prompt binding context (`processor/requirement-executor/binding_context.go`) shifted from "satisfy this check" framing to "this is the routing key / env binding qa-runner uses" framing. The dev still sees the literals because they're useful information; the framing no longer invites mechanical-pass-by-pasting.
+
+**Future direction.** Issue #113 lists Option B (AST-aware checks via per-language test-source inspection) and Option C (behavioral-evidence verification via qa-runner runtime tracing) as the architecturally right destinations. This amendment ships Option A (delete the literal checks) as the immediate fix; B/C are open for future work.
+
 ### Move 6: Req-reviewer tier-aware contract
 
 The requirement-level reviewer's contract changes from "do all tests satisfy all scenarios?" (ill-defined when scenarios cross tiers the dev can't observe) to "do the dev's tests satisfy the obligations at the dev tier?":

--- a/processor/requirement-executor/binding_context.go
+++ b/processor/requirement-executor/binding_context.go
@@ -49,9 +49,12 @@ func buildBindingContextBlock(scenarios []workflow.Scenario) string {
 	}
 
 	var b strings.Builder
-	b.WriteString("## Integration Test Requirements\n\n")
-	b.WriteString("The scenarios below require integration-tier test authoring. ")
-	b.WriteString("Satisfy each bullet to avoid mechanical rejections on the first review cycle.\n\n")
+	b.WriteString("## Integration Test Context\n\n")
+	b.WriteString("The scenarios below run under a system-owned test harness (qa-runner). ")
+	b.WriteString("The information below describes how qa-runner orchestrates the harness ")
+	b.WriteString("and routes tests — your test code needs to participate in that protocol, ")
+	b.WriteString("not just reference the literals. The reviewer judges whether your code ")
+	b.WriteString("actually exercises the harness; qa-runner runtime verifies it at execution.\n\n")
 
 	for _, sc := range relevant {
 		b.WriteString(formatScenarioBinding(sc))
@@ -116,34 +119,40 @@ func formatScenarioBinding(sc workflow.Scenario) string {
 			tag, bare, bare)
 	}
 
-	// Harness profile string literals — structural-validator checks the
-	// test contents for these literal strings (ADR-041 Move 5 binding
-	// check). Quoting them in the prompt makes the literal explicit.
+	// Harness profile routing keys. qa-runner uses these IDs as the tag
+	// selector to bring up the right service stack and route tagged tests
+	// against it. The dev's test code typically declares the binding via
+	// framework annotation (e.g. JUnit5 `@Tag` with a routing key) or by
+	// configuration. The literal need only appear where the framework
+	// actually consumes it — a dead reference does not bind anything.
+	// Reframed post-#113 (2026-06-03) — structural-validator no longer
+	// greps for these literals.
 	if len(sc.HarnessProfileIDs) > 0 {
-		fmt.Fprintf(&b, "  - Reference at least one of the bound harness profile ID(s) as a string literal in test source: %s.\n",
+		fmt.Fprintf(&b, "  - Harness profile routing key(s) qa-runner uses to bring up the stack: %s.\n",
 			quotedJoined(sc.HarnessProfileIDs))
 	}
 
-	// Env var consumption — the catalog declares which env vars the
-	// qa-runner injects at test time. Tests must read from these rather
-	// than hardcoding values (catalog-grounded env keys per the memory
-	// note feedback_catalog_grounded_env_keys).
+	// Env vars injected by qa-runner. The endpoint/config bindings come
+	// from these env vars at test runtime; hardcoding values would
+	// bypass the injection and ignore harness-specific configuration.
+	// The dev's test code reads them via the language's idiomatic env
+	// accessor (System.getenv / os.environ / std::env::var / etc.).
 	if len(sc.Env) > 0 {
 		keys := make([]string, 0, len(sc.Env))
 		for k := range sc.Env {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		fmt.Fprintf(&b, "  - Read these env var(s) at test runtime (qa-runner injects values): %s.\n",
+		fmt.Fprintf(&b, "  - Env vars qa-runner injects (read at test runtime, do not hardcode): %s.\n",
 			quotedJoined(keys))
 	}
 
-	// Required assertions — copy verbatim from catalog so the dev knows
-	// what the reviewer will demand. Capped at maxAssertionsPerScenario
-	// to guard prompt token budget against future bloated catalogs;
-	// truncation marker tells the dev to dig deeper if needed.
+	// Required assertions — copy verbatim from catalog. These describe
+	// the BEHAVIOR the test must demonstrate, not text the test must
+	// contain. The reviewer judges semantic satisfaction. Capped at
+	// maxAssertionsPerScenario to guard prompt token budget.
 	if len(sc.RequiredAssertions) > 0 {
-		b.WriteString("  - Required assertions:\n")
+		b.WriteString("  - Behavior the test must demonstrate (reviewer judges actual coverage, not text match):\n")
 		limit := len(sc.RequiredAssertions)
 		if limit > maxAssertionsPerScenario {
 			limit = maxAssertionsPerScenario

--- a/processor/requirement-executor/binding_context_test.go
+++ b/processor/requirement-executor/binding_context_test.go
@@ -65,7 +65,7 @@ func TestBuildBindingContextBlock_IntegrationScenario(t *testing.T) {
 		t.Fatal("expected non-empty block, got empty")
 	}
 
-	mustContain(t, got, "## Integration Test Requirements")
+	mustContain(t, got, "## Integration Test Context")
 	mustContain(t, got, "scenario.ebe27a10f9e4.1.1.3")
 	mustContain(t, got, "@integration")
 	mustContain(t, got, `"integration"`) // JUnit5 tag literal
@@ -212,7 +212,7 @@ func TestSynthesizeTaskDAGForStory_BindingBlockAppendedToPrompts(t *testing.T) {
 		descByID[t.ID] = t.Description
 	}
 	for _, n := range dag.Nodes {
-		if !strings.Contains(n.Prompt, "Integration Test Requirements") {
+		if !strings.Contains(n.Prompt, "Integration Test Context") {
 			t.Errorf("node %s prompt missing binding block:\n%s", n.ID, n.Prompt)
 		}
 		if !strings.Contains(n.Prompt, "mavlink.px4-sitl.mavsdk-smoke") {

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -135,15 +135,15 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		results = append(results, antiMockResult)
 	}
 
-	// Catalog-backed harness profile discipline check — fires whenever modified
-	// files include test files in ANY supported language (not just Go).
-	// Verifies that selected required catalog profiles are evidenced by the
-	// dev's tests. The catalog owns images, ports, readiness, and assertions.
-	// Per ADR-039, services-class profiles render as qa.yml services: blocks
-	// from the catalog (qa-runner brings the stack up; tests are consumers).
-	// testcontainers-class and pure-fixture profiles stay in project test code.
-	// This check is orchestration-agnostic: it verifies the dev's tests carry
-	// the required test assertions regardless of who starts the services.
+	// Catalog-backed harness profile discipline check — fires whenever
+	// modified files include test files in any supported language (the
+	// filterTestFiles gate stays as a no-op-cheap signal that a test
+	// dispatch is in flight). Post-issue #113 (2026-06-03) the check
+	// verifies only that the architect's harness_profile_selections
+	// resolve in the catalog. Binding correctness (the test actually
+	// exercises the bound harness) is enforced by the LLM reviewer +
+	// qa-runner runtime — see ADR-041 Move 5 amendment for why the
+	// literal-substring sub-checks were retired.
 	// Loads selections from .semspec/plans/<slug>/plan.json on disk;
 	// greenfield projects (no architecture) trivially pass.
 	if len(filterTestFiles(trigger.FilesModified)) > 0 {
@@ -158,8 +158,13 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 				Stdout:   fmt.Sprintf("load harness catalog: %v", err),
 			})
 		} else {
-			scenarios := loadScenarios(e.repoPath, trigger.Slug)
-			results = append(results, CheckHarnessProfileDiscipline(workDir, trigger.FilesModified, selections, scenarios, catalog))
+			// Issue #113 (2026-06-03): the discipline check no longer needs
+			// workDir/filesModified/scenarios. The literal-substring sub-
+			// checks were retired (goodhart-able); the simplified check
+			// just verifies the architect's selections resolve in the
+			// catalog. Binding correctness is enforced by LLM reviewer +
+			// qa-runner runtime.
+			results = append(results, CheckHarnessProfileDiscipline(selections, catalog))
 		}
 	}
 

--- a/processor/structural-validator/stub_artifact_detector.go
+++ b/processor/structural-validator/stub_artifact_detector.go
@@ -40,9 +40,11 @@ const stubJarSizeThreshold = 2048
 // reviewer/QA had no anchor to reject them. This is the deterministic
 // backstop that doesn't depend on persona compliance.
 //
-// Closes deferred item (c) from take-19 forensics. Pairs with
-// CheckHarnessProfileDiscipline (item d-equivalent: reviewer test-body
-// mismatch) for two-layer defense.
+// Closes deferred item (c) from take-19 forensics. Item d-equivalent
+// (test-body mismatch / faked implementations) is now owned by the
+// LLM reviewer + qa-runner runtime after issue #113 retired the
+// literal-substring harness-discipline checks; see ADR-041 Move 5
+// amendment.
 func CheckStubArtifacts(workDir string, filesModified []string) payloads.CheckResult {
 	jars := filterJarFiles(filesModified)
 	if len(jars) == 0 {

--- a/processor/structural-validator/testcontainers_discipline.go
+++ b/processor/structural-validator/testcontainers_discipline.go
@@ -12,36 +12,34 @@ import (
 	"github.com/c360studio/semspec/workflow/payloads"
 )
 
-// CheckHarnessProfileDiscipline scans modified test files for evidence that
-// selected required harness profiles are actually exercised AND, per ADR-041
-// Move 5, that @integration scenarios' authoring obligations are met:
+// CheckHarnessProfileDiscipline verifies the architect's harness profile
+// selections resolve in the catalog. Issue #113 (2026-06-03): the literal-
+// substring sub-checks (evidence-anchor presence, @integration binding
+// string, env-key consumption) were retired because they were goodhart-
+// able — any check that grades on "did you write this exact string" can
+// be satisfied with a dead string literal. PR #109 (#90) surfaced the
+// expected literals to the dev's first-cycle prompt, which made the
+// stub-passing attack visible and easy to construct.
 //
-//  1. The catalog's required test assertions (formerly evidence anchors) for
-//     each required profile appear somewhere in the modified test files —
-//     the existing rule, unchanged in behavior.
-//  2. For each @integration scenario with HarnessProfileIDs, at least one
-//     modified test file contains each bound profile ID as a string literal.
-//     Proves the test code is bound to a catalog profile by name so
-//     qa-runner can route via the tag selector.
-//  3. For each @integration scenario whose bound profile is services-class
-//     or testcontainers-class, at least one modified test file contains an
-//     environment-variable key from the catalog Profile's Env map. Proves
-//     the test reads its endpoint from the harness-injected env instead of
-//     hardcoding a host/port (pure-fixture profiles are exempt — no peer
-//     process, no endpoint to inject).
+// Binding correctness is now enforced by:
 //
-// The check name (harness-profile-discipline) stays as the stable operator
-// identifier; messaging and behavior expand. ADR-041 Move 5.
+//   - **LLM reviewer** — judges whether the test actually exercises the
+//     bound harness (catches "UDP probe facade is not real mavsdk_server
+//     lifecycle" — the smoke-9 reviewer's call).
+//   - **qa-runner runtime** — actually starts the bound service stack
+//     and runs the @integration test against it. A test that just
+//     references the literal but doesn't open the service fails here.
 //
-// No-op cases (pass without enforcement):
-//   - No harness profiles selected (greenfield / runtime_dep-only).
-//   - filesModified contains no test files (non-test scenarios;
-//     integration coverage is verified by other scenarios that DO
-//     produce tests).
+// This check now does one thing: verify that the architect didn't name
+// a profile that doesn't exist in the catalog. That's a plan-time
+// validity check, not a behavioral one. Unknown profile IDs surface as
+// a hard failure so plan-reviewer / Sarah can route on it.
 //
-// Unknown profile IDs, missing required-profile evidence, missing harness-
-// binding strings, and missing env-var consumption are hard failures.
-func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selections []workflow.HarnessProfileSelection, scenarios []workflow.Scenario, catalog *harnesscatalog.Catalog) payloads.CheckResult {
+// Future direction: see issue #113 for the path to AST-aware or
+// behavioral evidence (Option B / Option C). This commit ships
+// Option A — delete the literal checks; rely on LLM reviewer +
+// qa-runner runtime.
+func CheckHarnessProfileDiscipline(selections []workflow.HarnessProfileSelection, catalog *harnesscatalog.Catalog) payloads.CheckResult {
 	if len(selections) == 0 {
 		return passHarnessResult("no test environment profiles selected — nothing to enforce")
 	}
@@ -49,148 +47,9 @@ func CheckHarnessProfileDiscipline(workDir string, filesModified []string, selec
 	if err != nil {
 		return failHarnessResult(err.Error())
 	}
-	if len(required) == 0 {
-		return passHarnessResult("no required test environment profiles selected — compatibility/heavy profiles are advisory")
-	}
-
-	testFiles := filterTestFiles(filesModified)
-	if len(testFiles) == 0 {
-		return passHarnessResult("no test files in this scenario — integration coverage deferred to other scenarios")
-	}
-
-	contents := loadTestContents(workDir, testFiles)
-
-	var violations []string
-	for _, r := range required {
-		missing := missingEvidenceAnchors(contents, r.Profile.EvidenceAnchors)
-		if len(missing) > 0 {
-			violations = append(violations, formatHarnessViolation(r, missing))
-		}
-	}
-
-	// ADR-041 Move 5: @integration scenario authoring checks.
-	violations = append(violations, integrationBindingViolations(scenarios, contents, catalog)...)
-	violations = append(violations, integrationEnvConsumptionViolations(scenarios, contents, catalog)...)
-
-	if len(violations) == 0 {
-		return payloads.CheckResult{
-			Name:     "harness-profile-discipline",
-			Passed:   true,
-			Required: true,
-			Command:  "harness-profile-discipline (internal)",
-			Stdout:   fmt.Sprintf("required test environment profiles covered in modified tests: %d", len(required)),
-		}
-	}
-
-	return payloads.CheckResult{
-		Name:     "harness-profile-discipline",
-		Passed:   false,
-		Required: true,
-		Command:  "harness-profile-discipline (internal)",
-		Stdout:   strings.Join(violations, "\n"),
-	}
-}
-
-// integrationBindingViolations returns one violation per @integration scenario
-// whose bound HarnessProfileIDs aren't referenced as string literals anywhere
-// in the modified test files. Proves the dev's tests carry the catalog
-// cross-reference qa-runner needs to route tagged invocations.
-//
-// ADR-041 Move 5 check (1).
-func integrationBindingViolations(scenarios []workflow.Scenario, contents []string, _ *harnesscatalog.Catalog) []string {
-	var out []string
-	for _, s := range scenarios {
-		if !scenarioHasTag(s, workflow.TierIntegration) {
-			continue
-		}
-		var missing []string
-		for _, id := range s.HarnessProfileIDs {
-			if id == "" {
-				continue
-			}
-			if !containsAny(contents, id) {
-				missing = append(missing, id)
-			}
-		}
-		if len(missing) > 0 {
-			out = append(out, fmt.Sprintf(
-				"@integration scenario %q binds harness profile id(s) %s but no modified test file contains the id as a string literal — qa-runner's tag selector cannot route this scenario",
-				s.ID, strings.Join(quoteStrings(missing), ", ")))
-		}
-	}
-	return out
-}
-
-// integrationEnvConsumptionViolations returns one violation per @integration
-// scenario whose bound services/testcontainers profile declares Env keys
-// none of which appear in the modified test files. Catches hardcoded
-// host/port values that would break qa-runner's harness injection. Pure-
-// fixture profiles are exempt — no peer process means no endpoint to
-// inject.
-//
-// Heuristic: at least one of the catalog Profile.Env keys must appear as a
-// substring in some modified test file. False negatives (test reads env via
-// a wrapper utility that doesn't mention the key) are acceptable —
-// operators can override; the rule's purpose is to catch obvious hardcoded
-// endpoints. ADR-041 Move 5 check (2).
-func integrationEnvConsumptionViolations(scenarios []workflow.Scenario, contents []string, catalog *harnesscatalog.Catalog) []string {
-	if catalog == nil {
-		return nil
-	}
-	var out []string
-	for _, s := range scenarios {
-		if !scenarioHasTag(s, workflow.TierIntegration) {
-			continue
-		}
-		for _, id := range s.HarnessProfileIDs {
-			profile, ok := catalog.Profiles[id]
-			if !ok {
-				continue
-			}
-			orch := profile.EffectiveOrchestration()
-			if orch != harnesscatalog.OrchestrationServices && orch != harnesscatalog.OrchestrationTestcontainers {
-				continue
-			}
-			if len(profile.Env) == 0 {
-				continue
-			}
-			envKeys := make([]string, 0, len(profile.Env))
-			for k := range profile.Env {
-				envKeys = append(envKeys, k)
-			}
-			if anyEnvKeyReferenced(contents, envKeys) {
-				continue
-			}
-			out = append(out, fmt.Sprintf(
-				"@integration scenario %q binds harness profile %q (orchestration=%s) but no modified test file references any of the profile's declared env keys (%s) — the test appears to be reading hardcoded endpoints instead of consuming the harness-injected env",
-				s.ID, id, orch, strings.Join(quoteStrings(envKeys), ", ")))
-		}
-	}
-	return out
-}
-
-// scenarioHasTag reports whether the scenario carries the given tag.
-func scenarioHasTag(s workflow.Scenario, tag string) bool {
-	for _, t := range s.Tags {
-		if t == tag {
-			return true
-		}
-	}
-	return false
-}
-
-// anyEnvKeyReferenced reports whether any of envKeys appears as a substring
-// in any of the test file contents.
-func anyEnvKeyReferenced(contents []string, envKeys []string) bool {
-	for _, k := range envKeys {
-		if k == "" {
-			continue
-		}
-		if containsAny(contents, k) {
-			return true
-		}
-	}
-	return false
+	return passHarnessResult(fmt.Sprintf(
+		"required test environment profiles resolve in catalog: %d (binding correctness enforced by LLM reviewer + qa-runner runtime, not literal-grep — see issue #113)",
+		len(required)))
 }
 
 // loadHarnessProfiles reads the plan.json for the given slug and returns the
@@ -204,21 +63,9 @@ func loadHarnessProfiles(repoPath, slug string) []workflow.HarnessProfileSelecti
 	return plan.Architecture.HarnessProfiles
 }
 
-// loadScenarios reads the plan.json for the given slug and returns the
-// scenarios. Returns nil when plan.json is absent or unparseable. The
-// scenarios are consumed by CheckHarnessProfileDiscipline's ADR-041 Move 5
-// checks (@integration binding + env consumption).
-func loadScenarios(repoPath, slug string) []workflow.Scenario {
-	plan := loadPlanForDiscipline(repoPath, slug)
-	if plan == nil {
-		return nil
-	}
-	return plan.Scenarios
-}
-
-// loadPlanForDiscipline is the shared plan.json reader for loadHarnessProfiles
-// + loadScenarios. Returns nil on I/O or parse failure — callers treat that
-// as "no data, skip enforcement" rather than blocking.
+// loadPlanForDiscipline is the shared plan.json reader. Returns nil on
+// I/O or parse failure — callers treat that as "no data, skip
+// enforcement" rather than blocking.
 func loadPlanForDiscipline(repoPath, slug string) *workflow.Plan {
 	if repoPath == "" || slug == "" {
 		return nil
@@ -237,7 +84,9 @@ func loadPlanForDiscipline(repoPath, slug string) *workflow.Plan {
 
 // filterTestFiles returns the subset of files whose names match common
 // test-file conventions across Go, Java, Python, Node/TS, .NET, Rust.
-// More permissive than executor.go:hasTestFiles which is Go-only.
+// Kept after #113 because executor.go still uses it as a gate to skip
+// non-test-touching dispatches entirely. More permissive than
+// executor.go:hasTestFiles which is Go-only.
 func filterTestFiles(files []string) []string {
 	var out []string
 	for _, f := range files {
@@ -251,8 +100,8 @@ func filterTestFiles(files []string) []string {
 // isTestFileMultilang returns true for test-file naming conventions
 // across the languages semspec supports. Conservative — false negatives
 // (skipping a file that's actually a test) merely reduce coverage of
-// this check; false positives (treating non-test files as tests) would
-// pollute the test-content grep with non-test code.
+// the gate above; false positives (treating non-test files as tests)
+// would over-eagerly run the discipline check on non-test-touching PRs.
 func isTestFileMultilang(path string) bool {
 	base := strings.ToLower(filepath.Base(path))
 	switch {
@@ -278,60 +127,6 @@ func isTestFileMultilang(path string) bool {
 		return true
 	}
 	return false
-}
-
-// loadTestContents reads each test file relative to workDir and
-// returns the contents. I/O errors are silently skipped so a transient
-// read failure doesn't masquerade as a discipline violation.
-func loadTestContents(workDir string, testFiles []string) []string {
-	var contents []string
-	for _, f := range testFiles {
-		absPath := f
-		if !filepath.IsAbs(f) {
-			absPath = filepath.Join(workDir, f)
-		}
-		data, err := os.ReadFile(absPath)
-		if err != nil {
-			continue
-		}
-		contents = append(contents, string(data))
-	}
-	return contents
-}
-
-func containsAny(contents []string, needle string) bool {
-	if needle == "" {
-		return false
-	}
-	for _, c := range contents {
-		if strings.Contains(c, needle) {
-			return true
-		}
-	}
-	return false
-}
-
-func missingEvidenceAnchors(contents []string, anchors []string) []string {
-	var missing []string
-	for _, anchor := range anchors {
-		if !containsAny(contents, anchor) {
-			missing = append(missing, anchor)
-		}
-	}
-	return missing
-}
-
-func formatHarnessViolation(r harnesscatalog.ResolvedSelection, missing []string) string {
-	return fmt.Sprintf("required test environment profile %q is selected but no modified test file contains required test assertions: %s",
-		r.Profile.ID, strings.Join(quoteStrings(missing), ", "))
-}
-
-func quoteStrings(vals []string) []string {
-	out := make([]string, 0, len(vals))
-	for _, v := range vals {
-		out = append(out, fmt.Sprintf("%q", v))
-	}
-	return out
 }
 
 func passHarnessResult(stdout string) payloads.CheckResult {

--- a/processor/structural-validator/testcontainers_discipline_test.go
+++ b/processor/structural-validator/testcontainers_discipline_test.go
@@ -11,102 +11,54 @@ import (
 	"github.com/c360studio/semspec/workflow/harnesscatalog"
 )
 
+// Issue #113 (2026-06-03): the literal-substring sub-checks were
+// retired (evidence-anchor presence, @integration binding string,
+// env-key consumption). What remains is "do the architect's
+// selections resolve in the catalog?" — a plan-time validity check.
+// Binding correctness is enforced by LLM reviewer + qa-runner runtime.
+
 func TestCheckHarnessProfileDiscipline_NoSelections(t *testing.T) {
 	catalog := mustCatalog(t)
-	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/Foo.java"}, nil, nil, catalog)
+	result := CheckHarnessProfileDiscipline(nil, catalog)
 	if !result.Passed {
 		t.Errorf("greenfield project (no harness profiles) should pass, got: %s", result.Stdout)
 	}
 	if result.Name != "harness-profile-discipline" {
 		t.Errorf("Name = %q, want harness-profile-discipline", result.Name)
 	}
+	if !strings.Contains(result.Stdout, "nothing to enforce") {
+		t.Errorf("no-selections result should mention 'nothing to enforce': %s", result.Stdout)
+	}
 }
 
-func TestCheckHarnessProfileDiscipline_NoTestFilesModified(t *testing.T) {
-	catalog := mustCatalog(t)
+func TestCheckHarnessProfileDiscipline_RequiredProfileResolves(t *testing.T) {
 	selections := []workflow.HarnessProfileSelection{
 		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
 	}
-
-	result := CheckHarnessProfileDiscipline(t.TempDir(), []string{"src/main/java/Driver.java", "build.gradle"}, selections, nil, catalog)
+	result := CheckHarnessProfileDiscipline(selections, mustCatalog(t))
 	if !result.Passed {
-		t.Errorf("scenarios producing no tests should pass (other scenarios cover integration): %s", result.Stdout)
+		t.Errorf("known required profile should pass: %s", result.Stdout)
 	}
-}
-
-func TestCheckHarnessProfileDiscipline_RequiredEvidencePresent(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
-package com.example;
-
-class MavlinkDriverTest {
-    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
-    static final String IMAGE = "px4io/px4-sitl:latest";
-    static final int PORT = 14540;
-    void smoke() {
-        assert true : "mavsdk_core_connected";
-        assert true : "HEARTBEAT";
-    }
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
-	if !result.Passed {
-		t.Errorf("test file with required profile evidence should pass: %s", result.Stdout)
-	}
-}
-
-func TestCheckHarnessProfileDiscipline_RequiredEvidenceMissing(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
-package com.example;
-class MavlinkDriverTest {
-    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
-    // Missing image, port, and connection/assertion anchors.
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
-	if result.Passed {
-		t.Errorf("test file missing required evidence should fail: %s", result.Stdout)
-	}
-	if !result.Required {
-		t.Error("missing required profile evidence should be a hard failure")
-	}
-	for _, want := range []string{"px4io/px4-sitl", "14540", "mavsdk_core_connected", "HEARTBEAT"} {
-		if !strings.Contains(result.Stdout, want) {
-			t.Errorf("failure should name missing anchor %q: %s", want, result.Stdout)
-		}
+	if !strings.Contains(result.Stdout, "resolve in catalog") {
+		t.Errorf("resolved-selection result should mention 'resolve in catalog': %s", result.Stdout)
 	}
 }
 
 func TestCheckHarnessProfileDiscipline_CompatibilityProfileDoesNotHardFail(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/CompatTest.java", `class CompatTest {}`)
 	selections := []workflow.HarnessProfileSelection{
 		{ProfileID: "mavlink.ardupilot-sitl.compat", Purpose: "compatibility sweep"},
 	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(selections, mustCatalog(t))
 	if !result.Passed {
 		t.Errorf("compatibility-only profile should not hard-fail developer validation: %s", result.Stdout)
 	}
 }
 
 func TestCheckHarnessProfileDiscipline_UnknownProfileHardFails(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `class MavlinkDriverTest {}`)
 	selections := []workflow.HarnessProfileSelection{
 		{ProfileID: "mavlink.not-real", Purpose: "bad selection"},
 	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, nil, mustCatalog(t))
+	result := CheckHarnessProfileDiscipline(selections, mustCatalog(t))
 	if result.Passed {
 		t.Errorf("unknown harness profile should fail: %s", result.Stdout)
 	}
@@ -118,230 +70,37 @@ func TestCheckHarnessProfileDiscipline_UnknownProfileHardFails(t *testing.T) {
 	}
 }
 
-// TestCheckHarnessProfileDiscipline_IntegrationBindingPresent pins ADR-041
-// Move 5 check (1): an @integration scenario binding a profile ID must
-// surface that ID as a string literal in at least one modified test file.
-// Present → pass.
-func TestCheckHarnessProfileDiscipline_IntegrationBindingPresent(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
-package com.example;
-
-class MavlinkDriverTest {
-    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
-    static final String IMAGE = "px4io/px4-sitl:latest";
-    static final int PORT = 14540;
-    void smoke() {
-        // PX4_SIM_MODEL is the env key the catalog declares for this profile.
-        String model = System.getenv("PX4_SIM_MODEL");
-        assert true : "mavsdk_core_connected";
-        assert true : "HEARTBEAT";
-    }
-}
-`)
+// TestCheckHarnessProfileDiscipline_NoLiteralGrep is the post-#113
+// regression pin: a re-introduction of any of the deleted
+// literal-substring helpers would break this test (or the build, if
+// the function names are re-added) and force code-review attention.
+//
+// Deleted helpers (issue #113 / commit retiring testcontainers_discipline
+// literal scans):
+//
+//   - integrationBindingViolations  — grep'd test contents for harness profile IDs
+//   - integrationEnvConsumptionViolations  — grep'd test contents for env keys
+//   - missingEvidenceAnchors  — grep'd test contents for catalog evidence_anchors
+//   - loadTestContents  — read test files into memory for the above
+//   - scenarioHasTag, anyEnvKeyReferenced, containsAny  — helpers for the above
+//   - formatHarnessViolation, quoteStrings  — error rendering for the above
+//   - loadScenarios  — loaded plan.Scenarios for the above
+//
+// All were goodhart-able (graded on "did you write this exact string");
+// any reintroduction should surface in PR review with a pointer to
+// issue #113's options table (B = AST-aware, C = behavioral) as the
+// architecturally correct path.
+func TestCheckHarnessProfileDiscipline_NoLiteralGrep(t *testing.T) {
 	selections := []workflow.HarnessProfileSelection{
 		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
 	}
-	scenarios := []workflow.Scenario{
-		{
-			ID:                "scn.1",
-			RequirementID:     "r1",
-			Given:             "the SITL is configured via $PX4_SIM_MODEL",
-			When:              "the driver starts",
-			Then:              []string{"a HEARTBEAT is received"},
-			Tags:              []string{workflow.TierIntegration},
-			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
-		},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
+	// The function no longer takes test files; this test simply pins
+	// that the signature accepts (selections, catalog) and returns pass
+	// when selections resolve. There is no test-file scanning surface
+	// to subvert anymore.
+	result := CheckHarnessProfileDiscipline(selections, mustCatalog(t))
 	if !result.Passed {
-		t.Errorf("test file with profile-id binding + env consumption should pass: %s", result.Stdout)
-	}
-}
-
-// TestCheckHarnessProfileDiscipline_IntegrationBindingMissing pins that a
-// missing harness-binding string literal surfaces a violation naming the
-// scenario + the missing profile_id, so the regen LLM has a targeted
-// directive to add the literal. ADR-041 Move 5 check (1).
-func TestCheckHarnessProfileDiscipline_IntegrationBindingMissing(t *testing.T) {
-	dir := t.TempDir()
-	// Test file contains all the catalog evidence anchors EXCEPT the
-	// profile_id string itself — isolates the binding check from the
-	// pre-existing required-assertions check.
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
-package com.example;
-
-class MavlinkDriverTest {
-    static final String IMAGE = "px4io/px4-sitl:latest";
-    static final int PORT = 14540;
-    void smoke() {
-        String endpoint = System.getenv("SITL_ENDPOINT");
-        assert true : "mavsdk_core_connected";
-        assert true : "HEARTBEAT";
-    }
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
-	}
-	scenarios := []workflow.Scenario{
-		{
-			ID:                "scn.1",
-			Tags:              []string{workflow.TierIntegration},
-			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
-		},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
-	if result.Passed {
-		t.Fatalf("missing harness-binding string literal should fail; got passed with stdout: %s", result.Stdout)
-	}
-	if !strings.Contains(result.Stdout, "scn.1") {
-		t.Errorf("violation should name the scenario: %s", result.Stdout)
-	}
-	if !strings.Contains(result.Stdout, "mavlink.px4-sitl.mavsdk-smoke") {
-		t.Errorf("violation should name the unbound profile id: %s", result.Stdout)
-	}
-}
-
-// TestCheckHarnessProfileDiscipline_EnvConsumptionMissing pins ADR-041
-// Move 5 check (2): a test file referencing the profile_id but NOT any of
-// the catalog's declared env keys is treated as hardcoding the endpoint.
-// The mavlink.px4-sitl.mavsdk-smoke catalog entry declares SITL_ENDPOINT in
-// its Env map; a test file that contains the profile_id but not
-// SITL_ENDPOINT should fail.
-func TestCheckHarnessProfileDiscipline_EnvConsumptionMissing(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/MavlinkDriverTest.java", `
-package com.example;
-
-class MavlinkDriverTest {
-    static final String PROFILE = "mavlink.px4-sitl.mavsdk-smoke";
-    static final String IMAGE = "px4io/px4-sitl:latest";
-    static final int PORT = 14540;
-    void smoke() {
-        // Hardcoded endpoint — no env var reference.
-        String endpoint = "udp://127.0.0.1:14540";
-        assert true : "mavsdk_core_connected";
-        assert true : "HEARTBEAT";
-    }
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
-	}
-	scenarios := []workflow.Scenario{
-		{
-			ID:                "scn.1",
-			Tags:              []string{workflow.TierIntegration},
-			HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"},
-		},
-	}
-
-	catalog := mustCatalog(t)
-	// Only run the env-consumption assertion if the catalog actually
-	// declares env keys for this profile. (Catalog evolution should not
-	// break this test silently.)
-	profile, ok := catalog.Profiles["mavlink.px4-sitl.mavsdk-smoke"]
-	if !ok || len(profile.Env) == 0 {
-		t.Skipf("mavlink.px4-sitl.mavsdk-smoke profile has no Env keys declared in the built-in catalog; check the env-consumption rule with a catalog override")
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, catalog)
-	if result.Passed {
-		t.Fatalf("hardcoded endpoint (no env key reference) should fail: %s", result.Stdout)
-	}
-	if !strings.Contains(result.Stdout, "scn.1") {
-		t.Errorf("violation should name the scenario: %s", result.Stdout)
-	}
-	if !strings.Contains(result.Stdout, "env") {
-		t.Errorf("violation should reference 'env': %s", result.Stdout)
-	}
-}
-
-// TestCheckHarnessProfileDiscipline_PureFixtureSkipsEnvCheck pins that
-// pure-fixture profiles don't trigger the env-consumption check — there's
-// no peer process and no endpoint to inject. Binding check still applies
-// (the test file should still reference the profile_id as a literal).
-func TestCheckHarnessProfileDiscipline_PureFixtureSkipsEnvCheck(t *testing.T) {
-	// We need a synthetic catalog with a pure-fixture profile because the
-	// built-in catalog may not have a profile shaped this way at this layer.
-	pureFixtureCatalog := &harnesscatalog.Catalog{
-		Profiles: map[string]harnesscatalog.Profile{
-			"test.pure-fixture": {
-				ID:                 "test.pure-fixture",
-				Tier:               harnesscatalog.TierRequired,
-				Orchestration:      harnesscatalog.OrchestrationPureFixture,
-				EvidenceAnchors:    []string{"FIXTURE_LOADED"},
-				RequiredAssertions: []string{"FIXTURE_LOADED"},
-				Env:                map[string]string{"SHOULD_BE_IGNORED": "x"},
-			},
-		},
-	}
-
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/FixtureTest.java", `
-package com.example;
-class FixtureTest {
-    static final String PROFILE = "test.pure-fixture";
-    void smoke() {
-        // No SHOULD_BE_IGNORED reference — fine for pure-fixture.
-        assert true : "FIXTURE_LOADED";
-    }
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "test.pure-fixture", Purpose: "in-process fixture"},
-	}
-	scenarios := []workflow.Scenario{
-		{
-			ID:                "scn.1",
-			Tags:              []string{workflow.TierIntegration},
-			HarnessProfileIDs: []string{"test.pure-fixture"},
-		},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, pureFixtureCatalog)
-	if !result.Passed {
-		t.Errorf("pure-fixture profile should not trigger env-consumption check: %s", result.Stdout)
-	}
-}
-
-// TestCheckHarnessProfileDiscipline_UnitScenariosIgnored pins that @unit
-// scenarios DO NOT trigger the binding or env-consumption checks — those
-// fire only for @integration. Without this guard, every @unit scenario
-// would falsely demand harness-binding string literals.
-func TestCheckHarnessProfileDiscipline_UnitScenariosIgnored(t *testing.T) {
-	dir := t.TempDir()
-	testFile := writeTestFile(t, dir, "src/test/java/UnitTest.java", `
-package com.example;
-class UnitTest {
-    // No profile_id, no env var — but this is a @unit scenario, so the new
-    // checks must NOT fire. Existing evidence-anchor check IS still in effect
-    // for the selected profile; we satisfy it by adding the anchor strings.
-    static final String PROFILE_ANCHOR = "mavlink.px4-sitl.mavsdk-smoke";
-    static final String IMAGE = "px4io/px4-sitl:latest";
-    static final int PORT = 14540;
-    void test() {
-        assert true : "mavsdk_core_connected";
-        assert true : "HEARTBEAT";
-    }
-}
-`)
-	selections := []workflow.HarnessProfileSelection{
-		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke", Purpose: "prove SITL"},
-	}
-	scenarios := []workflow.Scenario{
-		{
-			ID:   "scn.unit",
-			Tags: []string{workflow.TierUnit},
-		},
-	}
-
-	result := CheckHarnessProfileDiscipline(dir, []string{testFile}, selections, scenarios, mustCatalog(t))
-	if !result.Passed {
-		t.Errorf("@unit scenarios should not trigger Move 5 checks: %s", result.Stdout)
+		t.Errorf("simplified check should pass on any valid selection regardless of test files: %s", result.Stdout)
 	}
 }
 
@@ -441,18 +200,4 @@ func mustCatalog(t *testing.T) *harnesscatalog.Catalog {
 		t.Fatalf("LoadBuiltIn: %v", err)
 	}
 	return catalog
-}
-
-// writeTestFile writes a test file inside dir and returns the relative path
-// the caller should pass in filesModified.
-func writeTestFile(t *testing.T, dir, relPath, content string) string {
-	t.Helper()
-	abs := filepath.Join(dir, relPath)
-	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
-	}
-	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", abs, err)
-	}
-	return relPath
 }

--- a/test/plumbing/plumbing_discipline_test.go
+++ b/test/plumbing/plumbing_discipline_test.go
@@ -144,7 +144,7 @@ func TestPlumbingDiscipline_FullChain(t *testing.T) {
 	// In practice the synthesizer is called by the executor on
 	// requirement dispatch.
 	prompt := requirementexecutor.BuildDevPromptForTesting(plan, story)
-	if !strings.Contains(prompt, "## Integration Test Requirements") {
+	if !strings.Contains(prompt, "## Integration Test Context") {
 		t.Errorf("dev prompt should include the binding block:\n%s", prompt)
 	}
 	if !strings.Contains(prompt, "plumbing.test-profile") {
@@ -192,7 +192,7 @@ func TestPlumbingDiscipline_UnitOnlyChain(t *testing.T) {
 	}
 
 	prompt := requirementexecutor.BuildDevPromptForTesting(plan, story)
-	if strings.Contains(prompt, "Integration Test Requirements") {
+	if strings.Contains(prompt, "Integration Test Context") {
 		t.Errorf("unit-only story prompt should NOT include binding block:\n%s", prompt)
 	}
 	if prompt != "Write a unit test." {


### PR DESCRIPTION
Closes #113.

## Summary

The three literal-substring sub-checks in `CheckHarnessProfileDiscipline` were goodhart-able — any check that grades on "did you write this exact string" can be satisfied with a dead string literal. PR #109 (#90) made the attack surface visible by surfacing the expected literals to the dev's first-cycle prompt, turning a latent footgun into an active invitation. A goodhart-passable check + literal-revealing prompt would corrupt the next paid run's forensics (couldn't tell from a trajectory whether the dev "learned" or "cheated").

This PR ships **Option A** from #113's options table: delete the literal sub-checks; rely on LLM reviewer + qa-runner runtime for binding correctness; reframe the dev prompt from "satisfy this check" to "this is the routing key qa-runner uses."

Option B (AST-aware) is the right architectural destination and remains open per #113. Option A is the smallest in-context fix that closes the goodhart gap before the next paid run.

## Diff stats

`-573 / +142` across 8 files — a meaningful simplification.

## Changes

| File | Change |
|---|---|
| `structural-validator/testcontainers_discipline.go` | Deleted 10 private helpers (~250 lines); simplified `CheckHarnessProfileDiscipline(selections, catalog)` to plan-time validity only |
| `structural-validator/executor.go` | New signature wired; `loadScenarios` call removed; block doc comment rewritten |
| `structural-validator/stub_artifact_detector.go` | Updated stale "two-layer defense" cross-reference |
| `structural-validator/testcontainers_discipline_test.go` | Removed tests asserting deleted behavior (~330 lines); added `NoLiteralGrep` regression pin with a deleted-names list comment so a re-introduction surfaces in code review |
| `requirement-executor/binding_context.go` | Reframed dev prompt header + labels: "satisfy this check" → "qa-runner uses this routing key / env binding" |
| `requirement-executor/binding_context_test.go` | 2 string assertions updated |
| `test/plumbing/plumbing_discipline_test.go` | 2 string assertions updated |
| `docs/adr/ADR-041-...md` | Move-5 amendment documenting retirement + new enforcement boundary |

## Binding correctness is now enforced by

- **LLM reviewer** — smoke 9 demonstrated this works: *"UDP heartbeat probe facade is not real `mavsdk_server` lifecycle management"* is exactly the stub shape a literal check cannot distinguish.
- **qa-runner runtime** — actually starts the bound service stack; a test that references the literal but doesn't open the service fails at runtime.

## Test plan

- [x] `go test ./...` — all green
- [x] `gofmt -l` — clean
- [x] go-reviewer pre-commit: APPROVE with 3 minor recommendations → all 3 addressed
- [ ] Next paid run (`task e2e:watch:llm -- hybrid-gpt5 mavlink-hard`) with this + #91/#88/#89/#90/#92/#94 merged → expect trustworthy forensics (no goodhart-corrupted signal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)