### PR TITLE
fix(architecture): aggregate all arch-gen validator failures per attempt

### DIFF
--- a/processor/architecture-generator/component.go
+++ b/processor/architecture-generator/component.go
@@ -586,11 +586,13 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 	}
 }
 
-// validateGeneratedArchitecture runs the ADR-043 arch-gen validators in order.
-// Returns a non-empty (rule, msg) on the first rejection (empty rule = valid):
+// validateGeneratedArchitecture runs ALL the ADR-043 arch-gen validators and
+// reports EVERY failure together (empty rule = valid). The validators:
 //   - component_implementation_files: each component owns ≥1 source-code file.
 //   - capability_coverage: every analyst-declared capability is implemented by
 //     ≥1 component.
+//   - upstream_import_resolution: code-symbol APIs carry a qualified import.
+//   - upstream_coordinate_resolution (#126): each coordinate resolves for real.
 //   - harness_profile_resolution: every architecture.harness_profiles[] entry
 //     names a real catalog profile_id. Guards architect hallucination (e.g.
 //     "docker.generic", 2026-06-06 gemini mavlink-hard DEBUG run) at the source
@@ -598,35 +600,64 @@ func (c *Component) watchLoopCompletions(ctx context.Context) {
 //     models still invent; without this guard the bad ID passes arch-gen,
 //     persists, is faithfully copied by the scenario-generator, and only
 //     surfaces two layers downstream at the scenario gate where the retry can't
-//     reach back to fix the architect within the R2 cap. The retry message
-//     appends the valid options so the architect picks a real profile. Catalog
-//     load failure is non-fatal (skip rather than block on infra — matches
-//     harnessProfileCards()).
+//     reach back to fix the architect within the R2 cap. Catalog load failure is
+//     non-fatal (skip rather than block on infra — matches harnessProfileCards()).
+//
+// AGGREGATE reporting (2026-06-07): the validators used to short-circuit on the
+// first failure, so a single retry only ever surfaced ONE problem. With multiple
+// independent checks (coverage + coordinate + harness) an architecture that
+// violates two of them produced cross-validator oscillation — the architect
+// fixed the reported one, blindly restructured, and regressed the other, never
+// seeing "satisfy BOTH at once" (caught on a mavlink-hard run: A1 coverage → A2
+// coordinate → A3 coverage-again, exhausted). Running every validator and
+// returning every failure lets the architect close all constraints in one cycle.
+// The combined rule is comma-joined (for logging) and the combined msg lists
+// each failure delimited.
 func (c *Component) validateGeneratedArchitecture(ctx context.Context, architecture *workflow.ArchitectureDocument, kvPlan *workflow.Plan) (rule, msg string) {
+	type failure struct{ rule, msg string }
+	var failures []failure
+
 	if err := workflow.ValidateComponentImplementationFiles(architecture.ComponentBoundaries); err != nil {
-		return "component_implementation_files", fmt.Sprintf("architecture validation failed (implementation files): %s", err.Error())
+		failures = append(failures, failure{"component_implementation_files",
+			fmt.Sprintf("architecture validation failed (implementation files): %s", err.Error())})
 	}
 	if kvPlan != nil {
 		if err := workflow.ValidateCapabilityCoverage(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
-			return "capability_coverage", fmt.Sprintf("architecture validation failed (capability coverage): %s", err.Error())
+			failures = append(failures, failure{"capability_coverage",
+				fmt.Sprintf("architecture validation failed (capability coverage): %s", err.Error())})
 		}
 	}
 	if err := workflow.ValidateUpstreamImports(architecture.UpstreamResolutions); err != nil {
-		return "upstream_import_resolution", fmt.Sprintf("architecture validation failed (upstream import resolution): %s", err.Error())
+		failures = append(failures, failure{"upstream_import_resolution",
+			fmt.Sprintf("architecture validation failed (upstream import resolution): %s", err.Error())})
 	}
-	if rule, msg := c.validateUpstreamCoordinates(ctx, architecture.UpstreamResolutions); rule != "" {
-		return rule, msg
+	if r, m := c.validateUpstreamCoordinates(ctx, architecture.UpstreamResolutions); r != "" {
+		failures = append(failures, failure{r, m})
 	}
 	if cat, catErr := harnesscatalog.Load(""); catErr == nil {
 		if err := cat.ValidateSelections(architecture.HarnessProfiles); err != nil {
-			return "harness_profile_resolution", fmt.Sprintf(
+			failures = append(failures, failure{"harness_profile_resolution", fmt.Sprintf(
 				"architecture validation failed (harness profile resolution): %s — %s",
-				err.Error(), harnessResolutionHint(cat, err))
+				err.Error(), harnessResolutionHint(cat, err))})
 		}
 	} else {
 		c.logger.Warn("Harness catalog load failed; skipping harness-profile resolution check", "error", catErr)
 	}
-	return "", ""
+
+	if len(failures) == 0 {
+		return "", ""
+	}
+	if len(failures) == 1 {
+		return failures[0].rule, failures[0].msg
+	}
+	rules := make([]string, len(failures))
+	var combined strings.Builder
+	fmt.Fprintf(&combined, "architecture has %d validation issues — fix ALL of them in your next submission; fixing one while regressing another will be rejected again:\n", len(failures))
+	for i, f := range failures {
+		rules[i] = f.rule
+		fmt.Fprintf(&combined, "\n[%d] (%s) %s\n", i+1, f.rule, f.msg)
+	}
+	return strings.Join(rules, ","), combined.String()
 }
 
 // harnessResolutionHint tailors the retry guidance to the validation failure

--- a/processor/architecture-generator/upstream_verifier_test.go
+++ b/processor/architecture-generator/upstream_verifier_test.go
@@ -114,3 +114,39 @@ func TestValidateUpstreamCoordinates(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateGeneratedArchitecture_AggregatesFailures pins that an architecture
+// violating MULTIPLE validators reports ALL of them at once (not first-only), so
+// the architect can fix every constraint in one cycle instead of oscillating
+// (2026-06-07 mavlink-hard: A1 coverage → A2 coordinate → A3 coverage-again).
+func TestValidateGeneratedArchitecture_AggregatesFailures(t *testing.T) {
+	c := newTestComponent(fakeVerifier{exists: map[string]bool{}}) // nothing resolves
+	arch := &workflow.ArchitectureDocument{
+		ComponentBoundaries: []workflow.ComponentDef{
+			{Name: "driver", ImplementationFiles: []string{"src/Driver.java"}, Capabilities: []string{"cap-a"}},
+		},
+		// fabricated maven coordinate → #126 rejects; no APIs → import check passes
+		UpstreamResolutions: []workflow.UpstreamResolution{
+			{Name: "Fake", Coordinate: "com.fake:nope:1.0"},
+		},
+	}
+	// exploration declares cap-b which no component covers → capability_coverage fails
+	kvPlan := &workflow.Plan{Exploration: &workflow.Exploration{Capabilities: []workflow.Capability{
+		{Name: "cap-a"}, {Name: "cap-b"},
+	}}}
+
+	rule, msg := c.validateGeneratedArchitecture(context.Background(), arch, kvPlan)
+	if rule == "" {
+		t.Fatal("expected rejection")
+	}
+	for _, want := range []string{"capability_coverage", "upstream_coordinate_resolution"} {
+		if !strings.Contains(rule, want) {
+			t.Errorf("combined rule %q missing %q", rule, want)
+		}
+	}
+	for _, want := range []string{"fix ALL", "cap-b", "com.fake:nope:1.0", "[1]", "[2]"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("combined msg missing %q\n--- msg ---\n%s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`validateGeneratedArchitecture` short-circuited on the **first** failing validator, so each retry surfaced only **one** problem. With multiple independent checks (`capability_coverage` + `upstream_coordinate_resolution` #126 + harness + import + impl-files), an architecture violating two produced **cross-validator oscillation**: the architect fixed the reported one, blindly restructured, regressed the other — never seeing "satisfy both at once."

Observed on a 2026-06-07 `mavlink-hard` DEBUG run (after the coverage-hint fix #130):
- **A1** → rejected `capability_coverage`
- **A2** → passed coverage, rejected `#126` (`org.sensorhub:sensorhub-core:2.0.0-SNAPSHOT` → 0 on Central) ← *#126 working live*
- **A3** → fixed the coordinate, **regressed to A1's exact coverage gap** → exhausted

Both prior fixes worked (the complete coverage hint got A2 past coverage; #126 caught the SNAPSHOT fabrication), but each retry carried only the single most-recent rejection, so the two constraints fought each other.

## Fix
Run **every** validator and return **every** failure together:
- single failure → existing `(rule, msg)` shape unchanged;
- multiple → comma-joined rules (logging) + a delimited combined message: *"architecture has N validation issues — fix ALL of them … fixing one while regressing another will be rejected again"*, then `[1]…[N]`.

The architect now sees the full constraint set and can close it in one cycle. **Retries stay at 2.**

Tradeoff: #126's network probes now run even when an earlier validator fails — a few HEAD requests, non-fatal on error, worth it for complete feedback.

## Tests
`TestValidateGeneratedArchitecture_AggregatesFailures` pins that a coverage + coordinate double-violation reports both (rules comma-joined; msg carries "fix ALL", both rule names, both offending values, `[1]`/`[2]`). Existing single-failure tests unchanged. `go test ./...` + `task lint` green.

## Validation
Not paid-validated yet. Completes the trio (complete coverage hint #130 + #126 coordinate gate #129 + aggregate reporting) needed for the architect to converge on `mavlink-hard` within 2 retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)