### PR TITLE
fix(recovery): handle recovery-agent action-omission (prompt + safe parse fallback)

### DIFF
--- a/processor/recovery-agent/result.go
+++ b/processor/recovery-agent/result.go
@@ -78,8 +78,24 @@ func parseRecoveryResult(raw string) (*parsedRecoveryResult, error) {
 	if err := json.Unmarshal([]byte(raw), &rr); err != nil {
 		return nil, fmt.Errorf("unmarshal recovery result: %w", err)
 	}
+	// Recovery agents (esp. mid-tier models) sometimes write an action's
+	// payload but omit the structured `action` label, describing the fix only
+	// in prose. Rather than terminal-fail a wedge the agent believed
+	// recoverable, infer the action when the payload makes it UNAMBIGUOUS.
+	// Only refine_prompt qualifies: a non-empty refined_prompt has exactly one
+	// matching action. scope_changes is deliberately NOT inferred — it maps to
+	// both narrow_scope and split_req, so guessing would pick the wrong one.
+	// Caught 2026-06-06 gemini mavlink-hard run #7: the agent emitted a
+	// refine_prompt-shaped diagnosis ("needs a refined prompt with explicit
+	// file paths") + recovery_succeeded but no action → execution_exhausted →
+	// requirement terminal-failed → plan rejected. The prompt-side fix
+	// (action-first directive) is primary; this is the parse-side safety net.
 	if rr.Action == "" {
-		return nil, errResultMissingAction
+		if strings.TrimSpace(rr.RefinedPrompt) != "" {
+			rr.Action = string(payloads.RecoveryActionRefinePrompt)
+		} else {
+			return nil, errResultMissingAction
+		}
 	}
 	if rr.Diagnosis == "" {
 		return nil, errResultMissingDiag

--- a/processor/recovery-agent/result_test.go
+++ b/processor/recovery-agent/result_test.go
@@ -108,6 +108,53 @@ func TestParseRecoveryResult(t *testing.T) {
 		}
 	})
 
+	// Action-omission safety net (go-reviewer / run #7): mid-tier models
+	// sometimes write the refined_prompt payload but drop the `action` label.
+	// When the payload is unambiguous (refined_prompt present), infer
+	// refine_prompt instead of terminal-failing the wedge.
+	t.Run("infers refine_prompt when action omitted but refined_prompt present", func(t *testing.T) {
+		raw := `{"diagnosis":"Agent created the test in org/sensorhub/driver/mavsdk instead of org/sensorhub/impl/sensor/mavsdk; needs explicit file paths.","recovery_succeeded":true,"refined_prompt":"Create the source files at src/main/java/org/sensorhub/impl/sensor/mavsdk/ per the architecture."}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected inference to succeed, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionRefinePrompt {
+			t.Errorf("Action: got %q, want refine_prompt (inferred)", got.Action)
+		}
+		if !strings.Contains(got.RefinedPrompt, "impl/sensor/mavsdk") {
+			t.Errorf("refined_prompt content lost: %q", got.RefinedPrompt)
+		}
+		// Mirror the run-#7 incident shape: recovery_succeeded was true.
+		if !got.RecoverySucceeded {
+			t.Error("RecoverySucceeded should survive inference (incident had it true)")
+		}
+	})
+
+	// But an action-less result with NO unambiguous payload still errors —
+	// scope_changes is ambiguous (narrow_scope vs split_req) so it is NOT
+	// inferred, and diagnosis-only stays human-gated.
+	t.Run("does not infer from scope_changes (ambiguous)", func(t *testing.T) {
+		raw := `{"diagnosis":"too broad","recovery_succeeded":true,"scope_changes":{"keep":["a.go"]}}`
+		_, err := parseRecoveryResult(raw)
+		if !errors.Is(err, errResultMissingAction) {
+			t.Errorf("expected errResultMissingAction (scope_changes is ambiguous), got %v", err)
+		}
+	})
+
+	// Both payloads present + no action: refined_prompt wins (refine_prompt
+	// maps to the same requirement_change kind as narrow_scope/split_req, so
+	// this picks the unambiguous one and the downstream cascade is identical).
+	t.Run("infers refine_prompt when both refined_prompt and scope_changes present", func(t *testing.T) {
+		raw := `{"diagnosis":"d","recovery_succeeded":true,"refined_prompt":"do X at path Y","scope_changes":{"keep":["a.go"]}}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected inference to succeed, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionRefinePrompt {
+			t.Errorf("Action: got %q, want refine_prompt (refined_prompt is unambiguous)", got.Action)
+		}
+	})
+
 	cases := []struct {
 		name string
 		raw  string

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1613,8 +1613,20 @@ Rules:
 			Roles:    []prompt.Role{prompt.RoleRecoveryAgent},
 			Content: `Output Format — submit_work arguments
 
+The FIRST field you write MUST be "action". It is the decision; the diagnosis
+only explains it. Decide the action before you write anything else, and never
+omit it — a submit_work without an "action" cannot be applied and the wedge is
+abandoned. The shape is:
+
+  {
+    "action": "refine_prompt",            // REQUIRED FIRST — pick one from the set below
+    "recovery_succeeded": true,
+    "diagnosis": "...",                    // REQUIRED — explains the action
+    "refined_prompt": "..."               // only for refine_prompt
+  }
+
 Required fields:
-- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | architecture_revise | escalate_human | mark_unrecoverable
+- action: one of refine_prompt | narrow_scope | split_req | story_reprepare | architecture_revise | escalate_human | mark_unrecoverable. REQUIRED — write it first.
 - diagnosis: 2-6 sentences describing what the trajectory shows the agent doing wrong and what the underlying mistake is. REQUIRED for every action.
 - recovery_succeeded: true when refine_prompt | narrow_scope | split_req | story_reprepare | architecture_revise plausibly fixes the wedge; false for escalate_human | mark_unrecoverable.
 


### PR DESCRIPTION
## What

On the 2026-06-06 paid gemini mavlink-hard run, the wedge-recovery agent emitted a valid diagnosis + `recovery_succeeded:true` but **omitted the structured `action` field** (it described a `refine_prompt` fix only in prose: *"needs a refined prompt with explicit file paths… wrong package org/sensorhub/driver/mavsdk vs …/impl/sensor/mavsdk"*). `parseRecoveryResult` errored `"missing action"` → the dispatcher mapped that to a terminal `execution_exhausted` PlanDecision → the requirement terminal-failed → **the whole plan was rejected**. A recoverable wedge abandoned over a missing label.

Same failure class as the plan-reviewer verdict/summary mismatch: a mid-tier model writes the prose deliverable but drops the structured decision field.

## Fix (two layers)

1. **Prompt (primary)** — `prompt/domain/software.go` recovery output-format fragment now leads with *"the FIRST field you write MUST be `action`"* and a JSON example with `action` as the first key. JSON-example-first + action-first reliably gets the field emitted by mid-tier models.

2. **Parser safety net** — `processor/recovery-agent/result.go`: when `action` is omitted, infer `refine_prompt` **iff** a non-empty `refined_prompt` is present (unambiguous — exactly one action uses that payload). `scope_changes` is **not** inferred (maps to both narrow_scope and split_req); diagnosis-only still errors `missing-action`. A mis-inference is harmless: `refine_prompt` maps to the same `requirement_change` kind as narrow_scope/split_req, and the diagnosis (Rationale) is what re-drives the dev loop — not the structured payload.

## Testing
`go test ./...` + `task lint` green. New tests: infer-from-refined_prompt success (mirrors the incident, recovery_succeeded=true), both-payloads-present picks refine_prompt, scope_changes-ambiguous still errors, diagnosis-only still errors. go-reviewer: no critical/high, inference verified safe (blast radius effectively zero).

## Context
Found during the run that validated #119/#120 (reached `implementing`, 4/5 requirements, 6/7 Playwright). This action-omission was the single thing that turned a likely-green hard-tier run into a reject. Sponsor pack: `/tmp/sponsor-pack-mavlink-hard-gemini-20260606/`.

Follow-ups (not in this PR): test-7 should fast-fail when the recovery decision is `execution_exhausted` rather than waiting 3h; bump the poll `WEDGE_DETECT` threshold above hard-tier execution time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)