### PR TITLE
fix(architecture): complete capability-coverage hint (no more whack-a-mole)

### DIFF
--- a/workflow/plan_story.go
+++ b/workflow/plan_story.go
@@ -390,10 +390,18 @@ func ValidateTaskDAG(parentStoryID string, tasks []Task) error {
 // plans and back-compat reads pass through clean. The check fires once the
 // exploration is populated AND the architecture has components.
 //
-// Returns ErrInvalidStoryStructure wrapped with the first unresolved
-// capability name. The architecture-generator surfaces this back to Winston
-// via retry-feedback so the LLM can extend the offending component or add
-// a new one in the next cycle.
+// Returns ErrInvalidStoryStructure wrapped with a COMPLETE coverage hint: ALL
+// uncovered capabilities (not just the first), the full declared-capability set,
+// and the architect's current component→capabilities mapping. The
+// architecture-generator surfaces this back to Winston via retry-feedback.
+//
+// Reporting only the first miss (the pre-2026-06-07 behavior) produced
+// whack-a-mole across retries: the architect fixed the named capability, blindly
+// restructured, and dropped another — on a 2026-06-07 mavlink-hard run it
+// oscillated (4 components → 1 → 1) and exhausted all retries without ever
+// covering all four capabilities. The complete hint gives the architect the full
+// target plus its current state so it can close coverage in one cycle (mirrors
+// harnessResolutionHint listing all valid catalog IDs).
 func ValidateCapabilityCoverage(exp *Exploration, components []ComponentDef) error {
 	if exp == nil || len(exp.Capabilities) == 0 || len(components) == 0 {
 		return nil
@@ -404,13 +412,33 @@ func ValidateCapabilityCoverage(exp *Exploration, components []ComponentDef) err
 			covered[capName] = struct{}{}
 		}
 	}
+
+	var uncovered, declared []string
 	for _, cap := range exp.Capabilities {
+		declared = append(declared, cap.Name)
 		if _, ok := covered[cap.Name]; !ok {
-			return fmt.Errorf("%w: capability %q has no component whose capabilities list contains it — every capability declared by the analyst must be implemented by at least one component",
-				ErrInvalidStoryStructure, cap.Name)
+			uncovered = append(uncovered, cap.Name)
 		}
 	}
-	return nil
+	if len(uncovered) == 0 {
+		return nil
+	}
+
+	var current strings.Builder
+	for i, c := range components {
+		if i > 0 {
+			current.WriteString("; ")
+		}
+		fmt.Fprintf(&current, "%s=[%s]", c.Name, strings.Join(c.Capabilities, ", "))
+	}
+
+	return fmt.Errorf("%w: capability coverage incomplete — %d of %d analyst-declared capabilities are implemented by no component. "+
+		"UNCOVERED (add each to some component's capabilities list): %s. "+
+		"ALL declared capabilities (every one MUST appear in at least one component's capabilities list): %s. "+
+		"Your current components → capabilities: %s. "+
+		"A single component MAY list multiple capabilities — extend an existing component or add one so every declared capability is covered; do not drop a previously-covered capability while adding the missing ones",
+		ErrInvalidStoryStructure, len(uncovered), len(declared),
+		strings.Join(uncovered, ", "), strings.Join(declared, ", "), current.String())
 }
 
 // ValidateComponentImplementationFiles checks that every ComponentDef in

--- a/workflow/plan_story_test.go
+++ b/workflow/plan_story_test.go
@@ -591,7 +591,20 @@ func TestValidateCapabilityCoverage(t *testing.T) {
 				{Name: "auth-service", Capabilities: []string{"auth"}},
 			},
 			wantErr:   ErrInvalidStoryStructure,
-			errPhrase: `capability "session" has no component`,
+			errPhrase: `UNCOVERED (add each to some component's capabilities list): session`,
+		},
+		{
+			name: "multiple uncovered are ALL reported (complete hint, not first-only)",
+			exp: &Exploration{Capabilities: []Capability{
+				{Name: "osh-mavsdk-driver"}, {Name: "cs-api-telemetry"},
+				{Name: "cs-api-control"}, {Name: "raw-mavlink-fallback"},
+			}},
+			components: []ComponentDef{
+				{Name: "driver", Capabilities: []string{"cs-api-control"}},
+			},
+			wantErr: ErrInvalidStoryStructure,
+			// all three uncovered named + full declared set + current mapping
+			errPhrase: "osh-mavsdk-driver, cs-api-telemetry, raw-mavlink-fallback",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Problem
A 2026-06-07 `mavlink-hard` run exhausted all 3 architecture-generation attempts on `capability_coverage` **without converging** — the architect (gemini-pro) oscillated `4 components → 1 → 1` and dropped a different capability each attempt (osh-mavsdk-driver → cs-api-telemetry → osh-mavsdk-driver). Plan went terminal before execution.

## Diagnosis (evidence-backed, the gate for "should we add retries?")
- **Feedback WAS injected**: the rejection appears 66× in the architect's prompt history. ✅
- **Not converging**: 4→1→1 components, oscillating which capability was dropped. ❌
- **Hint was incomplete**: `ValidateCapabilityCoverage` returned on the **first** uncovered capability — naming one, showing neither the full declared set nor the architect's current component→capability mapping. The architect fixed the named one, restructured blind, broke another. ❌

Per that gate, widening retries would only buy more oscillation — so **retries stay at 2**. The lever is the hint.

## Fix
`ValidateCapabilityCoverage` now emits a **complete** hint:
- **all** uncovered capabilities (not first-only),
- the **full declared-capability set** (every one must appear in ≥1 component),
- the architect's **current components → capabilities** mapping,
- explicit "do not drop a previously-covered capability while adding the missing ones."

Gives the architect the full target + current state to close coverage in one cycle. Mirrors `harnessResolutionHint` (lists all valid catalog IDs) and the retry-feedback-completeness pattern.

## Tests
`TestValidateCapabilityCoverage` gains a multi-uncovered case pinning that ALL gaps are reported; existing single-miss case updated to the new message. `go test ./...` + `task lint` green.

## Validation
A `mavlink-hard` DEBUG=1 re-run is being kicked off from this branch's working tree (e2e builds the image from source) to confirm the architect converges with the complete hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)