### PR TITLE
fix(e2e): add ADR-039 worktree-leak governance to gemini config

### DIFF
--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -348,7 +348,224 @@
         "consumer": {
           "ack_wait": "2100s",
           "heartbeat_interval": "240s"
+        },
+        "tool_call_governance": {
+          "mode": "enforce",
+          "timeout": "1s"
         }
+      }
+    },
+    "rule-processor": {
+      "name": "rule-processor",
+      "type": "processor",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {
+              "name": "rule_toolcall_proposed_in",
+              "subject": "agent.toolcall.proposed.>",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 proposed tool calls awaiting governance verdict"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "toolcall_approved_out",
+              "subject": "agent.toolcall.approved.>",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 approve verdicts to agentic-loop (loop_id.call_id subject shape per migration doc)"
+            },
+            {
+              "name": "toolcall_rejected_out",
+              "subject": "agent.toolcall.rejected.>",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 reject verdicts to agentic-loop (loop_id.call_id subject shape per migration doc)"
+            }
+          ]
+        },
+        "inline_rules": [
+          {
+            "id": "tool-call-governance",
+            "type": "expression",
+            "name": "Tool-call governance — race-free worktree-leak deny + default approve",
+            "description": "Single consolidated rule per semstreams beta.72 / ADR-041 unified evaluator. Fires on every proposed tool call (rule-level condition is a tautological non-empty check on $message.tool_name). Each worktree-leak pattern's publish+deny pair is gated by per-action When clauses on $message.tool_name and $message.command. When a deny action fires, stateful_evaluator short-circuits the remaining actions per its 'break on ErrDenyVerdict' contract, so the unconditional approve at the end only publishes when no deny matched. Race-free in enforce mode — exactly one verdict per call_id, no Go-map-iteration order race. Replaces three sibling rules from beta.71 (block-bash-cd-workspace, block-bash-redirect-workspace, block-bash-tee-workspace) which raced under map iteration when more than one matched (or did not match) the same call.",
+            "enabled": true,
+            "conditions": [
+              {"field": "$message.tool_name", "operator": "ne", "value": "", "required": false}
+            ],
+            "logic": "and",
+            "on_enter": [
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "cd /workspace(\\s|$|[;&|])"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "bash 'cd /workspace' blocked — stay in worktree"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "cd /workspace(\\s|$|[;&|])"}
+                ],
+                "reason": "bash 'cd /workspace' blocked — stay in worktree"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "> /workspace/"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "bash redirect into /workspace/ blocked — write to worktree path"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "> /workspace/"}
+                ],
+                "reason": "bash redirect into /workspace/ blocked — write to worktree path"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "tee /workspace/"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "bash 'tee /workspace/' blocked — write to worktree path"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "tee /workspace/"}
+                ],
+                "reason": "bash 'tee /workspace/' blocked — write to worktree path"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "docker "},
+                  {"field": "$message.command", "operator": "contains", "value": "--privileged"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "docker --privileged blocked — Testcontainers does not need privileged containers; use programmatic Testcontainers API instead"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "docker "},
+                  {"field": "$message.command", "operator": "contains", "value": "--privileged"}
+                ],
+                "reason": "docker --privileged blocked — Testcontainers does not need privileged containers; use programmatic Testcontainers API instead"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "docker "},
+                  {"field": "$message.command", "operator": "contains", "value": "/var/run/docker.sock"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "docker bind-mount of /var/run/docker.sock blocked — nested socket grants sibling-container creation, breaks the sandbox trust boundary"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "contains", "value": "docker "},
+                  {"field": "$message.command", "operator": "contains", "value": "/var/run/docker.sock"}
+                ],
+                "reason": "docker bind-mount of /var/run/docker.sock blocked — nested socket grants sibling-container creation, breaks the sandbox trust boundary"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "docker\\s+run.*(-v|--volume)\\s+/:"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "docker host-root bind-mount blocked — exposes the host filesystem to the spawned container"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "docker\\s+run.*(-v|--volume)\\s+/:"}
+                ],
+                "reason": "docker host-root bind-mount blocked — exposes the host filesystem to the spawned container"
+              },
+              {
+                "type": "publish",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "docker\\s+run.*--network[\\s=]host"}
+                ],
+                "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "rejected",
+                  "call_id": "$message.call_id",
+                  "reason": "docker --network host blocked — bypasses container network isolation; Testcontainers uses bridge networking by default"
+                }
+              },
+              {
+                "type": "deny",
+                "when": [
+                  {"field": "$message.tool_name", "operator": "eq", "value": "bash"},
+                  {"field": "$message.command", "operator": "regex", "value": "docker\\s+run.*--network[\\s=]host"}
+                ],
+                "reason": "docker --network host blocked — bypasses container network isolation; Testcontainers uses bridge networking by default"
+              },
+              {
+                "type": "publish",
+                "subject": "agent.toolcall.approved.$message.loop_id.$message.call_id",
+                "properties": {
+                  "decision": "approved",
+                  "call_id": "$message.call_id"
+                }
+              }
+            ],
+            "metadata": {
+              "category": "governance",
+              "tier": 0,
+              "adr": "041"
+            }
+          }
+        ]
       }
     },
     "agentic-model": {
@@ -863,6 +1080,9 @@
         "agent.created.>",
         "agent.failed.>",
         "agent.context.compaction.>",
+        "agent.toolcall.proposed.>",
+        "agent.toolcall.approved.>",
+        "agent.toolcall.rejected.>",
         "context.build.>",
         "context.built.>",
         "tool.execute.>",


### PR DESCRIPTION
Copies the ADR-039 worktree-leak tool-call governance wiring from the hybrid-gpt5 config to the gemini e2e config so the gemini tier gets the same fail-closed guard. Validated live in the 2026-06-10 `WITH_EPIC=1 gemini mavlink-hard` run (tool calls approved, 0 fail-closed — didn't brick).

Replaces #146, which GitHub auto-closed when its stacked base branch (`fix/e2e-config-parity`, #145) was deleted on merge. Rebased onto main so it now carries only the governance commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)