### PR TITLE
fix(architecture): architect references capabilities by index, not retyped name

### DIFF
--- a/processor/architecture-generator/component.go
+++ b/processor/architecture-generator/component.go
@@ -345,6 +345,18 @@ func (c *Component) dispatchArchitectureGenerator(ctx context.Context, plan *wor
 		}
 	}
 
+	// Capability list (indexed) so the architect references capabilities by
+	// capability_index in component_boundaries instead of re-typing names.
+	var capCards []prompt.CapabilityCard
+	if plan.Exploration != nil {
+		for _, cap := range plan.Exploration.Capabilities {
+			capCards = append(capCards, prompt.CapabilityCard{
+				Name:        cap.Name,
+				Description: cap.Description,
+			})
+		}
+	}
+
 	archCtx := &prompt.ArchitectPromptContext{
 		Goal:                     plan.Goal,
 		PlanContext:              plan.Context,
@@ -352,6 +364,7 @@ func (c *Component) dispatchArchitectureGenerator(ctx context.Context, plan *wor
 		ScopeExclude:             plan.Scope.Exclude,
 		ScopeProtected:           plan.Scope.DoNotTouch,
 		Requirements:             reqSummaries,
+		Capabilities:             capCards,
 		HarnessProfiles:          c.harnessProfileCards(),
 		PreviousError:            previousError,
 		PreviousArchitectureJSON: plan.PreviousArchitectureJSON,
@@ -622,7 +635,16 @@ func (c *Component) validateGeneratedArchitecture(ctx context.Context, architect
 			fmt.Sprintf("architecture validation failed (implementation files): %s", err.Error())})
 	}
 	if kvPlan != nil {
-		if err := workflow.ValidateCapabilityCoverage(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
+		// Resolve architect-authored capability_indices into capability names
+		// FIRST (mutates ComponentBoundaries in place) so the coverage check —
+		// and everything downstream — sees canonical names, not paraphrases.
+		// An out-of-range index is its own failure; when it occurs the names
+		// aren't resolved, so skip the (now-meaningless) coverage check this
+		// round and let the architect fix the indices.
+		if err := workflow.ResolveCapabilityIndices(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
+			failures = append(failures, failure{"capability_index_resolution",
+				fmt.Sprintf("architecture validation failed (capability index resolution): %s", err.Error())})
+		} else if err := workflow.ValidateCapabilityCoverage(kvPlan.Exploration, architecture.ComponentBoundaries); err != nil {
 			failures = append(failures, failure{"capability_coverage",
 				fmt.Sprintf("architecture validation failed (capability coverage): %s", err.Error())})
 		}

--- a/prompt/context_architect.go
+++ b/prompt/context_architect.go
@@ -2,12 +2,16 @@ package prompt
 
 // ArchitectPromptContext carries data for the architect user-prompt fragment.
 type ArchitectPromptContext struct {
-	Goal            string
-	PlanContext     string
-	ScopeInclude    []string
-	ScopeExclude    []string
-	ScopeProtected  []string
-	Requirements    []ExistingRequirementSummary
+	Goal           string
+	PlanContext    string
+	ScopeInclude   []string
+	ScopeExclude   []string
+	ScopeProtected []string
+	Requirements   []ExistingRequirementSummary
+	// Capabilities is the analyst's capability list, rendered to the architect
+	// with 0-based indices. The architect references these by capability_index
+	// in component_boundaries (2026-06-07) instead of re-typing names.
+	Capabilities    []CapabilityCard
 	HarnessProfiles []HarnessProfileCard
 	PreviousError   string
 	ReviewFindings  string

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -1377,6 +1377,8 @@ BEFORE submit_work:
 
 7. For EVERY component in component_boundaries that depends on an external library: populate component_boundaries[].upstream_refs with the names of the matching upstream_resolutions entries. Bidirectional with upstream_resolutions[].used_by — both sides must agree.
 
+7b. Map EVERY analyst capability to a component via component_boundaries[].capability_indices — the 0-based indices from the "## Capabilities (from analyst)" block in your prompt. Reference capabilities by INDEX, never re-type their names: a paraphrased name (typed-control-streams → typed-controlstreams, or a renamed raw-mavlink-io → raw-mavlink-fallback) fails coverage and the system rejects it. The system resolves your indices to the canonical names. Every capability index must appear in at least one component's capability_indices, and one component MAY cover several (use multiple indices); an index outside the list's range is rejected.
+
 8. Every entry in technology_choices MUST be either:
    (a) the choice declared by a manifest you read in step 2 OR by a quality gate you read in step 3, with rationale citing the file path, OR
    (b) a greenfield choice, with rationale stating "no existing manifest; picking X because Y".
@@ -1412,7 +1414,7 @@ Do NOT instruct the developer to "explore the upstream codebase" or "research th
     {"category": "web_framework", "choice": "Flask", "rationale": "Existing project framework (workspace/requirements.txt:3)"}
   ],
   "component_boundaries": [
-    {"name": "driver", "responsibility": "Meshtastic protocol handler", "dependencies": [], "upstream_refs": ["OpenSensorHub Core", "Meshtastic Java"]}
+    {"name": "driver", "responsibility": "Meshtastic protocol handler", "dependencies": [], "upstream_refs": ["OpenSensorHub Core", "Meshtastic Java"], "implementation_files": ["src/main/java/org/sensorhub/driver/Driver.java"], "capability_indices": [0, 1]}
   ],
   "data_flow": "Mesh node -> Meshtastic Java client -> driver -> OSH SensorHub event bus",
   "decisions": [

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -706,6 +706,18 @@ func renderArchitectPrompt(p *prompt.ArchitectPromptContext) string {
 	scopeExclude := formatScopeListLocal(p.ScopeExclude, "none")
 	scopeProtected := formatScopeListLocal(p.ScopeProtected, "none")
 
+	var capSection strings.Builder
+	if len(p.Capabilities) > 0 {
+		capSection.WriteString("\n## Capabilities (from analyst)\n\n")
+		capSection.WriteString("Map every capability to a component. In each component_boundaries[] entry, set `capability_indices` to the 0-based indices below (index 0 = first entry) — do NOT re-type capability names; reference them by index so the mapping can't drift. Every capability MUST appear in at least one component's `capability_indices`.\n\n")
+		for i, c := range p.Capabilities {
+			fmt.Fprintf(&capSection, "### Capability #%d — %s\n", i, c.Name)
+			if c.Description != "" {
+				fmt.Fprintf(&capSection, "%s\n\n", c.Description)
+			}
+		}
+	}
+
 	var reqSection strings.Builder
 	if len(p.Requirements) > 0 {
 		reqSection.WriteString("\n## Requirements\n\n")
@@ -769,6 +781,7 @@ Below is the architecture you produced last round. Start from it and make the MI
 - Protected (do not touch): %s
 %s
 %s
+%s
 ## Your Task
 
 1. Use bash and graph tools to explore the codebase — understand the existing technology stack, project structure, and patterns already in use.
@@ -798,7 +811,7 @@ Below is the architecture you produced last round. Start from it and make the MI
 **Optional fields** — human documentation in plan.md; only include when they add real value:
 
 - **technology_choices**: array of {category, choice, rationale} — when introducing or formally endorsing a stack choice. Skip when reusing whatever the project already has.
-- **component_boundaries**: array of {name, responsibility, dependencies[]} — when the change introduces a new module or service. Skip for changes scoped to existing components.
+- **component_boundaries**: array of {name, responsibility, dependencies[], implementation_files[], capability_indices[]} — every component maps to capabilities via capability_indices (0-based indices into the Capabilities list above), NOT re-typed names. Every analyst capability must appear in at least one component's capability_indices.
 - **data_flow**: string — when data movement between components is non-obvious. Skip for trivial flows.
 - **decisions**: array of {id, title, decision, rationale} — architecture decision records (use IDs like ARCH-001) for trade-offs future contributors will want to understand. Skip for routine choices.
 
@@ -807,7 +820,7 @@ Below is the architecture you produced last round. Start from it and make the MI
 - Walk actors[]: each human or system actor with a trigger that produces user-visible output needs one e2e_flow. Scheduler and event actors only need e2e coverage if the flow touches the UI or external systems; otherwise integration coverage is sufficient.
 - It's fine for test_surface.integration_flows to reference requirement scenarios via scenario_refs — reviewers use this to verify the test authors wrote tests that actually implement the declared surface.
 %s`, p.Goal, p.PlanContext, scopeInclude, scopeExclude, scopeProtected,
-		reqSection.String(), harnessSection, prevErr)
+		capSection.String(), reqSection.String(), harnessSection, prevErr)
 }
 
 func renderArchitectHarnessCards(cards []prompt.HarnessProfileCard) string {

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -2096,6 +2096,10 @@ components:
                                         items:
                                             type: string
                                         type: array
+                                    capability_indices:
+                                        items:
+                                            type: integer
+                                        type: array
                                     dependencies:
                                         items:
                                             type: string
@@ -2828,6 +2832,10 @@ components:
                                     capabilities:
                                         items:
                                             type: string
+                                        type: array
+                                    capability_indices:
+                                        items:
+                                            type: integer
                                         type: array
                                     dependencies:
                                         items:

--- a/tools/terminal/schemas.go
+++ b/tools/terminal/schemas.go
@@ -403,7 +403,7 @@ func architectureSchema() map[string]any {
 			},
 			"component_boundaries": map[string]any{
 				"type":        "array",
-				"description": "Component definitions with name, responsibility, dependencies, upstream_refs, implementation_files, and capabilities. ADR-043 Move 1 — Winston declares the BMAD tech-spec scope here: every component owns its file space AND maps to capabilities. Sarah uses this in the next phase to shard requirements into ready-for-dev stories.",
+				"description": "Component definitions with name, responsibility, dependencies, upstream_refs, implementation_files, and capability_indices. ADR-043 Move 1 — Winston declares the BMAD tech-spec scope here: every component owns its file space AND maps to capabilities. Sarah uses this in the next phase to shard requirements into ready-for-dev stories.",
 				"items": map[string]any{
 					"type": "object",
 					"properties": map[string]any{
@@ -423,13 +423,13 @@ func architectureSchema() map[string]any {
 							"items":       map[string]any{"type": "string"},
 							"description": "Workspace-relative paths this component owns (ADR-043 Move 1). Source these from plan.scope.create for new components or the existing project tree for modified components. Emit at least one entry, and at least one entry MUST be a source-code file (.java/.go/.ts/.py/.rs/…); companion documentation files (.md/.txt) MAY appear alongside source but never alone. The min-1 + at-least-one-source invariants are enforced by workflow.ValidateComponentImplementationFiles at architecture-generator parse time and by plan-reviewer R2 rules architecture.component_missing_implementation_files and architecture.component_implementation_files_doc_only — strict-mode JSON schema does not support minItems so the cardinality lives in the validator.",
 						},
-						"capabilities": map[string]any{
+						"capability_indices": map[string]any{
 							"type":        "array",
-							"items":       map[string]any{"type": "string"},
-							"description": "Kebab-case capability names from plan.exploration.capabilities[] that this component implements (ADR-043 Move 1). Bidirectional bridge between Mary's capability list and the file space this component just declared. Emit at least one entry. Every capability MUST appear in at least one component's list, otherwise plan-reviewer R2 rule capability.unresolved_in_architecture rejects the architecture. The min-1 invariant is enforced by workflow.ValidateCapabilityCoverage at architecture-generator parse time.",
+							"items":       map[string]any{"type": "integer", "minimum": 0},
+							"description": "0-based indices into the prompt's '## Capabilities (from analyst)' list — the capabilities this component implements (ADR-043 Move 1; indexed form 2026-06-07). Reference capabilities by INDEX, never re-type their names: paraphrased kebab-case names ('typed-control-streams' → 'typed-controlstreams') fail coverage. The system resolves indices to names. Emit at least one entry. Every analyst capability MUST appear in at least one component's capability_indices, else plan-reviewer R2 rule capability.unresolved_in_architecture rejects; an out-of-range index is rejected at architecture-generator parse time.",
 						},
 					},
-					"required":             []string{"name", "responsibility", "dependencies", "upstream_refs", "implementation_files", "capabilities"},
+					"required":             []string{"name", "responsibility", "dependencies", "upstream_refs", "implementation_files", "capability_indices"},
 					"additionalProperties": false,
 				},
 			},

--- a/ui/src/lib/types/api.generated.ts
+++ b/ui/src/lib/types/api.generated.ts
@@ -2732,6 +2732,7 @@ export interface components {
                 }[];
                 component_boundaries: {
                     capabilities?: string[];
+                    capability_indices?: number[];
                     dependencies: string[];
                     implementation_files?: string[];
                     name: string;
@@ -3004,6 +3005,7 @@ export interface components {
                 }[];
                 component_boundaries: {
                     capabilities?: string[];
+                    capability_indices?: number[];
                     dependencies: string[];
                     implementation_files?: string[];
                     name: string;

--- a/workflow/plan_story.go
+++ b/workflow/plan_story.go
@@ -382,26 +382,49 @@ func ValidateTaskDAG(parentStoryID string, tasks []Task) error {
 	return nil
 }
 
-// ValidateCapabilityCoverage checks that every Capability declared in the
-// exploration is implemented by at least one ComponentDef whose Capabilities
-// list contains the capability's Name (ADR-043 Move 1, plan-reviewer R2
-// rule capability.unresolved_in_architecture). Empty exploration or empty
-// components slice is treated as "nothing to validate yet" — pre-PR 2
-// plans and back-compat reads pass through clean. The check fires once the
-// exploration is populated AND the architecture has components.
+// ResolveCapabilityIndices populates each component's Capabilities (names) from
+// its architect-authored CapabilityIndices, resolving indices against the
+// analyst's Exploration capability list. This is what makes the
+// architect→analyst capability link mismatch-proof (2026-06-07): the architect
+// references capabilities by index, the system fills in the canonical names, so
+// a paraphrased name can never slip through coverage.
 //
-// Returns ErrInvalidStoryStructure wrapped with a COMPLETE coverage hint: ALL
-// uncovered capabilities (not just the first), the full declared-capability set,
-// and the architect's current component→capabilities mapping. The
-// architecture-generator surfaces this back to Winston via retry-feedback.
-//
-// Reporting only the first miss (the pre-2026-06-07 behavior) produced
-// whack-a-mole across retries: the architect fixed the named capability, blindly
-// restructured, and dropped another — on a 2026-06-07 mavlink-hard run it
-// oscillated (4 components → 1 → 1) and exhausted all retries without ever
-// covering all four capabilities. The complete hint gives the architect the full
-// target plus its current state so it can close coverage in one cycle (mirrors
-// harnessResolutionHint listing all valid catalog IDs).
+// An out-of-range index is rejected (the architect referenced a capability that
+// doesn't exist). Components that carry no CapabilityIndices are left untouched
+// (back-compat with records/tests that authored Capabilities names directly).
+// No-op when the exploration has no capabilities.
+func ResolveCapabilityIndices(exp *Exploration, components []ComponentDef) error {
+	if exp == nil || len(exp.Capabilities) == 0 {
+		return nil
+	}
+	n := len(exp.Capabilities)
+	for i := range components {
+		c := &components[i]
+		if len(c.CapabilityIndices) == 0 {
+			continue
+		}
+		names := make([]string, 0, len(c.CapabilityIndices))
+		seen := make(map[int]bool, len(c.CapabilityIndices))
+		for _, idx := range c.CapabilityIndices {
+			if idx < 0 || idx >= n {
+				return fmt.Errorf("%w: component %q references capability_index %d which is out of range (0..%d) — index into the analyst's Capabilities list, do not invent indices",
+					ErrInvalidStoryStructure, c.Name, idx, n-1)
+			}
+			if seen[idx] {
+				continue
+			}
+			seen[idx] = true
+			names = append(names, exp.Capabilities[idx].Name)
+		}
+		c.Capabilities = names
+	}
+	return nil
+}
+
+// ValidateCapabilityCoverage checks that every capability is implemented by at
+// least one component. With ResolveCapabilityIndices run first, the component
+// names are guaranteed to be canonical, so this is now a pure coverage check
+// (no name-mismatch class).
 func ValidateCapabilityCoverage(exp *Exploration, components []ComponentDef) error {
 	if exp == nil || len(exp.Capabilities) == 0 || len(components) == 0 {
 		return nil
@@ -473,8 +496,12 @@ func ValidateComponentImplementationFiles(components []ComponentDef) error {
 			return fmt.Errorf("%w: component %q implementation_files %v contains only documentation files — every component must own at least one source-code file",
 				ErrInvalidStoryStructure, c.Name, c.ImplementationFiles)
 		}
-		if len(c.Capabilities) == 0 {
-			return fmt.Errorf("%w: component %q has empty capabilities — every component must implement at least one capability from plan.exploration.capabilities[]",
+		// Capability declared via either form: indexed (capability_indices, the
+		// architect's contract) or named (Capabilities, back-compat / post-resolution).
+		// This check runs before ResolveCapabilityIndices populates names, so it
+		// must accept the indices form.
+		if len(c.Capabilities) == 0 && len(c.CapabilityIndices) == 0 {
+			return fmt.Errorf("%w: component %q has empty capability_indices — every component must implement at least one capability (reference the analyst's Capabilities list by 0-based index)",
 				ErrInvalidStoryStructure, c.Name)
 		}
 	}

--- a/workflow/plan_story_test.go
+++ b/workflow/plan_story_test.go
@@ -543,6 +543,55 @@ func TestValidateStoryFileOwnership(t *testing.T) {
 	})
 }
 
+func TestResolveCapabilityIndices(t *testing.T) {
+	exp := &Exploration{Capabilities: []Capability{
+		{Name: "mavsdk-lifecycle"}, {Name: "typed-control-streams"}, {Name: "raw-mavlink-io"},
+	}}
+
+	t.Run("indices resolve to canonical names (mismatch-proof)", func(t *testing.T) {
+		comps := []ComponentDef{{Name: "driver", CapabilityIndices: []int{0, 2}}}
+		if err := ResolveCapabilityIndices(exp, comps); err != nil {
+			t.Fatal(err)
+		}
+		got := comps[0].Capabilities
+		if len(got) != 2 || got[0] != "mavsdk-lifecycle" || got[1] != "raw-mavlink-io" {
+			t.Fatalf("got %v, want canonical names from indices", got)
+		}
+		// And coverage now sees canonical names — no paraphrase possible.
+		comps2 := []ComponentDef{{Name: "driver", CapabilityIndices: []int{0, 1, 2}}}
+		_ = ResolveCapabilityIndices(exp, comps2)
+		if err := ValidateCapabilityCoverage(exp, comps2); err != nil {
+			t.Fatalf("full index coverage should pass: %v", err)
+		}
+	})
+
+	t.Run("out-of-range index rejected", func(t *testing.T) {
+		comps := []ComponentDef{{Name: "driver", CapabilityIndices: []int{0, 5}}}
+		err := ResolveCapabilityIndices(exp, comps)
+		if err == nil || !errors.Is(err, ErrInvalidStoryStructure) {
+			t.Fatalf("expected out-of-range rejection, got %v", err)
+		}
+	})
+
+	t.Run("dedups repeated indices", func(t *testing.T) {
+		comps := []ComponentDef{{Name: "driver", CapabilityIndices: []int{1, 1, 1}}}
+		_ = ResolveCapabilityIndices(exp, comps)
+		if len(comps[0].Capabilities) != 1 {
+			t.Fatalf("expected dedup to 1, got %v", comps[0].Capabilities)
+		}
+	})
+
+	t.Run("no indices leaves authored Capabilities untouched (back-compat)", func(t *testing.T) {
+		comps := []ComponentDef{{Name: "driver", Capabilities: []string{"legacy-name"}}}
+		if err := ResolveCapabilityIndices(exp, comps); err != nil {
+			t.Fatal(err)
+		}
+		if len(comps[0].Capabilities) != 1 || comps[0].Capabilities[0] != "legacy-name" {
+			t.Fatalf("back-compat authored names should be preserved, got %v", comps[0].Capabilities)
+		}
+	})
+}
+
 func TestValidateCapabilityCoverage(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -668,12 +717,19 @@ func TestValidateComponentImplementationFiles(t *testing.T) {
 			errPhrase: "only documentation files",
 		},
 		{
-			name: "empty capabilities rejected",
+			name: "no capability (neither indices nor names) rejected",
 			components: []ComponentDef{
 				{Name: "a", ImplementationFiles: []string{"src/a.go"}, Capabilities: nil},
 			},
 			wantErr:   ErrInvalidStoryStructure,
-			errPhrase: "empty capabilities",
+			errPhrase: "empty capability_indices",
+		},
+		{
+			name: "capability via indices (no names yet) is accepted",
+			components: []ComponentDef{
+				{Name: "a", ImplementationFiles: []string{"src/a.go"}, CapabilityIndices: []int{0}},
+			},
+			wantErr: nil,
 		},
 	}
 	for _, tc := range cases {

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -870,15 +870,28 @@ type ComponentDef struct {
 	// entry per component once PR 2 ships.
 	ImplementationFiles []string `json:"implementation_files,omitempty"`
 
+	// CapabilityIndices are 0-based indices into the analyst's Exploration
+	// capability list — the capabilities this component implements (ADR-043
+	// Move 1, indexed form added 2026-06-07). The architect references
+	// capabilities by INDEX rather than re-typing names: mid-tier models
+	// paraphrase kebab-case identifiers ("typed-control-streams" →
+	// "typed-controlstreams"), and exact-string capability matching then
+	// fails coverage on cosmetically-wrong names. Indexing makes the
+	// architect→analyst capability link mismatch-proof. The system resolves
+	// these to Capabilities (the names) via workflow.ResolveCapabilityIndices;
+	// an out-of-range index is rejected at arch-gen.
+	CapabilityIndices []int `json:"capability_indices,omitempty"`
+
 	// Capabilities are kebab-case Capability.Name entries this component
-	// implements (ADR-043 Move 1). Winston's bidirectional bridge between
-	// Mary's capability list and the file space he just declared.
-	// Plan-reviewer R2 rule capability.unresolved_in_architecture rejects
-	// capabilities that have no component whose Capabilities list contains
-	// them.
+	// implements (ADR-043 Move 1). SYSTEM-DERIVED from CapabilityIndices when
+	// those are present (the architect no longer authors names); falls back to
+	// architect-authored values for records/tests predating the indexed form.
+	// Winston's bidirectional bridge between Mary's capability list and the
+	// file space he just declared. Plan-reviewer R2 rule
+	// capability.unresolved_in_architecture rejects capabilities that have no
+	// component whose Capabilities list contains them.
 	//
-	// omitempty for the same back-compat reason as ImplementationFiles;
-	// new plans require ≥1 entry per component once PR 2 ships.
+	// omitempty for the same back-compat reason as ImplementationFiles.
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 


### PR DESCRIPTION
## Problem
On `mavlink-hard` runs the architect (gemini-pro) repeatedly failed `capability_coverage` by **paraphrasing** the analyst's kebab-case capability names:

| analyst declared | architect wrote |
|---|---|
| `typed-control-streams` | `typed-controlstreams` |
| `typed-telemetry-datastreams` | `typed-telemetry-streams` |
| `raw-mavlink-io` | `generic-raw-mavlink-fallback` |

Coverage matches on exact string, so each restructure re-introduced a fresh mismatch → the plan exhausted its retries at architecture and never reached execution.

## Root cause
`ArchitectPromptContext` **never carried the capability list at all** — the architect was *inventing* component capability names loosely from the requirements, with nothing to copy. Asking a mid-tier model to reproduce exact identifiers it was never shown is inherently fragile.

## Fix — mirror Sarah's ADR-044 `capability_indices` contract
- The architect prompt now renders the analyst capability list with 0-based indices (`## Capabilities (from analyst)`), and `component_boundaries[]` declares `capability_indices` (ints) instead of re-typed `capabilities` (strings).
- `workflow.ResolveCapabilityIndices` resolves indices → canonical names server-side and populates `ComponentDef.Capabilities`; an **out-of-range index is rejected** at arch-gen. **Name mismatch is now structurally impossible.**
- `ValidateCapabilityCoverage` runs on the resolved names (pure coverage check). `ValidateComponentImplementationFiles` accepts the indices form (it runs before resolution).
- `ComponentDef` gains `CapabilityIndices` (architect-authored); `Capabilities` is system-derived, with back-compat fallback to authored names.

This is the non-gaming fix (vs fuzzy name-matching, which would wrongly accept `raw-mavlink-io` ≈ `generic-raw-mavlink-fallback`).

## Tests
`TestResolveCapabilityIndices` (resolve, out-of-range reject, dedup, back-compat) + `ValidateComponentImplementationFiles` accepts indices form. `go test ./...` (69 pkgs) + `task lint` green. Regenerated openapi + ui TS types.

## Validation
This was the last architect-convergence blocker. With it, plan-prep should reliably reach execution on `mavlink-hard` (paid re-run pending). Secondary follow-up still open: the architect won't switch OSH to `source_build` despite #126's hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)