### PR TITLE
fix(e2e): raise sandbox resource caps (2G→8G) for parallel OSH-from-source builds

### DIFF
--- a/ui/docker-compose.e2e-llm.yml
+++ b/ui/docker-compose.e2e-llm.yml
@@ -86,9 +86,13 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2"
-          memory: 2G
-          pids: 256
+          # Sized for parallel OSH-from-source gradle builds (WITH_EPIC hard tiers).
+          # The 2G/2cpu/256pid cap starved 8 concurrent dev-loop builds in the
+          # 2026-06-10 mavlink-hard run — sandbox pinned at 1.75/2 GiB with idle,
+          # memory-starved gradle daemons + zombie java procs → execution crawled.
+          cpus: "4"
+          memory: 8G
+          pids: 512
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8090/health"]
       interval: 5s


### PR DESCRIPTION
The UI e2e sandbox `deploy.resources.limits` were `cpus=2 / memory=2G / pids=256`. In the 2026-06-10 `WITH_EPIC=1 gemini mavlink-hard` run, 8 concurrent dev-loop gradle builds — each building `osh-core` from source (OSH has no Maven jar) — **starved**: sandbox pinned at 1.75/2 GiB with idle, memory-starved gradle daemons + zombie java procs → no node completions for ~16 min.

Raises to **`cpus=4 / memory=8G / pids=512`** so parallel OSH builds can run. Intentionally sizing the resources up (not stripping graph-ingest) so the next run reveals the **real resource footprint** for documentation. Host has 23 GiB; with nats ~5G + seminstruct ~6G + semspec ~1G, an 8G sandbox leaves headroom.

Pairs with #147 (the ENTITY_STATES triple-leak fix) — both needed for a completing WITH_EPIC mavlink-hard run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)