### PR TITLE
fix(scenario-generator): make harness_profile_ids system-owned, not LLM-echoed

### DIFF
--- a/processor/scenario-generator/component.go
+++ b/processor/scenario-generator/component.go
@@ -588,7 +588,31 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		return
 	}
 
-	scenarios, err := c.parseScenariosFromResult(loop.Result, slug, requirementID, storyID)
+	// Recover the canonical RequiredTiers from the tracked dispatch request so
+	// the system attaches the authoritative harness profile IDs by tier instead
+	// of trusting the LLM's echoed copy (see parseScenariosFromResult). Reuses
+	// the binding already computed by Classify at dispatch — no re-derivation.
+	//
+	// Invariant: the retry entry is present here. handleLoopCompletion only runs
+	// for loops that complete LIVE in the session that dispatched them (the
+	// replay guard discards pre-restart completions), and Track ran at dispatch;
+	// Snapshot precedes the Clear below. If that invariant ever breaks (durable
+	// dispatchretry, or relaxed replay guard) requiredTiers is nil → empty
+	// harness bindings; we log so the degradation is observable rather than
+	// silent. We deliberately do NOT fall back to the LLM echo — that would
+	// reintroduce the truncation bug this fix removes.
+	var requiredTiers []payloads.RequiredTier
+	if entry, ok := c.retry.Snapshot(key); ok && entry != nil {
+		if p, _ := entry.Payload.(*scenarioRetryPayload); p != nil && p.req != nil {
+			requiredTiers = p.req.RequiredTiers
+		}
+	}
+	if requiredTiers == nil {
+		c.logger.Warn("No tracked RequiredTiers at scenario completion; harness profile bindings will be empty",
+			"slug", slug, "requirement_id", requirementID, "story_id", storyID, "loop_id", loop.ID)
+	}
+
+	scenarios, err := c.parseScenariosFromResult(loop.Result, slug, requirementID, storyID, requiredTiers)
 	if err != nil {
 		c.generationsFailed.Add(1)
 		parseErrorMsg := fmt.Sprintf("failed to parse scenarios: %s", err.Error())
@@ -797,7 +821,28 @@ func (c *Component) sendGenerationFailed(ctx context.Context, slug, feedback str
 // #73 closed C2, which surfaces this collision — and this PR closes it.
 //
 // Closes go-reviewer Pass-2 finding C3.
-func (c *Component) parseScenariosFromResult(result, slug, requirementID, storyID string) ([]workflow.Scenario, error) {
+// canonicalHarnessIDs returns the system-owned harness profile IDs for a
+// scenario's tier — the classifier's canonical RequiredTier binding looked up by
+// the scenario's tier tag. Returns nil when the tier has no binding (@unit/@e2e,
+// or @integration when only operator-tier/pure-fixture profiles are selected).
+// Deduped, order-stable. This is the authoritative value stored on the scenario;
+// the LLM's echoed harness_profile_ids are intentionally discarded.
+func canonicalHarnessIDs(tags []string, canonByTag map[string][]string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, tag := range tags {
+		for _, id := range canonByTag[tag] {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func (c *Component) parseScenariosFromResult(result, slug, requirementID, storyID string, requiredTiers []payloads.RequiredTier) ([]workflow.Scenario, error) {
 	if result == "" {
 		return nil, fmt.Errorf("empty result")
 	}
@@ -837,6 +882,26 @@ func (c *Component) parseScenariosFromResult(result, slug, requirementID, storyI
 	reqSeq := requirementSequence(requirementID)
 	storySeq := storySequence(storyID)
 
+	// harness_profile_ids is a SYSTEM-OWNED binding, not authorial. The
+	// classifier already computed the canonical catalog IDs per tier
+	// (RequiredTier, dispatched in the request); we attach them here by tier
+	// rather than trusting the LLM's echoed copy. Mid-tier models (gemini-flash)
+	// truncate/mangle the long dotted IDs — 2026-06-06 flash dropped the
+	// "mavlink." prefix → harness_id_unresolved reject on a value the system
+	// already knew. This mirrors how story-preparer stores architecture-resolved
+	// canonical values instead of LLM-typed strings. Bob still AUTHORS the tier
+	// TAG (@unit/@integration/…) and the given/when/then prose; the system owns
+	// the catalog ID binding. Tiers with no canonical binding (@unit, or
+	// @integration when only operator-tier/pure-fixture profiles exist) get no
+	// IDs — correct: operator-tier proof reaches the operator via qa.yml, not a
+	// sandbox-gated scenario binding (ADR-045).
+	canonByTag := make(map[string][]string, len(requiredTiers))
+	for _, t := range requiredTiers {
+		if len(t.HarnessProfileIDs) > 0 {
+			canonByTag[t.Tag] = append(canonByTag[t.Tag], t.HarnessProfileIDs...)
+		}
+	}
+
 	now := time.Now()
 	scenarios := make([]workflow.Scenario, len(raw))
 	for i, s := range raw {
@@ -859,7 +924,7 @@ func (c *Component) parseScenariosFromResult(result, slug, requirementID, storyI
 			When:              s.When,
 			Then:              s.Then,
 			Tags:              s.Tags,
-			HarnessProfileIDs: s.HarnessProfileIDs,
+			HarnessProfileIDs: canonicalHarnessIDs(s.Tags, canonByTag),
 			Status:            workflow.ScenarioStatusPending,
 			CreatedAt:         now,
 			UpdatedAt:         now,

--- a/processor/scenario-generator/scenario_id_test.go
+++ b/processor/scenario-generator/scenario_id_test.go
@@ -4,7 +4,79 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/c360studio/semspec/workflow/payloads"
 )
+
+// TestParseScenariosFromResult_StoresCanonicalHarnessIDsNotEcho pins the fix for
+// the 2026-06-06 flash-truncation incident: harness_profile_ids is a
+// SYSTEM-OWNED binding. The system stores the canonical IDs from the
+// RequiredTier binding, NOT the LLM's echoed (here: truncated) copy.
+func TestParseScenariosFromResult_StoresCanonicalHarnessIDsNotEcho(t *testing.T) {
+	c := &Component{logger: slog.Default()}
+
+	// Bob echoes a TRUNCATED id (missing the "mavlink." prefix) — exactly the
+	// flash failure. A @unit scenario also wrongly carries a harness id.
+	result := `{"scenarios":[
+		{"title":"integ","given":"the SITL env is up","when":"the driver connects","then":["a heartbeat is received"],"tags":["@integration"],"harness_profile_ids":["px4-sitl.mavsdk-smoke"]},
+		{"title":"unit","given":"a config","when":"the builder runs","then":["the fallback string is used"],"tags":["@unit"],"harness_profile_ids":["px4-sitl.mavsdk-smoke"]}
+	]}`
+	tiers := []payloads.RequiredTier{
+		{Tag: "@integration", HarnessProfileIDs: []string{"mavlink.px4-sitl.mavsdk-smoke"}},
+	}
+
+	got, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1", tiers)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d scenarios, want 2", len(got))
+	}
+	// @integration scenario gets the CANONICAL fully-qualified id, not Bob's echo.
+	if len(got[0].HarnessProfileIDs) != 1 || got[0].HarnessProfileIDs[0] != "mavlink.px4-sitl.mavsdk-smoke" {
+		t.Errorf("integration harness ids = %v, want [mavlink.px4-sitl.mavsdk-smoke] (canonical, not the truncated echo)", got[0].HarnessProfileIDs)
+	}
+	// @unit scenario gets NO harness id regardless of what Bob echoed.
+	if len(got[1].HarnessProfileIDs) != 0 {
+		t.Errorf("unit harness ids = %v, want empty (no binding for @unit)", got[1].HarnessProfileIDs)
+	}
+}
+
+// TestParseScenariosFromResult_ServicesClassIntegrationGetsEmptyBinding pins the
+// ADR-045 contract: when no testcontainers @integration tier is bound (services-
+// class/SITL only — classifier emits no RequiredTier for it), an @integration
+// scenario gets EMPTY harness IDs and parses cleanly (no error). Operator-tier
+// proof reaches the operator via qa.yml, not a sandbox-gated scenario binding.
+func TestParseScenariosFromResult_ServicesClassIntegrationGetsEmptyBinding(t *testing.T) {
+	c := &Component{logger: slog.Default()}
+	// Bob authored an @integration scenario (and echoed a services id), but the
+	// dispatch carried NO @integration RequiredTier (services is operator-tier).
+	result := `{"scenarios":[
+		{"title":"sitl","given":"the SITL env is up","when":"the driver connects","then":["a heartbeat arrives"],"tags":["@integration"],"harness_profile_ids":["mavlink.px4-sitl.mavsdk-smoke"]}
+	]}`
+	got, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1", nil)
+	if err != nil {
+		t.Fatalf("services-class @integration must parse cleanly, got: %v", err)
+	}
+	if len(got) != 1 || len(got[0].HarnessProfileIDs) != 0 {
+		t.Errorf("services-class @integration harness ids = %v, want empty (operator-tier, qa.yml-owned)", got[0].HarnessProfileIDs)
+	}
+}
+
+// TestCanonicalHarnessIDs covers the pure tier→ids lookup: dedup, multi-tag,
+// and tiers with no binding return nil.
+func TestCanonicalHarnessIDs(t *testing.T) {
+	canon := map[string][]string{
+		"@integration": {"mavlink.px4-sitl.mavsdk-smoke", "mavlink.px4-sitl.mavsdk-smoke", "pg.testcontainers"},
+	}
+	got := canonicalHarnessIDs([]string{"@integration"}, canon)
+	if len(got) != 2 || got[0] != "mavlink.px4-sitl.mavsdk-smoke" || got[1] != "pg.testcontainers" {
+		t.Errorf("got %v, want deduped [mavlink.px4-sitl.mavsdk-smoke pg.testcontainers]", got)
+	}
+	if ids := canonicalHarnessIDs([]string{"@unit"}, canon); ids != nil {
+		t.Errorf("@unit (no binding) = %v, want nil", ids)
+	}
+}
 
 // TestScenarioIDFor_LegacyShape pins the pre-ADR-043 scenario ID format
 // for back-compat with mock fixtures and pre-Sarah plans: when no story
@@ -68,11 +140,11 @@ func TestParseScenariosFromResult_PerStoryProducesDistinctIDsAcrossStories(t *te
 		{"title":"happy","given":"a precondition","when":"an action","then":["an assertion"],"tags":["@unit"]}
 	]}`
 
-	storyA, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	storyA, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1", nil)
 	if err != nil {
 		t.Fatalf("parse storyA: %v", err)
 	}
-	storyB, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.2")
+	storyB, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.2", nil)
 	if err != nil {
 		t.Fatalf("parse storyB: %v", err)
 	}
@@ -102,7 +174,7 @@ func TestParseScenariosFromResult_LegacyDispatchPreservesPreADR043IDs(t *testing
 		{"title":"happy","given":"a precondition","when":"an action","then":["an assertion"],"tags":["@unit"]}
 	]}`
 
-	scenarios, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "")
+	scenarios, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "", nil)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -125,11 +197,11 @@ func TestParseScenariosFromResult_DeterministicAcrossReRuns(t *testing.T) {
 		{"title":"b","given":"g","when":"w","then":["t"],"tags":["@unit"]}
 	]}`
 
-	first, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	first, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1", nil)
 	if err != nil {
 		t.Fatalf("first parse: %v", err)
 	}
-	second, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1")
+	second, err := c.parseScenariosFromResult(result, "demo", "req.demo.1", "story.demo.1.1", nil)
 	if err != nil {
 		t.Fatalf("second parse: %v", err)
 	}


### PR DESCRIPTION
## What

Closes the **"echo-the-system-value" anti-pattern** for scenario harness bindings — the one you flagged as wasteful and risky.

`scenario.harness_profile_ids` is a **system-owned** binding: the classifier (`Classify()`) already computes the canonical catalog IDs per tier (`TierEmission.HarnessProfileIDs` → `RequiredTier`), dispatched in the scenario-generator request. Previously Bob (scenario-generator, runs on **gemini-flash**) was asked to *echo* those IDs back, and `parseScenariosFromResult` stored Bob's **echoed copy**.

On the 2026-06-06 DEBUG run, flash **truncated** `mavlink.px4-sitl.mavsdk-smoke` → `px4-sitl.mavsdk-smoke` (dropped the domain prefix) in 2 scenarios → `scenario.harness_id_unresolved` [ERROR] → plan rejected. **Verified from the live evidence** (not inferred): the fully-qualified ID was in Bob's prompt 27–34× *including the explicit corrective retry feedback*, and Bob's loops never compacted — pure flash output unreliability re-typing a value the system already owned and then discarded.

## Fix

Store the canonical binding; discard the echo. `parseScenariosFromResult` now takes the dispatched `RequiredTiers` (recovered from the tracked retry payload — **reuse, no re-derivation**) and sets `scenario.HarnessProfileIDs` from the canonical IDs keyed by the scenario's tier tag (`canonicalHarnessIDs`). Bob still authors the tier **tag** and the given/when/then prose; only the catalog-ID binding becomes system-owned. This mirrors the **story-preparer** pattern (index input + parse-time resolution, store canonical not echo).

Bonus: `denormalize` now runs on a valid catalog ID, so harness Env/assertions get injected where a truncated echo previously silently got none.

## Audit (your "ensure we're not repeating this elsewhere")

A thorough codebase sweep for the same anti-pattern found **only this instance**. Story-preparer's `ComponentName` / `RequirementIDs` / `CapabilityNames` already do it right (index input → parse-time resolution → store canonical). Scenario tier tags are authorial (no canonical to match). `upstream_resolutions` are read-only context. So the codebase is otherwise clean.

## Operator-tier note

Services-class (SITL) `@integration` scenarios now get **empty** harness IDs — correct per ADR-045 (operator proof reaches the operator via qa.yml, not a sandbox-gated scenario binding). Verified no rule requires an `@integration` scenario to bind a profile, and no downstream consumer (qa.yml render, denormalize, execution) breaks on it.

## Testing
`go test ./...` + `task lint` green. Tests: canonical-overrides-echo (real truncation shape), `@unit` gets none, services-class `@integration` → empty + clean parse, `canonicalHarnessIDs` dedup/nil. go-reviewer: **APPROVE** (no critical/high; the snapshot-present invariant verified, now logged + commented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)