### PR TITLE
refactor(prompt): mute the graph manifest (agents have no graph tools)

### DIFF
--- a/tools/workflow/graph_summary_test.go
+++ b/tools/workflow/graph_summary_test.go
@@ -76,6 +76,13 @@ func TestGraphQueryDescription_TeachesGraphQLNotSPARQL(t *testing.T) {
 // that exposed the manifest-vs-tool-description conflict. The fix
 // follows the semdragon pattern: drop literal examples from tool
 // descriptions, let the manifest carry truth.
+//
+// NOTE (2026-06-09): both the graph manifest (graphManifestMuted, see
+// manifest.go) and the graph_query tool itself (no role allows graph_* —
+// prompt.DefaultToolFilters) are currently DORMANT, so this contract is not
+// live. Retained intentionally as insurance: if graph query tools return
+// (e.g. semstreams research_graph), the description must still point at the
+// manifest rather than a fabricated literal. Do not delete with the mute.
 func TestGraphQueryDescription_NoLiteralFakeNamespaceExample(t *testing.T) {
 	exec := &GraphExecutor{}
 	var graphQuery *agentic.ToolDefinition

--- a/tools/workflow/manifest.go
+++ b/tools/workflow/manifest.go
@@ -6,6 +6,19 @@ import (
 	"github.com/c360studio/semspec/graph"
 )
 
+// graphManifestMuted gates injection of the Knowledge Graph manifest into agent
+// prompts. MUTED 2026-06-09: agent roles have no graph_* query tools (removed
+// 2026-05-12 — see prompt.DefaultToolFilters), so the manifest advertised a
+// queryable graph and handed out entity IDs ("e.g. <id>") that no agent could
+// act on. It was injected into all 10 prompt-building components
+// (~200-500 tokens/prompt plus a per-prompt graph-gateway summary fetch) for
+// zero actionable benefit, and the paired graph_query "copy IDs from the
+// manifest" guidance pointed at a tool no role can call. When fetchFn returns
+// "", GraphManifestFragment's Condition (fetchFn()!="") excludes the fragment
+// entirely — no header, no render, no HTTP. Flip to false to restore when graph
+// query tools return (e.g. semstreams research_graph).
+var graphManifestMuted = true
+
 // RegistrySummaryFetchFn returns a closure suitable for GraphManifestFragment
 // that fetches the formatted graph summary from the global SourceRegistry.
 // Replaces the legacy ManifestClient and FederatedManifestFetchFn with a single
@@ -13,6 +26,9 @@ import (
 // readiness, and multi-source aggregation internally).
 func RegistrySummaryFetchFn() func() string {
 	return func() string {
+		if graphManifestMuted {
+			return ""
+		}
 		reg := graph.GlobalSources()
 		if reg == nil {
 			return ""


### PR DESCRIPTION
## Why

The Knowledge Graph manifest (`prompt.GraphManifestFragment`) is injected into **every LLM prompt across 10 components** (planner, architecture-generator, requirement-generator, scenario-generator, story-preparer, requirement-executor, execution-manager, plan-reviewer, qa-reviewer, lesson-decomposer). It advertises a queryable graph and hands out entity IDs (`e.g. <id>`) for a `graph_query` capability that **no agent role has** — `graph_*` tools were removed from every role 2026-05-12 (`prompt.DefaultToolFilters`).

So today it's:
- **~200–500 tokens of prompt bloat per call** (largest in the epic/hard stack, which lists 4 federated sources — exactly where we're pace-constrained),
- a **per-prompt graph-gateway summary fetch** (5s timeout / 5-min cache),
- and a mild hazard — the paired `graph_query` "copy IDs from the manifest" guidance points agents at a tool they can't call.

…for zero actionable benefit.

## Change

Mute at the single choke point. `RegistrySummaryFetchFn` returns `""` when the new `graphManifestMuted` flag is set, short-circuiting before the registry fetch. `GraphManifestFragment`'s `Condition` is `fetchFn() != ""`, so the fragment is **excluded entirely across all 10 sites** — no header, no render, no HTTP.

**Reversible:** flip `graphManifestMuted` to `false` when graph query tools return (e.g. semstreams `research_graph`).

## Review

- **go-reviewer: approved, 0 critical/high.** It verified `RegistrySummaryFetchFn` is the *only* live source-graph prompt-injection path (other `FormatSummaryForPrompt` callers are a health endpoint + the unreachable `graph_summary` tool + tests; the `software.go`/`research.go` graph fragments are static prose gated on `HasTool("graph_summary")`, never true in prod). Compiles clean (no lint/unreachable risk), breaks no tests.
- Added a note to `TestGraphQueryDescription_NoLiteralFakeNamespaceExample` marking the contract dormant-but-retained.

## Pairs with #143

#143 leaves the indexing gate disabled in e2e. Together, the source-graph-for-agents subsystem is cleanly dormant: no manifest, no tools, no gate — nothing in the agent path reads the source graph.

### Follow-ups (not in this PR)
- `planner.waitForGraphReady` (`processor/planner/component.go`) is a ~60s startup wait "so agents have graph data" — now vestigial with the manifest muted; candidate for removal.
- If the gate/manifest are ever re-enabled, the gate needs a real-fixture integration test (current `indexing_gate_test.go` uses synthetic blobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)