### PR TITLE
fix(graph-mirror): upsert plan/execution/project triples instead of append-only (1 MiB entity bloat)

### DIFF
--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -735,8 +735,8 @@ func (c *Component) createWorktree(ctx context.Context, exec *taskExecution) err
 	}
 	exec.WorktreePath = wtInfo.Path
 	exec.WorktreeBranch = wtInfo.Branch
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.WorktreePath, wtInfo.Path)
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.WorktreeBranch, wtInfo.Branch)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.WorktreePath, wtInfo.Path)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.WorktreeBranch, wtInfo.Branch)
 	c.logger.Info("Worktree created",
 		"slug", exec.Slug,
 		"task_id", exec.TaskID,
@@ -915,11 +915,9 @@ func (c *Component) handleDeveloperCompleteLocked(ctx context.Context, event *ag
 		return
 	}
 
-	// Write developer output triples — one triple per modified file.
-	for _, f := range exec.FilesModified {
-		_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.FilesModified, f)
-	}
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseValidating); err != nil {
+	// Write developer output triples — replace the whole modified-file list.
+	_ = c.tripleWriter.ReplaceTripleList(ctx, exec.EntityID, wf.FilesModified, exec.FilesModified)
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseValidating); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseValidating, "error", err)
 	}
 	exec.Stage = phaseValidating
@@ -1073,12 +1071,12 @@ func (c *Component) handleReviewerCompleteLocked(ctx context.Context, event *age
 	exec.Feedback = result.Feedback
 	exec.ReviewerLLMRequestIDs = result.LLMRequestIDs
 
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Verdict, result.Verdict)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Verdict, result.Verdict)
 	if result.Feedback != "" {
-		_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Feedback, result.Feedback)
+		_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Feedback, result.Feedback)
 	}
 	if result.RejectionType != "" {
-		_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.RejectionType, result.RejectionType)
+		_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.RejectionType, result.RejectionType)
 	}
 
 	c.logger.Info("Code review verdict",
@@ -1146,7 +1144,7 @@ func (c *Component) parseCodeReviewResult(raw string, slug string) (payloads.Tas
 // triple, classifies feedback, and routes the retry or escalation.
 func (c *Component) handleRejectionLocked(ctx context.Context, exec *taskExecution, result payloads.TaskCodeReviewResult) {
 	exec.Stage = phaseRejected
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseRejected); err != nil {
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseRejected); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseRejected, "error", err)
 	}
 
@@ -1273,7 +1271,7 @@ func (c *Component) markApprovedLocked(ctx context.Context, exec *taskExecution)
 	exec.terminated = true
 
 	exec.Stage = phaseApproved
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseApproved); err != nil {
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseApproved); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseApproved, "error", err)
 	}
 	c.syncToStore(ctx, exec)
@@ -1316,10 +1314,10 @@ func (c *Component) markEscalatedLocked(ctx context.Context, exec *taskExecution
 	// budget exhausted upstream" log fires with escalation_reason="".
 	// Caught 2026-05-08 take 7 OpenRouter @easy.
 	exec.EscalationReason = reason
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseEscalated); err != nil {
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseEscalated); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseEscalated, "error", err)
 	}
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.EscalationReason, reason)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.EscalationReason, reason)
 	c.syncToStore(ctx, exec)
 
 	c.executionsEscalated.Add(1)
@@ -1419,11 +1417,11 @@ func (c *Component) markErrorLocked(ctx context.Context, exec *taskExecution, re
 	exec.Stage = phaseError
 	exec.ErrorReason = reason
 	exec.ErrorClass = workflow.ClassifyErrorReason(reason)
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseError); err != nil {
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseError); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseError, "error", err)
 	}
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.ErrorReason, reason)
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.ErrorClass, exec.ErrorClass)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.ErrorReason, reason)
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.ErrorClass, exec.ErrorClass)
 	c.syncToStore(ctx, exec)
 
 	c.errors.Add(1)
@@ -1505,8 +1503,8 @@ func (c *Component) startDeveloperRetryLocked(ctx context.Context, exec *taskExe
 	// Keep Feedback — accumulated for next developer prompt.
 	exec.Feedback = feedback
 
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.TDDCycle, exec.TDDCycle)
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseDeveloping); err != nil {
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.TDDCycle, exec.TDDCycle)
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseDeveloping); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseDeveloping, "error", err)
 	}
 	exec.Stage = phaseDeveloping
@@ -1874,10 +1872,10 @@ func (c *Component) dispatchValidatorLocked(ctx context.Context, exec *taskExecu
 	exec.ValidationPassed = result.Passed
 	exec.ValidationResults = result.CheckResults
 
-	_ = c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.ValidationPassed, fmt.Sprintf("%t", exec.ValidationPassed))
+	_ = c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.ValidationPassed, fmt.Sprintf("%t", exec.ValidationPassed))
 
 	if !exec.ValidationPassed {
-		if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseValidationFailed); err != nil {
+		if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseValidationFailed); err != nil {
 			c.logger.Error("Failed to write phase triple", "phase", phaseValidationFailed, "error", err)
 		}
 		exec.Stage = phaseValidationFailed
@@ -1899,7 +1897,7 @@ func (c *Component) dispatchValidatorLocked(ctx context.Context, exec *taskExecu
 		"tdd_cycle", exec.TDDCycle,
 	)
 
-	if err := c.tripleWriter.WriteTriple(ctx, exec.EntityID, wf.Phase, phaseReviewing); err != nil {
+	if err := c.tripleWriter.UpdateTriple(ctx, exec.EntityID, wf.Phase, phaseReviewing); err != nil {
 		c.logger.Error("Failed to write phase triple", "phase", phaseReviewing, "error", err)
 	}
 	exec.Stage = phaseReviewing

--- a/processor/execution-manager/execution_store.go
+++ b/processor/execution-manager/execution_store.go
@@ -373,52 +373,50 @@ func (s *executionStore) writeTaskTriples(ctx context.Context, exec *workflow.Ta
 		entityID = workflow.TaskExecutionEntityID(exec.Slug, exec.TaskID)
 	}
 
-	_ = tw.WriteTriple(ctx, entityID, wf.Type, "task-execution")
-	_ = tw.WriteTriple(ctx, entityID, wf.Slug, exec.Slug)
-	_ = tw.WriteTriple(ctx, entityID, wf.TaskID, exec.TaskID)
-	_ = tw.WriteTriple(ctx, entityID, wf.Title, exec.Title)
-	_ = tw.WriteTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
-	if err := tw.WriteTriple(ctx, entityID, wf.Phase, exec.Stage); err != nil {
+	_ = tw.UpdateTriple(ctx, entityID, wf.Type, "task-execution")
+	_ = tw.UpdateTriple(ctx, entityID, wf.Slug, exec.Slug)
+	_ = tw.UpdateTriple(ctx, entityID, wf.TaskID, exec.TaskID)
+	_ = tw.UpdateTriple(ctx, entityID, wf.Title, exec.Title)
+	_ = tw.UpdateTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
+	if err := tw.UpdateTriple(ctx, entityID, wf.Phase, exec.Stage); err != nil {
 		return fmt.Errorf("write phase: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, wf.TDDCycle, exec.TDDCycle)
-	_ = tw.WriteTriple(ctx, entityID, wf.MaxTDDCycles, exec.MaxTDDCycles)
+	_ = tw.UpdateTriple(ctx, entityID, wf.TDDCycle, exec.TDDCycle)
+	_ = tw.UpdateTriple(ctx, entityID, wf.MaxTDDCycles, exec.MaxTDDCycles)
 	if exec.TraceID != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.TraceID, exec.TraceID)
+		_ = tw.UpdateTriple(ctx, entityID, wf.TraceID, exec.TraceID)
 	}
 	if exec.WorktreePath != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.WorktreePath, exec.WorktreePath)
+		_ = tw.UpdateTriple(ctx, entityID, wf.WorktreePath, exec.WorktreePath)
 	}
 	if exec.WorktreeBranch != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.WorktreeBranch, exec.WorktreeBranch)
+		_ = tw.UpdateTriple(ctx, entityID, wf.WorktreeBranch, exec.WorktreeBranch)
 	}
-	// Files modified — one triple per path.
-	for _, f := range exec.FilesModified {
-		_ = tw.WriteTriple(ctx, entityID, wf.FilesModified, f)
-	}
+	// Files modified — replace the whole list (multi-valued, re-written each save).
+	_ = tw.ReplaceTripleList(ctx, entityID, wf.FilesModified, exec.FilesModified)
 	if exec.ValidationPassed {
-		_ = tw.WriteTriple(ctx, entityID, wf.ValidationPassed, "true")
+		_ = tw.UpdateTriple(ctx, entityID, wf.ValidationPassed, "true")
 	}
 	if exec.Verdict != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.Verdict, exec.Verdict)
+		_ = tw.UpdateTriple(ctx, entityID, wf.Verdict, exec.Verdict)
 	}
 	if exec.Feedback != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.Feedback, exec.Feedback)
+		_ = tw.UpdateTriple(ctx, entityID, wf.Feedback, exec.Feedback)
 	}
 	if exec.RejectionType != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.RejectionType, exec.RejectionType)
+		_ = tw.UpdateTriple(ctx, entityID, wf.RejectionType, exec.RejectionType)
 	}
 	if exec.ErrorReason != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.ErrorReason, exec.ErrorReason)
+		_ = tw.UpdateTriple(ctx, entityID, wf.ErrorReason, exec.ErrorReason)
 	}
 	if exec.EscalationReason != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.EscalationReason, exec.EscalationReason)
+		_ = tw.UpdateTriple(ctx, entityID, wf.EscalationReason, exec.EscalationReason)
 	}
 	if exec.AgentID != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.AgentID, exec.AgentID)
+		_ = tw.UpdateTriple(ctx, entityID, wf.AgentID, exec.AgentID)
 	}
 	if exec.Model != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.Model, exec.Model)
+		_ = tw.UpdateTriple(ctx, entityID, wf.Model, exec.Model)
 	}
 
 	return nil
@@ -434,24 +432,24 @@ func (s *executionStore) writeReqTriples(ctx context.Context, exec *workflow.Req
 		entityID = workflow.RequirementExecutionEntityID(exec.Slug, exec.RequirementID)
 	}
 
-	_ = tw.WriteTriple(ctx, entityID, wf.Type, "requirement-execution")
-	_ = tw.WriteTriple(ctx, entityID, wf.Slug, exec.Slug)
-	_ = tw.WriteTriple(ctx, entityID, wf.RequirementID, exec.RequirementID)
-	_ = tw.WriteTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
-	if err := tw.WriteTriple(ctx, entityID, wf.Phase, exec.Stage); err != nil {
+	_ = tw.UpdateTriple(ctx, entityID, wf.Type, "requirement-execution")
+	_ = tw.UpdateTriple(ctx, entityID, wf.Slug, exec.Slug)
+	_ = tw.UpdateTriple(ctx, entityID, wf.RequirementID, exec.RequirementID)
+	_ = tw.UpdateTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
+	if err := tw.UpdateTriple(ctx, entityID, wf.Phase, exec.Stage); err != nil {
 		return fmt.Errorf("write phase: %w", err)
 	}
 	if exec.TraceID != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.TraceID, exec.TraceID)
+		_ = tw.UpdateTriple(ctx, entityID, wf.TraceID, exec.TraceID)
 	}
 	if exec.NodeCount > 0 {
-		_ = tw.WriteTriple(ctx, entityID, wf.NodeCount, exec.NodeCount)
+		_ = tw.UpdateTriple(ctx, entityID, wf.NodeCount, exec.NodeCount)
 	}
 	if exec.ErrorReason != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.ErrorReason, exec.ErrorReason)
+		_ = tw.UpdateTriple(ctx, entityID, wf.ErrorReason, exec.ErrorReason)
 	}
 	if exec.ReviewVerdict != "" {
-		_ = tw.WriteTriple(ctx, entityID, wf.Verdict, exec.ReviewVerdict)
+		_ = tw.UpdateTriple(ctx, entityID, wf.Verdict, exec.ReviewVerdict)
 	}
 
 	return nil

--- a/processor/execution-manager/task_watcher.go
+++ b/processor/execution-manager/task_watcher.go
@@ -161,19 +161,19 @@ func (c *Component) initTaskExecution(ctx context.Context, exec *taskExecution) 
 
 	// Write initial triples from exec fields (no trigger needed).
 	entityID := exec.EntityID
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Type, "task-execution")
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Phase, phaseDeveloping)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Slug, exec.Slug)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.TaskID, exec.TaskID)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Title, exec.Title)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.TDDCycle, 0)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.MaxTDDCycles, exec.MaxTDDCycles)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.TraceID, exec.TraceID)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Model, exec.Model)
-	_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.CurrentStage, phaseDeveloping)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Type, "task-execution")
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Phase, phaseDeveloping)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Slug, exec.Slug)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.TaskID, exec.TaskID)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Title, exec.Title)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.ProjectID, exec.ProjectID)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.TDDCycle, 0)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.MaxTDDCycles, exec.MaxTDDCycles)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.TraceID, exec.TraceID)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Model, exec.Model)
+	_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.CurrentStage, phaseDeveloping)
 	if exec.Prompt != "" {
-		_ = c.tripleWriter.WriteTriple(ctx, entityID, wf.Prompt, exec.Prompt)
+		_ = c.tripleWriter.UpdateTriple(ctx, entityID, wf.Prompt, exec.Prompt)
 	}
 
 	if err := c.createWorktree(ctx, exec); err != nil {

--- a/processor/plan-manager/plan_store.go
+++ b/processor/plan-manager/plan_store.go
@@ -348,72 +348,70 @@ func (s *planStore) writeTriples(ctx context.Context, plan *workflow.Plan) error
 	}
 	entityID := workflow.PlanEntityID(plan.Slug)
 
+	// Single-valued scalars use UpdateTriple (remove+add upsert) so the entity
+	// holds the LATEST value per predicate instead of accumulating every
+	// historical value — graph-ingest AddTriple is append-only, so plain
+	// WriteTriple on every plan mutation grew the entity past the 1 MiB KV cap
+	// (2026-06-07 plan-prep wedge). Multi-valued lists use ReplaceTripleList.
+
 	// Core identity
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanSlug, plan.Slug)
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanTitle, plan.Title)
-	_ = tw.WriteTriple(ctx, entityID, semspec.DCTitle, plan.Title)
-	if err := tw.WriteTriple(ctx, entityID, semspec.PredicatePlanStatus, string(plan.EffectiveStatus())); err != nil {
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanSlug, plan.Slug)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanTitle, plan.Title)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, plan.Title)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.PredicatePlanStatus, string(plan.EffectiveStatus())); err != nil {
 		return fmt.Errorf("write plan status: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
 
 	// Project association
 	if plan.ProjectID != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanProject, plan.ProjectID)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanProject, plan.ProjectID)
 	}
 
 	// Plan content
 	if plan.Goal != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanGoal, plan.Goal)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanGoal, plan.Goal)
 	}
 	if plan.Context != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanContext, plan.Context)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanContext, plan.Context)
 	}
 
 	// Approval
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved))
 	if plan.ApprovedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339))
 	}
 
 	// Review
 	if plan.ReviewVerdict != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewVerdict, plan.ReviewVerdict)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewVerdict, plan.ReviewVerdict)
 	}
 	if plan.ReviewSummary != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewSummary, plan.ReviewSummary)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewSummary, plan.ReviewSummary)
 	}
 	if plan.ReviewedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339))
 	}
 	if plan.ReviewFormattedFindings != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings)
 	}
 	if plan.ReviewIteration > 0 {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewIteration, plan.ReviewIteration)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewIteration, plan.ReviewIteration)
 	}
 
 	// Error annotations
 	if plan.LastError != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanLastError, plan.LastError)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastError, plan.LastError)
 	}
 	if plan.LastErrorAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339))
 	}
 
-	// Scope (atomic triples — one per entry to avoid JSON objects as KV keys)
-	for _, inc := range plan.Scope.Include {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeInclude, inc)
-	}
-	for _, exc := range plan.Scope.Exclude {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeExclude, exc)
-	}
-	for _, dnt := range plan.Scope.DoNotTouch {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeProtected, dnt)
-	}
-	for _, cr := range plan.Scope.Create {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeCreate, cr)
-	}
+	// Scope (atomic triples — replace the whole list each write)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeInclude, plan.Scope.Include)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeExclude, plan.Scope.Exclude)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeProtected, plan.Scope.DoNotTouch)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeCreate, plan.Scope.Create)
 
 	// ADR-040: Exploration snapshot + open question audit trail. The
 	// individual Capability entities are written by writeChildTriples;
@@ -421,17 +419,13 @@ func (s *planStore) writeTriples(ctx context.Context, plan *workflow.Plan) error
 	// finds the exploration without traversing to capabilities.
 	if plan.Exploration != nil {
 		if blob, err := json.Marshal(plan.Exploration); err == nil {
-			_ = tw.WriteTriple(ctx, entityID, semspec.PlanExploration, string(blob))
+			_ = tw.UpdateTriple(ctx, entityID, semspec.PlanExploration, string(blob))
 		}
-		for _, q := range plan.Exploration.OpenQuestions {
-			_ = tw.WriteTriple(ctx, entityID, semspec.PlanOpenQuestions, q)
-		}
+		_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanOpenQuestions, plan.Exploration.OpenQuestions)
 	}
 
-	// Execution trace IDs (one triple per ID — avoid JSON arrays as KV keys)
-	for _, traceID := range plan.ExecutionTraceIDs {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanExecutionTraceID, traceID)
-	}
+	// Execution trace IDs (replace the whole list each write)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanExecutionTraceID, plan.ExecutionTraceIDs)
 
 	// Requirements and Scenarios — write individual entity triples so the graph
 	// stays consistent when the plan is updated.

--- a/processor/project-manager/project_store.go
+++ b/processor/project-manager/project_store.go
@@ -226,22 +226,22 @@ func (s *projectStore) writeConfigTriples(ctx context.Context, pc *workflow.Proj
 	}
 	entityID := workflow.ProjectConfigEntityID("project")
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigType, "project")
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ProjectConfigFile)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigName, pc.Name)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigOrg, pc.Org)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigPlatform, pc.Platform)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, pc.UpdatedAt.Format(time.RFC3339))
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApproved, pc.ApprovedAt != nil)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "project")
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ProjectConfigFile)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigName, pc.Name)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigOrg, pc.Org)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigPlatform, pc.Platform)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, pc.UpdatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, pc.ApprovedAt != nil)
 	if pc.ApprovedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, pc.ApprovedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, pc.ApprovedAt.Format(time.RFC3339))
 	}
 
 	jsonBlob, err := json.Marshal(pc)
 	if err != nil {
 		return err
 	}
-	return tw.WriteTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
 }
 
 // writeChecklistTriples writes triples for checklist config.
@@ -252,19 +252,19 @@ func (s *projectStore) writeChecklistTriples(ctx context.Context, cl *workflow.C
 	}
 	entityID := workflow.ProjectConfigEntityID("checklist")
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigType, "checklist")
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ChecklistFile)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, cl.UpdatedAt.Format(time.RFC3339))
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApproved, cl.ApprovedAt != nil)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "checklist")
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ChecklistFile)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, cl.UpdatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, cl.ApprovedAt != nil)
 	if cl.ApprovedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, cl.ApprovedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, cl.ApprovedAt.Format(time.RFC3339))
 	}
 
 	jsonBlob, err := json.Marshal(cl)
 	if err != nil {
 		return err
 	}
-	return tw.WriteTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
 }
 
 // writeStandardsTriples writes triples for standards config.
@@ -275,19 +275,19 @@ func (s *projectStore) writeStandardsTriples(ctx context.Context, st *workflow.S
 	}
 	entityID := workflow.ProjectConfigEntityID("standards")
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigType, "standards")
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.StandardsFile)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, st.UpdatedAt.Format(time.RFC3339))
-	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApproved, st.ApprovedAt != nil)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "standards")
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.StandardsFile)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, st.UpdatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, st.ApprovedAt != nil)
 	if st.ApprovedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, st.ApprovedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, st.ApprovedAt.Format(time.RFC3339))
 	}
 
 	jsonBlob, err := json.Marshal(st)
 	if err != nil {
 		return err
 	}
-	return tw.WriteTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
 }
 
 // ----------------------------------------------------------------------------

--- a/workflow/graph_marshal.go
+++ b/workflow/graph_marshal.go
@@ -19,77 +19,70 @@ func writePlanTriples(ctx context.Context, tw *graphutil.TripleWriter, plan *Pla
 	}
 	entityID := PlanEntityID(plan.Slug)
 
+	// Single-valued scalars upsert (UpdateTriple = remove+add) so the entity
+	// holds the latest value per predicate; graph-ingest AddTriple is
+	// append-only, so plain WriteTriple on every mutation accumulates history and
+	// eventually exceeds the 1 MiB KV value cap. Lists use ReplaceTripleList.
+
 	// Core identity
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanSlug, plan.Slug)
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanTitle, plan.Title)
-	_ = tw.WriteTriple(ctx, entityID, semspec.DCTitle, plan.Title)
-	if err := tw.WriteTriple(ctx, entityID, semspec.PredicatePlanStatus, string(plan.EffectiveStatus())); err != nil {
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanSlug, plan.Slug)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanTitle, plan.Title)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, plan.Title)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.PredicatePlanStatus, string(plan.EffectiveStatus())); err != nil {
 		return fmt.Errorf("write plan status: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
 
 	// Project association
 	if plan.ProjectID != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanProject, plan.ProjectID)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanProject, plan.ProjectID)
 	}
 
 	// Plan content
 	if plan.Goal != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanGoal, plan.Goal)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanGoal, plan.Goal)
 	}
 	if plan.Context != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanContext, plan.Context)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanContext, plan.Context)
 	}
 
 	// Approval
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved))
 	if plan.ApprovedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339))
 	}
 
 	// Review
 	if plan.ReviewVerdict != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewVerdict, plan.ReviewVerdict)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewVerdict, plan.ReviewVerdict)
 	}
 	if plan.ReviewSummary != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewSummary, plan.ReviewSummary)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewSummary, plan.ReviewSummary)
 	}
 	if plan.ReviewedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339))
 	}
 	if plan.ReviewFormattedFindings != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings)
 	}
 	if plan.ReviewIteration > 0 {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanReviewIteration, plan.ReviewIteration)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewIteration, plan.ReviewIteration)
 	}
 
 	// Error annotations
 	if plan.LastError != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanLastError, plan.LastError)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastError, plan.LastError)
 	}
 	if plan.LastErrorAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339))
 	}
 
-	// Scope (atomic triples — one per entry to avoid JSON objects as KV keys)
-	for _, inc := range plan.Scope.Include {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeInclude, inc)
-	}
-	for _, exc := range plan.Scope.Exclude {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeExclude, exc)
-	}
-	for _, dnt := range plan.Scope.DoNotTouch {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeProtected, dnt)
-	}
-	for _, cr := range plan.Scope.Create {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanScopeCreate, cr)
-	}
-
-	// Execution trace IDs (one triple per ID — avoid JSON arrays as KV keys)
-	for _, traceID := range plan.ExecutionTraceIDs {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanExecutionTraceID, traceID)
-	}
+	// Scope + execution trace IDs (replace the whole list each write)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeInclude, plan.Scope.Include)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeExclude, plan.Scope.Exclude)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeProtected, plan.Scope.DoNotTouch)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeCreate, plan.Scope.Create)
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanExecutionTraceID, plan.ExecutionTraceIDs)
 
 	return nil
 }

--- a/workflow/graphutil/triple.go
+++ b/workflow/graphutil/triple.go
@@ -89,6 +89,83 @@ func (tw *TripleWriter) WriteTriple(ctx context.Context, entityID, predicate str
 	return nil
 }
 
+// RemoveTriple removes ALL triples for (entityID, predicate) via
+// graph.mutation.triple.remove. Idempotent: removing a predicate that does not
+// exist (or an absent entity) is a no-op success.
+func (tw *TripleWriter) RemoveTriple(ctx context.Context, entityID, predicate string) error {
+	req := graph.RemoveTripleRequest{Subject: entityID, Predicate: predicate}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal remove request: %w", err)
+	}
+	if tw.NATSClient == nil {
+		return nil
+	}
+	respData, err := tw.NATSClient.RequestWithRetry(ctx, "graph.mutation.triple.remove", data, 5*time.Second, natsclient.DefaultRetryConfig())
+	if err != nil {
+		tw.Logger.Warn("Triple remove request failed",
+			"predicate", predicate, "entity_id", entityID, "error", err)
+		return fmt.Errorf("triple remove request: %w", err)
+	}
+	var resp graph.RemoveTripleResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal remove response: %w", err)
+	}
+	if !resp.Success {
+		tw.Logger.Warn("Triple remove rejected by graph-ingest",
+			"predicate", predicate, "entity_id", entityID, "error", resp.Error)
+		return fmt.Errorf("triple remove rejected: %s", resp.Error)
+	}
+	return nil
+}
+
+// UpdateTriple upserts a SINGLE-VALUED predicate: it removes any existing
+// triples for (entityID, predicate), then writes the new value, so the entity
+// holds exactly one value per predicate rather than accumulating every
+// historical value.
+//
+// WHY this exists: graph-ingest's AddTriple is APPEND-ONLY
+// (entity.Triples = append(...), never replace-by-(subject,predicate)). Writing
+// a scalar with WriteTriple on every mutation therefore grows the entity
+// unboundedly. A retry-heavy plan-prep run bloated the plan entity past the
+// 1 MiB KV value cap (2026-06-07), after which every write — including the
+// recovery PlanDecision — was rejected and the plan went terminal. UpdateTriple
+// bounds the entity to its field set.
+//
+// Use UpdateTriple for scalar fields that change over an entity's lifetime
+// (status, title, timestamps, last_error, review fields). Keep WriteTriple
+// (append) for genuinely multi-valued predicates — list members and edges
+// (scope entries, trace IDs, affected requirement IDs, capability links).
+func (tw *TripleWriter) UpdateTriple(ctx context.Context, entityID, predicate string, object any) error {
+	// Best-effort remove: a failed remove only risks a lingering stale value, it
+	// must not block recording the latest. The common path removes cleanly and
+	// keeps the entity bounded.
+	if err := tw.RemoveTriple(ctx, entityID, predicate); err != nil {
+		tw.Logger.Warn("UpdateTriple remove step failed (continuing with add)",
+			"predicate", predicate, "entity_id", entityID, "error", err)
+	}
+	return tw.WriteTriple(ctx, entityID, predicate, object)
+}
+
+// ReplaceTripleList replaces ALL values of a multi-valued predicate with the
+// given set: it removes every existing (entityID, predicate) triple, then
+// appends one per value. Use for list/edge predicates (scope entries, trace
+// IDs, open questions) so re-writing the list on each mutation does not append
+// duplicates and grow the entity without bound. Pass nil/empty to clear it.
+func (tw *TripleWriter) ReplaceTripleList(ctx context.Context, entityID, predicate string, objects []string) error {
+	if err := tw.RemoveTriple(ctx, entityID, predicate); err != nil {
+		tw.Logger.Warn("ReplaceTripleList remove step failed (continuing)",
+			"predicate", predicate, "entity_id", entityID, "error", err)
+	}
+	var firstErr error
+	for _, o := range objects {
+		if err := tw.WriteTriple(ctx, entityID, predicate, o); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 // ReadEntity fetches an entity's triples from ENTITY_STATES via graph-ingest
 // NATS request/reply. Returns a map of predicate → object (as string).
 // Non-string objects are JSON-encoded.


### PR DESCRIPTION
## Problem
On a retry-heavy `mavlink-hard` plan-prep run the plan's ENTITY_STATES graph-mirror entity grew past the **1 MiB KV value cap**. Once over, every triple write — including the `architecture_revise` recovery PlanDecision — was rejected (`value size validation failed: size 1048703 exceeds maximum 1048576`) and the plan went terminal.

## Root cause
graph-ingest's `AddTriple` is **append-only** (`entity.Triples = append(...)`, never replaces by subject+predicate). Our `graphutil.TripleWriter` only ever called `graph.mutation.triple.add`, so every save re-appended the entity's scalars (2 KB title ×2, multi-KB `LastError`, ~8 KB `ReviewFormattedFindings`, exploration blob, lists), accumulating every historical value forever. semstreams **already serves `graph.mutation.triple.remove`** — we'd rolled an add-only writer and never wired it up.

## Fix — make the writer upsert, using the existing remove
- `graphutil.TripleWriter` gains `RemoveTriple`, `UpdateTriple` (remove+add upsert for single-valued predicates), `ReplaceTripleList` (replace whole list for multi-valued).
- **plan-manager** `writeTriples` + **workflow** `writePlanTriples`: scalars → `UpdateTriple`, lists (scope, trace IDs, open questions) → `ReplaceTripleList`.
- **execution-manager** (`execution_store.go`, `component.go` per-phase writes, `task_watcher.go`) and **project-manager** (`project_store.go`): same conversion — they re-write churny scalars on every mutation too, and would hit the identical bloat one layer down once the pipeline reaches execution.

Each entity now holds exactly its **current** field set, bounded regardless of how many mutations/retries a run takes. Restores the documented model: ENTITY_STATES mirrors current facts; the graph stays the system's source of truth without unbounded history. **No upstream change needed.**

No trajectory/state loss: agent trajectories live in `AGENT_LOOPS` (untouched); plan/exec reconciliation reads single-value-per-predicate already; the append-only duplicates were never consumed as history.

## Validation
`go build ./...` + `go test ./...` (69 pkgs) + `task lint` green. `TripleWriter` is a thin NATS shim (e2e-covered) — behavioral proof is the `mavlink-hard` paid re-run: entities stay bounded, the recovery PlanDecision persists, and the pipeline reaches execution.

## Optional follow-up
A single atomic `graph.mutation.triple.update` subject upstream to collapse remove+add into one round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)