### PR TITLE
fix(e2e): semsource reads /workspace in place so new commits re-index

### DIFF
--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -27,9 +27,11 @@ services:
       - SEMSOURCE_LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       - ../../docker/semsource.json:/etc/semsource/semsource.json:ro
-      # Bind-mount a gitconfig that marks every repo as safe. Without this, git
-      # refuses host-owned repos when semsource runs as root and initial clone
-      # retries for 2m30s before succeeding on subsequent attempts.
+      # Bind-mount a gitconfig that marks every repo as safe. The git source
+      # reads /workspace IN PLACE (path-based, no clone — see semsource.json),
+      # running `git rev-parse`/`git log` as root against a host-owned repo;
+      # without safe.directory=* git refuses those reads. (This also covered the
+      # old clone path's 2m30s safe.directory retry, now eliminated.)
       - ../../docker/semsource.gitconfig:/root/.gitconfig:ro
       - ../../test/e2e/workspace:/workspace:ro
     command: ["run", "--config", "/etc/semsource/semsource.json", "--log-level", "${LOG_LEVEL:-info}"]

--- a/docker/semsource.json
+++ b/docker/semsource.json
@@ -5,6 +5,7 @@
     {
       "type": "git",
       "url": "/workspace",
+      "path": "/workspace",
       "branch": "main",
       "poll_interval": "10s",
       "watch": true


### PR DESCRIPTION
## Problem

The git source in `docker/semsource.json` was configured with `url:/workspace`. semsource's `git` type requires a `url`, and a `url` without a `path` forces the **remote-clone** path: semsource does `git clone /workspace …` once at startup, then the watch loop only runs `git rev-parse HEAD` against that **frozen clone** — it never fetches new commits. So commits made during a run were never re-indexed into the source graph.

## Fix

Add `"path": "/workspace"` alongside the existing `"url"`. `resolveRepoPath` prefers `path` → semsource reads `/workspace` **in place** (no clone, full history, 10s poll) — matching how the `ast`/`docs`/`config` sources are already configured. Validated live against `ghcr.io/c360studio/semsource:latest` (no rebuild): a new commit re-indexed in ~4s vs never.

## Honest scope: this is correctness + hygiene, not a run-quality fix

Earlier framing (that this removed a "~40% review-reject" churn) was **inherited speculation and is retracted.** I have no measured evidence semsource staleness degraded runs, and the causal chain is in fact weak:
- The **code context** agents use (files/AST/docs) flows through the `ast`/`docs`/`config` sources, which are path-based and were never broken — only the **commit** entities (this source) were frozen.
- Developers read code via **bash**, not the graph.
- Agent roles have **no `graph_*` tools** (removed 2026-05-12), and the prompt graph manifest is being **muted** (#144) — so nothing in the agent path reads the source graph at all.

So this PR's value is: (1) it's the **correct** config — semsource should read a local repo in place, not clone-freeze it; (2) **hygiene** — kills a latent bug; (3) keeps the source graph fresh for the **non-agent** consumers that do use it (graph-gateway `/debug`, OpenSpec import, health); (4) **insurance** for when the graph-for-agents subsystem is revived. It is not a measured quality fix.

> ⚠️ Sharp edge: semsource seeds the `semstreams_config` KV once and doesn't overwrite on boot; that bucket persists on the `nats-data` volume. `task e2e:*` does `down -v`, so this takes effect on the first run. A prod stack would need a KV wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)