### PR TITLE
fix(execution): make the indexing gate correct, keep it disabled in e2e (dormant graph subsystem)

### DIFF
--- a/cmd/sandbox/server.go
+++ b/cmd/sandbox/server.go
@@ -447,8 +447,18 @@ type mergeRequest struct {
 // (silent work-drop). String-matching the Note field is the legacy path
 // and must not be relied on.
 type mergeResponse struct {
-	Status          string           `json:"status"`
-	Commit          string           `json:"commit,omitempty"`
+	Status string `json:"status"`
+	Commit string `json:"commit,omitempty"`
+
+	// WorkCommit is the SHA of the worktree's own commit (the agent's actual
+	// work), captured before the --no-ff merge. Commit, by contrast, is the
+	// MERGE commit that --no-ff always creates. semsource walks `git log
+	// --no-merges`, so it never indexes the merge commit — only WorkCommit is
+	// a regular commit reachable from main and therefore indexed. The indexing
+	// gate must wait on WorkCommit, not Commit, or it can never observe the
+	// commit and always times out. Empty in the nothing-to-commit case.
+	WorkCommit string `json:"work_commit,omitempty"`
+
 	Note            string           `json:"note,omitempty"`
 	NothingToCommit bool             `json:"nothing_to_commit,omitempty"`
 	FilesChanged    []fileChangeInfo `json:"files_changed,omitempty"`
@@ -945,6 +955,7 @@ func (s *Server) mergeIntoMainRepo(ctx context.Context, taskID, hash string, req
 				return mergeResponse{
 					Status:         "merged",
 					Commit:         mergeHash,
+					WorkCommit:     hash,
 					FilesChanged:   filesChanged,
 					RecoveryNote:   recovered.note,
 					DiscardedPaths: recovered.discarded,
@@ -997,6 +1008,7 @@ func (s *Server) mergeIntoMainRepo(ctx context.Context, taskID, hash string, req
 	return mergeResponse{
 		Status:       "merged",
 		Commit:       mergeHash,
+		WorkCommit:   hash,
 		FilesChanged: filesChanged,
 	}, nil
 }

--- a/configs/e2e-claude.json
+++ b/configs/e2e-claude.json
@@ -594,7 +594,7 @@
         "max_tdd_cycles": 5,
         "timeout_seconds": 3600,
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s"
       }
     },

--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -684,7 +684,7 @@
         "max_tdd_cycles": 7,
         "timeout_seconds": ${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s",
         "enable_positive_lessons": true
       }

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -878,7 +878,7 @@
         "max_tdd_cycles": 5,
         "timeout_seconds": ${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s",
         "enable_positive_lessons": true
       }

--- a/configs/e2e-hybrid.json
+++ b/configs/e2e-hybrid.json
@@ -877,7 +877,7 @@
         "max_tdd_cycles": 5,
         "timeout_seconds": ${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s",
         "enable_positive_lessons": true
       }

--- a/configs/e2e-openrouter.json
+++ b/configs/e2e-openrouter.json
@@ -724,7 +724,7 @@
         "max_tdd_cycles": 5,
         "timeout_seconds": 3600,
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s",
         "enable_positive_lessons": true
       }

--- a/configs/e2e-sparky.json
+++ b/configs/e2e-sparky.json
@@ -576,7 +576,7 @@
         "max_tdd_cycles": 5,
         "timeout_seconds": 3600,
         "sandbox_url": "http://sandbox:8090",
-        "graph_gateway_url": "http://localhost:8082",
+        "graph_gateway_url": "",
         "indexing_budget": "60s",
         "enable_positive_lessons": true
       }

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -20,6 +20,7 @@
 package executionmanager
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2320,9 +2321,14 @@ func (c *Component) mergeWorktree(exec *taskExecution) error {
 	// gate only fires when FilesModified is non-empty.
 	exec.MergeCommit = result.Commit
 
-	// Wait for semsource to index the merge commit so dependent tasks
-	// get fresh graph context. Soft gate: proceeds with warning on timeout.
-	c.awaitIndexing(result.Commit, exec.TaskID)
+	// Wait for semsource to index this task's work so dependent tasks get fresh
+	// graph context. Soft gate: proceeds with warning on timeout. Gate on
+	// WorkCommit (the worktree's own regular commit), NOT result.Commit (the
+	// --no-ff merge commit) — semsource walks `git log --no-merges`, so it never
+	// indexes the merge commit and a gate keyed on it could never pass. cmp.Or
+	// falls back to the merge commit when the sandbox didn't report a work commit
+	// (older sandbox), preserving prior behavior rather than silently skipping.
+	c.awaitIndexing(cmp.Or(result.WorkCommit, result.Commit), exec.TaskID)
 	return nil
 }
 

--- a/tools/sandbox/client.go
+++ b/tools/sandbox/client.go
@@ -184,8 +184,16 @@ func (c *Client) DeleteWorktree(ctx context.Context, taskID string) error {
 // `Commit == ""`. An empty Commit without NothingToCommit==true means the
 // sandbox response was malformed or the contract was violated.
 type MergeResult struct {
-	Status          string           `json:"status"`
-	Commit          string           `json:"commit,omitempty"`
+	Status string `json:"status"`
+	Commit string `json:"commit,omitempty"`
+
+	// WorkCommit is the worktree's own commit SHA (the agent's work), captured
+	// before the --no-ff merge. Commit is the MERGE commit. semsource indexes
+	// via `git log --no-merges`, so only WorkCommit (a regular commit) ever
+	// becomes a graph entity — the indexing gate must wait on WorkCommit, not
+	// the merge Commit. Empty in the nothing-to-commit case.
+	WorkCommit string `json:"work_commit,omitempty"`
+
 	Note            string           `json:"note,omitempty"`
 	NothingToCommit bool             `json:"nothing_to_commit,omitempty"`
 	FilesChanged    []FileChangeInfo `json:"files_changed,omitempty"`

--- a/workflow/indexing_gate.go
+++ b/workflow/indexing_gate.go
@@ -19,13 +19,28 @@ const (
 	indexingQueryTimeout = 3 * time.Second // per-query HTTP timeout
 	maxIndexingBytes     = 1 << 20         // 1 MiB response limit
 
-	// GraphQL query to find commit entities by predicate.
-	// NOTE: This fetches ALL commit entities. As the graph accumulates history,
-	// this response grows. The maxIndexingBytes limit (1 MiB) provides a safety
-	// cap. Future improvement: use a targeted entity ID query once the commit
-	// entity ID format (org.semsource.git.system.commit.<sha7>) is known.
-	commitQueryGQL = `{"query":"{ entitiesByPredicate(predicate: \"source.git.commit.sha\") { id predicates { predicate object } } }"}`
+	// commitSHAPredicate is the vocabulary predicate semsource attaches to a git
+	// commit entity carrying the FULL 40-char SHA (semsource handler/git emits
+	// both source.git.commit.sha [full] and .short_sha). The graph-gateway
+	// entitiesByPredicate resolver supports a `value:` argument that filters
+	// server-side on this predicate's object, so we pass the full SHA directly.
+	commitSHAPredicate = "source.git.commit.sha"
 )
+
+// commitQueryGQL builds the graph-gateway GraphQL request that asks for the
+// entity IDs whose source.git.commit.sha predicate equals fullSHA.
+//
+// graph-gateway's entitiesByPredicate returns a list of entity-ID STRINGS
+// (wire shape {"data":{"entitiesByPredicate":{"entities":[...]}}}), not entity
+// objects — so the query carries no sub-selection. The `value:` arg lets the
+// resolver filter by the SHA object server-side; we still verify the returned
+// IDs client-side (see containsCommitSHA) so correctness does not depend on the
+// value filter being honored. fullSHA is hex, so no escaping is required.
+func commitQueryGQL(fullSHA string) string {
+	return fmt.Sprintf(
+		`{"query":"{ entitiesByPredicate(predicate: \"%s\", value: \"%s\") }"}`,
+		commitSHAPredicate, fullSHA)
+}
 
 // IndexingGate checks whether semsource has indexed a specific commit
 // by querying graph-gateway for the commit entity.
@@ -111,7 +126,7 @@ func (g *IndexingGate) isCommitIndexed(ctx context.Context, commitSHA string) bo
 
 	req, err := http.NewRequestWithContext(queryCtx, http.MethodPost,
 		g.graphGatewayURL+"/graphql",
-		strings.NewReader(commitQueryGQL))
+		strings.NewReader(commitQueryGQL(commitSHA)))
 	if err != nil {
 		g.logger.Debug("indexing gate: request creation failed", "error", err)
 		return false
@@ -139,30 +154,62 @@ func (g *IndexingGate) isCommitIndexed(ctx context.Context, commitSHA string) bo
 	return containsCommitSHA(body, commitSHA)
 }
 
-// containsCommitSHA parses a GraphQL response and checks if any entity
-// has a source.git.commit.sha predicate matching the target SHA.
+// containsCommitSHA parses a graph-gateway entitiesByPredicate response and
+// reports whether the target commit is indexed.
+//
+// The resolver returns a list of entity-ID STRINGS, not entity objects. semsource
+// builds the commit entity ID with the SHORT (7-char) sha
+// (e.g. semspec.semsource.git.workspace.commit.<sha7>), while AwaitCommitIndexed
+// is handed a full SHA. We therefore match the ".commit.<sha7>" suffix rather
+// than a full-string compare — which also makes the result correct even if the
+// gateway ignores the value: filter and returns every commit ID.
+//
+// The confirmed wire shape is {"data":{"entitiesByPredicate":{"entities":[...]}}}.
+// We also tolerate a bare {"entitiesByPredicate":[...]} array, since the
+// introspection schema advertises [String] and gateway versions may differ.
 func containsCommitSHA(body []byte, targetSHA string) bool {
+	short := targetSHA
+	if len(short) > 7 {
+		short = short[:7]
+	}
+	if short == "" {
+		return false
+	}
+	suffix := ".commit." + short
+
 	var gqlResp struct {
 		Data struct {
-			EntitiesByPredicate []struct {
-				Predicates []struct {
-					Predicate string `json:"predicate"`
-					Object    string `json:"object"`
-				} `json:"predicates"`
-			} `json:"entitiesByPredicate"`
+			EntitiesByPredicate json.RawMessage `json:"entitiesByPredicate"`
 		} `json:"data"`
 	}
-
 	if err := json.Unmarshal(body, &gqlResp); err != nil {
 		return false
 	}
+	raw := gqlResp.Data.EntitiesByPredicate
+	if len(raw) == 0 {
+		return false
+	}
 
-	for _, entity := range gqlResp.Data.EntitiesByPredicate {
-		for _, p := range entity.Predicates {
-			if p.Predicate == "source.git.commit.sha" && p.Object == targetSHA {
+	matches := func(ids []string) bool {
+		for _, id := range ids {
+			if strings.HasSuffix(id, suffix) {
 				return true
 			}
 		}
+		return false
+	}
+
+	// Confirmed shape: object with an "entities" string list.
+	var obj struct {
+		Entities []string `json:"entities"`
+	}
+	if json.Unmarshal(raw, &obj) == nil && matches(obj.Entities) {
+		return true
+	}
+	// Fallback shape: bare array of entity-ID strings.
+	var ids []string
+	if json.Unmarshal(raw, &ids) == nil && matches(ids) {
+		return true
 	}
 	return false
 }

--- a/workflow/indexing_gate_test.go
+++ b/workflow/indexing_gate_test.go
@@ -14,25 +14,27 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
-// commitResponse builds a GraphQL response containing a commit entity
-// with the given SHA.
+// commitResponse builds a graph-gateway entitiesByPredicate response in the
+// real wire shape: {"data":{"entitiesByPredicate":{"entities":[<id>...]}}}.
+// semsource builds the commit entity ID with the SHORT 7-char sha, so the ID
+// suffix is ".commit.<sha7>" regardless of the full SHA the gate is handed.
 func commitResponse(sha string) []byte {
-	return []byte(fmt.Sprintf(`{
-		"data": {
-			"entitiesByPredicate": [{
-				"id": "acme.semsource.git.repo.commit.%s",
-				"predicates": [
-					{"predicate": "source.git.commit.sha", "object": %q},
-					{"predicate": "source.git.commit.subject", "object": "feat: something"}
-				]
-			}]
-		}
-	}`, sha[:7], sha))
+	return []byte(fmt.Sprintf(
+		`{"data":{"entitiesByPredicate":{"entities":["acme.semsource.git.repo.commit.%s"]}}}`,
+		sha[:7]))
 }
 
-// emptyResponse builds a GraphQL response with no matching entities.
+// emptyResponse builds a response with no matching entities (object shape).
 func emptyResponse() []byte {
-	return []byte(`{"data": {"entitiesByPredicate": []}}`)
+	return []byte(`{"data":{"entitiesByPredicate":{"entities":[]}}}`)
+}
+
+// bareArrayResponse builds the legacy/introspection [String] shape:
+// {"data":{"entitiesByPredicate":[<id>...]}} — exercised by the parser fallback.
+func bareArrayResponse(sha string) []byte {
+	return []byte(fmt.Sprintf(
+		`{"data":{"entitiesByPredicate":["acme.semsource.git.repo.commit.%s"]}}`,
+		sha[:7]))
 }
 
 func newTestGate(srv *httptest.Server) *IndexingGate {
@@ -63,12 +65,13 @@ func TestNewIndexingGate_EmptyURL(t *testing.T) {
 }
 
 func TestNewIndexingGate_ValidURL(t *testing.T) {
-	g := NewIndexingGate("http://localhost:8082", nil)
+	const url = "http://localhost:8080/graph-gateway"
+	g := NewIndexingGate(url, nil)
 	if g == nil {
 		t.Fatal("expected non-nil gate for valid URL")
 	}
-	if g.graphGatewayURL != "http://localhost:8082" {
-		t.Errorf("gatewayURL = %q, want http://localhost:8082", g.graphGatewayURL)
+	if g.graphGatewayURL != url {
+		t.Errorf("gatewayURL = %q, want %q", g.graphGatewayURL, url)
 	}
 }
 
@@ -232,8 +235,46 @@ func TestContainsCommitSHA_EmptyResponse(t *testing.T) {
 	}
 }
 
+// The live graph-gateway returns {"entities":null} (not []) when nothing
+// matches the value filter — captured from a real probe.
+func TestContainsCommitSHA_NullEntities(t *testing.T) {
+	body := []byte(`{"data":{"entitiesByPredicate":{"entities":null}}}`)
+	if containsCommitSHA(body, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef") {
+		t.Error("expected false for null entities (live empty-match shape)")
+	}
+}
+
 func TestContainsCommitSHA_MalformedJSON(t *testing.T) {
 	if containsCommitSHA([]byte(`{bad json`), "anything") {
 		t.Error("expected false for malformed JSON")
+	}
+}
+
+// The gate is handed a FULL 40-char SHA but the entity ID embeds only the
+// short 7-char sha; the match must normalize.
+func TestContainsCommitSHA_FullSHAMatchesShortID(t *testing.T) {
+	full := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	if !containsCommitSHA(commitResponse(full), full) {
+		t.Error("expected full SHA to match the short-sha entity ID suffix")
+	}
+}
+
+// A different commit's full SHA must not match (different 7-char prefix).
+func TestContainsCommitSHA_DifferentCommitNotFound(t *testing.T) {
+	indexed := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	other := "fedcba9876543210fedcba9876543210fedcba98"
+	if containsCommitSHA(commitResponse(indexed), other) {
+		t.Error("expected a non-indexed commit to not match")
+	}
+}
+
+// The parser must also handle the bare [String] array shape.
+func TestContainsCommitSHA_BareArrayShape(t *testing.T) {
+	sha := "abc123def456abc123def456abc123def456abc1"
+	if !containsCommitSHA(bareArrayResponse(sha), sha) {
+		t.Error("expected true for bare-array entitiesByPredicate shape")
+	}
+	if containsCommitSHA(bareArrayResponse(sha), "fedcba9876543210fedcba9876543210fedcba98") {
+		t.Error("expected false for non-matching SHA in bare-array shape")
 	}
 }


### PR DESCRIPTION
## What this is now

The indexing gate (`execution-manager` → `workflow/indexing_gate.go`) was broken 4 ways and could never pass (closes #139). This PR **fixes all four in code** so the gate is *correct if re-enabled* — but **leaves it disabled in e2e** because the source-graph-for-agents subsystem is currently dormant.

### The 4 bugs (all fixed in code)

| # | Bug | Fix |
|---|-----|-----|
| 1 | URL `:8082` (standalone bind, not served in the deployed path) | gate code correct; URL now config-driven |
| 2 | Query asked for `{ id predicates{…} }` vs flat `{entities:[…]}` | `entitiesByPredicate(predicate, value:<fullSHA>)`, server-side value filter (live-validated) |
| 3 | Parsed wrong shape + full-SHA vs short-sha-in-ID | parse `entities[]string` (+ bare-array/null fallback), match `.commit.<sha7>` suffix |
| **4** | **(dominant)** waited on the `--no-ff` merge commit that `--no-merges` never indexes | sandbox surfaces the worktree `WorkCommit`; execution-manager gates on it (`cmp.Or` fallback) |

The old test mocked a **guessed** response shape (masking bugs 2–3); rewritten against the real wire shape (live-probed) + null/bare-array/full-vs-short coverage. go-reviewer: approved, 0 critical/high.

### Why it's left disabled

`graph_gateway_url` is set to `""` in all 6 e2e configs (same as prod) → `NewIndexingGate` returns nil → `awaitIndexing` is a no-op. **No gate calls, no timeouts, no connection-refused spam.**

The source-graph subsystem is dormant: agent roles have **no `graph_*` tools** (removed 2026-05-12, see `prompt.DefaultToolFilters`) and the prompt **graph manifest is muted** (companion PR). Nothing in the agent path reads the source graph, so gating dependent tasks on its freshness would add up to 60s/merge of latency for zero benefit.

### Re-enabling later

When graph query tools return (e.g. semstreams `research_graph`), flip `graph_gateway_url` back to `http://localhost:8080/graph-gateway` — the gate code is correct and ready.

### Honesty note

Earlier framing of this gate as a "~40% review-reject contributor" was **inherited speculation and is retracted** — there is no measured run-quality impact. This PR is correctness + hygiene + insurance, not a quality fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)