### PR TITLE
fix(architecture): validate harness profile_ids against catalog at arch-gen

### DIFF
--- a/processor/architecture-generator/component.go
+++ b/processor/architecture-generator/component.go
@@ -573,6 +573,64 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 	}
 }
 
+// validateGeneratedArchitecture runs the ADR-043 arch-gen validators in order.
+// Returns a non-empty (rule, msg) on the first rejection (empty rule = valid):
+//   - component_implementation_files: each component owns ≥1 source-code file.
+//   - capability_coverage: every analyst-declared capability is implemented by
+//     ≥1 component.
+//   - harness_profile_resolution: every architecture.harness_profiles[] entry
+//     names a real catalog profile_id. Guards architect hallucination (e.g.
+//     "docker.generic", 2026-06-06 gemini mavlink-hard DEBUG run) at the source
+//     layer — the prompt lists the valid IDs + "do not invent", but mid-tier
+//     models still invent; without this guard the bad ID passes arch-gen,
+//     persists, is faithfully copied by the scenario-generator, and only
+//     surfaces two layers downstream at the scenario gate where the retry can't
+//     reach back to fix the architect within the R2 cap. The retry message
+//     appends the valid options so the architect picks a real profile. Catalog
+//     load failure is non-fatal (skip rather than block on infra — matches
+//     harnessProfileCards()).
+func (c *Component) validateGeneratedArchitecture(architecture *workflow.ArchitectureDocument, kvPlan *workflow.Plan) (rule, msg string) {
+	if err := workflow.ValidateComponentImplementationFiles(architecture.ComponentBoundaries); err != nil {
+		return "component_implementation_files", fmt.Sprintf("architecture validation failed (implementation files): %s", err.Error())
+	}
+	if kvPlan != nil {
+		if err := workflow.ValidateCapabilityCoverage(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
+			return "capability_coverage", fmt.Sprintf("architecture validation failed (capability coverage): %s", err.Error())
+		}
+	}
+	if cat, catErr := harnesscatalog.Load(""); catErr == nil {
+		if err := cat.ValidateSelections(architecture.HarnessProfiles); err != nil {
+			return "harness_profile_resolution", fmt.Sprintf(
+				"architecture validation failed (harness profile resolution): %s — %s",
+				err.Error(), harnessResolutionHint(cat, err))
+		}
+	} else {
+		c.logger.Warn("Harness catalog load failed; skipping harness-profile resolution check", "error", catErr)
+	}
+	return "", ""
+}
+
+// harnessResolutionHint tailors the retry guidance to the validation failure
+// class so the architect's next cycle gets the RIGHT correction, not a
+// contradictory one:
+//   - unknown profile_id → list the valid catalog IDs to pick from (the
+//     hallucination case, e.g. "docker.generic").
+//   - duplicate profile_id → consolidate, don't re-list. A profile_id is
+//     selected ONCE with a multi-element used_by[]; repeating it is malformed
+//     per the schema (workflow.HarnessProfileSelection) — "select from catalog"
+//     would be misleading here since the ID is already valid.
+//   - empty profile_id → drop the empty entry.
+func harnessResolutionHint(cat *harnesscatalog.Catalog, err error) string {
+	switch {
+	case strings.Contains(err.Error(), "duplicate"):
+		return "list each profile_id at most once — use a single harness_profiles[] entry with a multi-element used_by[] instead of repeating the profile"
+	case strings.Contains(err.Error(), "is required"):
+		return "remove the harness_profiles[] entry with the empty profile_id, or set it to a valid catalog ID"
+	default: // unknown harness profile
+		return "select ONLY from the available catalog profiles: " + strings.Join(cat.ValidIDsSorted(), ", ")
+	}
+}
+
 // handleLoopCompletion processes a completed architecture-generator agent loop.
 // It parses the ArchitectureDocument from the loop result and sends a mutation
 // to plan-manager via plan.mutation.architecture.generated.
@@ -629,28 +687,15 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		}
 	}
 
-	// ADR-043 PR 2: Winston's tech-spec scope must be complete before
-	// persistence. Each component owns ≥1 source-code file; every capability
-	// declared by the analyst is implemented by ≥1 component. Validator
-	// failures funnel through retryOrFail so the LLM gets another cycle with
-	// the rejection message as feedback — mirrors the parse-failure path.
-	if err := workflow.ValidateComponentImplementationFiles(architecture.ComponentBoundaries); err != nil {
+	// ADR-043: validate Winston's tech-spec scope before persistence. Validator
+	// failures funnel through retryOrFail so the LLM gets another cycle with the
+	// rejection message as feedback — mirrors the parse-failure path.
+	if rule, msg := c.validateGeneratedArchitecture(architecture, kvPlan); rule != "" {
 		c.generationsFailed.Add(1)
-		msg := fmt.Sprintf("architecture validation failed (implementation files): %s", err.Error())
 		c.logger.Warn("Architecture rejected by ADR-043 validator",
-			"slug", slug, "loop_id", loop.ID, "rule", "component_implementation_files", "error", err)
+			"slug", slug, "loop_id", loop.ID, "rule", rule, "error", msg)
 		c.retryOrFail(ctx, slug, msg)
 		return
-	}
-	if kvPlan != nil {
-		if err := workflow.ValidateCapabilityCoverage(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
-			c.generationsFailed.Add(1)
-			msg := fmt.Sprintf("architecture validation failed (capability coverage): %s", err.Error())
-			c.logger.Warn("Architecture rejected by ADR-043 validator",
-				"slug", slug, "loop_id", loop.ID, "rule", "capability_coverage", "error", err)
-			c.retryOrFail(ctx, slug, msg)
-			return
-		}
 	}
 
 	if err := c.publishArchitectureGenerated(ctx, slug, architecture); err != nil {

--- a/processor/architecture-generator/harness_validation_test.go
+++ b/processor/architecture-generator/harness_validation_test.go
@@ -1,0 +1,92 @@
+package architecturegenerator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/harnesscatalog"
+)
+
+// TestHarnessResolutionHint pins that the arch-gen retry hint matches the
+// validation failure CLASS, so the architect's next cycle gets the right
+// correction (go-reviewer H1). Errors are produced by the real catalog
+// validator so the test tracks its actual messages, not a guessed shape.
+func TestHarnessResolutionHint(t *testing.T) {
+	cat, err := harnesscatalog.LoadBuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		sel       []workflow.HarnessProfileSelection
+		wantInHnt string
+	}{
+		{
+			name:      "unknown id (the docker.generic hallucination) → list valid catalog IDs",
+			sel:       []workflow.HarnessProfileSelection{{ProfileID: "docker.generic"}},
+			wantInHnt: "select ONLY from the available catalog profiles",
+		},
+		{
+			name: "duplicate valid id → consolidate, not 'select from catalog'",
+			sel: []workflow.HarnessProfileSelection{
+				{ProfileID: "mavlink.px4-sitl.mavsdk-smoke"},
+				{ProfileID: "mavlink.px4-sitl.mavsdk-smoke"},
+			},
+			wantInHnt: "at most once",
+		},
+		{
+			name:      "empty id → drop the empty entry",
+			sel:       []workflow.HarnessProfileSelection{{ProfileID: ""}},
+			wantInHnt: "empty profile_id",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verr := cat.ValidateSelections(tc.sel)
+			if verr == nil {
+				t.Fatalf("precondition: expected ValidateSelections to reject %v", tc.sel)
+			}
+			hint := harnessResolutionHint(cat, verr)
+			if !strings.Contains(hint, tc.wantInHnt) {
+				t.Errorf("hint = %q, want it to contain %q", hint, tc.wantInHnt)
+			}
+			// The duplicate hint must NOT misdirect to "select from catalog".
+			if tc.name[:9] == "duplicate" && strings.Contains(hint, "select ONLY from") {
+				t.Errorf("duplicate hint wrongly says 'select from catalog': %q", hint)
+			}
+		})
+	}
+}
+
+// TestValidateGeneratedArchitecture_HarnessGate pins the end-to-end gate: a
+// hallucinated harness profile_id is rejected with rule=harness_profile_resolution
+// and the retry message carries the valid options; a clean architecture passes.
+func TestValidateGeneratedArchitecture_HarnessGate(t *testing.T) {
+	c := &Component{}
+
+	bad := &workflow.ArchitectureDocument{
+		ComponentBoundaries: []workflow.ComponentDef{
+			{Name: "driver", ImplementationFiles: []string{"src/Driver.java"}, Capabilities: []string{"cap-a"}},
+		},
+		HarnessProfiles: []workflow.HarnessProfileSelection{{ProfileID: "docker.generic"}},
+	}
+	rule, msg := c.validateGeneratedArchitecture(bad, nil)
+	if rule != "harness_profile_resolution" {
+		t.Fatalf("rule = %q, want harness_profile_resolution (msg=%q)", rule, msg)
+	}
+	if !strings.Contains(msg, "mavlink.px4-sitl.mavsdk-smoke") {
+		t.Errorf("retry msg should list valid catalog IDs, got %q", msg)
+	}
+
+	good := &workflow.ArchitectureDocument{
+		ComponentBoundaries: []workflow.ComponentDef{
+			{Name: "driver", ImplementationFiles: []string{"src/Driver.java"}, Capabilities: []string{"cap-a"}},
+		},
+		HarnessProfiles: []workflow.HarnessProfileSelection{{ProfileID: "mavlink.px4-sitl.mavsdk-smoke"}},
+	}
+	if rule, msg := c.validateGeneratedArchitecture(good, nil); rule != "" {
+		t.Errorf("clean architecture rejected: rule=%q msg=%q", rule, msg)
+	}
+}

--- a/workflow/harnesscatalog/catalog.go
+++ b/workflow/harnesscatalog/catalog.go
@@ -181,6 +181,21 @@ func (c *Catalog) RequiredProfiles(selections []workflow.HarnessProfileSelection
 	return required, nil
 }
 
+// ValidIDsSorted returns the catalog's profile IDs in deterministic order. Used
+// to build a precise "select only from: …" hint when a selection fails to
+// resolve, so an architecture-generation retry sees the valid options inline.
+func (c *Catalog) ValidIDsSorted() []string {
+	if c == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(c.Profiles))
+	for id := range c.Profiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // ProfilesSorted returns catalog profiles ordered by ID for deterministic
 // prompt rendering and tests.
 func (c *Catalog) ProfilesSorted() []Profile {

--- a/workflow/harnesscatalog/catalog_test.go
+++ b/workflow/harnesscatalog/catalog_test.go
@@ -3,6 +3,7 @@ package harnesscatalog
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -168,6 +169,59 @@ func TestResolveSelectionsRejectsUnknownAndSplitsRequired(t *testing.T) {
 	}
 	if len(required) != 1 || required[0].Profile.ID != "mavlink.px4-sitl.mavsdk-smoke" {
 		t.Fatalf("RequiredProfiles() = %#v, want only PX4 smoke", required)
+	}
+}
+
+// TestValidateSelectionsCatchesArchitectHallucination pins the arch-gen guard
+// for the 2026-06-06 incident: the architect selected "docker.generic" (not in
+// the catalog), twice. ValidateSelections must reject it, and ValidIDsSorted
+// must surface the real options for the retry hint.
+func TestValidateSelectionsCatchesArchitectHallucination(t *testing.T) {
+	catalog, err := LoadBuiltIn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The exact incident shape: a hallucinated id, selected twice.
+	err = catalog.ValidateSelections([]workflow.HarnessProfileSelection{
+		{ProfileID: "docker.generic"},
+		{ProfileID: "docker.generic"},
+	})
+	if err == nil {
+		t.Fatal("ValidateSelections accepted hallucinated 'docker.generic'; expected rejection")
+	}
+
+	// A real catalog selection must pass.
+	if err := catalog.ValidateSelections([]workflow.HarnessProfileSelection{
+		{ProfileID: "mavlink.px4-sitl.mavsdk-smoke"},
+	}); err != nil {
+		t.Fatalf("ValidateSelections rejected a real profile_id: %v", err)
+	}
+
+	// Empty selections are valid (architecture may select no harness profiles).
+	if err := catalog.ValidateSelections(nil); err != nil {
+		t.Fatalf("ValidateSelections(nil) = %v, want nil", err)
+	}
+
+	// ValidIDsSorted surfaces the real options (the retry hint) deterministically.
+	ids := catalog.ValidIDsSorted()
+	if len(ids) == 0 {
+		t.Fatal("ValidIDsSorted returned no profile IDs")
+	}
+	if !sort.StringsAreSorted(ids) {
+		t.Errorf("ValidIDsSorted not sorted: %v", ids)
+	}
+	found := false
+	for _, id := range ids {
+		if id == "mavlink.px4-sitl.mavsdk-smoke" {
+			found = true
+		}
+		if id == "docker.generic" {
+			t.Error("ValidIDsSorted contains the hallucinated id")
+		}
+	}
+	if !found {
+		t.Errorf("ValidIDsSorted missing a known catalog id: %v", ids)
 	}
 }
 


### PR DESCRIPTION
## What

The 2026-06-06 gemini mavlink-hard DEBUG run rejected at the scenarios gate because the **architect selected harness `profile_id` `docker.generic`** — which isn't in the catalog.

**Verified from the live evidence** (this is the key point — it's our code, not the model): the architect's prompt *does* list the valid catalog `profile_id` cards (`mavlink.px4-sitl.mavsdk-smoke`, `raw-mavlink-direct`, `ardupilot-sitl.compat`, `px4-gazebo-peripherals`) with *"use ONLY these / do not invent."* The model hallucinated anyway — and **arch-gen validated component-implementation-files + capability-coverage but NOT harness-profile-id resolution.** So the bad ID passed arch-gen, persisted into `architecture.harness_profiles`, was **faithfully copied by the scenario-generator** (Bob did exactly as instructed: "copy the bound profile IDs verbatim"), and only surfaced two layers downstream at the scenario gate (`scenario.harness_id_unresolved`) where the R2 retry couldn't reach back to fix the architect within the revision cap → plan rejected.

`capability_coverage` *is* guarded at arch-gen (so the architect retries and fixes it); harness-profile-id resolution wasn't. That asymmetry was the whole failure.

## Fix (close the gap at the source layer, mirroring `capability_coverage`)
- **architecture-generator** now validates `architecture.harness_profiles[]` against the catalog at arch-gen time and `retryOrFail`s with a precise, **failure-class-specific** hint — so the architect (which already has the catalog cards in its prompt) gets a source-layer retry, exactly like `capability_coverage` already converges. Extracted the three validators into `validateGeneratedArchitecture` (function-length).
- `harnessResolutionHint`: unknown id → list valid catalog IDs; **duplicate** → consolidate into one entry with multi-element `used_by[]` (not "select from catalog", which would misdirect since the ID is valid); empty → drop the entry. The reused `ValidateSelections` already catches all three classes — the gap was purely that it was never called at arch-gen.
- `harnesscatalog.ValidIDsSorted()` surfaces the valid options for the hint.

## Testing
`go test ./...` + `task lint` green. New tests:
- catalog: `docker.generic` ×2 rejected, valid passes, empty passes, `ValidIDsSorted` sorted + excludes the bad id.
- architecture-generator (first test file for the package): `harnessResolutionHint` per failure class; `validateGeneratedArchitecture` end-to-end harness gate (rejects hallucinated id with valid options in the retry msg; clean architecture passes).

go-reviewer: no critical/high. Addressed H1 (retry hint by error class), L2 (doc placement). M2 (no component test) addressed by the new test file.

## Context
Found by inspecting the live DEBUG-run prompts (the run that confirmed #119/#120/#121 held). Synthesis across today's runs: the shipped fixes are all correct; the remaining barrier was gemini plan-prep agents producing catalog-invalid output with no source-layer guard. This closes the architect side. Sponsor packs in `/tmp/sponsor-pack-mavlink-hard-gemini-*20260606/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)