### PR TITLE
fix(e2e): config parity — ack_wait redelivery bug, recovery caps, disable dormant graph-clustering

### DIFF
--- a/configs/e2e-claude.json
+++ b/configs/e2e-claude.json
@@ -718,9 +718,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-claude.json
+++ b/configs/e2e-claude.json
@@ -213,6 +213,21 @@
         "fallback": [
           "claude-sonnet"
         ]
+      },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["claude-opus"],
+        "fallback": ["claude-sonnet"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["claude-opus"],
+        "fallback": ["claude-sonnet"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["claude-opus"],
+        "fallback": ["claude-sonnet"]
       }
     },
     "defaults": {
@@ -288,6 +303,10 @@
       "config": {
         "max_iterations": 50,
         "timeout": "3600s",
+        "consumer": {
+          "ack_wait": "3900s",
+          "heartbeat_interval": "240s"
+        },
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
         "content_bucket": "AGENT_CONTENT",
@@ -300,7 +319,23 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "3600s"
+        "timeout": "900s",
+        "ports": {
+          "inputs": [
+            {
+              "name": "agent.request",
+              "type": "jetstream",
+              "subject": "agent.request.>",
+              "stream_name": "AGENT",
+              "required": true,
+              "config": { "ack_wait": "1200s", "heartbeat_interval": "240s" }
+            }
+          ],
+          "outputs": [
+            { "name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true },
+            { "name": "agent.stream", "type": "nats", "subject": "agent.stream.*", "required": false }
+          ]
+        }
       }
     },
     "agentic-tools": {

--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -52,7 +52,7 @@
         "tool_format": "openai",
         "stream": false,
         "reasoning_effort": "medium",
-        "request_timeout": "300s",
+        "request_timeout": "900s",
         "wire_backend": "wire"
       },
       "semembed": {
@@ -346,7 +346,7 @@
         "content_bucket": "AGENT_CONTENT",
         "trajectory_detail": "full",
         "consumer": {
-          "ack_wait": "1440s",
+          "ack_wait": "2100s",
           "heartbeat_interval": "240s"
         }
       }
@@ -357,7 +357,7 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "1800s",
+        "timeout": "900s",
         "ports": {
           "inputs": [
             {
@@ -367,7 +367,7 @@
               "stream_name": "AGENT",
               "required": true,
               "config": {
-                "ack_wait": "1440s",
+                "ack_wait": "1200s",
                 "heartbeat_interval": "240s"
               }
             }
@@ -681,7 +681,7 @@
       "type": "processor",
       "enabled": true,
       "config": {
-        "max_tdd_cycles": 7,
+        "max_tdd_cycles": 5,
         "timeout_seconds": ${SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS:-3600},
         "sandbox_url": "http://sandbox:8090",
         "graph_gateway_url": "",

--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -810,9 +810,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -271,6 +271,21 @@
         "fallback": [
           "gpt-5-5"
         ]
+      },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["gemini-pro"],
+        "fallback": ["gpt-5-5"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["gemini-pro"],
+        "fallback": ["gpt-5-5"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["gemini-pro"],
+        "fallback": ["gpt-5-5"]
       }
     },
     "defaults": {
@@ -346,6 +361,10 @@
       "config": {
         "max_iterations": 120,
         "timeout": "1800s",
+        "consumer": {
+          "ack_wait": "2100s",
+          "heartbeat_interval": "240s"
+        },
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
         "content_bucket": "AGENT_CONTENT",
@@ -362,7 +381,23 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "900s"
+        "timeout": "900s",
+        "ports": {
+          "inputs": [
+            {
+              "name": "agent.request",
+              "type": "jetstream",
+              "subject": "agent.request.>",
+              "stream_name": "AGENT",
+              "required": true,
+              "config": { "ack_wait": "1200s", "heartbeat_interval": "240s" }
+            }
+          ],
+          "outputs": [
+            { "name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true },
+            { "name": "agent.stream", "type": "nats", "subject": "agent.stream.*", "required": false }
+          ]
+        }
       }
     },
     "agentic-tools": {
@@ -998,7 +1033,7 @@
         },
         "detection_interval": "30s",
         "batch_size": 100,
-        "enable_llm": true,
+        "enable_llm": false,
         "min_community_size": 2,
         "max_iterations": 100,
         "enable_structural": true,

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -1004,9 +1004,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-hybrid.json
+++ b/configs/e2e-hybrid.json
@@ -270,6 +270,21 @@
         "fallback": [
           "claude-sonnet"
         ]
+      },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["gemini-pro"],
+        "fallback": ["claude-sonnet"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["gemini-pro"],
+        "fallback": ["claude-sonnet"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["gemini-pro"],
+        "fallback": ["claude-sonnet"]
       }
     },
     "defaults": {
@@ -345,6 +360,10 @@
       "config": {
         "max_iterations": 120,
         "timeout": "1800s",
+        "consumer": {
+          "ack_wait": "2100s",
+          "heartbeat_interval": "240s"
+        },
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
         "content_bucket": "AGENT_CONTENT",
@@ -361,7 +380,23 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "900s"
+        "timeout": "900s",
+        "ports": {
+          "inputs": [
+            {
+              "name": "agent.request",
+              "type": "jetstream",
+              "subject": "agent.request.>",
+              "stream_name": "AGENT",
+              "required": true,
+              "config": { "ack_wait": "1200s", "heartbeat_interval": "240s" }
+            }
+          ],
+          "outputs": [
+            { "name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true },
+            { "name": "agent.stream", "type": "nats", "subject": "agent.stream.*", "required": false }
+          ]
+        }
       }
     },
     "agentic-tools": {
@@ -997,7 +1032,7 @@
         },
         "detection_interval": "30s",
         "batch_size": 100,
-        "enable_llm": true,
+        "enable_llm": false,
         "min_community_size": 2,
         "max_iterations": 100,
         "enable_structural": true,

--- a/configs/e2e-hybrid.json
+++ b/configs/e2e-hybrid.json
@@ -1003,9 +1003,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-local.json
+++ b/configs/e2e-local.json
@@ -725,9 +725,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-local.json
+++ b/configs/e2e-local.json
@@ -224,6 +224,21 @@
         "fallback": [
           "qwen3-14b"
         ]
+      },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["qwen3-14b"],
+        "fallback": ["qwen3-14b"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["qwen3-14b"],
+        "fallback": ["qwen3-14b"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["qwen3-14b"],
+        "fallback": ["qwen3-14b"]
       }
     },
     "defaults": {
@@ -304,7 +319,7 @@
         "content_bucket": "AGENT_CONTENT",
         "trajectory_detail": "full",
         "consumer": {
-          "ack_wait": "5m",
+          "ack_wait": "1200s",
           "heartbeat_interval": "2m",
           "max_deliver": 2
         }
@@ -316,7 +331,23 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "900s"
+        "timeout": "900s",
+        "ports": {
+          "inputs": [
+            {
+              "name": "agent.request",
+              "type": "jetstream",
+              "subject": "agent.request.>",
+              "stream_name": "AGENT",
+              "required": true,
+              "config": { "ack_wait": "1200s", "heartbeat_interval": "240s" }
+            }
+          ],
+          "outputs": [
+            { "name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true },
+            { "name": "agent.stream", "type": "nats", "subject": "agent.stream.*", "required": false }
+          ]
+        }
       }
     },
     "agentic-tools": {
@@ -608,7 +639,7 @@
       "type": "processor",
       "enabled": true,
       "config": {
-        "max_tdd_cycles": 3,
+        "max_tdd_cycles": 5,
         "timeout_seconds": 900,
         "sandbox_url": "http://sandbox:8090"
       }

--- a/configs/e2e-openrouter.json
+++ b/configs/e2e-openrouter.json
@@ -849,9 +849,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,

--- a/configs/e2e-openrouter.json
+++ b/configs/e2e-openrouter.json
@@ -257,6 +257,21 @@
           "openrouter-llama-3-3-70b"
         ]
       },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["openrouter-qwen3-6-27b"],
+        "fallback": ["openrouter-llama-3-3-70b"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["openrouter-qwen3-6-27b"],
+        "fallback": ["openrouter-llama-3-3-70b"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["openrouter-qwen3-6-27b"],
+        "fallback": ["openrouter-llama-3-3-70b"]
+      },
       "fast": {
         "description": "Quick responses, classification",
         "preferred": [
@@ -382,7 +397,7 @@
         "content_bucket": "AGENT_CONTENT",
         "trajectory_detail": "full",
         "consumer": {
-          "ack_wait": "720s",
+          "ack_wait": "1200s",
           "heartbeat_interval": "240s"
         }
       }
@@ -403,7 +418,7 @@
               "stream_name": "AGENT",
               "required": true,
               "config": {
-                "ack_wait": "720s",
+                "ack_wait": "1200s",
                 "heartbeat_interval": "240s"
               }
             }

--- a/configs/e2e-sparky.json
+++ b/configs/e2e-sparky.json
@@ -192,6 +192,21 @@
         "fallback": [
           "sparky-qwen"
         ]
+      },
+      "plan_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for plan-manager escalations (revision-cap exhaustion, plan-review wedges)",
+        "preferred": ["sparky-qwen"],
+        "fallback": ["sparky-qwen"]
+      },
+      "execution_wedge_recovery": {
+        "description": "ADR-037 stage 1 recovery agent for execution-manager escalations (TDD-cycle exhaustion, tool-loop wedges, fixable-rejection cascades)",
+        "preferred": ["sparky-qwen"],
+        "fallback": ["sparky-qwen"]
+      },
+      "coordinator_recovery": {
+        "description": "ADR-037 stage 2 coordinator recovery agent for QA failures and cross-phase wedges",
+        "preferred": ["sparky-qwen"],
+        "fallback": ["sparky-qwen"]
       }
     },
     "defaults": {
@@ -267,6 +282,10 @@
       "config": {
         "max_iterations": 50,
         "timeout": "900s",
+        "consumer": {
+          "ack_wait": "1200s",
+          "heartbeat_interval": "240s"
+        },
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
         "content_bucket": "AGENT_CONTENT",
@@ -279,7 +298,23 @@
       "enabled": true,
       "config": {
         "stream_name": "AGENT",
-        "timeout": "900s"
+        "timeout": "900s",
+        "ports": {
+          "inputs": [
+            {
+              "name": "agent.request",
+              "type": "jetstream",
+              "subject": "agent.request.>",
+              "stream_name": "AGENT",
+              "required": true,
+              "config": { "ack_wait": "1200s", "heartbeat_interval": "240s" }
+            }
+          ],
+          "outputs": [
+            { "name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true },
+            { "name": "agent.stream", "type": "nats", "subject": "agent.stream.*", "required": false }
+          ]
+        }
       }
     },
     "agentic-tools": {

--- a/configs/e2e-sparky.json
+++ b/configs/e2e-sparky.json
@@ -701,9 +701,9 @@
         "enable_structural": true,
         "pivot_count": 16,
         "max_hop_distance": 10,
-        "enable_anomaly_detection": true,
+        "enable_anomaly_detection": false,
         "anomaly_config": {
-          "enabled": true,
+          "enabled": false,
           "max_anomalies_per_run": 100,
           "core_anomaly": {
             "enabled": true,


### PR DESCRIPTION
Reconciles systematic drift across the 7 e2e LLM configs. Two stacked commits.

**Validated:** all 7 configs load + `Validate()` via the real `loadConfigWithEnvSubstitution` path (the function `main()` uses). `go build ./cmd/semspec` passes.

## `0fea700d` — disable graph-clustering anomaly detection
The semantic-gap detector fired a `graph.embedding.query.similar` NATS request per pivot entity every 30s. The pivot index accumulates unbounded ephemeral execution telemetry (94.6% of hits were `agent.agentic-loop.step`), graph-embedding has no vector for them, so ~91% return the framework's `"error: …"` reply that FindSimilar then fails to JSON-unmarshal (`invalid character 'e'`). Measured **547,859 failures / run (~3,852–4,671/min)** — no useful output (no agent reads the graph since graph tools were removed), but it floods NATS and the log. Disabling is safe: separable flag, e2e-only (not in prod `semspec.json`), `/graph-summary` community detection untouched.

## `cf51bf9f` — config parity reconciliation
**ack_wait redelivery bug (both consumer layers):**
- agentic-loop consumer `ack_wait = loop.timeout + 300s` (was ≤ loop.timeout or missing→90s in 6/7) — loops near budget had their task message redelivered mid-flight.
- agentic-model port `ack_wait = 1200s` (was missing→120s in 5/7) — a >120s LLM call (gemini-pro/gpt-5.5 @ 900s) got its model-request redelivered → **duplicate frontier-model call**. Declared the `agent.request` input port (matching semstreams `DefaultConfig` exactly) where absent.

**Normalizations:**
- `agentic-model.timeout` → 900s uniform (per-call timeout; evidence shows calls run well under).
- `max_tdd_cycles` → 5 (was 7 gemini / 3 local).
- `gemini-pro` `request_timeout` 300→900s (300s was timing out slow pro calls → silent fallback to flash; ~842 fallback events last run).
- ADR-037 recovery capabilities added to the 6 configs missing them (were falling to the `gemini-flash` default — wedge-recovery on the weakest model). Each uses its config's `task_decomposition` model chain.
- graph-clustering `enable_llm` → false in the 2 hybrids (graph dormant).

## Not in this PR (separate decisions)
- **ADR-039 worktree-leak governance** (`rule-processor` + `agentic-loop.tool_call_governance`) exists only in the 2 hybrids; gemini + 4 others have none, and gemini's dev hits the leak class it prevents. Adding it needs efficacy validation + a per-call-latency call.
- `version` fields left as-is (e2e stacks run fresh via `down -v`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)