### PR TITLE
fix(workflow): upsert requirement/capability/decision triples — stop ENTITY_STATES leak

### DIFF
--- a/workflow/lessons/writer.go
+++ b/workflow/lessons/writer.go
@@ -269,7 +269,11 @@ func (w *Writer) RotateLessonsForRole(ctx context.Context, role string, limit in
 	now := time.Now()
 	for i := range selected {
 		eid := agentgraph.LessonEntityID(selected[i].ID)
-		if err := w.TW.WriteTriple(ctx, eid, agentgraph.PredicateLessonLastInjectedAt, now.Format(time.RFC3339)); err != nil {
+		// Upsert (remove+add), not append: this fires on every injection cycle for
+		// the same lesson entity. Plain WriteTriple accumulated a LastInjectedAt
+		// triple per injection and grew lesson entities unboundedly during long
+		// executions (the same ENTITY_STATES leak class as the plan child triples).
+		if err := w.TW.UpdateTriple(ctx, eid, agentgraph.PredicateLessonLastInjectedAt, now.Format(time.RFC3339)); err != nil {
 			if w.Logger != nil {
 				w.Logger.Debug("Failed to bump LastInjectedAt — rotation degrades to recency",
 					"lesson_id", selected[i].ID, "error", err)

--- a/workflow/plan_capability.go
+++ b/workflow/plan_capability.go
@@ -58,27 +58,33 @@ func writeCapabilityTriples(ctx context.Context, tw *graphutil.TripleWriter, c *
 	}
 	entityID := CapabilityEntityID(slug, c.Name)
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityName, c.Name)
-	if err := tw.WriteTriple(ctx, entityID, semspec.CapabilityLifecycle, string(c.Lifecycle)); err != nil {
+	// Upsert scalars + replace edge lists so re-persisting on every plan
+	// mutation doesn't accumulate duplicate triples (graph-ingest AddTriple is
+	// append-only — the #132 plan-entity bloat class, applied to capabilities).
+	_ = tw.UpdateTriple(ctx, entityID, semspec.CapabilityName, c.Name)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.CapabilityLifecycle, string(c.Lifecycle)); err != nil {
 		return fmt.Errorf("write capability lifecycle: %w", err)
 	}
 	if c.Description != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDescription, c.Description)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.CapabilityDescription, c.Description)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityPlan, planEntityID)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.CapabilityPlan, planEntityID)
 
-	// Multi-valued depends_on — one triple per edge, value is the hashed
-	// instance ID of the prerequisite Capability (matches the entity-ID
-	// suffix scheme used by RequirementDependsOn).
+	// Multi-valued depends_on — value is the hashed instance ID of the
+	// prerequisite Capability (matches RequirementDependsOn's suffix scheme).
+	deps := make([]string, 0, len(c.DependsOn))
 	for _, dep := range c.DependsOn {
-		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilityDependsOn, HashInstanceID(slug, dep))
+		deps = append(deps, HashInstanceID(slug, dep))
 	}
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.CapabilityDependsOn, deps)
 
-	// Multi-valued surfaces (ADR-041 Move 2). One triple per declared surface;
-	// SurfaceUI is the gate for downstream @e2e scenario emission.
+	// Multi-valued surfaces (ADR-041 Move 2). SurfaceUI is the gate for
+	// downstream @e2e scenario emission.
+	surfaces := make([]string, 0, len(c.Surfaces))
 	for _, surface := range c.Surfaces {
-		_ = tw.WriteTriple(ctx, entityID, semspec.CapabilitySurface, string(surface))
+		surfaces = append(surfaces, string(surface))
 	}
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.CapabilitySurface, surfaces)
 	return nil
 }
 

--- a/workflow/plan_decision.go
+++ b/workflow/plan_decision.go
@@ -49,26 +49,31 @@ func writePlanDecisionTriples(ctx context.Context, tw *graphutil.TripleWriter, p
 		title = string([]rune(title)[:97]) + "..."
 	}
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionTitle, p.Title)
-	_ = tw.WriteTriple(ctx, entityID, semspec.DCTitle, title)
-	if err := tw.WriteTriple(ctx, entityID, semspec.PlanDecisionStatus, string(p.Status)); err != nil {
+	// Upsert scalars + replace the affected-requirement edge list so re-persisting
+	// on every plan mutation doesn't accumulate duplicate triples (graph-ingest
+	// AddTriple is append-only — the #132 plan-entity bloat class).
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionTitle, p.Title)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, title)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionStatus, string(p.Status)); err != nil {
 		return fmt.Errorf("write change proposal status: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionProposedBy, p.ProposedBy)
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionPlan, p.PlanID)
-	_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionCreatedAt, p.CreatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionProposedBy, p.ProposedBy)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionPlan, p.PlanID)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionCreatedAt, p.CreatedAt.Format(time.RFC3339))
 
 	if p.Rationale != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionRationale, p.Rationale)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionRationale, p.Rationale)
 	}
 	if p.DecidedAt != nil {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionDecidedAt, p.DecidedAt.Format(time.RFC3339))
+		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanDecisionDecidedAt, p.DecidedAt.Format(time.RFC3339))
 	}
 
-	// Write each affected requirement ID as an individual triple (proper graph edges).
+	// Affected requirement IDs as edges (proper graph edges).
+	mutates := make([]string, 0, len(p.AffectedReqIDs))
 	for _, reqID := range p.AffectedReqIDs {
-		_ = tw.WriteTriple(ctx, entityID, semspec.PlanDecisionMutates, reqID)
+		mutates = append(mutates, reqID)
 	}
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanDecisionMutates, mutates)
 
 	return nil
 }

--- a/workflow/plan_requirement.go
+++ b/workflow/plan_requirement.go
@@ -195,23 +195,31 @@ func writeRequirementTriples(ctx context.Context, tw *graphutil.TripleWriter, re
 	}
 	entityID := RequirementEntityID(req.ID)
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.RequirementTitle, req.Title)
-	_ = tw.WriteTriple(ctx, entityID, semspec.DCTitle, req.Title)
-	if err := tw.WriteTriple(ctx, entityID, semspec.RequirementStatus, string(req.Status)); err != nil {
+	// Upsert scalars (UpdateTriple = remove+add) and replace edge lists
+	// (ReplaceTripleList) so re-persisting the requirement on every plan
+	// mutation — which happens on every execution status update — does not
+	// accumulate duplicate triples. graph-ingest AddTriple is append-only, so
+	// plain WriteTriple here grew requirement entities unboundedly during
+	// execution (the #132 plan-entity bloat, same class, applied to requirements).
+	_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementTitle, req.Title)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, req.Title)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.RequirementStatus, string(req.Status)); err != nil {
 		return fmt.Errorf("write requirement status: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.RequirementPlan, req.PlanID)
-	_ = tw.WriteTriple(ctx, entityID, semspec.RequirementCreatedAt, req.CreatedAt.Format(time.RFC3339))
-	_ = tw.WriteTriple(ctx, entityID, semspec.RequirementUpdatedAt, req.UpdatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementPlan, req.PlanID)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementCreatedAt, req.CreatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementUpdatedAt, req.UpdatedAt.Format(time.RFC3339))
 	if req.Description != "" {
-		_ = tw.WriteTriple(ctx, entityID, semspec.RequirementDescription, req.Description)
+		_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementDescription, req.Description)
 	}
 
-	// Write each dependency as an individual triple (proper graph edges).
-	// Hash each dep ID so the stored value is the entity-ID suffix.
+	// Replace the full dependency edge set each persist. Hash each dep ID so the
+	// stored value is the entity-ID suffix.
+	deps := make([]string, 0, len(req.DependsOn))
 	for _, dep := range req.DependsOn {
-		_ = tw.WriteTriple(ctx, entityID, semspec.RequirementDependsOn, HashInstanceID(dep))
+		deps = append(deps, HashInstanceID(dep))
 	}
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.RequirementDependsOn, deps)
 
 	// ADR-043 Move 4 removed Requirement.FilesOwned. File-ownership triples
 	// (semspec.story.files_owned) now emit from the story-persistence path
@@ -230,5 +238,5 @@ func writeRequirementCapabilityTriple(ctx context.Context, tw *graphutil.TripleW
 	}
 	entityID := RequirementEntityID(req.ID)
 	capEntityID := CapabilityEntityID(planSlug, req.CapabilityName)
-	_ = tw.WriteTriple(ctx, entityID, semspec.RequirementCapability, capEntityID)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.RequirementCapability, capEntityID)
 }

--- a/workflow/plan_scenario.go
+++ b/workflow/plan_scenario.go
@@ -41,39 +41,41 @@ func writeScenarioTriples(ctx context.Context, tw *graphutil.TripleWriter, s *Sc
 	}
 	entityID := ScenarioEntityID(s.ID)
 
-	_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioGiven, s.Given)
-	_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioWhen, s.When)
-	if err := tw.WriteTriple(ctx, entityID, semspec.ScenarioStatus, string(s.Status)); err != nil {
+	// Upsert scalars (UpdateTriple = remove+add) and replace edge lists
+	// (ReplaceTripleList) so re-persisting the scenario on every plan mutation —
+	// which happens on every execution status update via writeChildTriples — does
+	// not accumulate duplicate triples. graph-ingest AddTriple is append-only, so
+	// plain WriteTriple here grew scenario entities unboundedly during execution
+	// (the #132 plan-entity bloat, same class as requirements/capabilities/decisions).
+	// Scenarios are the most numerous child (N per requirement, each with several
+	// Then clauses), so this was the largest contributor to the ENTITY_STATES leak.
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ScenarioGiven, s.Given)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ScenarioWhen, s.When)
+	if err := tw.UpdateTriple(ctx, entityID, semspec.ScenarioStatus, string(s.Status)); err != nil {
 		return fmt.Errorf("write scenario status: %w", err)
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioRequirement, RequirementEntityID(s.RequirementID))
-	_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioCreatedAt, s.CreatedAt.Format(time.RFC3339))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ScenarioRequirement, RequirementEntityID(s.RequirementID))
+	_ = tw.UpdateTriple(ctx, entityID, semspec.ScenarioCreatedAt, s.CreatedAt.Format(time.RFC3339))
 
 	title := s.When
 	if len(title) > 100 {
 		title = title[:97] + "..."
 	}
-	_ = tw.WriteTriple(ctx, entityID, semspec.DCTitle, title)
+	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, title)
 
-	// Write each Then clause as an individual triple (proper graph edges).
-	for _, clause := range s.Then {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioThen, clause)
-	}
+	// Multi-valued Then clauses — replace the full edge list each persist.
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.ScenarioThen, s.Then)
 
-	// Tier + facet tags (ADR-041 Move 1). Multi-valued; one triple per tag.
-	for _, tag := range s.Tags {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioTag, tag)
-	}
+	// Tier + facet tags (ADR-041 Move 1). Multi-valued; replace the full list.
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.ScenarioTag, s.Tags)
 
-	// Harness profile bindings (ADR-041 Move 1). Multi-valued; one triple per
-	// bound profile ID. Values are catalog profile IDs (e.g.
-	// "mavlink.px4-sitl.mavsdk-smoke"), not hashed entity IDs — these are
-	// cross-reference strings into the harnesscatalog, not graph edges to
-	// other entities. Plan-reviewer rule scenario.harness_id_unresolved
-	// (Move 4) validates each ID resolves into the catalog.
-	for _, id := range s.HarnessProfileIDs {
-		_ = tw.WriteTriple(ctx, entityID, semspec.ScenarioHarnessProfile, id)
-	}
+	// Harness profile bindings (ADR-041 Move 1). Multi-valued; replace the full
+	// list. Values are catalog profile IDs (e.g. "mavlink.px4-sitl.mavsdk-smoke"),
+	// not hashed entity IDs — these are cross-reference strings into the
+	// harnesscatalog, not graph edges to other entities. Plan-reviewer rule
+	// scenario.harness_id_unresolved (Move 4) validates each ID resolves into the
+	// catalog.
+	_ = tw.ReplaceTripleList(ctx, entityID, semspec.ScenarioHarnessProfile, s.HarnessProfileIDs)
 
 	return nil
 }


### PR DESCRIPTION
Fixes an append-only graph-triple leak that bloated `ENTITY_STATES` during execution and starved a live `WITH_EPIC=1` mavlink-hard run.

## Root cause
#132 fixed the plan-entity 1 MiB bloat by converting the **plan** entity's scalar/list writes to `UpdateTriple`/`ReplaceTripleList` (remove+add) — but only the plan entity. The requirement, capability, and plan-decision entities persisted alongside it (`writeRequirementTriples` / `writeCapabilityTriples` / `writePlanDecisionTriples` in `workflow/`) still used append-only `WriteTriple`. `SaveRequirements`/`SaveCapabilities` re-run on **every** plan mutation — including every execution status update — so those entities accumulated duplicate triples unboundedly.

> Note: `execution-manager/execution_store.go` was already upsert — a red herring. The unfixed bug was in the workflow plan-graph marshaling.

## Live evidence (2026-06-10 `WITH_EPIC=1 gemini mavlink-hard`)
- `KV_ENTITY_STATES` grew **+32 MB / 5 min during execution** while semsource was static (execution-driven growth).
- `graph_index_processed_total` = 27,316 re-index ops on ~4,798 entities (~5.7×/entity, 22,025 CPU-s) → semspec pinned ~349% CPU on GC + re-indexing → starved the sandbox gradle builds → execution crawled.

## Change
Convert all three to the #132 pattern: `UpdateTriple` for scalars, `ReplaceTripleList` for edge lists (`DependsOn`, `Surfaces`, `AffectedReqIDs`, the capability link). Build + `workflow` tests pass.

## Scope note
This stops the **execution-driven** growth. The dominant static `ENTITY_STATES` baseline (~843 MB) is separately attributable to the WITH_EPIC OSH ast/docs graph entities — intentionally **not** stripped here; we want to measure the real resource footprint, sized via the sandbox memory bump (separate change), not hide it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)