### PR TITLE
feat(recovery): architecture_revise recovery action with live-execution teardown

### DIFF
--- a/docs/adr/ADR-045-bmad-story-gate-operator-executed-tiers.md
+++ b/docs/adr/ADR-045-bmad-story-gate-operator-executed-tiers.md
@@ -75,18 +75,42 @@ Implemented across four phases on `fix/role-context-audit-train`:
    `EffectiveQALevel` coerces any stale `integration`/`full` snapshot to `synthesis`. The harness
    catalog and the qa.yml emitter stay — qa.yml is now an operator-CI contract.
 
-## Deferred (designed, not yet implemented)
+## `architecture_revise` recovery action (implemented — follow-up to this ADR)
 
-- **`architecture_revise` recovery action.** When recovery diagnoses an *architecture-root* wedge
-  (a missing/mis-resolved upstream dependency, a wrong component boundary, an un-runnable
-  integration target), the right action is to re-run the architect with the prior architecture as
-  a revision base (`PreviousArchitectureJSON`, already plumbed) plus the wedge diagnosis. This
-  requires a new `RecoveryActionKind` + `PlanDecisionKind`, an accept handler that captures the
-  prior architecture and resets the execution/story/scenario state, **and a new back-transition
-  in the status DAG** (an execution-phase status → `requirements_generated`), which today is
-  strict-sequential and forward-only. That state-machine change + execution-state reset is a
-  focused follow-up. **Interim:** recovery now *sees* the architecture (Phase 1) and is steered to
-  `escalate_human` with a precise architecture diagnosis rather than `mark_unrecoverable`.
+When recovery diagnoses an *architecture-root* wedge (a missing/mis-resolved upstream dependency,
+a wrong component boundary, an un-runnable integration target), the recovery-agent now picks
+`architecture_revise` instead of `escalate_human`. On accept, plan-manager captures the prior
+architecture into `PreviousArchitectureJSON` (the revision base the architect already reads),
+routes the diagnosis into `ReviewFormattedFindings`, wipes Architecture + Stories + Scenarios,
+resets all requirement executions, and drives the new back-transition `implementing →
+requirements_generated`. The architect re-fires and *revises* the prior architecture against the
+diagnosis; the full pipeline (Sarah → Bob → execution) re-runs clean.
+
+Because this fires from `implementing` — a LIVE phase with in-flight executor state, unlike its
+sibling `story_reprepare` (which fires from the quiescent `stories_generated`) — three guards
+make it safe:
+
+1. **Auto-accept cap** (`plan-decision-handler.max_auto_architecture_revises`, default 1). Each
+   accepted `architecture_revise` is a full, expensive re-run; the cap bounds the
+   `implement → wedge → revise → …` loop. Past the cap the decision stays proposed for human
+   review. The count is monotonic — `PlanDecisions` survive the entity wipe.
+2. **Abandon-not-resume.** `PlanDecisionAcceptedEvent` now carries `Kind`; the requirement-executor
+   abandons (terminates + drops from `activeExecs`) all in-flight execs for the slug instead of
+   resuming the wedged one, so the stale DAG can't race the architect re-run on the shared
+   `req.<slug>.<reqID>` key.
+3. **Atomic-ish apply.** The back-transition is checked before any mutation or I/O (an out-of-window
+   accept is a clean no-op); the execution reset runs on a detached context before the in-memory
+   wipe, so a reset failure aborts the accept with the plan untouched.
+
+**Known limitation (LOW, cost not correctness):** the reset clears `req.<slug>.*` EXECUTION_STATES
+rows but not `task.<slug>.*` rows, and the requirement-executor has no channel to force-cancel
+in-flight execution-manager TDD loops. On a genuinely-parallel hard-tier plan, a sibling node's
+loop can run out its token budget before noticing the slug restarted (its terminal write is
+absorbed by the `activeExecs` cache-miss no-op — no corruption, just wasted spend). The M:N
+cohesive shape (one dev loop per Story) does not hit this. A follow-up could thread loop
+cancellation through execution-manager.
+
+## Deferred (designed, not yet implemented)
 
 - **Sarah-authored per-task scenario partitions.** Would let a fixable Story rejection re-run a
   *subset* of nodes instead of the whole Story. Requires a `Task.ScenarioIDs` schema + Sarah

--- a/processor/plan-decision-handler/architecture_revise_cap_test.go
+++ b/processor/plan-decision-handler/architecture_revise_cap_test.go
@@ -1,0 +1,54 @@
+package changeproposalhandler
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestCountAcceptedArchitectureRevises is the monotonic loop bound for the
+// architecture_revise auto-accept cap (go-reviewer C1). Only accepted
+// architecture_revise decisions count; proposed ones, other kinds, and
+// rejected ones do not.
+func TestCountAcceptedArchitectureRevises(t *testing.T) {
+	decisions := []workflow.PlanDecision{
+		{ID: "a", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusAccepted},
+		{ID: "b", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusProposed}, // not yet accepted
+		{ID: "c", Kind: workflow.PlanDecisionKindStoryReprepare, Status: workflow.PlanDecisionStatusAccepted},     // wrong kind
+		{ID: "d", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusRejected}, // rejected
+		{ID: "e", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusAccepted},
+	}
+
+	if got := countAcceptedArchitectureRevises(decisions); got != 2 {
+		t.Errorf("countAcceptedArchitectureRevises = %d, want 2 (only accepted architecture_revise)", got)
+	}
+	if got := countAcceptedArchitectureRevises(nil); got != 0 {
+		t.Errorf("countAcceptedArchitectureRevises(nil) = %d, want 0", got)
+	}
+}
+
+// TestArchitectureReviseCap_Gate documents the cap semantics the watch loop
+// enforces: once MaxAutoArchitectureRevises accepted architecture_revise
+// decisions exist on a plan, a further proposed one is NOT auto-accepted (it
+// stays for human review). With the default cap of 1, the first auto-accepts
+// and the second is gated.
+func TestArchitectureReviseCap_Gate(t *testing.T) {
+	const reviseCap = 1
+
+	// One already accepted; a new proposed one arrives. count(1) >= reviseCap(1) → gate.
+	withOneAccepted := []workflow.PlanDecision{
+		{ID: "first", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusAccepted},
+		{ID: "second", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusProposed},
+	}
+	if got := countAcceptedArchitectureRevises(withOneAccepted); got < reviseCap {
+		t.Fatalf("precondition: expected >= %d accepted, got %d", reviseCap, got)
+	}
+
+	// None accepted yet; the first proposed one is below cap → auto-acceptable.
+	noneAccepted := []workflow.PlanDecision{
+		{ID: "first", Kind: workflow.PlanDecisionKindArchitectureRevise, Status: workflow.PlanDecisionStatusProposed},
+	}
+	if got := countAcceptedArchitectureRevises(noneAccepted); got >= reviseCap {
+		t.Errorf("expected first architecture_revise below cap; got count %d >= reviseCap %d", got, reviseCap)
+	}
+}

--- a/processor/plan-decision-handler/component.go
+++ b/processor/plan-decision-handler/component.go
@@ -338,6 +338,7 @@ func (c *Component) publishAcceptedEvent(ctx context.Context, req *payloads.Plan
 		ProposalID:             req.ProposalID,
 		Slug:                   req.Slug,
 		TraceID:                req.TraceID,
+		Kind:                   result.Kind,
 		AffectedRequirementIDs: result.AffectedRequirementIDs,
 		AffectedScenarioIDs:    result.AffectedScenarioIDs,
 	}

--- a/processor/plan-decision-handler/config.go
+++ b/processor/plan-decision-handler/config.go
@@ -45,6 +45,18 @@ type Config struct {
 	// off so recovery stays diagnosis-only until the operator decides.
 	AutoAcceptRecovery bool `json:"auto_accept_recovery" schema:"type:boolean,description:Auto-accept PlanDecisions from recovery-agent (ADR-037 stage-2 apply path),category:advanced,default:false"`
 
+	// MaxAutoArchitectureRevises bounds how many architecture_revise recovery
+	// PlanDecisions the watcher will auto-accept for a single plan. Each accepted
+	// architecture_revise wipes Architecture + Stories + Scenarios and re-runs the
+	// whole pipeline from the architect — the heaviest, most expensive recovery
+	// action. Without a cap, a plan whose revised architecture still wedges would
+	// loop (implement → wedge → architecture_revise → implement → …) burning a
+	// full re-run each cycle. Once this many architecture_revise decisions are
+	// already accepted on the plan, further ones stay proposed for human review.
+	// The count is monotonic — PlanDecisions persist across the wipe. Default 1:
+	// one automatic architecture revision, then a human must decide.
+	MaxAutoArchitectureRevises int `json:"max_auto_architecture_revises" schema:"type:int,description:Max architecture_revise recovery decisions auto-accepted per plan before human review,category:advanced,default:1,min:0,max:10"`
+
 	// Ports contains input/output port definitions.
 	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Input/output port definitions,category:basic"`
 }
@@ -52,11 +64,12 @@ type Config struct {
 // DefaultConfig returns sensible default configuration.
 func DefaultConfig() Config {
 	return Config{
-		StreamName:      "WORKFLOW",
-		ConsumerName:    "plan-decision-handler",
-		TriggerSubject:  "workflow.trigger.plan-decision-cascade",
-		AcceptedSubject: "workflow.events.plan-decision.accepted",
-		TimeoutSeconds:  120,
+		StreamName:                 "WORKFLOW",
+		ConsumerName:               "plan-decision-handler",
+		TriggerSubject:             "workflow.trigger.plan-decision-cascade",
+		AcceptedSubject:            "workflow.events.plan-decision.accepted",
+		TimeoutSeconds:             120,
+		MaxAutoArchitectureRevises: 1,
 		Ports: &component.PortConfig{
 			Inputs: []component.PortDefinition{
 				{

--- a/processor/plan-decision-handler/recovery_autoaccept.go
+++ b/processor/plan-decision-handler/recovery_autoaccept.go
@@ -115,6 +115,18 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 			if _, seen := acceptedIDs[dec.ID]; seen {
 				continue
 			}
+			// architecture_revise cap (C1 loop guard): refuse to auto-accept
+			// past MaxAutoArchitectureRevises already-accepted architecture_revise
+			// decisions on this plan. Counted from the persisted PlanDecisions
+			// (monotonic across the wipe). Past the cap the decision stays
+			// proposed for human review rather than burning another full re-run.
+			if dec.Kind == workflow.PlanDecisionKindArchitectureRevise &&
+				countAcceptedArchitectureRevises(planView.PlanDecisions) >= c.config.MaxAutoArchitectureRevises {
+				c.logger.Warn("architecture_revise auto-accept budget exhausted; leaving for human review",
+					"slug", planView.Slug, "proposal_id", dec.ID,
+					"max_auto_architecture_revises", c.config.MaxAutoArchitectureRevises)
+				continue
+			}
 			acceptedIDs[dec.ID] = now
 			c.invokeAccept(ctx, planView.Slug, dec.ID)
 		}
@@ -132,12 +144,32 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 //     step 4). The cascade dirty-marks Stories + scenarios; plan-manager
 //     drives stories_generated → preparing_stories so Sarah re-runs with
 //     the diagnosis as Story.RecoveryHint.
+//   - PlanDecisionKindArchitectureRevise — architecture_revise action.
+//     plan-manager wipes Architecture + Stories + Scenarios + all
+//     requirement executions and drives implementing →
+//     requirements_generated so Winston re-runs with the diagnosis as
+//     ReviewFormattedFindings.
 //
 // Other kinds (execution_exhausted terminal records, qa-reviewer
 // proposals, human proposals) stay human-gated. AffectedReqIDs is the
 // load-bearing predicate for both auto-acceptable kinds: it scopes the
 // cascade target, and an empty list signals "the wedge isn't scoped to
 // specific work — needs human triage."
+// countAcceptedArchitectureRevises counts PlanDecisions already in accepted
+// status with Kind=architecture_revise. Used as the monotonic loop bound for
+// the architecture_revise auto-accept cap — the count survives the entity wipe
+// because PlanDecisions are never cleared, so it strictly increases each cycle.
+func countAcceptedArchitectureRevises(decisions []workflow.PlanDecision) int {
+	n := 0
+	for i := range decisions {
+		if decisions[i].Kind == workflow.PlanDecisionKindArchitectureRevise &&
+			decisions[i].Status == workflow.PlanDecisionStatusAccepted {
+			n++
+		}
+	}
+	return n
+}
+
 func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	if dec == nil {
 		return false
@@ -150,7 +182,8 @@ func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	}
 	switch dec.Kind {
 	case workflow.PlanDecisionKindRequirementChange,
-		workflow.PlanDecisionKindStoryReprepare:
+		workflow.PlanDecisionKindStoryReprepare,
+		workflow.PlanDecisionKindArchitectureRevise:
 		// auto-acceptable
 	default:
 		return false

--- a/processor/plan-decision-handler/should_auto_accept_test.go
+++ b/processor/plan-decision-handler/should_auto_accept_test.go
@@ -42,6 +42,17 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 			comment: "pre-existing path unchanged",
 		},
 		{
+			name: "architecture_revise is auto-acceptable",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindArchitectureRevise,
+				AffectedReqIDs: []string{"req.demo.1"},
+			},
+			wantOK:  true,
+			comment: "heaviest recovery kind; user chose auto-accept",
+		},
+		{
 			name: "execution_exhausted stays human-gated",
 			dec: &workflow.PlanDecision{
 				ProposedBy:     "recovery-agent",

--- a/processor/plan-manager/architecture_revise_test.go
+++ b/processor/plan-manager/architecture_revise_test.go
@@ -1,0 +1,117 @@
+package planmanager
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestReviseArchitectureState_HappyPath pins the pure state mutation an
+// accepted architecture_revise PlanDecision performs from the implementing
+// status: capture the prior architecture, wipe Architecture + Stories +
+// Scenarios, route the diagnosis into ReviewFormattedFindings, and drive the
+// back-transition to requirements_generated. This is the seam that the
+// EXECUTION_STATES reset (NATS I/O) wraps in applyArchitectureRevise.
+func TestReviseArchitectureState_HappyPath(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:   "mavlink-hard",
+		Status: workflow.StatusImplementing,
+		Architecture: &workflow.ArchitectureDocument{
+			DataFlow: "sensor -> driver -> mavsdk",
+		},
+		Stories:   []workflow.Story{{ID: "story-1"}},
+		Scenarios: []workflow.Scenario{{ID: "scenario-1"}},
+	}
+	proposal := &workflow.PlanDecision{
+		ID:        "plan-decision.mavlink-hard.recovery.abcd1234",
+		Kind:      workflow.PlanDecisionKindArchitectureRevise,
+		Rationale: "Winston pinned the 3.x mavsdk API but the driver needs 2.x; every dev cycle re-hallucinates coords.",
+	}
+
+	transitioned, from := reviseArchitectureState(plan, proposal)
+
+	if !transitioned {
+		t.Fatalf("expected back-transition to be applied, got transitioned=false (from=%q)", from)
+	}
+	if from != workflow.StatusImplementing {
+		t.Errorf("from status: got %q, want implementing", from)
+	}
+	if plan.Status != workflow.StatusRequirementsGenerated {
+		t.Errorf("plan.Status: got %q, want requirements_generated", plan.Status)
+	}
+	if plan.Architecture != nil {
+		t.Error("Architecture should be wiped")
+	}
+	if plan.Stories != nil {
+		t.Error("Stories should be wiped")
+	}
+	if plan.Scenarios != nil {
+		t.Error("Scenarios should be wiped")
+	}
+	if !strings.Contains(plan.PreviousArchitectureJSON, "mavsdk") {
+		t.Errorf("PreviousArchitectureJSON should capture the prior architecture, got %q", plan.PreviousArchitectureJSON)
+	}
+	if plan.ReviewFormattedFindings != proposal.Rationale {
+		t.Errorf("ReviewFormattedFindings: got %q, want the diagnosis", plan.ReviewFormattedFindings)
+	}
+}
+
+// TestReviseArchitectureState_OutOfWindow verifies that a plan which has
+// already moved past implementing (e.g. reached complete while the accept
+// landed late) is left ENTIRELY untouched: no transition, AND no entity wipe.
+// Wiping a terminal plan's architecture/stories/scenarios would corrupt it
+// (go-reviewer M2). The wipe must be gated behind the transition check.
+func TestReviseArchitectureState_OutOfWindow(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:         "mavlink-hard",
+		Status:       workflow.StatusComplete,
+		Architecture: &workflow.ArchitectureDocument{DataFlow: "x"},
+		Stories:      []workflow.Story{{ID: "story-1"}},
+		Scenarios:    []workflow.Scenario{{ID: "scenario-1"}},
+	}
+	proposal := &workflow.PlanDecision{
+		ID:        "plan-decision.mavlink-hard.recovery.abcd1234",
+		Kind:      workflow.PlanDecisionKindArchitectureRevise,
+		Rationale: "diagnosis",
+	}
+
+	transitioned, from := reviseArchitectureState(plan, proposal)
+
+	if transitioned {
+		t.Errorf("expected transitioned=false from %q, got true", from)
+	}
+	if plan.Status != workflow.StatusComplete {
+		t.Errorf("plan.Status should be unchanged, got %q", plan.Status)
+	}
+	if plan.Architecture == nil {
+		t.Error("Architecture must NOT be wiped on an out-of-window accept (M2)")
+	}
+	if plan.Stories == nil || plan.Scenarios == nil {
+		t.Error("Stories/Scenarios must NOT be wiped on an out-of-window accept (M2)")
+	}
+	if plan.ReviewFormattedFindings != "" {
+		t.Error("ReviewFormattedFindings must NOT be set on an out-of-window accept (M2)")
+	}
+}
+
+// TestReviseArchitectureState_NoPriorArchitecture confirms PreviousArchitectureJSON
+// stays empty (no stale leftover) when the plan has no architecture to capture,
+// and the transition + wipe still proceed.
+func TestReviseArchitectureState_NoPriorArchitecture(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:                     "mavlink-hard",
+		Status:                   workflow.StatusImplementing,
+		PreviousArchitectureJSON: "stale-leftover",
+	}
+	proposal := &workflow.PlanDecision{Kind: workflow.PlanDecisionKindArchitectureRevise}
+
+	transitioned, _ := reviseArchitectureState(plan, proposal)
+
+	if !transitioned {
+		t.Error("expected transition to requirements_generated")
+	}
+	if plan.PreviousArchitectureJSON != "" {
+		t.Errorf("PreviousArchitectureJSON should be cleared when no architecture exists, got %q", plan.PreviousArchitectureJSON)
+	}
+}

--- a/processor/plan-manager/http_plan_decision.go
+++ b/processor/plan-manager/http_plan_decision.go
@@ -492,45 +492,15 @@ func (c *Component) handleAcceptPlanDecision(w http.ResponseWriter, r *http.Requ
 	proposal.Status = workflow.PlanDecisionStatusAccepted
 	proposal.DecidedAt = &now
 
-	// ADR-037 stage-1 (a3): when accepting a recovery PlanDecision, apply
-	// the rationale as supplementary feedback on the affected entity(ies)
-	// via RecoveryHint. Execution-manager prepends Req.RecoveryHint onto
-	// exec.Feedback at next-cycle developer dispatch; Sarah reads
-	// Story.RecoveryHint at re-prep time (Train C step 4) so the
-	// manager-role agent's recommendation reaches the wedged role through
-	// the existing retry-feedback channel. No new prompt fragment, no new
-	// wire shape. Gated by ProposedBy="recovery-agent" so qa-reviewer +
-	// req-executor proposals (which use the same wire) don't get hint
-	// application.
-	if proposal.ProposedBy == "recovery-agent" && proposal.Rationale != "" {
-		applyRecoveryHint(plan, proposal)
-	}
-
-	// Train C step 4: when a story_reprepare PlanDecision is accepted,
-	// drive the back-transition stories_generated → preparing_stories so
-	// Sarah's watcher claims and re-preps. The affected Stories STAY in
-	// plan.Stories with their RecoveryHint set (written by
-	// applyRecoveryHint above) so Sarah's prompt iterates the full Story
-	// set and sees which entries need re-authoring; her emission then
-	// REPLACES plan.Stories per the existing handleStoriesMutation
-	// wipe-and-replace contract.
-	//
-	// In-place transition check (NOT setPlanStatusCached) avoids a double
-	// KV put: setPlanStatusCached would save, then the trailing ps.save
-	// below would save again — both putting status=preparing_stories. The
-	// watcher would see two identical events and dispatch Sarah twice. The
-	// inline check + mutation lets the existing trailing save be the sole
-	// persist point. An invalid transition (plan moved past
-	// stories_generated while the human review window was open) leaves the
-	// plan in place + logs a warning.
-	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
-		current := plan.EffectiveStatus()
-		if current.CanTransitionTo(workflow.StatusPreparingStories) {
-			plan.Status = workflow.StatusPreparingStories
-		} else {
-			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
-				"slug", slug, "proposal_id", proposalID, "current_status", current)
-		}
+	// Kind-specific accept effects — ADR-037 stage-1 (a3) recovery hint,
+	// story_reprepare back-transition (Train C step 4), architecture_revise
+	// wipe+reset — are shared with the mutation accept path via
+	// applyPlanDecisionAcceptEffects so both stay identical. See that helper
+	// for the per-kind contract.
+	if err := c.applyPlanDecisionAcceptEffects(r.Context(), plan, proposal, slug); err != nil {
+		c.logger.Error("Failed to apply plan decision accept effects", "slug", slug, "proposal_id", proposalID, "error", err)
+		http.Error(w, "Failed to accept plan decision", http.StatusInternalServerError)
+		return
 	}
 
 	if err := c.plans.save(r.Context(), plan); err != nil {

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1799,6 +1799,147 @@ func (c *Component) resetRequirementExecutionsByID(ctx context.Context, slug str
 	return resetCount, nil
 }
 
+// applyArchitectureRevise performs the state mutation for an accepted
+// architecture_revise PlanDecision (RecoveryActionArchitectureRevise). It is
+// the execution-phase counterpart of determineR2ReentryPoint's "architecture"
+// case: capture the prior architecture so the architect REVISES rather than
+// rewrites, wipe Architecture + Stories + Scenarios, reset every requirement
+// execution so the re-run can't fast-complete via the executor's Tier-1 dedup,
+// route the recovery diagnosis into ReviewFormattedFindings (the channel the
+// architecture-generator already reads on revision rounds — component.go:301),
+// and drive the back-transition implementing → requirements_generated so the
+// architect re-fires.
+//
+// Called inline from both accept paths (mutation + HTTP). It does the status
+// mutation IN PLACE rather than via setPlanStatusCached for the same reason
+// the story_reprepare block does: the trailing ps.save in the caller is the
+// sole persist point, so an inline status set avoids a double save / double
+// watcher event. The caller skips applyRecoveryHint for this kind — the
+// diagnosis reaches the architect through ReviewFormattedFindings, not through
+// per-entity RecoveryHints (which would otherwise leak stale architecture
+// context into a future developer prompt).
+//
+// The EXECUTION_STATES reset is I/O (NATS request/reply via resetRequirement-
+// Executions, scope "all"); a reset error is returned so the caller can fail
+// the accept rather than half-apply the revision. A back-transition that the
+// DAG rejects (plan already moved past implementing while a human-review
+// window was open) leaves the plan in place and logs a warning — consistent
+// with the story_reprepare block's defensive handling.
+func (c *Component) applyArchitectureRevise(ctx context.Context, plan *workflow.Plan, proposal *workflow.PlanDecision) error {
+	// Check the back-transition is legal BEFORE any mutation or I/O. An
+	// out-of-window accept (plan moved past implementing while the accept
+	// landed late) must be a clean no-op — wiping a terminal plan's entities
+	// or deleting its executions would corrupt it (closes go-reviewer M2).
+	from := plan.EffectiveStatus()
+	if !from.CanTransitionTo(workflow.StatusRequirementsGenerated) {
+		c.logger.Warn("architecture_revise accepted but plan cannot back-transition to requirements_generated; leaving plan untouched",
+			"slug", plan.Slug, "proposal_id", proposal.ID, "current_status", from)
+		return nil
+	}
+
+	// Reset all requirement executions BEFORE the in-memory wipe so a reset
+	// failure aborts the accept with the plan untouched (no half-applied
+	// revision). Detached context: the reset is N sequential NATS request/
+	// replies and must finish even if the caller's request context is
+	// cancelled mid-accept (closes go-reviewer H2/M3). Clearing EXECUTION_STATES
+	// stops the re-run from fast-completing via the executor's Tier-1 dedup.
+	resetCount, err := c.resetRequirementExecutions(context.WithoutCancel(ctx), plan.Slug, "all", nil)
+	if err != nil {
+		return fmt.Errorf("reset requirement executions for architecture_revise: %w", err)
+	}
+
+	reviseArchitectureState(plan, proposal)
+
+	c.logger.Info("Architecture revise applied — plan re-queued for architecture regeneration",
+		"slug", plan.Slug,
+		"proposal_id", proposal.ID,
+		"reset_count", resetCount,
+		"from_status", from,
+		"had_previous_architecture", plan.PreviousArchitectureJSON != "")
+	return nil
+}
+
+// applyPlanDecisionAcceptEffects performs the kind-specific state mutation when
+// a PlanDecision is accepted. Shared by the mutation and HTTP accept paths so
+// both stay byte-identical. Branches on proposal.Kind:
+//
+//   - architecture_revise → applyArchitectureRevise (capture prior architecture,
+//     wipe Architecture + Stories + Scenarios, reset all requirement executions,
+//     drive implementing → requirements_generated). Routes the diagnosis through
+//     ReviewFormattedFindings, so the recovery-hint + story_reprepare branches
+//     are intentionally skipped.
+//   - any other kind → apply the recovery hint when proposed_by=recovery-agent,
+//     and for story_reprepare drive stories_generated → preparing_stories so
+//     Sarah re-runs with Story.RecoveryHint set (Train C step 4).
+//
+// The status mutations are done IN PLACE (NOT setPlanStatusCached): the caller's
+// trailing save is the sole persist point, avoiding a double save / double
+// watcher event. An out-of-window plan (already moved past the source status
+// while a human-review window was open) is left in place with a warning.
+func (c *Component) applyPlanDecisionAcceptEffects(ctx context.Context, plan *workflow.Plan, proposal *workflow.PlanDecision, slug string) error {
+	if proposal.Kind == workflow.PlanDecisionKindArchitectureRevise {
+		return c.applyArchitectureRevise(ctx, plan, proposal)
+	}
+
+	if proposal.ProposedBy == "recovery-agent" && proposal.Rationale != "" {
+		applyRecoveryHint(plan, proposal)
+	}
+
+	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
+		current := plan.EffectiveStatus()
+		if current.CanTransitionTo(workflow.StatusPreparingStories) {
+			plan.Status = workflow.StatusPreparingStories
+		} else {
+			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
+				"slug", slug, "proposal_id", proposal.ID, "current_status", current)
+		}
+	}
+	return nil
+}
+
+// reviseArchitectureState performs the pure in-memory state mutation for an
+// accepted architecture_revise PlanDecision, with no I/O so it is unit-testable
+// in isolation (the seam):
+//
+//   - route the recovery diagnosis into ReviewFormattedFindings (the channel
+//     the architecture-generator reads on revision rounds);
+//   - capture the prior architecture into PreviousArchitectureJSON so the
+//     architect REVISES rather than rewrites (mirrors determineR2ReentryPoint's
+//     "architecture" case);
+//   - wipe Architecture + Stories + Scenarios;
+//   - drive the back-transition implementing → requirements_generated.
+//
+// The wipe is gated behind the same CanTransitionTo check the caller performs,
+// so it is also safe standalone: an out-of-window plan is left entirely
+// untouched and the function reports transitioned=false (closes go-reviewer M2 —
+// the wipe no longer precedes the transition check). Returns whether the
+// transition was applied and the status evaluated from. The EXECUTION_STATES
+// reset is the caller's responsibility — it is NATS I/O.
+func reviseArchitectureState(plan *workflow.Plan, proposal *workflow.PlanDecision) (transitioned bool, from workflow.Status) {
+	from = plan.EffectiveStatus()
+	if !from.CanTransitionTo(workflow.StatusRequirementsGenerated) {
+		return false, from
+	}
+
+	if proposal.Rationale != "" {
+		plan.ReviewFormattedFindings = proposal.Rationale
+	}
+
+	// Clear any stale carry-over first so a failed marshal leaves no leftover.
+	plan.PreviousArchitectureJSON = ""
+	if plan.Architecture != nil {
+		if b, err := json.Marshal(plan.Architecture); err == nil {
+			plan.PreviousArchitectureJSON = string(b)
+		}
+	}
+	plan.Architecture = nil
+	plan.Stories = nil
+	plan.Scenarios = nil
+
+	plan.Status = workflow.StatusRequirementsGenerated
+	return true, from
+}
+
 // determineR2ReentryPoint examines review findings to pick the minimal re-entry
 // point for Round 2. When findings carry phase markers, the plan can retry only
 // the affected phase instead of clearing everything.
@@ -2058,32 +2199,8 @@ func (c *Component) handlePlanDecisionAcceptMutation(ctx context.Context, data [
 	proposal.Status = workflow.PlanDecisionStatusAccepted
 	proposal.DecidedAt = &now
 
-	// Mirror HTTP path: apply recovery hint when proposed_by=recovery-agent.
-	// Gate stays on ProposedBy + non-empty Rationale; future apply shapes
-	// for other proposer roles land in this same branch.
-	if proposal.ProposedBy == "recovery-agent" && proposal.Rationale != "" {
-		applyRecoveryHint(plan, proposal)
-	}
-
-	// Mirror HTTP path: drive the stories_generated → preparing_stories
-	// back-transition when a story_reprepare PlanDecision is accepted.
-	// The affected Stories stay in plan.Stories with their RecoveryHint
-	// set (applyRecoveryHint above); Sarah's prompt iterates the full
-	// Story set on re-prep and her emission replaces plan.Stories per
-	// the existing handleStoriesMutation wipe-and-replace contract.
-	// Train C step 4.
-	//
-	// In-place transition check (NOT setPlanStatusCached) avoids a
-	// double-save / double-event — see the matching block in
-	// handleAcceptPlanDecision for the explanation.
-	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
-		current := plan.EffectiveStatus()
-		if current.CanTransitionTo(workflow.StatusPreparingStories) {
-			plan.Status = workflow.StatusPreparingStories
-		} else {
-			c.logger.Warn("Could not drive stories_generated → preparing_stories on story_reprepare accept; plan stays in place",
-				"slug", req.Slug, "proposal_id", req.ProposalID, "current_status", current)
-		}
+	if err := c.applyPlanDecisionAcceptEffects(ctx, plan, proposal, req.Slug); err != nil {
+		return MutationResponse{Success: false, Error: err.Error()}
 	}
 
 	if err := ps.save(ctx, plan); err != nil {

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -733,6 +733,10 @@ func (c *Component) deriveDecision(loop *agentic.LoopEntity, escalationReason st
 //     Story.RecoveryHint set. Pre-Train-C, story_reprepare mapped to
 //     requirement_change, which silently degraded into a scenarios-only
 //     cascade that left Sarah's stories unchanged.
+//   - architecture_revise → architecture_revise. Heaviest kind: plan-manager
+//     wipes Architecture + Stories + Scenarios + all requirement executions
+//     and drives implementing → requirements_generated so the architect
+//     re-fires. Distinct from story_reprepare (which keeps the architecture).
 //   - escalate_human / mark_unrecoverable → execution_exhausted. Terminal;
 //     plan-manager auto-archives when the subject req reaches a non-failed
 //     terminal state.
@@ -744,6 +748,8 @@ func recoveryActionToPlanDecisionKind(action payloads.RecoveryActionKind) workfl
 		return workflow.PlanDecisionKindRequirementChange
 	case payloads.RecoveryActionStoryReprepare:
 		return workflow.PlanDecisionKindStoryReprepare
+	case payloads.RecoveryActionArchitectureRevise:
+		return workflow.PlanDecisionKindArchitectureRevise
 	case payloads.RecoveryActionEscalateHuman, payloads.RecoveryActionMarkUnrecoverable:
 		return workflow.PlanDecisionKindExecutionExhausted
 	default:

--- a/processor/recovery-agent/plan_decision_kind_mapping_test.go
+++ b/processor/recovery-agent/plan_decision_kind_mapping_test.go
@@ -29,12 +29,13 @@ func TestRecoveryActionToPlanDecisionKind(t *testing.T) {
 	// default falls to execution_exhausted (terminal), so an unrecognized
 	// action will route to "terminal" without test failure — silent.
 	cases := map[payloads.RecoveryActionKind]workflow.PlanDecisionKind{
-		payloads.RecoveryActionRefinePrompt:      workflow.PlanDecisionKindRequirementChange,
-		payloads.RecoveryActionNarrowScope:       workflow.PlanDecisionKindRequirementChange,
-		payloads.RecoveryActionSplitReq:          workflow.PlanDecisionKindRequirementChange,
-		payloads.RecoveryActionStoryReprepare:    workflow.PlanDecisionKindStoryReprepare,
-		payloads.RecoveryActionEscalateHuman:     workflow.PlanDecisionKindExecutionExhausted,
-		payloads.RecoveryActionMarkUnrecoverable: workflow.PlanDecisionKindExecutionExhausted,
+		payloads.RecoveryActionRefinePrompt:       workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionNarrowScope:        workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionSplitReq:           workflow.PlanDecisionKindRequirementChange,
+		payloads.RecoveryActionStoryReprepare:     workflow.PlanDecisionKindStoryReprepare,
+		payloads.RecoveryActionArchitectureRevise: workflow.PlanDecisionKindArchitectureRevise,
+		payloads.RecoveryActionEscalateHuman:      workflow.PlanDecisionKindExecutionExhausted,
+		payloads.RecoveryActionMarkUnrecoverable:  workflow.PlanDecisionKindExecutionExhausted,
 	}
 	for action, want := range cases {
 		got := recoveryActionToPlanDecisionKind(action)

--- a/processor/recovery-agent/result.go
+++ b/processor/recovery-agent/result.go
@@ -91,6 +91,7 @@ func parseRecoveryResult(raw string) (*parsedRecoveryResult, error) {
 		payloads.RecoveryActionNarrowScope,
 		payloads.RecoveryActionSplitReq,
 		payloads.RecoveryActionStoryReprepare,
+		payloads.RecoveryActionArchitectureRevise,
 		payloads.RecoveryActionEscalateHuman,
 		payloads.RecoveryActionMarkUnrecoverable:
 	default:

--- a/processor/recovery-agent/result_test.go
+++ b/processor/recovery-agent/result_test.go
@@ -90,6 +90,24 @@ func TestParseRecoveryResult(t *testing.T) {
 		}
 	})
 
+	// architecture_revise is the heaviest action: the architecture itself is
+	// the wedge root (mis-resolved upstream dep, wrong component boundary).
+	// No extra fields beyond diagnosis — the diagnosis becomes the architect's
+	// revision feedback when plan-manager re-runs the architecture.
+	t.Run("happy path architecture_revise", func(t *testing.T) {
+		raw := `{"action":"architecture_revise","diagnosis":"Winston pinned io.mavsdk:mavsdk:3.16.0 but the driver requires the 2.x API; every dev cycle re-hallucinates the dep coords.","recovery_succeeded":true}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected ok, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionArchitectureRevise {
+			t.Errorf("Action: got %q, want architecture_revise", got.Action)
+		}
+		if !strings.Contains(got.Diagnosis, "mavsdk") {
+			t.Errorf("diagnosis content lost: %q", got.Diagnosis)
+		}
+	})
+
 	cases := []struct {
 		name string
 		raw  string

--- a/processor/requirement-executor/abandon_execs_test.go
+++ b/processor/requirement-executor/abandon_execs_test.go
@@ -1,0 +1,66 @@
+package requirementexecutor
+
+import (
+	"testing"
+	"time"
+)
+
+// TestAbandonExecsForSlug verifies the architecture_revise teardown
+// (go-reviewer C2/H1): every active exec for the target slug is marked
+// terminated and removed from activeExecs, while execs for OTHER slugs are
+// left untouched. This is what stops the wedged exec from being resumed on
+// the accepted event and prevents the abandoned exec from racing the fresh
+// architect-driven re-run on the shared req.<slug>.<reqID> key.
+func TestAbandonExecsForSlug(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+
+	// Distinct EntityIDs — newAwaitingExec derives EntityID from reqID alone,
+	// so a same-reqID exec on a different slug would otherwise collide in the
+	// cache.
+	target1 := newAwaitingExec("mavlink-hard", "req-0")
+	target1.EntityID = "entity-mavlink-req-0"
+	target1.awaitingRecovery = true
+	target2 := newAwaitingExec("mavlink-hard", "req-1") // sibling, still "running"
+	target2.EntityID = "entity-mavlink-req-1"
+	other := newAwaitingExec("other-plan", "req-0") // different slug — must survive
+	other.EntityID = "entity-other-req-0"
+
+	c.activeExecs.Set(target1.EntityID, target1)
+	c.activeExecs.Set(target2.EntityID, target2)
+	c.activeExecs.Set(other.EntityID, other)
+
+	abandoned := c.abandonExecsForSlug("mavlink-hard")
+
+	if abandoned != 2 {
+		t.Errorf("abandoned = %d, want 2 (both mavlink-hard execs)", abandoned)
+	}
+	if _, ok := c.activeExecs.Get(target1.EntityID); ok {
+		t.Error("target1 should have been removed from activeExecs")
+	}
+	if _, ok := c.activeExecs.Get(target2.EntityID); ok {
+		t.Error("target2 should have been removed from activeExecs")
+	}
+	if !target1.terminated {
+		t.Error("target1 should be marked terminated")
+	}
+	if target1.awaitingRecovery {
+		t.Error("target1.awaitingRecovery should be cleared (won't be resumed)")
+	}
+
+	// The other-plan exec must be untouched.
+	if _, ok := c.activeExecs.Get(other.EntityID); !ok {
+		t.Error("other-plan exec must NOT be removed")
+	}
+	if other.terminated {
+		t.Error("other-plan exec must NOT be marked terminated")
+	}
+}
+
+// TestAbandonExecsForSlug_Empty verifies no panic / zero count when there are
+// no execs for the slug.
+func TestAbandonExecsForSlug_Empty(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	if got := c.abandonExecsForSlug("nonexistent"); got != 0 {
+		t.Errorf("abandoned = %d, want 0", got)
+	}
+}

--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/nats-io/nats.go/jetstream"
@@ -281,6 +282,41 @@ func (c *Component) findAwaitingByRequirement(slug, requirementID string) *requi
 	return nil
 }
 
+// abandonExecsForSlug tears down every active requirement execution for a slug.
+// Called when an architecture_revise PlanDecision is accepted: the plan is
+// restarting from the architect, so all in-flight execs (the wedged one in
+// awaiting-recovery plus any siblings still running in parallel) are stale and
+// must be dropped before the re-run reaches execution. For each exec it stops
+// timers, marks it terminated (so any late cross-component callback — a task
+// completion that lands after the wipe — hits the terminated guard and no-ops
+// instead of writing to the deterministic req.<slug>.<reqID> key the fresh exec
+// will reuse), and removes it from activeExecs via cleanupExecutionLocked.
+//
+// Returns the count abandoned. The in-flight agentic loops themselves are not
+// force-cancelled here (req-executor has no cancellation channel to them); they
+// run to completion and their terminal writes are absorbed by the terminated
+// guard. EXECUTION_STATES rows were already deleted by plan-manager's reset.
+func (c *Component) abandonExecsForSlug(slug string) int {
+	abandoned := 0
+	for _, key := range c.activeExecs.Keys() {
+		exec, ok := c.activeExecs.Get(key)
+		if !ok || exec == nil {
+			continue
+		}
+		exec.mu.Lock()
+		if exec.Slug != slug {
+			exec.mu.Unlock()
+			continue
+		}
+		exec.terminated = true
+		exec.awaitingRecovery = false
+		c.cleanupExecutionLocked(exec, false)
+		exec.mu.Unlock()
+		abandoned++
+	}
+	return abandoned
+}
+
 // startPlanDecisionAcceptedConsumer subscribes req-executor to
 // workflow.events.plan-decision.accepted so the awaiting-recovery resume
 // path can fire on auto-accept (or human-accept). Best-effort: a watch
@@ -335,6 +371,23 @@ func (c *Component) handlePlanDecisionAccepted(lifecycleCtx, msgCtx context.Cont
 	}
 	if err := evt.Validate(); err != nil {
 		c.logger.Warn("Invalid PlanDecisionAcceptedEvent", "error", err)
+		_ = msg.Ack()
+		return
+	}
+
+	// architecture_revise restarts the plan from the architect: plan-manager
+	// has already wiped Architecture + Stories + Scenarios and reset the
+	// requirement executions in EXECUTION_STATES. The wedged exec(s) must NOT
+	// be resumed — resuming would re-decompose against the now-deleted DAG and
+	// race the architect re-run, and the resumed exec shares the deterministic
+	// req.<slug>.<reqID> store key with the fresh exec the re-run will create,
+	// so a late write would corrupt it. Abandon every active exec for the slug
+	// instead, then return before the resume loop below. The architect-driven
+	// re-run creates clean execs once it reaches execution.
+	if evt.Kind == workflow.PlanDecisionKindArchitectureRevise {
+		abandoned := c.abandonExecsForSlug(evt.Slug)
+		c.logger.Info("Abandoned in-flight execs on architecture_revise accept",
+			"slug", evt.Slug, "proposal_id", evt.ProposalID, "abandoned", abandoned)
 		_ = msg.Ack()
 		return
 	}

--- a/prompt/domain/phase1_render_test.go
+++ b/prompt/domain/phase1_render_test.go
@@ -32,8 +32,8 @@ func TestRenderArchitectPrompt_RevisionBaseInjected(t *testing.T) {
 }
 
 // TestRenderRecoveryAgentPrompt_ArchitectureContext verifies recovery sees the
-// architecture surface + the diagnosis steer when the wedged plan has an
-// architecture, and that the prompt does not reference a non-existent action.
+// architecture surface and is steered to architecture_revise (not escalate_human)
+// when the wedged plan has an architecture and the root looks architectural.
 func TestRenderRecoveryAgentPrompt_ArchitectureContext(t *testing.T) {
 	t.Parallel()
 	out := renderRecoveryAgentPrompt(&prompt.RecoveryPromptContext{
@@ -44,10 +44,7 @@ func TestRenderRecoveryAgentPrompt_ArchitectureContext(t *testing.T) {
 	if !strings.Contains(out, "io.mavsdk:mavsdk:3.16.0") {
 		t.Error("recovery prompt missing the architecture context")
 	}
-	if !strings.Contains(out, "escalate_human") {
-		t.Error("recovery prompt should steer architecture-root wedges to escalate_human (the honest interim landing)")
-	}
-	if strings.Contains(out, "architecture_revise") {
-		t.Error("recovery prompt must NOT name architecture_revise — that action does not exist until a later phase")
+	if !strings.Contains(out, "architecture_revise") {
+		t.Error("recovery prompt should steer architecture-root wedges to architecture_revise")
 	}
 }

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1585,6 +1585,8 @@ CLOSED ACTION SET (output one of these via submit_work):
 - refine_prompt — rewrite the wedged agent's task prompt with explicit context they missed. Use this when the trajectory shows they had the answer in front of them (e.g. a graph_search hit, a reviewer hint) but didn't act on it. REQUIRES "refined_prompt" field.
 - narrow_scope — reduce the wedged task's scope (e.g. limit to one file, one dependency). Use when the trajectory shows thrashing across too many concerns. Provide scope_changes as a structured JSON object describing the reduction.
 - split_req — decompose the requirement into smaller requirements. Heavier than narrow_scope; only when the plan-level decomposition was clearly wrong.
+- story_reprepare — Sarah's Story-shaping is the root cause (wrong task DAG, missing files_owned, mis-selected components). Reaches back to story-preparer for a re-prep cycle; your diagnosis becomes Sarah's RecoveryHint.
+- architecture_revise — the ARCHITECTURE is the root: a mis-resolved upstream dependency, a wrong component boundary, or an integration target the dev cannot satisfy. Re-runs the architect to revise the architecture, then re-runs the whole pipeline beneath it. Heaviest action — pick it only when the wedge is upstream of any single requirement or Story.
 - escalate_human — you analysed the wedge and the diagnosis is the deliverable; no programmatic action fits. Surfaces in the UI with your diagnosis.
 - mark_unrecoverable — the goal cannot succeed from current state regardless of agent (upstream artifact missing, fixture malformed, scope contradicts another requirement).
 
@@ -1612,21 +1614,23 @@ Rules:
 			Content: `Output Format — submit_work arguments
 
 Required fields:
-- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | escalate_human | mark_unrecoverable
+- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | architecture_revise | escalate_human | mark_unrecoverable
 - diagnosis: 2-6 sentences describing what the trajectory shows the agent doing wrong and what the underlying mistake is. REQUIRED for every action.
-- recovery_succeeded: true when refine_prompt | narrow_scope | split_req | story_reprepare plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
+- recovery_succeeded: true when refine_prompt | narrow_scope | split_req | story_reprepare | architecture_revise plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
 
 Action-specific fields:
 - refine_prompt requires: refined_prompt — a complete replacement task prompt that, when handed to the wedged role, would produce the work the agent should have produced.
 - narrow_scope and split_req require: scope_changes — a structured JSON object describing the reduction (which files / which sub-requirements / which concerns to keep, which to drop).
 - story_reprepare: no extra fields beyond diagnosis — the diagnosis becomes Sarah's RecoveryHint when she re-shards the requirement's Stories.
+- architecture_revise: no extra fields beyond diagnosis — the diagnosis becomes the architect's revision feedback (ReviewFormattedFindings) when the architecture is re-run.
 - escalate_human and mark_unrecoverable: no extra fields beyond diagnosis.
 
 Choosing between actions (ADR-043 PR 4i):
 - refine_prompt: the dev had the answer in front of it but didn't act. Same task, sharper prompt.
 - narrow_scope: the task's file surface was too broad; reduce it. Same DAG node, fewer files.
 - split_req: the plan-level decomposition was wrong; the requirement was too coarse. Heavier — mutates plan structure.
-- story_reprepare: Sarah's Story-shaping is the root cause — wrong task DAG, missing files_owned, mis-selected components. Reaches back to story-preparer for a re-prep cycle on the affected requirement; the diagnosis carries forward as Sarah's RecoveryHint.
+- story_reprepare: Sarah's Story-shaping is the root cause — wrong task DAG, missing files_owned, mis-selected components. Reaches back to story-preparer for a re-prep cycle on the affected requirement; the diagnosis carries forward as Sarah's RecoveryHint. The architecture itself is sound.
+- architecture_revise: the architecture is the root — a mis-resolved upstream dependency the dev keeps hallucinating, a wrong component boundary, an integration target no requirement can satisfy. Heavier than story_reprepare: it discards the architecture (not just the Stories) and re-runs the architect, then the whole pipeline beneath. Pick it when re-prepping Stories or sharpening the prompt against the SAME architecture would only re-wedge.
 - escalate_human: analysis is the deliverable; no programmatic action fits.
 - mark_unrecoverable: the wedge cannot succeed from current state regardless of refinements.
 

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -1373,7 +1373,7 @@ func renderRecoveryAgentPrompt(r *prompt.RecoveryPromptContext) string {
 	if r.ArchitectureContext != "" {
 		sb.WriteString("\n")
 		sb.WriteString(r.ArchitectureContext)
-		sb.WriteString("\nUse the architecture above to diagnose the ROOT of the wedge. A missing or mis-resolved upstream dependency, a wrong component boundary, or an integration target the dev cannot satisfy is an ARCHITECTURE problem — name it precisely in your diagnosis and choose escalate_human (do NOT mark_unrecoverable) so the architecture can be revised rather than the work abandoned.\n")
+		sb.WriteString("\nUse the architecture above to diagnose the ROOT of the wedge. A missing or mis-resolved upstream dependency, a wrong component boundary, or an integration target the dev cannot satisfy is an ARCHITECTURE problem — name it precisely in your diagnosis and choose architecture_revise so the architect re-runs and revises the architecture against your diagnosis (do NOT mark_unrecoverable, which abandons the work, and do NOT escalate_human, which only surfaces the problem without fixing it). Reserve story_reprepare for cases where the architecture is sound but Sarah's Story-shaping is wrong.\n")
 	}
 
 	if len(r.TrajectorySteps) == 0 {

--- a/workflow/cascade/cascade.go
+++ b/workflow/cascade/cascade.go
@@ -11,6 +11,14 @@ import (
 
 // Result summarizes the effect of accepting a PlanDecision.
 type Result struct {
+	// Kind echoes the accepted proposal's kind so downstream consumers of the
+	// PlanDecisionAcceptedEvent can branch on it without re-loading the plan.
+	// Load-bearing for architecture_revise: the requirement-executor abandons
+	// (rather than resumes) in-flight execs for the slug when it sees this kind,
+	// since the plan is restarting from the architect — resuming the wedged exec
+	// would race the re-run.
+	Kind workflow.PlanDecisionKind
+
 	AffectedRequirementIDs []string
 	// AffectedStoryIDs lists Story IDs the cascade dirty-marked. Populated
 	// for Kind=story_reprepare (the cascade target is Stories + Scenarios)
@@ -36,6 +44,10 @@ type Result struct {
 //   - Kind=execution_exhausted: terminal acknowledgement; cascade is a
 //     no-op (callers shouldn't invoke PlanDecision for this kind, but
 //     the function returns empty Result safely if they do).
+//   - Kind=architecture_revise: no-op. The plan-manager accept handler
+//     already wiped Architecture + Stories + Scenarios and reset all
+//     requirement executions inline; the re-run regenerates everything
+//     from the architect down, so there is nothing to dirty-mark.
 //
 // Pure business logic — no I/O. Caller loads the plan from KV and passes
 // stories + scenarios. Returns the IDs that were dirty-marked so
@@ -47,6 +59,7 @@ func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, sce
 	}
 
 	result := &Result{
+		Kind:                   proposal.Kind,
 		AffectedRequirementIDs: make([]string, 0, len(proposal.AffectedReqIDs)),
 		AffectedStoryIDs:       make([]string, 0),
 		AffectedScenarioIDs:    make([]string, 0),
@@ -86,6 +99,14 @@ func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, sce
 		// Terminal kind — cascade is a no-op beyond recording the
 		// AffectedRequirementIDs already populated above for caller
 		// telemetry. Stories + Scenarios stay empty.
+
+	case workflow.PlanDecisionKindArchitectureRevise:
+		// The plan-manager accept handler already wiped Architecture +
+		// Stories + Scenarios and reset all requirement executions inline,
+		// then drove implementing → requirements_generated. There is nothing
+		// left for the dirty-cascade to mark — the re-run regenerates every
+		// entity from the architect down. No-op beyond the recorded
+		// AffectedRequirementIDs (caller telemetry).
 
 	default:
 		// Kind=requirement_change OR unset (back-compat with pre-Kind records).

--- a/workflow/cascade/cascade_test.go
+++ b/workflow/cascade/cascade_test.go
@@ -31,3 +31,39 @@ func TestPlanDecision_NoAffectedRequirements(t *testing.T) {
 		t.Errorf("AffectedScenarioIDs = %d, want 0", len(result.AffectedScenarioIDs))
 	}
 }
+
+// TestPlanDecision_ArchitectureRevise_NoOp verifies the architecture_revise
+// cascade is a no-op even with Stories + Scenarios present: the plan-manager
+// accept handler already wiped those entities and reset execution inline, so
+// the cascade must not dirty-mark anything (it records only the affected reqs
+// for telemetry). Without an explicit case this kind would fall through to the
+// requirement_change default and wrongly dirty-mark scenarios.
+func TestPlanDecision_ArchitectureRevise_NoOp(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.slug.recovery.abcd1234",
+		Kind:           workflow.PlanDecisionKindArchitectureRevise,
+		AffectedReqIDs: []string{"req-0"},
+	}
+	stories := []workflow.Story{{ID: "story-1", RequirementIDs: []string{"req-0"}}}
+	scenarios := []workflow.Scenario{{ID: "scenario-1", RequirementID: "req-0", StoryID: "story-1"}}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.AffectedScenarioIDs) != 0 {
+		t.Errorf("AffectedScenarioIDs = %d, want 0 (cascade is a no-op for architecture_revise)", len(result.AffectedScenarioIDs))
+	}
+	if len(result.AffectedStoryIDs) != 0 {
+		t.Errorf("AffectedStoryIDs = %d, want 0", len(result.AffectedStoryIDs))
+	}
+	if len(result.AffectedRequirementIDs) != 1 {
+		t.Errorf("AffectedRequirementIDs = %d, want 1 (telemetry only)", len(result.AffectedRequirementIDs))
+	}
+	// Kind must be echoed onto the Result so the PlanDecisionAcceptedEvent
+	// carries it — the requirement-executor branches on it to abandon (not
+	// resume) in-flight execs.
+	if result.Kind != workflow.PlanDecisionKindArchitectureRevise {
+		t.Errorf("Result.Kind = %q, want architecture_revise", result.Kind)
+	}
+}

--- a/workflow/payloads/graph_refactor.go
+++ b/workflow/payloads/graph_refactor.go
@@ -259,11 +259,16 @@ var PlanDecisionCascadeRequestType = message.Type{
 // PlanDecisionAcceptedEvent is the payload published after a cascade completes
 // successfully. It summarizes what was affected by the accepted PlanDecision.
 type PlanDecisionAcceptedEvent struct {
-	ProposalID             string   `json:"proposal_id"`
-	Slug                   string   `json:"slug"`
-	TraceID                string   `json:"trace_id,omitempty"`
-	AffectedRequirementIDs []string `json:"affected_requirement_ids"`
-	AffectedScenarioIDs    []string `json:"affected_scenario_ids"`
+	ProposalID string `json:"proposal_id"`
+	Slug       string `json:"slug"`
+	TraceID    string `json:"trace_id,omitempty"`
+	// Kind echoes the accepted proposal's kind so consumers can branch without
+	// re-loading the plan. Empty for pre-existing/legacy producers (treated as
+	// requirement_change by consumers). The requirement-executor keys off
+	// architecture_revise to abandon — rather than resume — in-flight execs.
+	Kind                   workflow.PlanDecisionKind `json:"kind,omitempty"`
+	AffectedRequirementIDs []string                  `json:"affected_requirement_ids"`
+	AffectedScenarioIDs    []string                  `json:"affected_scenario_ids"`
 }
 
 // Schema implements message.Payload.

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -57,12 +57,37 @@ const (
 	// Distinct from narrow_scope: narrow_scope reduces the task's file
 	// surface; story_reprepare re-authors the task DAG itself.
 	//
-	// ADR-043 PR 4i lands the action vocabulary; callers materialize once
-	// execution dispatches per-Story (PR 4h). Until then this action is
-	// reserved infrastructure — the closed-set parser accepts it and the
-	// PlanDecision routing maps it, but no recovery dispatch currently
-	// emits it.
+	// ADR-043 PR 4i landed the action vocabulary; the recovery persona prompt
+	// now steers Story-shaping wedges here (software.go closed-action set), the
+	// closed-set parser accepts it, and the PlanDecision routing drives the
+	// stories_generated → preparing_stories re-prep on accept.
 	RecoveryActionStoryReprepare RecoveryActionKind = "story_reprepare"
+
+	// RecoveryActionArchitectureRevise — wedge analysis points at Winston's
+	// architecture as the ROOT: a mis-resolved upstream dependency, a wrong
+	// component boundary, or an integration target the dev cannot satisfy.
+	// The problem is upstream of Sarah's Story-shaping and upstream of any
+	// single requirement's prompt — re-prepping Stories or sharpening the
+	// dev prompt against a broken architecture only re-wedges.
+	//
+	// Heaviest action in the set. On accept, plan-manager captures the prior
+	// architecture into PreviousArchitectureJSON, clears Architecture +
+	// Stories + Scenarios, resets ALL requirement executions, writes the
+	// recovery diagnosis to ReviewFormattedFindings (the channel the
+	// architecture-generator already reads on revision rounds), and drives
+	// the back-transition implementing → requirements_generated so the
+	// architect re-fires and REVISES the prior architecture against the
+	// diagnosis. The full downstream pipeline (Sarah → Bob → execution)
+	// then re-runs clean.
+	//
+	// Distinct from story_reprepare: story_reprepare keeps Architecture and
+	// asks Sarah to re-shard; architecture_revise discards the architecture
+	// itself. Distinct from mark_unrecoverable: mark_unrecoverable abandons
+	// the work; architecture_revise repairs the root and continues. The
+	// recovery prompt steers an architecture-root diagnosis here (instead of
+	// escalate_human) when the architecture context is available — see
+	// software_render.go renderRecoveryAgentPrompt.
+	RecoveryActionArchitectureRevise RecoveryActionKind = "architecture_revise"
 )
 
 // RecoveryLayer identifies which recovery layer attempted the action. Per

--- a/workflow/plan_decision_kind_test.go
+++ b/workflow/plan_decision_kind_test.go
@@ -12,6 +12,7 @@ func TestPlanDecisionKind_IsValid(t *testing.T) {
 		PlanDecisionKindRequirementChange:  true,
 		PlanDecisionKindExecutionExhausted: true,
 		PlanDecisionKindStoryReprepare:     true,
+		PlanDecisionKindArchitectureRevise: true,
 		"":                                 false,
 		"not-a-kind":                       false,
 		"requirement-change":               false, // hyphen not underscore

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -310,10 +310,16 @@ func (s Status) CanTransitionTo(target Status) bool {
 		// implementing → awaiting_review (no QA, auto_approve_review=false or GitHub)
 		// implementing → complete (level=none; direct terminal with no review)
 		// implementing → changed (change proposal deprecated requirements)
+		// implementing → requirements_generated (architecture_revise recovery:
+		//   a wedge rooted in the architecture is escalated; the recovery-agent's
+		//   architecture_revise PlanDecision wipes Architecture/Stories/Scenarios +
+		//   all requirement executions and re-runs the architect. This is the one
+		//   execution-phase → plan-prep back-edge in the otherwise forward-only DAG;
+		//   gated to the architecture_revise accept path in plan-manager.)
 		// implementing → rejected (execution escalation)
 		return target == StatusReviewingRollup || target == StatusReviewingQA || target == StatusReadyForQA ||
 			target == StatusAwaitingReview || target == StatusComplete ||
-			target == StatusChanged || target == StatusRejected
+			target == StatusChanged || target == StatusRequirementsGenerated || target == StatusRejected
 	case StatusReviewingRollup:
 		// Legacy state — equivalent to reviewing_qa at level=synthesis. Kept for
 		// in-flight plans at upgrade time. New code should emit reviewing_qa.
@@ -1710,6 +1716,20 @@ const (
 	// story-shaping degraded into requirement_change cascades that didn't
 	// actually re-run Sarah. Closes the cross-pass synthesis Train C.
 	PlanDecisionKindStoryReprepare PlanDecisionKind = "story_reprepare"
+
+	// PlanDecisionKindArchitectureRevise marks a decision proposing that
+	// Winston re-run the architecture. Heaviest recovery kind: on accept,
+	// plan-manager captures PreviousArchitectureJSON, clears Architecture +
+	// Stories + Scenarios, resets all requirement executions, and drives the
+	// back-transition implementing → requirements_generated so the architect
+	// re-fires and revises the prior architecture against the recovery
+	// diagnosis (carried via ReviewFormattedFindings — the same channel the
+	// R2 architecture re-entry uses). Distinct from story_reprepare, whose
+	// cascade keeps Architecture and only re-shards Stories; this kind
+	// discards the architecture itself and the cascade is a no-op because the
+	// accept handler already performed the wipe inline. Emitted by the
+	// recovery-agent for the architecture_revise action.
+	PlanDecisionKindArchitectureRevise PlanDecisionKind = "architecture_revise"
 )
 
 // String returns the string representation of the plan decision kind.
@@ -1722,7 +1742,8 @@ func (k PlanDecisionKind) IsValid() bool {
 	switch k {
 	case PlanDecisionKindRequirementChange,
 		PlanDecisionKindExecutionExhausted,
-		PlanDecisionKindStoryReprepare:
+		PlanDecisionKindStoryReprepare,
+		PlanDecisionKindArchitectureRevise:
 		return true
 	default:
 		return false

--- a/workflow/types_plan_status_test.go
+++ b/workflow/types_plan_status_test.go
@@ -212,6 +212,16 @@ func TestPlanStatus_CanTransitionTo_NewStatuses(t *testing.T) {
 		{StatusApproved, StatusChanged, false},
 		{StatusReviewingRollup, StatusChanged, false}, // don't interrupt rollup
 
+		// architecture_revise recovery back-edge: implementing →
+		// requirements_generated (the architect re-runs after a wipe). This is
+		// the only execution-phase → plan-prep back-transition in the DAG.
+		{StatusImplementing, StatusRequirementsGenerated, true},
+		// ...but the symmetric forward states must NOT gain a free back-edge:
+		// only implementing carries the architecture_revise exception.
+		{StatusReadyForQA, StatusRequirementsGenerated, false},
+		{StatusReviewingQA, StatusRequirementsGenerated, false},
+		{StatusAwaitingReview, StatusRequirementsGenerated, false},
+
 		// QA phase transitions (Phase 2f branch-point move target)
 		// implementing → ready_for_qa (level=unit|integration|full)
 		{StatusImplementing, StatusReadyForQA, true},


### PR DESCRIPTION
## What

Adds the `architecture_revise` recovery action. When the wedge-recovery agent
diagnoses an **architecture-root** wedge — a mis-resolved upstream dependency,
a wrong component boundary, an unsatisfiable integration target — it now picks
`architecture_revise` instead of only `escalate_human`. On accept, plan-manager
captures `PreviousArchitectureJSON`, routes the diagnosis into
`ReviewFormattedFindings`, wipes Architecture + Stories + Scenarios, resets all
requirement executions, and drives the new back-transition
`implementing → requirements_generated`. The architect re-fires and **revises**
the prior architecture against the diagnosis; the full pipeline (Sarah → Bob →
execution) re-runs clean.

This closes the deferred item from ADR-045 and the run-#6 root cause
([upstream-resolutions-unwired]) at the recovery layer: instead of abandoning a
plan whose architecture is wrong, recovery can autonomously repair it.

User chose **auto-accept** (matching `story_reprepare`).

## The design subtlety

`architecture_revise` fires from the **live `implementing` phase** — with
in-flight executor goroutines and execution state — unlike its sibling
`story_reprepare`, which fires from the quiescent `stories_generated`. Treating
the wipe as if the system were idle is the trap. Two go-reviewer passes drove
the hardening (pass 1: 2 CRITICAL + 2 HIGH; pass 2: all closed).

### Safety guards
- **C1 — auto-accept cap.** `plan-decision-handler.max_auto_architecture_revises`
  (default 1) bounds the `implement → wedge → revise → …` loop. The count is
  monotonic because `PlanDecisions` survive the entity wipe; past the cap the
  decision stays proposed for human review.
- **C2 — abandon, don't resume.** `PlanDecisionAcceptedEvent` now carries
  `Kind`; the requirement-executor abandons (terminate + drop from
  `activeExecs`) all in-flight execs for the slug instead of resuming the
  wedged one, so the stale DAG can't race the architect re-run on the shared
  `req.<slug>.<reqID>` key.
- **M2 — out-of-window guard.** Transition legality is checked before any
  mutation or I/O; an out-of-window accept (plan already past `implementing`)
  is a clean no-op.
- **H2 — atomic-ish apply.** The execution reset runs on a detached context
  before the in-memory wipe; a reset failure aborts the accept with the plan
  untouched.

## Shape
- `RecoveryActionArchitectureRevise` + `PlanDecisionKindArchitectureRevise`
  consts; `IsValid`, closed-set parser, kind mapping, recovery persona prompt
  steer (`software.go` / `software_render.go`).
- One new status-DAG back-edge `implementing → requirements_generated` — the
  only execution-phase → plan-prep edge, gated to this accept path.
- Shared `applyPlanDecisionAcceptEffects` unifies the mutation + HTTP accept
  paths; `reviseArchitectureState` is the pure, testable seam.
- `cascade` no-op for the kind (entities already wiped inline).

## Known limitation (LOW — cost, not correctness; documented in ADR-045)
The reset clears `req.*` EXECUTION_STATES rows but not `task.*` rows, and the
requirement-executor has no channel to force-cancel in-flight execution-manager
TDD loops. On a genuinely-parallel hard-tier plan a sibling node's loop can run
out its token budget before noticing the restart (its terminal write is
absorbed by an `activeExecs` cache-miss no-op — no corruption, just wasted
spend). The M:N cohesive shape (one dev loop per Story) does not hit this.

## Testing
`go build ./...`, `go test ./...`, `task lint`, and `-race` on the new paths all
green. New unit tests cover the kind mapping, closed-set parsing, the DAG edge
(and that symmetric forward states do NOT gain a back-edge), the pure
`reviseArchitectureState` seam (happy path, out-of-window no-wipe, no-prior-
architecture), the cascade no-op + `Result.Kind`, the auto-accept cap counter,
and `abandonExecsForSlug`.

Not yet paid-validated — next step is a `mavlink-hard` real-LLM run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)