### PR TITLE
fix(e2e): forward per-tier backend timeout/retry env into the semspec container

### DIFF
--- a/ui/docker-compose.e2e-llm.yml
+++ b/ui/docker-compose.e2e-llm.yml
@@ -110,6 +110,18 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - SPARKY_API_KEY=${SPARKY_API_KEY:-}
       - BRAVE_API_KEY=${BRAVE_API_KEY:-}
+      # Per-tier backend timeouts/retries. taskfiles/e2e.yml sets these as task
+      # env for hard/mavlink-hard tiers, but they were NOT forwarded into the
+      # container, so configs/e2e-*.json fell back to its :-3600 default — on a
+      # 2026-06-08 mavlink-hard run the requirement-executor used 1h instead of
+      # the intended 2h and 3 still-progressing requirements were killed. Bare
+      # passthrough forwards each when set; when unset the config's own default
+      # applies (so non-llm/default runs are unaffected).
+      - SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS
+      - SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS
+      - SEMSPEC_SCENARIO_ORCH_TIMEOUT
+      - SEMSPEC_RECOVERY_TIMEOUT_SECONDS
+      - SEMSPEC_MAX_REQUIREMENT_RETRIES
     depends_on:
       sandbox:
         condition: service_healthy


### PR DESCRIPTION
## Bug
`taskfiles/e2e.yml` sets `SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS` (+ execution-manager / scenario-orch / recovery / max-requirement-retries) as task env for hard tiers, but `ui/docker-compose.e2e-llm.yml`'s `semspec` service never declared them — so they stayed in the compose *process* env and were **not forwarded into the container**. `configs/e2e-*.json` fell back to its `${...:-3600}` default.

**Effect:** on the 2026-06-08 mavlink-hard run the requirement-executor used a **1h** timeout instead of the intended **2h**, and 3 still-progressing requirements were killed mid-DAG → `AutoRejectOnExhaustion (completed=1 failed=3)`. Verified in-container: `SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS=` (empty).

## Fix
Bare passthrough of the 5 `SEMSPEC_*` timeout/retry vars on the semspec service. Bare form forwards each when set (hard tiers) and leaves the config default when unset (default/easy unaffected).

Validated with `docker compose config` (task env set) → rendered service now shows `SEMSPEC_REQ_EXECUTOR_TIMEOUT_SECONDS: "7200"`.

## Does NOT fully green hard-tier (honest)
The Playwright "execution completes" cap (~1.4h) and gemini-pro pace are still shorter than a 17-node hard fixture needs. Tracked separately:
- #138 — reconcile Playwright vs per-req timeout + pace
- #139 — indexing-gate stale-context drag
- #140 — NATS ack_wait vs loop duration (redelivery risk, esp. prod 5m)

This PR removes the one *confirmed config bug* so the intended per-tier budgets actually apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)