### PR TITLE
fix: migrate triple.add entity-creators to UpsertEntity before semstreams must-exist (#154)

### DIFF
--- a/docs/audit/mutation-api-graphable-bypass.md
+++ b/docs/audit/mutation-api-graphable-bypass.md
@@ -1,0 +1,286 @@
+# Mutation-API / Graphable-Bypass Audit
+
+Status: audit-only. No code changes in this pass. Pinned to
+`github.com/c360studio/semstreams v1.0.0-beta.103`.
+
+## Scope and stance
+
+This audit examines where semspec writes graph entity state through the
+`graph.mutation.*` subjects (via `workflow/graphutil.TripleWriter`) instead of
+declaring entities through the canonical `graph.Graphable` + `graph.ingest.entity`
+path. It runs in parallel with a similar audit on the semstreams side.
+
+The headline result corrects the framing of the initial pass: **for mutable,
+repeatedly-republished entities the mutation subject is not abuse — it is the only
+correct primitive at beta.103.** The genuine problems are narrower (truly conjured
+entities, raw per-triple writes used as a write path) plus one internal dual-writer
+hazard the first pass missed entirely.
+
+## The load-bearing contract (verified against beta.103)
+
+| Primitive | beta.103 behavior | Source |
+|-----------|-------------------|--------|
+| `graph.Graphable` | Pure declaration contract: `EntityID()` + `Triples()`. No replace/merge semantics. | `graph/graphable.go:54` |
+| `graph.ingest.entity` → `MergeEntity` | Append-only: `existing.Triples = append(existing.Triples, entity.Triples...)` on every re-publish; bumps `Version`; never replaces scalars. | `graph-ingest/component.go:946` |
+| `graph.mutation.entity.update_with_triples` | Only replace-own-predicates primitive: CAS that drops `RemoveTriples` predicates then appends `AddTriples`. | `graphutil/triple.go:524`, `:635` |
+
+Consequence: for an entity re-published on every status/phase change,
+`graph.ingest.entity` accumulates unbounded duplicate triples and lets stale
+scalars (e.g. an old `status`) coexist with new ones — the rule engine reads
+first-match while lifecycle reads last-match, so the divergence is a silent
+correctness bug. This is the gh#177 class, and the write amplification that
+Phase 3a eliminated. `TripleWriter.UpsertEntityIfChanged` over
+`update_with_triples` is the deliberate, correct choice for these entities; the
+reasoning is recorded inline at `graphutil/triple.go:568-603`.
+
+**Implication for any fix:** "migrate entity persistence to `graph.ingest.entity`"
+is safe only for write-once entities. Applying it to mutable entities would
+reintroduce gh#177 corruption and undo the merged Phase-3a leak fix.
+
+## The refined "abuse" definition: `triple.add` implicit entity-create
+
+The abuse is not "use of `graph.mutation.*`" and not "failure to be Graphable." It
+is narrower and sharper: **`graph.mutation.triple.add` silently materializes a
+missing entity from just `triple.Subject`, with no entity-declaration metadata.**
+
+`AddTriple` (`graph-ingest/component.go:1408-1438`) does an upsert: on a missing
+KV record it creates `EntityState{ID: triple.Subject, Version: 0}` — no
+`MessageType`, no producer contract, no Graphable-equivalent declaration — then
+appends the triple. Yet the request contract advertises the opposite:
+`AddTripleRequest` is documented as "adds a triple **to an existing entity**"
+(`graph/mutation_requests.go:77`). That contract-vs-behavior gap is the footgun:
+any `TripleWriter.WriteTriple` (and the add-half of `UpdateTriple` /
+`ReplaceTripleList`) can conjure a metadata-less entity shell.
+
+By contrast, the create-bearing path already carries metadata:
+`CreateEntityWithTriplesRequest.Entity` is a full `EntityState`
+(`mutation_requests.go:39`), so `UpsertEntity`'s create fallback stamps
+`MessageType` on creation. And `update_with_triples` already supports optimistic
+concurrency: `UpdateEntityWithTriplesRequest.ExpectedRevision` (ADR-049,
+`mutation_requests.go:61-71`) rejects on revision mismatch when non-zero — the
+primitive `lifecycle.Manager.Transition` uses for state-machine races. Every
+semspec caller passes zero today.
+
+### Write-class taxonomy
+
+Classify every graph write into one of three classes and bind each to a primitive:
+
+| Class | Definition | Correct primitive | Metadata requirement |
+|-------|------------|-------------------|----------------------|
+| **state** | mutable scalar lifecycle on an entity this writer owns | `update_with_triples` (replace-own); thread `ExpectedRevision` for contended entities | none beyond create-time |
+| **evidence** | append-only fact / relation stamped onto an entity that ALREADY exists | `triple.add` is acceptable **only** when the subject is guaranteed to exist | none (annotates an existing node) |
+| **entity-create** | materializing a new node | `create_with_triples` carrying `EntityState` with `MessageType` (Graphable-equivalent metadata) | **required** |
+
+The abuse is any **entity-create performed through `triple.add`'s implicit
+upsert** — i.e. an evidence/state write whose subject did not yet exist, so it
+births a metadata-less node instead of going through `create_with_triples`.
+
+### The abuse set in semspec (precise)
+
+Entity-create via `triple.add` (metadata-less conjuring) — these are the genuine
+"abuse" sites:
+
+- `workflow/lessons/writer.go` `RecordLesson` — conjures the lesson node via `WriteTriple`.
+- `workflow/parseincident/emit.go` — conjures the standalone incident node via `WriteTriple`.
+- `workflow/recoveryhint/emit.go` — conjures the recovery-incident node via `WriteTriple`.
+- `processor/project-manager/project_store.go` — the first `UpdateTriple` on a
+  fresh `project`/`checklist`/`standards` entity conjures it (no `MessageType`).
+- `agentgraph.Helper` (dead) — a worse variant: raw `kv.Put` whole-entity, no metadata.
+
+State-via-`triple.add` (wrong primitive for mutable lifecycle, no CAS) — the
+[#153](https://github.com/C360Studio/semspec/issues/153) dual-writer set in
+`execution-manager` `component.go` / `task_watcher.go`. Note `task_watcher.go:164-176`
+initializes the task-execution entity via `UpdateTriple`; if that is the first
+write, the entity is **born without `MessageType`** and the later
+`update_with_triples` path will not backfill it (update only adds/removes triples)
+— a concrete instance of the conjure-then-orphan hazard (ordering not yet traced).
+
+NOT abuse: every `UpsertEntity` / `UpsertEntityIfChanged` caller — create goes via
+`create_with_triples` (metadata-bearing), update via `update_with_triples`.
+
+## Per-finding verdicts
+
+| ID | Claim | Verdict | Correction |
+|----|-------|---------|------------|
+| F1 | `TripleWriter` is a mutation facade; large blast radius | Confirmed | Split it: `UpsertEntityIfChanged` (batched + sha256 dirty-track) is the Phase-3a-blessed form; raw `WriteTriple`/`UpdateTriple`/`ReplaceTripleList` used as a write path is the worst form. |
+| F2 | plan-manager persists plan + children via mutation | Confirmed, framing wrong | Entities are mutable-republished; mutation is forced, not abuse. Not ingest-migratable. |
+| F3 | execution-manager bypassed | Confirmed, framing wrong | Same as F2. `payload_registry.go:25` cite is the comment; methods at `:36/:39`. `publishEntity` writes only foreign rel-edges (legit-derived-stamp). |
+| F4 | requirement-executor mutates Graphable-ish entities | Confirmed, sharpened | `RequirementExecutionEntity` mutable → mutation correct. `DAGNodeEntity` is Flavor-A conjured (no registered dag-node payload); its doc comment ("for `graph.ingest.entity`") contradicts the code. |
+| F5 | project config conjured, no Graphable payload | Confirmed | Verified: zero `RegisterPayload` for project-config. Lower severity — `UpdateTriple` is scalar-safe (no append leak), writes are rare. Real gaps: no Graphable contract, per-triple amplification, and a full marshaled JSON blob stored as a triple object (`project_store.go:244`, `ProjectConfigJSON`). |
+| F6 | lessons + incidents create sidecar nodes by mutation | Confirmed, split | Incidents (`parseincident/emit.go`, `recoveryhint/emit.go`) are write-once → the clean migration target. Lessons are NOT write-once — `RetireLesson` (writer.go:311) + `RotateLessonsForRole` (writer.go:276) mutate them post-creation. |
+| O1 | exec-manager + requirement-executor co-write same req-exec entity | Confirmed — real single-writer violation | Predicate sets overlap on six predicates (`Type, Slug, Phase, TraceID, NodeCount, ErrorReason`); each writer's `RemoveTriples` strips the other's values → last-writer-wins. `execution_store.go:493-502` admits a "deferred ownership decision." |
+| O2 | DAGNode published under wrong message type | Confirmed | `publishEntity` hardcodes `RequirementExecutionPayloadType` for every entity (`payload_registry.go:74`); dag-nodes are stamped `requirement-execution/v1` though a correct `DAGNodeEntityType` is registered and unused (`workflow/entity.go:267`). Mislabeled `MessageType`, not a misrouted subject. |
+| O3 | agentgraph.Helper direct ENTITY_STATES KV writes | Confirmed but DEAD | `graph.go:114/310` are raw `kv.Put` whole-entity overwrites bypassing both canonical paths — but test-only dead code (only `graph_test.go` constructs `Helper`). Downgrade to: delete dead code. |
+
+## What the first pass missed
+
+### 1. TaskExecution has two live writers using two different primitives
+
+Highest-priority finding, independent of the ingest-vs-mutation axis. Tracked as
+[C360Studio/semspec#153](https://github.com/C360Studio/semspec/issues/153).
+
+- `execution_store.writeTaskTriples` — atomic `UpsertEntityIfChanged` with a
+  sha256 dirty-track cache and `OwnedPredicates` = the full scalar lifecycle set
+  (`execution_store.go:463-485`).
+- `component.go` + `task_watcher.go` — ~20 out-of-band `UpdateTriple` /
+  `ReplaceTripleList` calls writing the same predicates (`task_watcher.go:164-176`,
+  `component.go:920-921,1075-1080,1148,1275,1318-1321,1421-1425,1507-1508,1876-1879,1901`).
+
+The out-of-band writes mutate the graph without updating the dirty-track hash, so
+a later `saveTask` whose `exec` fields hash-match the cache is silently skipped,
+leaving whatever the fan-out last wrote. A few predicates (`ErrorClass`,
+`CurrentStage`, `Prompt`) are written only by the fan-out and are absent from
+`OwnedPredicates` → mixed ownership. The divergence is latent (provable from the
+code; runtime interleaving not yet traced) and needs single-writer consolidation
+regardless.
+
+### 2. Plan entity also has a second live writer
+
+`graph_marshal.go`'s fan-out `writePlanTriples` (UpdateTriple + ReplaceTripleList)
+is not dead — `workflow/project.go:112` calls it live, alongside
+`plan_store.writePlanTriples` (which uses `UpsertEntityIfChanged`). Same
+dual-primitive shape as #1 for the Plan entity; verify both fire on the same plan
+before asserting impact.
+
+### 3. Other missed call sites (all forced-mutation or clean)
+
+`question-manager` Question via `UpsertEntity` (mutable; has an unused
+`EntityPayload`); plan-manager `external_spec` + deletion-tombstone stamps
+(legit-derived); `plan-decision-handler` Cascade (forced-mutation). One Flavor-A
+candidate: `processor/ast/entities.go` `CodeEntity` has `Triples()` but no
+`EntityID()` (not Graphable) and appears unwired to any graph writer — likely a
+semsource-routed extraction lib or vestigial; verify before acting.
+
+### 4. A refuted hypothesis (recorded for completeness)
+
+`execution-manager/config.go:168` and `requirement-executor/config.go:138`
+(`graph.mutation.triple.add`) are output port declarations, not consumer
+subscriptions. There is no mutation-stream feedback loop.
+
+## Fix shape (corrected) — five-point program
+
+CAS mutation is first-class. The target is not "make everything Graphable"; it is
+to bind each write class to the right primitive and to close the `triple.add`
+entity-create footgun.
+
+**1. Keep CAS mutation as first-class.** `graph.mutation.entity.update_with_triples`
+(replace-own-predicates) stays the canonical write path for mutable entities. The
+Phase-3a `UpsertEntityIfChanged` path is correct and is retained.
+
+**2. State writers use `update_with_triples` with `ExpectedRevision`.** Thread the
+entity's last-known KV revision (ADR-049) so two writers transitioning the same
+entity from the same revision can't both silently commit — the loser gets a
+revision-mismatch and re-reads. This is the canonical fix for the
+[#153](https://github.com/C360Studio/semspec/issues/153) TaskExecution dual-writer
+incoherence, and applies equally to the Plan second-writer (#2 above) and the
+RequirementExecution six-predicate overlap (O1). Replaces the ad-hoc `UpdateTriple`
+fan-outs in `execution-manager` `component.go` / `task_watcher.go` with a single
+CAS state writer.
+
+**3. Stop or constrain `triple.add` upsert-create.** The semstreams-side ask:
+`AddTriple` should not silently materialize a missing entity. Either reject on
+missing subject (forcing callers to create first) or require the create to carry
+metadata. This structurally prevents metadata-less conjuring. Until that lands,
+semspec entity-creators must stop using `triple.add` to create (point 4).
+
+**4. Require entity-declaration metadata only on create.** When a write
+**creates** an entity (or declares a new entity-producer contract), route it
+through `create_with_triples` with a `MessageType` (Graphable-equivalent
+metadata). Mutating an existing entity's predicates needs no re-declaration.
+Concretely: the abuse-set creators — lessons (`writer.go`), parse incidents
+(`parseincident/emit.go`), recovery incidents (`recoveryhint/emit.go`), project
+config (`project_store.go`) — switch their node-create from `WriteTriple` /
+`UpdateTriple` to a metadata-bearing create, and gain a registered payload. The
+write-once incidents can use `graph.ingest.entity` (a registered Graphable
+payload; append-merge harmless). Lessons and project config are mutable, so they
+create via `create_with_triples` + update via `update_with_triples`, not ingest.
+Also: DAGNode (O2) is a create that stamps the wrong `MessageType` — plumb each
+Graphable's own `message.Type` into `publishEntity` and use `DAGNodeEntityType`.
+
+**5. Make the write-API taxonomy explicit.** Add a "state vs evidence vs
+entity-create" distinction to `TripleWriter` (or its callers) so the choice of
+primitive is enforced, not incidental: a `StampEvidence` that asserts the subject
+exists, a `CreateEntity` that demands metadata, and the existing
+`UpsertEntityIfChanged` for state. Delete dead `agentgraph.Helper` (O3) and the
+project-config JSON-blob-in-triple (F5) as part of this pass.
+
+**Still blocked on semstreams:** the mutable entities (Plan, Requirement, Scenario,
+Capability, PlanDecision, Question, Task/RequirementExecution, DAGNode, Cascade,
+lesson body) cannot move to `graph.ingest.entity` until that path gains
+replace-own semantics — they stay on `update_with_triples`. That is consistent
+with point 1, not a migration target.
+
+## Cross-audit coupling (the ask for semstreams)
+
+The semspec and semstreams audits are coupled at two points:
+
+1. **Constrain `triple.add` (point 3).** Make `AddTriple` reject-on-missing or
+   require create metadata, so the implicit metadata-less upsert-create can't
+   happen. This is the structural fix that turns "abuse" from a discipline problem
+   into an impossible one.
+2. **A replace-capable Graphable path.** So that mutable entities could one day be
+   declared canonically: either a Graphable-aware ingest variant that does
+   CAS-replace-own (like `update_with_triples`) instead of `MergeEntity`'s raw
+   append, or an explicit blessing of `update_with_triples` as the canonical write
+   path for mutable Graphable entities (in which case semspec is already correct).
+
+Until those land, treating the mutation **subject** as abuse for mutable entities
+is the wrong target. The real abuse is `triple.add` entity-create; the actionable
+semspec work (points 2, 4, 5) stands on its own.
+
+## Impact: the incoming `triple.add` must-exist change
+
+semstreams is changing `graph.mutation.triple.add` to **must-exist** semantics
+(ADR pending): `AddTriple` will stop conjuring a missing entity. This is point 3 of
+the program landing upstream. Per-entity ordering was traced to classify exposure
+(create-via-`triple.add` breaks; stamp-onto-existing survives; CAS paths are
+untouched).
+
+**Failure mode is silent, not loud.** Almost nothing crashes — the exposed sites
+are best-effort observability writes whose errors are swallowed. The realistic
+outcome is that affected subsystems **quietly stop populating the graph**, noticed
+only when something reads them empty.
+
+### Safe — no change (the whole CAS mirror)
+
+Everything created via `UpsertEntity` / `UpsertEntityIfChanged` already creates
+through `create_with_triples`, never `triple.add`:
+
+| Entity class | Why safe |
+|--------------|----------|
+| **TaskExecution** (~11 `UpdateTriple` sites, `component.go` / `task_watcher.go`) | `saveTask → writeTaskTriples → UpsertEntityIfChanged` runs synchronously inside the create mutation, **before the KV put is visible** to the watcher — the create wins the race every time. |
+| **RequirementExecution + DAGNode** | All writes via `UpsertEntity`; no raw triple writes exist. |
+| **Plan + children (production)** | `handleCreatePlan → planStore.writeTriples → UpsertEntityIfChanged`. |
+| **Question, Cascade** | `UpsertEntity`. |
+| `external_spec` + deletion-tombstone stamps | Stamp entities created earlier via the CAS path. |
+
+### Breaks / silent-drop — the migration set
+
+| Subsystem | Site | Verdict | Consequence |
+|-----------|------|---------|-------------|
+| **Agent lessons** | `workflow/lessons/writer.go:134` (create), `:276` / `:311` (stamps) | BREAKS / silent-drop | `RecordLesson`'s first `WriteTriple` is rejected; all 4 producers swallow the error → the **ADR-033 lessons graph subsystem silently empties**; injection reads nothing. |
+| **Parse + recovery incidents** | `parseincident/emit.go:124`, `recoveryhint/emit.go:90` (node create); `:114` / `:80` (relation) | BREAKS / at-risk | Incident nodes vanish → **ADR-035 CP-1/CP-2 telemetry goes dark**. The relation stamp is also at-risk: the call/loop entity lives only in `AGENT_LOOPS` KV and may have no graph node to attach to. |
+| **Project config** | `project_store.go:229-290` (6× `UpdateTriple` create) | silent-drop | project/checklist/standards graph mirror disappears. Low functional impact — `.semspec/*.json` is durable, HTTP still 200 — but graph reads of config return nothing. |
+| **Plan seeding (tests only)** | `graph_marshal.go:28-85` via `workflow.CreatePlan` | BREAKS | 7 `scenario-orchestrator/integration_test.go` seeds fail. Confirmed test-only — zero production callers; production uses `planStore`. |
+
+### Fix — convert each creator to `UpsertEntity`
+
+Uniform, small, and independently correct (also kills the `triple.add`
+write-amplification). Must land **before** the semstreams bump that ships
+must-exist. Tracked in [#154](https://github.com/C360Studio/semspec/issues/154).
+
+1. `workflow/lessons/writer.go` `RecordLesson` → `UpsertEntity` — highest value.
+2. `parseincident/emit.go` + `recoveryhint/emit.go` incident node → `UpsertEntity`;
+   attach the relation only when the parent exists.
+3. `project_store.go` `writeConfig/Checklist/StandardsTriples` → `UpsertEntity` +
+   a registered project-config payload — lower urgency.
+4. `workflow/graph_marshal.go` `writePlanTriples` → `UpsertEntity` (or route
+   `CreateProjectPlan` through `planStore`) — unblocks the integration tests.
+
+## Clean / excluded (confirmed)
+
+- `semsource/payload.go:22` — compile-time `graph.Graphable` assertion;
+  publishes via `graph.ingest.entity`.
+- `tools/httptool/ingest.go:123` — builds Graphable web payloads → `graph.ingest.entity`.
+- `processor/plan-manager/graph.go:39` — approvals are write-once (fresh UUID per
+  call) → `graph.ingest.entity`; append-merge is harmless.

--- a/processor/project-manager/project_store.go
+++ b/processor/project-manager/project_store.go
@@ -8,10 +8,26 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/semspec"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
 )
+
+// projectConfigEntityType is the message.Type for project-config entities.
+// Domain mirrors the entity ID namespace {prefix}.wf.project.config.{hash}.
+// All three config entities (project, checklist, standards) share this type —
+// they are distinguished by the semspec.ProjectConfigType predicate value
+// ("project" / "checklist" / "standards").
+//
+// Kept local to this package per issue #154 slice #3; DO NOT add to workflow/entity.go
+// (another slice edits nearby).
+var projectConfigEntityType = message.Type{
+	Domain:   "project-config",
+	Category: "entity",
+	Version:  "v1",
+}
 
 // projectStore owns the lifecycle of project configuration entities
 // (project.json, checklist.json, standards.json).
@@ -218,76 +234,142 @@ func (s *projectStore) saveStandards(ctx context.Context, st *workflow.Standards
 // Triple writers
 // ----------------------------------------------------------------------------
 
-// writeConfigTriples writes individual predicates + full JSON blob for project config.
+// writeConfigTriples persists the project config entity via a single
+// metadata-bearing UpsertEntity call (update_with_triples + create_with_triples
+// fallback). This ensures the entity carries a MessageType from its very first
+// write and survives the semstreams triple.add must-exist change (issue #154
+// slice #3).
 func (s *projectStore) writeConfigTriples(ctx context.Context, pc *workflow.ProjectConfig) error {
-	tw := s.tripleWriter
-	if tw == nil {
+	if s.tripleWriter == nil {
 		return nil
 	}
 	entityID := workflow.ProjectConfigEntityID("project")
-
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "project")
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ProjectConfigFile)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigName, pc.Name)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigOrg, pc.Org)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigPlatform, pc.Platform)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, pc.UpdatedAt.Format(time.RFC3339))
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, pc.ApprovedAt != nil)
-	if pc.ApprovedAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, pc.ApprovedAt.Format(time.RFC3339))
-	}
-
-	jsonBlob, err := json.Marshal(pc)
-	if err != nil {
-		return err
-	}
-	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	return s.tripleWriter.UpsertEntity(ctx, projectConfigEntityType, entityID, buildConfigTriples(entityID, pc))
 }
 
-// writeChecklistTriples writes triples for checklist config.
+// writeChecklistTriples persists the checklist config entity via a single
+// metadata-bearing UpsertEntity call (issue #154 slice #3).
 func (s *projectStore) writeChecklistTriples(ctx context.Context, cl *workflow.Checklist) error {
-	tw := s.tripleWriter
-	if tw == nil {
+	if s.tripleWriter == nil {
 		return nil
 	}
 	entityID := workflow.ProjectConfigEntityID("checklist")
-
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "checklist")
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.ChecklistFile)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, cl.UpdatedAt.Format(time.RFC3339))
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, cl.ApprovedAt != nil)
-	if cl.ApprovedAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, cl.ApprovedAt.Format(time.RFC3339))
-	}
-
-	jsonBlob, err := json.Marshal(cl)
-	if err != nil {
-		return err
-	}
-	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	return s.tripleWriter.UpsertEntity(ctx, projectConfigEntityType, entityID, buildChecklistTriples(entityID, cl))
 }
 
-// writeStandardsTriples writes triples for standards config.
+// writeStandardsTriples persists the standards config entity via a single
+// metadata-bearing UpsertEntity call (issue #154 slice #3).
 func (s *projectStore) writeStandardsTriples(ctx context.Context, st *workflow.Standards) error {
-	tw := s.tripleWriter
-	if tw == nil {
+	if s.tripleWriter == nil {
 		return nil
 	}
 	entityID := workflow.ProjectConfigEntityID("standards")
+	return s.tripleWriter.UpsertEntity(ctx, projectConfigEntityType, entityID, buildStandardsTriples(entityID, st))
+}
 
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigType, "standards")
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigFile, workflow.StandardsFile)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, st.UpdatedAt.Format(time.RFC3339))
-	_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApproved, st.ApprovedAt != nil)
+// ----------------------------------------------------------------------------
+// Pure triple builders (testable without NATS)
+// ----------------------------------------------------------------------------
+
+// buildConfigTriples constructs the full []message.Triple for a project config entity.
+// It is a pure function so it can be unit-tested without a NATS connection.
+//
+// Every predicate emitted by the old per-predicate UpdateTriple fan-out is preserved
+// with identical gating. ProjectConfigApproved is always present ("true"/"false").
+// ProjectConfigApprovedAt is conditional on ApprovedAt != nil, matching the original
+// behavior. ProjectConfigJSON is always present so the reconcile path can round-trip.
+//
+// TODO(#154): ProjectConfigJSON is a JSON-blob-in-triple; evaluate dropping once
+// reconcile no longer needs it (requires verifying reconcileConfig/reconcileChecklist/
+// reconcileStandards no longer read it).
+func buildConfigTriples(eid string, pc *workflow.ProjectConfig) []message.Triple {
+	approved := "false"
+	if pc.ApprovedAt != nil {
+		approved = "true"
+	}
+
+	// JSON blob for round-trip reconciliation. The error is intentionally
+	// ignored: ProjectConfig is a plain JSON-marshalable struct (no chan/func/
+	// cyclic fields), so Marshal cannot fail here. The graph write is a
+	// best-effort mirror anyway — the .semspec/*.json file is the durable copy.
+	jsonBlob, _ := json.Marshal(pc)
+
+	triples := []message.Triple{
+		{Subject: eid, Predicate: semspec.ProjectConfigType, Object: "project"},
+		{Subject: eid, Predicate: semspec.ProjectConfigFile, Object: workflow.ProjectConfigFile},
+		{Subject: eid, Predicate: semspec.ProjectConfigName, Object: pc.Name},
+		{Subject: eid, Predicate: semspec.ProjectConfigOrg, Object: pc.Org},
+		{Subject: eid, Predicate: semspec.ProjectConfigPlatform, Object: pc.Platform},
+		{Subject: eid, Predicate: semspec.ProjectConfigUpdatedAt, Object: pc.UpdatedAt.Format(time.RFC3339)},
+		{Subject: eid, Predicate: semspec.ProjectConfigApproved, Object: approved},
+		{Subject: eid, Predicate: semspec.ProjectConfigJSON, Object: string(jsonBlob)},
+	}
+	if pc.ApprovedAt != nil {
+		triples = append(triples, message.Triple{
+			Subject:   eid,
+			Predicate: semspec.ProjectConfigApprovedAt,
+			Object:    pc.ApprovedAt.Format(time.RFC3339),
+		})
+	}
+	return triples
+}
+
+// buildChecklistTriples constructs the full []message.Triple for a checklist entity.
+// Same invariants as buildConfigTriples.
+//
+// TODO(#154): ProjectConfigJSON is a JSON-blob-in-triple; evaluate dropping once
+// reconcile no longer needs it.
+func buildChecklistTriples(eid string, cl *workflow.Checklist) []message.Triple {
+	approved := "false"
+	if cl.ApprovedAt != nil {
+		approved = "true"
+	}
+	jsonBlob, _ := json.Marshal(cl)
+
+	triples := []message.Triple{
+		{Subject: eid, Predicate: semspec.ProjectConfigType, Object: "checklist"},
+		{Subject: eid, Predicate: semspec.ProjectConfigFile, Object: workflow.ChecklistFile},
+		{Subject: eid, Predicate: semspec.ProjectConfigUpdatedAt, Object: cl.UpdatedAt.Format(time.RFC3339)},
+		{Subject: eid, Predicate: semspec.ProjectConfigApproved, Object: approved},
+		{Subject: eid, Predicate: semspec.ProjectConfigJSON, Object: string(jsonBlob)},
+	}
+	if cl.ApprovedAt != nil {
+		triples = append(triples, message.Triple{
+			Subject:   eid,
+			Predicate: semspec.ProjectConfigApprovedAt,
+			Object:    cl.ApprovedAt.Format(time.RFC3339),
+		})
+	}
+	return triples
+}
+
+// buildStandardsTriples constructs the full []message.Triple for a standards entity.
+// Same invariants as buildConfigTriples.
+//
+// TODO(#154): ProjectConfigJSON is a JSON-blob-in-triple; evaluate dropping once
+// reconcile no longer needs it.
+func buildStandardsTriples(eid string, st *workflow.Standards) []message.Triple {
+	approved := "false"
 	if st.ApprovedAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigApprovedAt, st.ApprovedAt.Format(time.RFC3339))
+		approved = "true"
 	}
+	jsonBlob, _ := json.Marshal(st)
 
-	jsonBlob, err := json.Marshal(st)
-	if err != nil {
-		return err
+	triples := []message.Triple{
+		{Subject: eid, Predicate: semspec.ProjectConfigType, Object: "standards"},
+		{Subject: eid, Predicate: semspec.ProjectConfigFile, Object: workflow.StandardsFile},
+		{Subject: eid, Predicate: semspec.ProjectConfigUpdatedAt, Object: st.UpdatedAt.Format(time.RFC3339)},
+		{Subject: eid, Predicate: semspec.ProjectConfigApproved, Object: approved},
+		{Subject: eid, Predicate: semspec.ProjectConfigJSON, Object: string(jsonBlob)},
 	}
-	return tw.UpdateTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
+	if st.ApprovedAt != nil {
+		triples = append(triples, message.Triple{
+			Subject:   eid,
+			Predicate: semspec.ProjectConfigApprovedAt,
+			Object:    st.ApprovedAt.Format(time.RFC3339),
+		})
+	}
+	return triples
 }
 
 // ----------------------------------------------------------------------------

--- a/processor/project-manager/project_store_triples_test.go
+++ b/processor/project-manager/project_store_triples_test.go
@@ -1,0 +1,261 @@
+package projectmanager
+
+// Tests for the pure triple-builder helpers extracted in issue #154 slice #3.
+//
+// These are unit tests that exercise buildConfigTriples, buildChecklistTriples,
+// and buildStandardsTriples without a live NATS connection. They pin:
+//   - the projectConfigEntityType Domain/Category/Version values
+//   - every required scalar predicate is present with the correct value
+//   - ProjectConfigApprovedAt is emitted when ApprovedAt is set, absent when nil
+//   - ProjectConfigJSON blob triple is always present
+//   - all Subject fields match the supplied entity ID
+//
+// The seam pattern is copied from workflow/lessons/writer_test.go (slice #1).
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/message"
+
+	"github.com/c360studio/semspec/vocabulary/semspec"
+	"github.com/c360studio/semspec/workflow"
+)
+
+// indexByPred builds predicate → []string from a triple slice. It verifies
+// every triple's Subject equals wantEID and every Object is a string.
+func indexByPred(t *testing.T, wantEID string, triples []message.Triple) map[string][]string {
+	t.Helper()
+	byPred := make(map[string][]string)
+	for _, tr := range triples {
+		if tr.Subject != wantEID {
+			t.Errorf("triple subject %q != entity ID %q", tr.Subject, wantEID)
+		}
+		val, ok := tr.Object.(string)
+		if !ok {
+			t.Errorf("predicate %q: Object is %T, want string", tr.Predicate, tr.Object)
+			continue
+		}
+		byPred[tr.Predicate] = append(byPred[tr.Predicate], val)
+	}
+	return byPred
+}
+
+// require asserts that predicate pred has exactly one triple with value want.
+func requirePred(t *testing.T, byPred map[string][]string, pred, want string) {
+	t.Helper()
+	vals := byPred[pred]
+	if len(vals) == 0 {
+		t.Errorf("predicate %q absent from triples", pred)
+		return
+	}
+	if vals[0] != want {
+		t.Errorf("predicate %q = %q, want %q", pred, vals[0], want)
+	}
+}
+
+// absentPred asserts that predicate pred has no triples.
+func absentPred(t *testing.T, byPred map[string][]string, pred string) {
+	t.Helper()
+	if len(byPred[pred]) > 0 {
+		t.Errorf("predicate %q should be absent, got %v", pred, byPred[pred])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// projectConfigEntityType: Domain / Category / Version
+// ---------------------------------------------------------------------------
+
+// TestProjectConfigEntityType_Fields pins the exact message.Type values chosen
+// for the project-config entity. These must match the entity ID namespace
+// {prefix}.wf.project.config.{hash}.
+func TestProjectConfigEntityType_Fields(t *testing.T) {
+	if projectConfigEntityType.Domain != "project-config" {
+		t.Errorf("Domain = %q, want %q", projectConfigEntityType.Domain, "project-config")
+	}
+	if projectConfigEntityType.Category != "entity" {
+		t.Errorf("Category = %q, want %q", projectConfigEntityType.Category, "entity")
+	}
+	if projectConfigEntityType.Version != "v1" {
+		t.Errorf("Version = %q, want %q", projectConfigEntityType.Version, "v1")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildConfigTriples
+// ---------------------------------------------------------------------------
+
+func TestBuildConfigTriples_RequiredScalars(t *testing.T) {
+	eid := "semspec.local.wf.project.config.abc"
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	pc := &workflow.ProjectConfig{
+		Name:      "myproject",
+		Org:       "myorg",
+		Platform:  "myplat",
+		UpdatedAt: now,
+	}
+
+	byPred := indexByPred(t, eid, buildConfigTriples(eid, pc))
+
+	requirePred(t, byPred, semspec.ProjectConfigType, "project")
+	requirePred(t, byPred, semspec.ProjectConfigFile, workflow.ProjectConfigFile)
+	requirePred(t, byPred, semspec.ProjectConfigName, "myproject")
+	requirePred(t, byPred, semspec.ProjectConfigOrg, "myorg")
+	requirePred(t, byPred, semspec.ProjectConfigPlatform, "myplat")
+	requirePred(t, byPred, semspec.ProjectConfigUpdatedAt, now.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "false")
+}
+
+func TestBuildConfigTriples_JSONBlobPresent(t *testing.T) {
+	eid := "semspec.local.wf.project.config.abc"
+	pc := &workflow.ProjectConfig{Name: "blob-test", Org: "o", Platform: "p", UpdatedAt: time.Now()}
+
+	byPred := indexByPred(t, eid, buildConfigTriples(eid, pc))
+
+	blob := byPred[semspec.ProjectConfigJSON]
+	if len(blob) == 0 || blob[0] == "" {
+		t.Fatal("ProjectConfigJSON blob predicate absent or empty")
+	}
+	// Verify the blob round-trips.
+	var rt workflow.ProjectConfig
+	if err := json.Unmarshal([]byte(blob[0]), &rt); err != nil {
+		t.Fatalf("JSON blob round-trip unmarshal failed: %v", err)
+	}
+	if rt.Name != "blob-test" {
+		t.Errorf("round-trip Name = %q, want blob-test", rt.Name)
+	}
+}
+
+func TestBuildConfigTriples_ApprovedAtAbsentWhenNil(t *testing.T) {
+	eid := "semspec.local.wf.project.config.abc"
+	pc := &workflow.ProjectConfig{Name: "p", Org: "o", Platform: "pl", UpdatedAt: time.Now()}
+	// ApprovedAt is nil — predicate must be absent.
+
+	byPred := indexByPred(t, eid, buildConfigTriples(eid, pc))
+	absentPred(t, byPred, semspec.ProjectConfigApprovedAt)
+}
+
+func TestBuildConfigTriples_ApprovedAtPresentWhenSet(t *testing.T) {
+	eid := "semspec.local.wf.project.config.abc"
+	approvedAt := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	pc := &workflow.ProjectConfig{
+		Name:       "approved",
+		Org:        "o",
+		Platform:   "pl",
+		UpdatedAt:  time.Now(),
+		ApprovedAt: &approvedAt,
+	}
+
+	byPred := indexByPred(t, eid, buildConfigTriples(eid, pc))
+	requirePred(t, byPred, semspec.ProjectConfigApprovedAt, approvedAt.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "true")
+}
+
+// ---------------------------------------------------------------------------
+// buildChecklistTriples
+// ---------------------------------------------------------------------------
+
+func TestBuildChecklistTriples_RequiredScalars(t *testing.T) {
+	eid := "semspec.local.wf.project.config.def"
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	cl := &workflow.Checklist{
+		Version:   "1.0.0",
+		UpdatedAt: now,
+	}
+
+	byPred := indexByPred(t, eid, buildChecklistTriples(eid, cl))
+
+	requirePred(t, byPred, semspec.ProjectConfigType, "checklist")
+	requirePred(t, byPred, semspec.ProjectConfigFile, workflow.ChecklistFile)
+	requirePred(t, byPred, semspec.ProjectConfigUpdatedAt, now.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "false")
+}
+
+func TestBuildChecklistTriples_JSONBlobPresent(t *testing.T) {
+	eid := "semspec.local.wf.project.config.def"
+	cl := &workflow.Checklist{Version: "1.0.0", UpdatedAt: time.Now()}
+
+	byPred := indexByPred(t, eid, buildChecklistTriples(eid, cl))
+
+	blob := byPred[semspec.ProjectConfigJSON]
+	if len(blob) == 0 || blob[0] == "" {
+		t.Fatal("ProjectConfigJSON blob predicate absent or empty for checklist")
+	}
+}
+
+func TestBuildChecklistTriples_ApprovedAtAbsentWhenNil(t *testing.T) {
+	eid := "semspec.local.wf.project.config.def"
+	cl := &workflow.Checklist{Version: "1.0.0", UpdatedAt: time.Now()}
+
+	byPred := indexByPred(t, eid, buildChecklistTriples(eid, cl))
+	absentPred(t, byPred, semspec.ProjectConfigApprovedAt)
+}
+
+func TestBuildChecklistTriples_ApprovedAtPresentWhenSet(t *testing.T) {
+	eid := "semspec.local.wf.project.config.def"
+	approvedAt := time.Date(2026, 4, 15, 8, 0, 0, 0, time.UTC)
+	cl := &workflow.Checklist{
+		Version:    "1.0.0",
+		UpdatedAt:  time.Now(),
+		ApprovedAt: &approvedAt,
+	}
+
+	byPred := indexByPred(t, eid, buildChecklistTriples(eid, cl))
+	requirePred(t, byPred, semspec.ProjectConfigApprovedAt, approvedAt.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "true")
+}
+
+// ---------------------------------------------------------------------------
+// buildStandardsTriples
+// ---------------------------------------------------------------------------
+
+func TestBuildStandardsTriples_RequiredScalars(t *testing.T) {
+	eid := "semspec.local.wf.project.config.ghi"
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	st := &workflow.Standards{
+		Version:   "1.0.0",
+		UpdatedAt: now,
+	}
+
+	byPred := indexByPred(t, eid, buildStandardsTriples(eid, st))
+
+	requirePred(t, byPred, semspec.ProjectConfigType, "standards")
+	requirePred(t, byPred, semspec.ProjectConfigFile, workflow.StandardsFile)
+	requirePred(t, byPred, semspec.ProjectConfigUpdatedAt, now.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "false")
+}
+
+func TestBuildStandardsTriples_JSONBlobPresent(t *testing.T) {
+	eid := "semspec.local.wf.project.config.ghi"
+	st := &workflow.Standards{Version: "1.0.0", UpdatedAt: time.Now()}
+
+	byPred := indexByPred(t, eid, buildStandardsTriples(eid, st))
+
+	blob := byPred[semspec.ProjectConfigJSON]
+	if len(blob) == 0 || blob[0] == "" {
+		t.Fatal("ProjectConfigJSON blob predicate absent or empty for standards")
+	}
+}
+
+func TestBuildStandardsTriples_ApprovedAtAbsentWhenNil(t *testing.T) {
+	eid := "semspec.local.wf.project.config.ghi"
+	st := &workflow.Standards{Version: "1.0.0", UpdatedAt: time.Now()}
+
+	byPred := indexByPred(t, eid, buildStandardsTriples(eid, st))
+	absentPred(t, byPred, semspec.ProjectConfigApprovedAt)
+}
+
+func TestBuildStandardsTriples_ApprovedAtPresentWhenSet(t *testing.T) {
+	eid := "semspec.local.wf.project.config.ghi"
+	approvedAt := time.Date(2026, 3, 20, 10, 0, 0, 0, time.UTC)
+	st := &workflow.Standards{
+		Version:    "1.0.0",
+		UpdatedAt:  time.Now(),
+		ApprovedAt: &approvedAt,
+	}
+
+	byPred := indexByPred(t, eid, buildStandardsTriples(eid, st))
+	requirePred(t, byPred, semspec.ProjectConfigApprovedAt, approvedAt.Format(time.RFC3339))
+	requirePred(t, byPred, semspec.ProjectConfigApproved, "true")
+}

--- a/tools/bash/recovery.go
+++ b/tools/bash/recovery.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/c360studio/semspec/vocabulary/observability"
 	"github.com/c360studio/semspec/workflow/recoveryhint"
+	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/metric"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -104,10 +105,11 @@ type pathMissEntry struct {
 
 // tripleEmitter is the minimal interface PathMissDetector needs to
 // emit a tool.recovery.incident triple. graphutil.TripleWriter
-// satisfies it via WriteTriple. recoveryhint.Emit takes the same
-// shape, so we pass through directly.
+// satisfies both methods. recoveryhint.Emit requires UpsertEntity
+// (added in issue #154 slice #2 — migration off triple.add must-exist).
 type tripleEmitter interface {
 	WriteTriple(ctx context.Context, entityID, predicate string, object any) error
+	UpsertEntity(ctx context.Context, entityType message.Type, entityID string, triples []message.Triple) error
 }
 
 // PathMissDetector tracks recent path-miss bash failures per task

--- a/tools/bash/recovery_test.go
+++ b/tools/bash/recovery_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/c360studio/semstreams/message"
 )
 
 func TestClassifyPathMiss(t *testing.T) {
@@ -176,6 +178,18 @@ func (r *recordingTripleWriter) WriteTriple(_ context.Context, subject, predicat
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.triples = append(r.triples, recordedTriple{subject, predicate, object})
+	return nil
+}
+
+func (r *recordingTripleWriter) UpsertEntity(_ context.Context, _ message.Type, _ string, triples []message.Triple) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Flatten upserted triples into the same recording slice so existing
+	// triple-value assertions continue working after the WriteTriple→UpsertEntity
+	// migration (issue #154 slice #2).
+	for _, t := range triples {
+		r.triples = append(r.triples, recordedTriple{t.Subject, t.Predicate, t.Object})
+	}
 	return nil
 }
 

--- a/tools/terminal/scope_validator.go
+++ b/tools/terminal/scope_validator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/c360studio/semspec/vocabulary/observability"
 	"github.com/c360studio/semspec/workflow/recoveryhint"
+	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/metric"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -52,10 +53,12 @@ func registerScopeValidatorMetrics(reg *metric.MetricsRegistry) error {
 
 // scopeValidatorTripleEmitter is the minimal interface needed to
 // emit a tool.recovery.incident triple for planner scope misses.
-// Identical to tools/bash's tripleEmitter; kept local to avoid a
-// cross-package import.
+// Mirrors tools/bash's tripleEmitter; kept local to avoid a
+// cross-package import. UpsertEntity added in issue #154 slice #2 —
+// recoveryhint.Emit migrated off triple.add must-exist.
 type scopeValidatorTripleEmitter interface {
 	WriteTriple(ctx context.Context, entityID, predicate string, object any) error
+	UpsertEntity(ctx context.Context, entityType message.Type, entityID string, triples []message.Triple) error
 }
 
 // extractScopeIncludePaths pulls the scope.include array from a plan

--- a/tools/terminal/scope_validator_test.go
+++ b/tools/terminal/scope_validator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/c360studio/semspec/vocabulary/observability"
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
 )
 
 func TestExtractScopeIncludePaths(t *testing.T) {
@@ -125,6 +126,18 @@ func (r *recordingTripleWriter) WriteTriple(_ context.Context, subject, predicat
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.triples = append(r.triples, recordedTriple{subject, predicate, object})
+	return nil
+}
+
+func (r *recordingTripleWriter) UpsertEntity(_ context.Context, _ message.Type, _ string, triples []message.Triple) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Flatten upserted triples into the same recording slice so existing
+	// triple-value assertions continue working after the WriteTriple→UpsertEntity
+	// migration (issue #154 slice #2).
+	for _, t := range triples {
+		r.triples = append(r.triples, recordedTriple{t.Subject, t.Predicate, t.Object})
+	}
 	return nil
 }
 

--- a/vocabulary/observability/predicates.go
+++ b/vocabulary/observability/predicates.go
@@ -55,6 +55,18 @@ const (
 	// absent) otherwise. Read RawResponse alongside this predicate to
 	// know whether you're seeing the full or truncated text.
 	RawResponseTruncated = "llm.parse.raw_response_truncated"
+
+	// IncidentCallID is the agentic loop ID (loop.ID) that produced the
+	// response that triggered this incident. Stored as a node attribute
+	// on the incident entity rather than as an inbound relation from the
+	// call entity, because the loop lives only in AGENT_LOOPS KV and has
+	// no ENTITY_STATES graph node (WriteSpawnIdentity conjures loop triples
+	// at runtime, but that path breaks under triple.add must-exist — a
+	// semstreams concern). The call_id attribute preserves the logical
+	// linkage and is queryable by the IncidentRateExceeded detector
+	// (ADR-035 step 5) without requiring a graph-traversal of the loop node.
+	// Also applies to tool.recovery.incident nodes (see vocabulary/observability/tool_recovery.go).
+	IncidentCallID = "llm.parse.call_id"
 )
 
 // Partition keys. Aggregating incidents by (Role, Model, PromptVersion)
@@ -165,6 +177,11 @@ func registerOutcomePredicates() {
 		vocabulary.WithDescription("True when the raw_response triple on this incident was truncated at the per-call size cap (4 KiB)"),
 		vocabulary.WithDataType("boolean"),
 		vocabulary.WithIRI(Namespace+"rawResponseTruncated"))
+
+	vocabulary.Register(IncidentCallID,
+		vocabulary.WithDescription("Agentic loop ID (loop.ID) that produced the response triggering this incident; stored as a node attribute because the loop has no ENTITY_STATES graph node"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(Namespace+"callId"))
 }
 
 func registerPartitionPredicates() {

--- a/vocabulary/observability/predicates_test.go
+++ b/vocabulary/observability/predicates_test.go
@@ -19,6 +19,7 @@ var allPredicates = []string{
 	Role,
 	Model,
 	PromptVersion,
+	IncidentCallID,
 }
 
 func TestPredicatesRegistered(t *testing.T) {
@@ -49,6 +50,7 @@ func TestPredicateDataTypes(t *testing.T) {
 		{Role, "string"},
 		{Model, "string"},
 		{PromptVersion, "string"},
+		{IncidentCallID, "string"},
 		// Relation — incident pointer is an entity_id.
 		{Incident, "entity_id"},
 	}
@@ -99,6 +101,7 @@ func TestPredicateIRIs(t *testing.T) {
 		{Role, Namespace + "role"},
 		{Model, Namespace + "model"},
 		{PromptVersion, Namespace + "promptVersion"},
+		{IncidentCallID, Namespace + "callId"},
 	}
 
 	for _, tt := range tests {

--- a/workflow/entity.go
+++ b/workflow/entity.go
@@ -188,6 +188,17 @@ var DAGNodeEntityType = message.Type{
 	Version:  "v1",
 }
 
+// LessonEntityType is the message type for agent-lesson entity payloads.
+// The Domain "agent-lesson" mirrors the entity ID namespace
+// {prefix}.agent.lessons.lesson.{hash} (DomainAgent / SystemLessons / TypeLesson
+// from agentgraph/entities.go). Category and Version follow the uniform
+// entity-type convention used across all workflow/*EntityType declarations.
+var LessonEntityType = message.Type{
+	Domain:   "agent-lesson",
+	Category: "entity",
+	Version:  "v1",
+}
+
 // EntityPayload is the unified entity payload for all workflow graph entities
 // (plans, phases, approvals, tasks, questions). The message type is set at construction
 // via NewEntityPayload and returned by Schema().
@@ -266,6 +277,7 @@ var workflowEntityTypes = []struct {
 	{"plan-decision", "PlanDecision entity payload for graph ingestion", PlanDecisionEntityType},
 	{"dag-node", "DAG execution node entity payload for graph ingestion", DAGNodeEntityType},
 	{"capability", "Capability entity payload for graph ingestion", CapabilityEntityType},
+	{"agent-lesson", "Agent lesson entity payload for graph ingestion", LessonEntityType},
 }
 
 // RegisterPayloads registers every payload type owned by the workflow package

--- a/workflow/graph_marshal.go
+++ b/workflow/graph_marshal.go
@@ -7,84 +7,123 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/semspec"
 	"github.com/c360studio/semspec/workflow/graphutil"
 )
 
-// writePlanTriples writes all Plan fields as individual triples to ENTITY_STATES.
-// Same pattern as execution-orchestrator: one WriteTriple call per field.
+// writePlanTriples persists all Plan fields to ENTITY_STATES as a single
+// metadata-bearing entity upsert: update_with_triples with a create_with_triples
+// fallback on first write. This ensures the plan node carries a MessageType
+// (PlanEntityType) from its very first write and survives the incoming semstreams
+// triple.add must-exist change — see docs/audit/mutation-api-graphable-bypass.md
+// ("Impact" section) and issue #154 (slice #4).
+//
+// NOTE: this is the test-seed path only (called by CreateProjectPlan, which has
+// zero production callers). Production plan creation goes through
+// processor/plan-manager planStore.writePlanTriples which already uses
+// UpsertEntityIfChanged.
 func writePlanTriples(ctx context.Context, tw *graphutil.TripleWriter, plan *Plan) error {
 	if tw == nil {
 		return nil
 	}
 	entityID := PlanEntityID(plan.Slug)
-
-	// Single-valued scalars upsert (UpdateTriple = remove+add) so the entity
-	// holds the latest value per predicate; graph-ingest AddTriple is
-	// append-only, so plain WriteTriple on every mutation accumulates history and
-	// eventually exceeds the 1 MiB KV value cap. Lists use ReplaceTripleList.
-
-	// Core identity
-	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanSlug, plan.Slug)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanTitle, plan.Title)
-	_ = tw.UpdateTriple(ctx, entityID, semspec.DCTitle, plan.Title)
-	if err := tw.UpdateTriple(ctx, entityID, semspec.PredicatePlanStatus, string(plan.EffectiveStatus())); err != nil {
-		return fmt.Errorf("write plan status: %w", err)
+	if err := tw.UpsertEntity(ctx, PlanEntityType, entityID, buildPlanTriples(entityID, plan)); err != nil {
+		return fmt.Errorf("write plan triples: %w", err)
 	}
-	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
+	return nil
+}
 
-	// Project association
+// buildPlanTriples constructs the full []message.Triple for a plan entity.
+// It is a pure function so it can be unit-tested independently of NATS.
+//
+// Required scalars (PlanSlug, PlanTitle, DCTitle, PredicatePlanStatus,
+// PlanCreatedAt, PlanApproved) are always emitted. Conditional scalars
+// (ProjectID, Goal, Context, ApprovedAt, the five Review fields, the two
+// Error fields) are emitted only when their Plan fields are non-zero/non-nil
+// to keep entities lean. List predicates (PlanScopeInclude/Exclude/Protected/
+// Create, PlanExecutionTraceID) emit one triple per element — never
+// JSON-encoded — per feedback_no_json_in_triples. UpsertEntity's
+// RemoveTriples = distinctPredicates(addTriples) replaces the whole list,
+// which is the same net effect as the prior ReplaceTripleList calls.
+func buildPlanTriples(entityID string, plan *Plan) []message.Triple {
+	t := func(pred, obj string) message.Triple {
+		return message.Triple{Subject: entityID, Predicate: pred, Object: obj}
+	}
+
+	triples := []message.Triple{
+		t(semspec.PlanSlug, plan.Slug),
+		t(semspec.PlanTitle, plan.Title),
+		t(semspec.DCTitle, plan.Title),
+		t(semspec.PredicatePlanStatus, string(plan.EffectiveStatus())),
+		t(semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339)),
+		t(semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved)),
+	}
+
+	// Project association.
 	if plan.ProjectID != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanProject, plan.ProjectID)
+		triples = append(triples, t(semspec.PlanProject, plan.ProjectID))
 	}
 
-	// Plan content
+	// Plan content.
 	if plan.Goal != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanGoal, plan.Goal)
+		triples = append(triples, t(semspec.PlanGoal, plan.Goal))
 	}
 	if plan.Context != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanContext, plan.Context)
+		triples = append(triples, t(semspec.PlanContext, plan.Context))
 	}
 
-	// Approval
-	_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApproved, fmt.Sprintf("%t", plan.Approved))
+	// Approval timestamp.
 	if plan.ApprovedAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339))
+		triples = append(triples, t(semspec.PlanApprovedAt, plan.ApprovedAt.Format(time.RFC3339)))
 	}
 
-	// Review
+	// Review fields.
 	if plan.ReviewVerdict != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewVerdict, plan.ReviewVerdict)
+		triples = append(triples, t(semspec.PlanReviewVerdict, plan.ReviewVerdict))
 	}
 	if plan.ReviewSummary != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewSummary, plan.ReviewSummary)
+		triples = append(triples, t(semspec.PlanReviewSummary, plan.ReviewSummary))
 	}
 	if plan.ReviewedAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339))
+		triples = append(triples, t(semspec.PlanReviewedAt, plan.ReviewedAt.Format(time.RFC3339)))
 	}
 	if plan.ReviewFormattedFindings != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings)
+		triples = append(triples, t(semspec.PlanReviewFormattedFindings, plan.ReviewFormattedFindings))
 	}
 	if plan.ReviewIteration > 0 {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanReviewIteration, plan.ReviewIteration)
+		triples = append(triples, t(semspec.PlanReviewIteration, strconv.Itoa(plan.ReviewIteration)))
 	}
 
-	// Error annotations
+	// Error annotations.
 	if plan.LastError != "" {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastError, plan.LastError)
+		triples = append(triples, t(semspec.PlanLastError, plan.LastError))
 	}
 	if plan.LastErrorAt != nil {
-		_ = tw.UpdateTriple(ctx, entityID, semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339))
+		triples = append(triples, t(semspec.PlanLastErrorAt, plan.LastErrorAt.Format(time.RFC3339)))
 	}
 
-	// Scope + execution trace IDs (replace the whole list each write)
-	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeInclude, plan.Scope.Include)
-	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeExclude, plan.Scope.Exclude)
-	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeProtected, plan.Scope.DoNotTouch)
-	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanScopeCreate, plan.Scope.Create)
-	_ = tw.ReplaceTripleList(ctx, entityID, semspec.PlanExecutionTraceID, plan.ExecutionTraceIDs)
+	// Scope lists — one triple per element (no JSON encoding).
+	for _, v := range plan.Scope.Include {
+		triples = append(triples, t(semspec.PlanScopeInclude, v))
+	}
+	for _, v := range plan.Scope.Exclude {
+		triples = append(triples, t(semspec.PlanScopeExclude, v))
+	}
+	for _, v := range plan.Scope.DoNotTouch {
+		triples = append(triples, t(semspec.PlanScopeProtected, v))
+	}
+	for _, v := range plan.Scope.Create {
+		triples = append(triples, t(semspec.PlanScopeCreate, v))
+	}
 
-	return nil
+	// Execution trace IDs — one triple per ID.
+	for _, v := range plan.ExecutionTraceIDs {
+		triples = append(triples, t(semspec.PlanExecutionTraceID, v))
+	}
+
+	return triples
 }
 
 // PlanFromTripleMap reconstructs a Plan from a predicate→value map.

--- a/workflow/graph_marshal_test.go
+++ b/workflow/graph_marshal_test.go
@@ -1,0 +1,383 @@
+package workflow
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/message"
+
+	"github.com/c360studio/semspec/vocabulary/semspec"
+	"github.com/c360studio/semspec/workflow/graphutil"
+)
+
+// ---------------------------------------------------------------------------
+// Slice #4 (issue #154): writePlanTriples must create the plan entity via the
+// metadata-bearing UpsertEntity path (update_with_triples + create_with_triples
+// fallback), not through a sequence of bare triple.add writes.
+//
+// The seam is buildPlanTriples — a pure helper that constructs the
+// []message.Triple slice writePlanTriples hands to UpsertEntity. Exercising it
+// directly lets the test assert the full predicate set in one place without
+// needing a live NATS connection.
+// ---------------------------------------------------------------------------
+
+// nilPlanTripleWriter returns a TripleWriter with nil NATSClient.
+// UpsertEntity returns nil (no-op), so writePlanTriples/CreatePlan
+// can be exercised for the triple-shape path without NATS.
+func nilPlanTripleWriter() *graphutil.TripleWriter {
+	return &graphutil.TripleWriter{
+		Logger:        slog.Default(),
+		ComponentName: "test",
+	}
+}
+
+// indexPlanTriplesByPred builds a predicate → []string map from a triple slice.
+// All triple Objects must be strings; non-string Objects cause test failure.
+func indexPlanTriplesByPred(t *testing.T, eid string, triples []message.Triple) map[string][]string {
+	t.Helper()
+	byPred := make(map[string][]string)
+	for _, tr := range triples {
+		if tr.Subject != eid {
+			t.Errorf("triple subject %q != entity ID %q", tr.Subject, eid)
+		}
+		val, ok := tr.Object.(string)
+		if !ok {
+			t.Errorf("predicate %q: Object is %T (%v), want string", tr.Predicate, tr.Object, tr.Object)
+			continue
+		}
+		byPred[tr.Predicate] = append(byPred[tr.Predicate], val)
+	}
+	return byPred
+}
+
+// TestBuildPlanTriples_RequiredScalars verifies that buildPlanTriples always
+// emits the unconditional core scalar predicates, regardless of optional-field
+// state. This test fails until buildPlanTriples is extracted.
+func TestBuildPlanTriples_RequiredScalars(t *testing.T) {
+	slug := "test-plan"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:        eid,
+		Slug:      slug,
+		Title:     "My Test Plan",
+		Approved:  false,
+		CreatedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	require := func(pred, want string) {
+		t.Helper()
+		vals := byPred[pred]
+		if len(vals) == 0 {
+			t.Errorf("required predicate %q absent from triples", pred)
+			return
+		}
+		if vals[0] != want {
+			t.Errorf("predicate %q = %q, want %q", pred, vals[0], want)
+		}
+	}
+
+	require(semspec.PlanSlug, "test-plan")
+	require(semspec.PlanTitle, "My Test Plan")
+	require(semspec.DCTitle, "My Test Plan")
+	require(semspec.PredicatePlanStatus, string(plan.EffectiveStatus()))
+	require(semspec.PlanCreatedAt, plan.CreatedAt.Format(time.RFC3339))
+	require(semspec.PlanApproved, "false")
+}
+
+// TestBuildPlanTriples_ConditionalScalars verifies that optional scalar
+// predicates are present when the corresponding Plan field is non-zero and
+// absent when it is zero/nil.
+func TestBuildPlanTriples_ConditionalScalars(t *testing.T) {
+	approvedAt := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC)
+	reviewedAt := time.Date(2026, 6, 3, 10, 0, 0, 0, time.UTC)
+	lastErrorAt := time.Date(2026, 6, 4, 11, 0, 0, 0, time.UTC)
+
+	slug := "full-plan"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:                      eid,
+		Slug:                    slug,
+		Title:                   "Full Plan",
+		Approved:                true,
+		ApprovedAt:              &approvedAt,
+		CreatedAt:               time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		ProjectID:               ProjectEntityID("my-project"),
+		Goal:                    "Build the thing",
+		Context:                 "Because we need it",
+		ReviewVerdict:           "approved",
+		ReviewSummary:           "Looks good",
+		ReviewedAt:              &reviewedAt,
+		ReviewFormattedFindings: "All findings addressed.",
+		ReviewIteration:         3,
+		LastError:               "some transient error",
+		LastErrorAt:             &lastErrorAt,
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	require := func(pred, want string) {
+		t.Helper()
+		vals := byPred[pred]
+		if len(vals) == 0 {
+			t.Errorf("predicate %q absent, want %q", pred, want)
+			return
+		}
+		if vals[0] != want {
+			t.Errorf("predicate %q = %q, want %q", pred, vals[0], want)
+		}
+	}
+
+	require(semspec.PlanProject, ProjectEntityID("my-project"))
+	require(semspec.PlanGoal, "Build the thing")
+	require(semspec.PlanContext, "Because we need it")
+	require(semspec.PlanApproved, "true")
+	require(semspec.PlanApprovedAt, approvedAt.Format(time.RFC3339))
+	require(semspec.PlanReviewVerdict, "approved")
+	require(semspec.PlanReviewSummary, "Looks good")
+	require(semspec.PlanReviewedAt, reviewedAt.Format(time.RFC3339))
+	require(semspec.PlanReviewFormattedFindings, "All findings addressed.")
+	require(semspec.PlanReviewIteration, "3")
+	require(semspec.PlanLastError, "some transient error")
+	require(semspec.PlanLastErrorAt, lastErrorAt.Format(time.RFC3339))
+}
+
+// TestBuildPlanTriples_ConditionalScalarsAbsent verifies that optional scalar
+// predicates are NOT emitted when their corresponding Plan fields are zero/nil.
+func TestBuildPlanTriples_ConditionalScalarsAbsent(t *testing.T) {
+	slug := "minimal-plan"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:        eid,
+		Slug:      slug,
+		Title:     "Minimal",
+		CreatedAt: time.Now(),
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	absent := []string{
+		semspec.PlanProject,
+		semspec.PlanGoal,
+		semspec.PlanContext,
+		semspec.PlanApprovedAt,
+		semspec.PlanReviewVerdict,
+		semspec.PlanReviewSummary,
+		semspec.PlanReviewedAt,
+		semspec.PlanReviewFormattedFindings,
+		semspec.PlanReviewIteration,
+		semspec.PlanLastError,
+		semspec.PlanLastErrorAt,
+	}
+	for _, pred := range absent {
+		if len(byPred[pred]) > 0 {
+			t.Errorf("predicate %q should be absent when Plan field is zero/nil, got %v", pred, byPred[pred])
+		}
+	}
+}
+
+// TestBuildPlanTriples_ListPredicates verifies that list predicates
+// (Scope.Include/Exclude/DoNotTouch/Create and ExecutionTraceIDs) emit one
+// triple per element — never as a JSON-encoded blob — mirroring the
+// ReplaceTripleList behavior that UpsertEntity replaces.
+func TestBuildPlanTriples_ListPredicates(t *testing.T) {
+	slug := "list-plan"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:    eid,
+		Slug:  slug,
+		Title: "List Plan",
+		Scope: Scope{
+			Include:    []string{"api/", "lib/"},
+			Exclude:    []string{"vendor/"},
+			DoNotTouch: []string{"config.yaml", "secrets.yaml"},
+			Create:     []string{"docs/"},
+		},
+		ExecutionTraceIDs: []string{"trace-aaa", "trace-bbb", "trace-ccc"},
+		CreatedAt:         time.Now(),
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	checkList := func(pred string, want []string) {
+		t.Helper()
+		got := byPred[pred]
+		if len(got) != len(want) {
+			t.Errorf("predicate %q: got %d triples, want %d (%v)", pred, len(got), len(want), want)
+			return
+		}
+		for i, w := range want {
+			if got[i] != w {
+				t.Errorf("predicate %q[%d] = %q, want %q", pred, i, got[i], w)
+			}
+		}
+	}
+
+	checkList(semspec.PlanScopeInclude, []string{"api/", "lib/"})
+	checkList(semspec.PlanScopeExclude, []string{"vendor/"})
+	checkList(semspec.PlanScopeProtected, []string{"config.yaml", "secrets.yaml"})
+	checkList(semspec.PlanScopeCreate, []string{"docs/"})
+	checkList(semspec.PlanExecutionTraceID, []string{"trace-aaa", "trace-bbb", "trace-ccc"})
+}
+
+// TestBuildPlanTriples_EmptyListsProduceNoTriples verifies that nil/empty list
+// fields produce no triples for their predicates, so the entity stays lean.
+func TestBuildPlanTriples_EmptyListsProduceNoTriples(t *testing.T) {
+	slug := "empty-lists"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:        eid,
+		Slug:      slug,
+		Title:     "Empty Lists",
+		CreatedAt: time.Now(),
+		// Scope fields nil/empty, ExecutionTraceIDs nil.
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	for _, pred := range []string{
+		semspec.PlanScopeInclude,
+		semspec.PlanScopeExclude,
+		semspec.PlanScopeProtected,
+		semspec.PlanScopeCreate,
+		semspec.PlanExecutionTraceID,
+	} {
+		if len(byPred[pred]) > 0 {
+			t.Errorf("predicate %q should be absent for empty list, got %v", pred, byPred[pred])
+		}
+	}
+}
+
+// TestBuildPlanTriples_StatusViaEffectiveStatus verifies that the status
+// triple reflects plan.EffectiveStatus() rather than plan.Status directly,
+// preserving the pre-refactor behaviour where the explicit UpdateTriple call
+// passed string(plan.EffectiveStatus()).
+func TestBuildPlanTriples_StatusViaEffectiveStatus(t *testing.T) {
+	slug := "approved-plan"
+	eid := PlanEntityID(slug)
+	plan := &Plan{
+		ID:        eid,
+		Slug:      slug,
+		Title:     "Approved Plan",
+		Approved:  true, // Status is zero → EffectiveStatus() returns StatusApproved
+		CreatedAt: time.Now(),
+	}
+
+	byPred := indexPlanTriplesByPred(t, eid, buildPlanTriples(eid, plan))
+
+	vals := byPred[semspec.PredicatePlanStatus]
+	if len(vals) == 0 {
+		t.Fatal("PredicatePlanStatus absent from triples")
+	}
+	want := string(plan.EffectiveStatus())
+	if vals[0] != want {
+		t.Errorf("PredicatePlanStatus = %q, want EffectiveStatus() = %q", vals[0], want)
+	}
+}
+
+// TestWritePlanTriples_NilTWIsNoop verifies the existing guard: when
+// TripleWriter is nil (no NATS), writePlanTriples returns nil without panicking.
+func TestWritePlanTriples_NilTWIsNoop(t *testing.T) {
+	plan := &Plan{Slug: "noop", Title: "Noop"}
+	plan.ID = PlanEntityID(plan.Slug)
+	if err := writePlanTriples(t.Context(), nil, plan); err != nil {
+		t.Fatalf("writePlanTriples(nil tw) should return nil, got %v", err)
+	}
+}
+
+// TestWritePlanTriples_NilNATSClientIsNoop verifies that a TripleWriter with
+// nil NATSClient is a no-op (UpsertEntity returns nil when NATSClient==nil).
+func TestWritePlanTriples_NilNATSClientIsNoop(t *testing.T) {
+	tw := nilPlanTripleWriter()
+	plan := &Plan{
+		Slug:      "nats-noop",
+		Title:     "NATS Noop",
+		CreatedAt: time.Now(),
+	}
+	plan.ID = PlanEntityID(plan.Slug)
+	if err := writePlanTriples(t.Context(), tw, plan); err != nil {
+		t.Fatalf("writePlanTriples with nil NATSClient should return nil, got %v", err)
+	}
+}
+
+// TestBuildPlanTriples_RoundTripScalars exercises the scalar fields end-to-end
+// through PlanFromTripleMap: build triples → collapse to predicate map →
+// reconstruct plan and verify field values. This pins that the predicate names
+// used in buildPlanTriples match the predicate names PlanFromTripleMap reads.
+func TestBuildPlanTriples_RoundTripScalars(t *testing.T) {
+	approvedAt := time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC)
+	reviewedAt := time.Date(2026, 6, 11, 9, 0, 0, 0, time.UTC)
+
+	slug := "roundtrip"
+	eid := PlanEntityID(slug)
+	orig := &Plan{
+		ID:              eid,
+		Slug:            slug,
+		Title:           "Roundtrip Plan",
+		Approved:        true,
+		ApprovedAt:      &approvedAt,
+		CreatedAt:       time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		ProjectID:       ProjectEntityID("proj"),
+		Goal:            "Do the thing",
+		Context:         "Because reasons",
+		ReviewVerdict:   "approved",
+		ReviewSummary:   "All good",
+		ReviewedAt:      &reviewedAt,
+		ReviewIteration: 2,
+		LastError:       "transient",
+	}
+
+	triples := buildPlanTriples(eid, orig)
+
+	// Collapse []message.Triple → map[string]string (take first value per
+	// predicate) to match what PlanFromTripleMap expects.
+	collapsed := make(map[string]string)
+	for _, tr := range triples {
+		val := fmt.Sprintf("%v", tr.Object)
+		if _, exists := collapsed[tr.Predicate]; !exists {
+			collapsed[tr.Predicate] = val
+		}
+	}
+
+	got := PlanFromTripleMap(eid, collapsed)
+
+	if got.Slug != orig.Slug {
+		t.Errorf("Slug = %q, want %q", got.Slug, orig.Slug)
+	}
+	if got.Title != orig.Title {
+		t.Errorf("Title = %q, want %q", got.Title, orig.Title)
+	}
+	if got.ProjectID != orig.ProjectID {
+		t.Errorf("ProjectID = %q, want %q", got.ProjectID, orig.ProjectID)
+	}
+	if got.Goal != orig.Goal {
+		t.Errorf("Goal = %q, want %q", got.Goal, orig.Goal)
+	}
+	if got.Context != orig.Context {
+		t.Errorf("Context = %q, want %q", got.Context, orig.Context)
+	}
+	if !got.Approved {
+		t.Error("Approved should be true")
+	}
+	if got.ApprovedAt == nil || !got.ApprovedAt.Equal(approvedAt) {
+		t.Errorf("ApprovedAt = %v, want %v", got.ApprovedAt, approvedAt)
+	}
+	if got.ReviewVerdict != orig.ReviewVerdict {
+		t.Errorf("ReviewVerdict = %q, want %q", got.ReviewVerdict, orig.ReviewVerdict)
+	}
+	if got.ReviewSummary != orig.ReviewSummary {
+		t.Errorf("ReviewSummary = %q, want %q", got.ReviewSummary, orig.ReviewSummary)
+	}
+	if got.ReviewedAt == nil || !got.ReviewedAt.Equal(reviewedAt) {
+		t.Errorf("ReviewedAt = %v, want %v", got.ReviewedAt, reviewedAt)
+	}
+	if got.ReviewIteration != 2 {
+		t.Errorf("ReviewIteration = %d, want 2", got.ReviewIteration)
+	}
+	if got.LastError != orig.LastError {
+		t.Errorf("LastError = %q, want %q", got.LastError, orig.LastError)
+	}
+}

--- a/workflow/lessons/writer.go
+++ b/workflow/lessons/writer.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/agentgraph"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
@@ -86,58 +88,69 @@ func (w *Writer) RecordLesson(ctx context.Context, lesson workflow.Lesson) error
 
 	eid := agentgraph.LessonEntityID(lesson.ID)
 
-	type triple struct {
-		predicate string
-		value     any
+	// Single metadata-bearing entity upsert: update_with_triples with a
+	// create_with_triples fallback on first write. This ensures the lesson node
+	// carries a MessageType (workflow.LessonEntityType) from its very first write
+	// and survives the incoming semstreams triple.add must-exist change — see
+	// docs/audit/mutation-api-graphable-bypass.md ("Impact" section) and
+	// issue #154 (slice #1).
+	if err := w.TW.UpsertEntity(ctx, workflow.LessonEntityType, eid, buildLessonTriples(eid, lesson)); err != nil {
+		return fmt.Errorf("lessons: upsert entity: %w", err)
 	}
-	triples := []triple{
-		{agentgraph.PredicateLessonID, lesson.ID},
-		{agentgraph.PredicateLessonSource, lesson.Source},
-		{agentgraph.PredicateLessonScenarioID, lesson.ScenarioID},
-		{agentgraph.PredicateLessonSummary, lesson.Summary},
-		{agentgraph.PredicateLessonRole, lesson.Role},
-		{agentgraph.PredicateLessonCreatedAt, lesson.CreatedAt.Format(time.RFC3339)},
+
+	return nil
+}
+
+// buildLessonTriples constructs the full []message.Triple for a lesson entity.
+// It is a pure function so it can be tested independently of NATS.
+//
+// Required scalars are always emitted. Optional ADR-033 fields are emitted only
+// when non-zero/non-nil to keep entities lean for legacy lessons. Multi-valued
+// fields (CategoryIDs, EvidenceSteps, EvidenceFiles) emit one triple per element —
+// never JSON-encoded — per feedback_no_json_in_triples.
+func buildLessonTriples(eid string, lesson workflow.Lesson) []message.Triple {
+	triples := []message.Triple{
+		{Subject: eid, Predicate: agentgraph.PredicateLessonID, Object: lesson.ID},
+		{Subject: eid, Predicate: agentgraph.PredicateLessonSource, Object: lesson.Source},
+		{Subject: eid, Predicate: agentgraph.PredicateLessonScenarioID, Object: lesson.ScenarioID},
+		{Subject: eid, Predicate: agentgraph.PredicateLessonSummary, Object: lesson.Summary},
+		{Subject: eid, Predicate: agentgraph.PredicateLessonRole, Object: lesson.Role},
+		{Subject: eid, Predicate: agentgraph.PredicateLessonCreatedAt, Object: lesson.CreatedAt.Format(time.RFC3339)},
 	}
 
 	// One triple per category ID — atomic, no JSON encoding.
 	for _, cat := range lesson.CategoryIDs {
-		triples = append(triples, triple{agentgraph.PredicateLessonCategories, cat})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonCategories, Object: cat})
 	}
 
-	// ADR-033 Phase 1+ optional fields — only written when set, to keep
+	// ADR-033 Phase 1+ optional fields — only emitted when set, to keep
 	// triple count small for legacy lessons.
 	if lesson.Detail != "" {
-		triples = append(triples, triple{agentgraph.PredicateLessonDetail, lesson.Detail})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonDetail, Object: lesson.Detail})
 	}
 	if lesson.InjectionForm != "" {
-		triples = append(triples, triple{agentgraph.PredicateLessonInjectionForm, lesson.InjectionForm})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonInjectionForm, Object: lesson.InjectionForm})
 	}
 	for _, step := range lesson.EvidenceSteps {
-		triples = append(triples, triple{agentgraph.PredicateLessonEvidenceSteps, encodeStepRef(step)})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonEvidenceSteps, Object: encodeStepRef(step)})
 	}
 	for _, file := range lesson.EvidenceFiles {
-		triples = append(triples, triple{agentgraph.PredicateLessonEvidenceFiles, encodeFileRef(file)})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonEvidenceFiles, Object: encodeFileRef(file)})
 	}
 	if lesson.RootCauseRole != "" {
-		triples = append(triples, triple{agentgraph.PredicateLessonRootCauseRole, lesson.RootCauseRole})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonRootCauseRole, Object: lesson.RootCauseRole})
 	}
 	if lesson.Positive {
-		triples = append(triples, triple{agentgraph.PredicateLessonPositive, "true"})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonPositive, Object: "true"})
 	}
 	if lesson.RetiredAt != nil {
-		triples = append(triples, triple{agentgraph.PredicateLessonRetiredAt, lesson.RetiredAt.Format(time.RFC3339)})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonRetiredAt, Object: lesson.RetiredAt.Format(time.RFC3339)})
 	}
 	if lesson.LastInjectedAt != nil {
-		triples = append(triples, triple{agentgraph.PredicateLessonLastInjectedAt, lesson.LastInjectedAt.Format(time.RFC3339)})
+		triples = append(triples, message.Triple{Subject: eid, Predicate: agentgraph.PredicateLessonLastInjectedAt, Object: lesson.LastInjectedAt.Format(time.RFC3339)})
 	}
 
-	for _, t := range triples {
-		if err := w.TW.WriteTriple(ctx, eid, t.predicate, t.value); err != nil {
-			return fmt.Errorf("lessons: write triple %s: %w", t.predicate, err)
-		}
-	}
-
-	return nil
+	return triples
 }
 
 // encodeStepRef serialises a StepRef as `<loop_id>|<step_index>`.

--- a/workflow/lessons/writer_test.go
+++ b/workflow/lessons/writer_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/agentgraph"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
@@ -478,6 +480,226 @@ func lessonIDs(ls []workflow.Lesson) []string {
 		out[i] = l.ID
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// Slice #1 (issue #154): RecordLesson must create the lesson entity via the
+// metadata-bearing UpsertEntity path (update_with_triples + create_with_triples
+// fallback), not through a sequence of bare triple.add writes.
+//
+// The seam is buildLessonTriples — a pure helper that constructs the
+// []message.Triple slice RecordLesson hands to UpsertEntity. Exercising it
+// directly lets the test assert the full predicate set in one place without
+// needing a live NATS connection.
+// ---------------------------------------------------------------------------
+
+// indexTriplesByPred builds a predicate → []string map from a triple slice.
+// All triple Objects must be strings; non-string Objects are skipped and
+// reported as test failures. The returned map is safe to use directly in
+// assertion helpers.
+func indexTriplesByPred(t *testing.T, eid string, triples []message.Triple) map[string][]string {
+	t.Helper()
+	byPred := make(map[string][]string)
+	for _, tr := range triples {
+		if tr.Subject != eid {
+			t.Errorf("triple subject %q != entity ID %q", tr.Subject, eid)
+		}
+		val, ok := tr.Object.(string)
+		if !ok {
+			t.Errorf("predicate %q: Object is %T, want string", tr.Predicate, tr.Object)
+			continue
+		}
+		byPred[tr.Predicate] = append(byPred[tr.Predicate], val)
+	}
+	return byPred
+}
+
+// TestBuildLessonTriples_RequiredAndCategory verifies that buildLessonTriples
+// emits all required scalar predicates and one triple per CategoryID. This
+// test fails (won't compile) until buildLessonTriples is implemented.
+func TestBuildLessonTriples_RequiredAndCategory(t *testing.T) {
+	eid := "semspec.local.agent.lessons.lesson.abcdef"
+	lesson := workflow.Lesson{
+		ID:          "lesson-1",
+		Source:      "reviewer-feedback",
+		ScenarioID:  "task-42",
+		Summary:     "Missing error handling",
+		Role:        "developer",
+		CategoryIDs: []string{"missing_tests", "sop_violation"},
+	}
+	lesson.CreatedAt = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	byPred := indexTriplesByPred(t, eid, buildLessonTriples(eid, lesson))
+
+	require := func(pred, want string) {
+		t.Helper()
+		vals := byPred[pred]
+		if len(vals) == 0 {
+			t.Errorf("predicate %q absent from triples", pred)
+			return
+		}
+		if vals[0] != want {
+			t.Errorf("predicate %q = %q, want %q", pred, vals[0], want)
+		}
+	}
+
+	require(agentgraph.PredicateLessonID, "lesson-1")
+	require(agentgraph.PredicateLessonSource, "reviewer-feedback")
+	require(agentgraph.PredicateLessonScenarioID, "task-42")
+	require(agentgraph.PredicateLessonSummary, "Missing error handling")
+	require(agentgraph.PredicateLessonRole, "developer")
+	require(agentgraph.PredicateLessonCreatedAt, lesson.CreatedAt.Format(time.RFC3339))
+
+	cats := byPred[agentgraph.PredicateLessonCategories]
+	if len(cats) != 2 {
+		t.Errorf("CategoryIDs: %d triples, want 2", len(cats))
+	} else if cats[0] != "missing_tests" || cats[1] != "sop_violation" {
+		t.Errorf("CategoryIDs = %v, want [missing_tests sop_violation]", cats)
+	}
+}
+
+// TestBuildLessonTriples_OptionalAndEvidence verifies that ADR-033 optional
+// fields (Detail, InjectionForm, RootCauseRole, Positive, RetiredAt,
+// LastInjectedAt) and multi-valued evidence (EvidenceSteps, EvidenceFiles)
+// are each emitted as individual triples when set.
+func TestBuildLessonTriples_OptionalAndEvidence(t *testing.T) {
+	retired := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	lastInj := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+
+	eid := "semspec.local.agent.lessons.lesson.abcdef"
+	lesson := workflow.Lesson{
+		ID:            "lesson-1",
+		Source:        "s",
+		Detail:        "long-form root-cause narrative",
+		InjectionForm: "case study form",
+		EvidenceSteps: []workflow.StepRef{
+			{LoopID: "l1", StepIndex: 3},
+			{LoopID: "l2", StepIndex: 7},
+		},
+		EvidenceFiles: []workflow.FileRef{
+			{Path: "main.go", LineStart: 10, LineEnd: 20, CommitSHA: "deadbeef"},
+		},
+		RootCauseRole:  "architect",
+		Positive:       true,
+		RetiredAt:      &retired,
+		LastInjectedAt: &lastInj,
+	}
+	lesson.CreatedAt = time.Now()
+
+	byPred := indexTriplesByPred(t, eid, buildLessonTriples(eid, lesson))
+
+	require := func(pred, want string) {
+		t.Helper()
+		vals := byPred[pred]
+		if len(vals) == 0 {
+			t.Errorf("predicate %q absent from triples", pred)
+			return
+		}
+		if vals[0] != want {
+			t.Errorf("predicate %q = %q, want %q", pred, vals[0], want)
+		}
+	}
+
+	require(agentgraph.PredicateLessonDetail, "long-form root-cause narrative")
+	require(agentgraph.PredicateLessonInjectionForm, "case study form")
+	require(agentgraph.PredicateLessonRootCauseRole, "architect")
+	require(agentgraph.PredicateLessonPositive, "true")
+	require(agentgraph.PredicateLessonRetiredAt, retired.Format(time.RFC3339))
+	require(agentgraph.PredicateLessonLastInjectedAt, lastInj.Format(time.RFC3339))
+
+	steps := byPred[agentgraph.PredicateLessonEvidenceSteps]
+	if len(steps) != 2 {
+		t.Errorf("EvidenceSteps: %d triples, want 2", len(steps))
+	} else {
+		if steps[0] != encodeStepRef(lesson.EvidenceSteps[0]) {
+			t.Errorf("EvidenceSteps[0] = %q, want %q", steps[0], encodeStepRef(lesson.EvidenceSteps[0]))
+		}
+		if steps[1] != encodeStepRef(lesson.EvidenceSteps[1]) {
+			t.Errorf("EvidenceSteps[1] = %q, want %q", steps[1], encodeStepRef(lesson.EvidenceSteps[1]))
+		}
+	}
+	files := byPred[agentgraph.PredicateLessonEvidenceFiles]
+	if len(files) != 1 {
+		t.Errorf("EvidenceFiles: %d triples, want 1", len(files))
+	} else if files[0] != encodeFileRef(lesson.EvidenceFiles[0]) {
+		t.Errorf("EvidenceFiles[0] = %q, want %q", files[0], encodeFileRef(lesson.EvidenceFiles[0]))
+	}
+}
+
+// TestBuildLessonTriples_OptionalFieldsAbsent verifies that absent optional
+// fields produce no triples so the entity stays lean.
+func TestBuildLessonTriples_OptionalFieldsAbsent(t *testing.T) {
+	eid := "semspec.local.agent.lessons.lesson.xyz"
+	lesson := workflow.Lesson{
+		ID:         "lesson-2",
+		Source:     "decomposer",
+		ScenarioID: "task-10",
+		Summary:    "some finding",
+		Role:       "developer",
+		// Positive=false (zero), RetiredAt=nil, LastInjectedAt=nil,
+		// Detail="", InjectionForm="", RootCauseRole="",
+		// CategoryIDs=nil, EvidenceSteps=nil, EvidenceFiles=nil.
+	}
+	lesson.CreatedAt = time.Now()
+
+	triples := buildLessonTriples(eid, lesson)
+
+	byPred := make(map[string]int)
+	for _, tr := range triples {
+		byPred[tr.Predicate]++
+	}
+
+	optional := []string{
+		agentgraph.PredicateLessonDetail,
+		agentgraph.PredicateLessonInjectionForm,
+		agentgraph.PredicateLessonRootCauseRole,
+		agentgraph.PredicateLessonPositive,
+		agentgraph.PredicateLessonRetiredAt,
+		agentgraph.PredicateLessonLastInjectedAt,
+		agentgraph.PredicateLessonCategories,
+		agentgraph.PredicateLessonEvidenceSteps,
+		agentgraph.PredicateLessonEvidenceFiles,
+	}
+	for _, pred := range optional {
+		if byPred[pred] > 0 {
+			t.Errorf("optional predicate %q should be absent when field is zero/nil, got %d triple(s)", pred, byPred[pred])
+		}
+	}
+}
+
+// TestRecordLesson_UsesEntityUpsert exercises RecordLesson end-to-end against a
+// nil-NATS TripleWriter and asserts it returns nil. NOTE this only pins the
+// no-op contract: both UpsertEntity and the old WriteTriple short-circuit to nil
+// when NATSClient == nil, so this test cannot by itself distinguish the create
+// path. The triple SHAPE is pinned by TestBuildLessonTriples_RequiredAndCategory
+// and TestBuildLessonTriples_OptionalAndEvidence; the structural guarantee that
+// the create uses UpsertEntity (not triple.add) is delivered by the
+// buildLessonTriples extraction + the absence of WriteTriple in RecordLesson. A
+// genuine path assertion needs an upserter-interface seam on Writer.TW — deferred
+// to the write-API taxonomy work (audit fix-point 5, issue #154).
+func TestRecordLesson_UsesEntityUpsert(t *testing.T) {
+	w := &Writer{TW: nilTripleWriter(), Logger: testLogger()}
+
+	now := time.Now()
+	lesson := workflow.Lesson{
+		Source:        "reviewer-feedback",
+		Summary:       "seam test — must use UpsertEntity",
+		Role:          "developer",
+		EvidenceSteps: []workflow.StepRef{{LoopID: "l1", StepIndex: 1}},
+		EvidenceFiles: []workflow.FileRef{{Path: "x.go", LineStart: 1, LineEnd: 2, CommitSHA: "abc"}},
+		// Exercise every optional field so buildLessonTriples coverage is maximal.
+		CategoryIDs:    []string{"sop_violation"},
+		Detail:         "narrative",
+		InjectionForm:  "case study",
+		RootCauseRole:  "architect",
+		Positive:       true,
+		RetiredAt:      &now,
+		LastInjectedAt: &now,
+	}
+
+	if err := w.RecordLesson(context.Background(), lesson); err != nil {
+		t.Fatalf("RecordLesson must succeed when TW.UpsertEntity is a no-op, got: %v", err)
+	}
 }
 
 func TestRotateLessonsForRole_ErrorsWithNoNATS(t *testing.T) {

--- a/workflow/parseincident/emit.go
+++ b/workflow/parseincident/emit.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"unicode/utf8"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/observability"
 )
 
@@ -58,6 +60,17 @@ type IncidentEvent struct {
 	RawResponse string   // Unmodified LLM output. Truncated at MaxRawResponseBytes by Emit; truncation flagged via a separate predicate.
 }
 
+// ParseIncidentEntityType is the message.Type for parse-incident entities.
+// Domain "parse-incident" names the entity class (the incident node IDs are
+// `<call_id>.parse.<checkpoint>`). Kept local to avoid touching
+// workflow/entity.go while nearby slices are editing it (issue #154); a future
+// pass may register it in workflowEntityTypes for parity with LessonEntityType.
+var ParseIncidentEntityType = message.Type{
+	Domain:   "parse-incident",
+	Category: "entity",
+	Version:  "v1",
+}
+
 // tripleWriter is the minimal interface Emit needs from the graph
 // write surface. graphutil.TripleWriter satisfies it implicitly. The
 // interface is unexported so a second implementation outside this
@@ -65,17 +78,19 @@ type IncidentEvent struct {
 // accident.
 type tripleWriter interface {
 	WriteTriple(ctx context.Context, entityID, predicate string, object any) error
+	UpsertEntity(ctx context.Context, entityType message.Type, entityID string, triples []message.Triple) error
 }
 
-// Emit writes the parse.incident triple set for a checkpoint result.
+// Emit writes the parse.incident entity for a checkpoint result.
 // Returns the incident node ID on success, or "" when no incident was
 // emitted (strict outcome or nil writer).
 //
-// Triple write order matters: the relation triple
-// `(call_id) -[parse.incident]-> (incident_node)` is written first so
-// a partial-write failure still leaves the relation findable. Each
-// attribute predicate (checkpoint, outcome, role, etc.) follows;
-// individual write failures bubble up after all writes are attempted.
+// The incident node is created via UpsertEntity (routes to
+// create_with_triples on first write, update_with_triples on retry),
+// which is metadata-bearing and survives the semstreams triple.add
+// must-exist change (issue #154, slice #2). call_id is carried as a
+// node attribute so the linkage to the agentic loop is preserved even
+// though the loop entity has no ENTITY_STATES graph node.
 //
 // Strict outcomes are no-ops — the audit's "tolerance is the
 // deviation worth recording" framing means strict parses don't need
@@ -109,77 +124,67 @@ func Emit(ctx context.Context, tw tripleWriter, ic IncidentContext, ev IncidentE
 
 	incidentID := fmt.Sprintf("%s.parse.%s", ic.CallID, ev.Checkpoint)
 
-	// Relation first so a partial write still leaves the incident
-	// findable from the call entity.
-	if err := tw.WriteTriple(ctx, ic.CallID, observability.Incident, incidentID); err != nil {
-		return "", fmt.Errorf("write parse.incident relation: %w", err)
-	}
-
-	// Required attribute predicates (always populated).
-	required := []predicateWrite{
-		{observability.Checkpoint, ev.Checkpoint},
-		{observability.Outcome, ev.Outcome},
-	}
-	for _, w := range required {
-		if err := tw.WriteTriple(ctx, incidentID, w.predicate, w.object); err != nil {
-			return incidentID, fmt.Errorf("write %s: %w", w.predicate, err)
-		}
-	}
-
-	// Optional attribute predicates — skipped on empty values so the
-	// graph doesn't accumulate sentinel-value triples that need a
-	// later cleanup pass.
-	optional := []predicateWrite{
-		{observability.Reason, ev.Reason},
-		{observability.Role, ic.Role},
-		{observability.Model, ic.Model},
-		{observability.PromptVersion, ic.PromptVersion},
-	}
-	for _, w := range optional {
-		if w.object == "" {
-			continue
-		}
-		if err := tw.WriteTriple(ctx, incidentID, w.predicate, w.object); err != nil {
-			return incidentID, fmt.Errorf("write %s: %w", w.predicate, err)
-		}
-	}
-
-	// Raw response — always retained on rejected/tolerated_quirk per
-	// ADR-035 §3, but capped at MaxRawResponseBytes with a separate
-	// truncation flag so readers know whether they're seeing the full
-	// or clipped text.
-	if ev.RawResponse != "" {
-		body, truncated := truncateUTF8Safe(ev.RawResponse, MaxRawResponseBytes)
-		if err := tw.WriteTriple(ctx, incidentID, observability.RawResponse, body); err != nil {
-			return incidentID, fmt.Errorf("write raw_response: %w", err)
-		}
-		if truncated {
-			if err := tw.WriteTriple(ctx, incidentID, observability.RawResponseTruncated, true); err != nil {
-				return incidentID, fmt.Errorf("write raw_response_truncated: %w", err)
-			}
-		}
-	}
-
-	// Multi-valued quirk predicates — one triple per fired quirk so
-	// the IncidentRateExceeded detector (ADR-035 step 5) can slice by
-	// individual quirk ID without parsing concatenated values.
-	for _, q := range ev.Quirks {
-		if q == "" {
-			continue
-		}
-		if err := tw.WriteTriple(ctx, incidentID, observability.Quirk, q); err != nil {
-			return incidentID, fmt.Errorf("write quirk %q: %w", q, err)
-		}
+	triples := buildIncidentTriples(incidentID, ic, ev)
+	if err := tw.UpsertEntity(ctx, ParseIncidentEntityType, incidentID, triples); err != nil {
+		return "", fmt.Errorf("parseincident: upsert entity: %w", err)
 	}
 
 	return incidentID, nil
 }
 
-// predicateWrite pairs a predicate constant with its object value for
-// table-driven writes inside Emit.
-type predicateWrite struct {
-	predicate string
-	object    any
+// buildIncidentTriples constructs the full []message.Triple for a parse-incident
+// entity. It is a pure function so it can be tested independently of NATS.
+//
+// Required scalars (Checkpoint, Outcome, CallID) are always emitted. Optional
+// fields (Reason, Role, Model, PromptVersion, RawResponse) are emitted only when
+// non-empty. Multi-valued fields (Quirks) emit one triple per element — never
+// JSON-encoded — per feedback_no_json_in_triples. RawResponse is capped at
+// MaxRawResponseBytes with a truncation flag when the original exceeds the cap.
+func buildIncidentTriples(incidentID string, ic IncidentContext, ev IncidentEvent) []message.Triple {
+	triples := []message.Triple{
+		{Subject: incidentID, Predicate: observability.Checkpoint, Object: ev.Checkpoint},
+		{Subject: incidentID, Predicate: observability.Outcome, Object: ev.Outcome},
+		// call_id is carried as an attribute so the linkage to the agentic loop
+		// is preserved even though the loop has no ENTITY_STATES graph node.
+		{Subject: incidentID, Predicate: observability.IncidentCallID, Object: ic.CallID},
+	}
+
+	// Optional attribute predicates — omit empty values so the graph does
+	// not accumulate sentinel-value triples that need a later cleanup pass.
+	if ev.Reason != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.Reason, Object: ev.Reason})
+	}
+	if ic.Role != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.Role, Object: ic.Role})
+	}
+	if ic.Model != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.Model, Object: ic.Model})
+	}
+	if ic.PromptVersion != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.PromptVersion, Object: ic.PromptVersion})
+	}
+
+	// Raw response — retained on rejected/tolerated_quirk per ADR-035 §3,
+	// capped at MaxRawResponseBytes with a separate truncation flag.
+	if ev.RawResponse != "" {
+		body, truncated := truncateUTF8Safe(ev.RawResponse, MaxRawResponseBytes)
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.RawResponse, Object: body})
+		if truncated {
+			triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.RawResponseTruncated, Object: true})
+		}
+	}
+
+	// Multi-valued quirk predicates — one triple per fired quirk so the
+	// IncidentRateExceeded detector (ADR-035 step 5) can slice by individual
+	// quirk ID without parsing concatenated values.
+	for _, q := range ev.Quirks {
+		if q == "" {
+			continue
+		}
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.Quirk, Object: q})
+	}
+
+	return triples
 }
 
 // EmitForResult is a convenience wrapper that derives the IncidentEvent

--- a/workflow/parseincident/emit_test.go
+++ b/workflow/parseincident/emit_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/observability"
 )
 
@@ -19,51 +21,287 @@ import (
 // fails loudly at unit-test time instead of silently in production.
 var natsKVKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_./=-]+$`)
 
-// recordedTriple captures a single WriteTriple invocation for
-// table-driven assertions on the emitted triple set.
-type recordedTriple struct {
-	subject   string
-	predicate string
-	object    any
+// recordedUpsert captures a single UpsertEntity invocation.
+type recordedUpsert struct {
+	entityType message.Type
+	entityID   string
+	triples    []message.Triple
 }
 
-// recordingWriter implements tripleWriter by appending every call to
-// an in-memory slice. Tests assert on the slice's length, ordering,
-// and predicate/object pairs.
+// recordingWriter implements tripleWriter for tests. It records UpsertEntity
+// calls in upserts and WriteTriple calls in writeCalls. Tests assert that
+// Emit uses exactly one UpsertEntity and zero WriteTriple calls — the path
+// pin that confirms the migration off graph.mutation.triple.add.
 type recordingWriter struct {
-	triples []recordedTriple
-	failOn  string // when set, return an error on the matching predicate
+	upserts    []recordedUpsert
+	writeCalls int  // count of WriteTriple calls — must stay 0 after migration
+	failUpsert bool // when true, UpsertEntity returns an error
 }
 
-func (rw *recordingWriter) WriteTriple(_ context.Context, subject, predicate string, object any) error {
-	if rw.failOn != "" && rw.failOn == predicate {
-		return errors.New("recording-writer simulated failure")
-	}
-	rw.triples = append(rw.triples, recordedTriple{subject, predicate, object})
+func (rw *recordingWriter) WriteTriple(_ context.Context, _, _ string, _ any) error {
+	rw.writeCalls++
 	return nil
 }
 
-// findTriple returns the first triple matching subject+predicate, or nil.
-func (rw *recordingWriter) findTriple(subject, predicate string) *recordedTriple {
-	for i := range rw.triples {
-		if rw.triples[i].subject == subject && rw.triples[i].predicate == predicate {
-			return &rw.triples[i]
+func (rw *recordingWriter) UpsertEntity(_ context.Context, entityType message.Type, entityID string, triples []message.Triple) error {
+	if rw.failUpsert {
+		return errors.New("recording-writer simulated UpsertEntity failure")
+	}
+	rw.upserts = append(rw.upserts, recordedUpsert{entityType, entityID, triples})
+	return nil
+}
+
+// findTriple returns the first triple matching predicate in the most recent
+// upsert, or nil. Helpers mirror the old recordedTriple helpers so individual
+// predicate assertions read identically.
+func (rw *recordingWriter) findTriple(_, predicate string) *message.Triple {
+	if len(rw.upserts) == 0 {
+		return nil
+	}
+	last := rw.upserts[len(rw.upserts)-1]
+	for i := range last.triples {
+		if last.triples[i].Predicate == predicate {
+			return &last.triples[i]
 		}
 	}
 	return nil
 }
 
-func (rw *recordingWriter) findAll(subject, predicate string) []recordedTriple {
-	var out []recordedTriple
-	for _, t := range rw.triples {
-		if t.subject == subject && t.predicate == predicate {
+func (rw *recordingWriter) findAll(_, predicate string) []message.Triple {
+	if len(rw.upserts) == 0 {
+		return nil
+	}
+	last := rw.upserts[len(rw.upserts)-1]
+	var out []message.Triple
+	for _, t := range last.triples {
+		if t.Predicate == predicate {
 			out = append(out, t)
 		}
 	}
 	return out
 }
 
-func TestEmit_StrictOutcome_NoTriples(t *testing.T) {
+// ----- buildIncidentTriples — pure unit tests --------------------------------
+
+// TestBuildIncidentTriples_FullAttributeSet verifies the pure helper emits all
+// attributes including call_id, with optional fields present when non-empty and
+// quirks emitted one-per-triple. No NATS involved.
+func TestBuildIncidentTriples_FullAttributeSet(t *testing.T) {
+	ic := IncidentContext{
+		CallID:        "loop-build",
+		Role:          "planner",
+		Model:         "openrouter-qwen3-moe",
+		PromptVersion: "v3.2",
+	}
+	ev := IncidentEvent{
+		Checkpoint:  observability.CheckpointResponseParse,
+		Outcome:     observability.OutcomeToleratedQuirk,
+		Quirks:      []string{"fenced_json_wrapper", "trailing_commas"},
+		Reason:      "stripped fences",
+		RawResponse: "```json\n{\"x\":1,}\n```",
+	}
+	incidentID := "loop-build.parse.response_parse"
+
+	triples := buildIncidentTriples(incidentID, ic, ev)
+
+	// Helper to find by predicate value.
+	find := func(pred string) *message.Triple {
+		for i := range triples {
+			if triples[i].Predicate == pred {
+				return &triples[i]
+			}
+		}
+		return nil
+	}
+	findAll := func(pred string) []message.Triple {
+		var out []message.Triple
+		for _, t := range triples {
+			if t.Predicate == pred {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	// Required always-present predicates.
+	required := map[string]any{
+		observability.Checkpoint:     observability.CheckpointResponseParse,
+		observability.Outcome:        observability.OutcomeToleratedQuirk,
+		observability.IncidentCallID: "loop-build",
+		observability.Reason:         "stripped fences",
+		observability.Role:           "planner",
+		observability.Model:          "openrouter-qwen3-moe",
+		observability.PromptVersion:  "v3.2",
+		observability.RawResponse:    "```json\n{\"x\":1,}\n```",
+	}
+	for pred, want := range required {
+		got := find(pred)
+		if got == nil {
+			t.Errorf("missing triple for predicate %q", pred)
+			continue
+		}
+		if got.Object != want {
+			t.Errorf("predicate %q object = %v, want %v", pred, got.Object, want)
+		}
+	}
+
+	// Quirks — one per fired quirk.
+	quirks := findAll(observability.Quirk)
+	if len(quirks) != 2 {
+		t.Errorf("expected 2 quirk triples, got %d", len(quirks))
+	}
+	gotQ := map[any]bool{}
+	for _, q := range quirks {
+		gotQ[q.Object] = true
+	}
+	if !gotQ["fenced_json_wrapper"] || !gotQ["trailing_commas"] {
+		t.Errorf("expected both fenced_json_wrapper and trailing_commas in quirks, got %v", gotQ)
+	}
+
+	// All subjects must equal incidentID.
+	for _, tr := range triples {
+		if tr.Subject != incidentID {
+			t.Errorf("triple subject = %q, want %q (predicate %q)", tr.Subject, incidentID, tr.Predicate)
+		}
+	}
+}
+
+// TestBuildIncidentTriples_OptionalAbsentWhenEmpty confirms empty optional
+// fields produce no triples — no sentinel-value pollution.
+func TestBuildIncidentTriples_OptionalAbsentWhenEmpty(t *testing.T) {
+	ic := IncidentContext{CallID: "loop-min"} // Role/Model/PromptVersion all empty
+	ev := IncidentEvent{
+		Checkpoint: observability.CheckpointResponseParse,
+		Outcome:    observability.OutcomeRejected,
+		// Reason, RawResponse empty
+	}
+	incidentID := "loop-min.parse.response_parse"
+
+	triples := buildIncidentTriples(incidentID, ic, ev)
+
+	find := func(pred string) *message.Triple {
+		for i := range triples {
+			if triples[i].Predicate == pred {
+				return &triples[i]
+			}
+		}
+		return nil
+	}
+
+	// Optional fields that were empty must not appear.
+	for _, pred := range []string{
+		observability.Reason,
+		observability.Role,
+		observability.Model,
+		observability.PromptVersion,
+		observability.RawResponse,
+		observability.RawResponseTruncated,
+	} {
+		if t2 := find(pred); t2 != nil {
+			t.Errorf("empty optional field %q must not generate a triple; got %+v", pred, t2)
+		}
+	}
+
+	// call_id is required even when other optionals are absent.
+	if t2 := find(observability.IncidentCallID); t2 == nil {
+		t.Error("call_id triple must always be present")
+	}
+}
+
+// TestBuildIncidentTriples_TruncationFlag pins that a response over the cap
+// produces a truncated body triple AND a raw_response_truncated triple.
+func TestBuildIncidentTriples_TruncationFlag(t *testing.T) {
+	huge := strings.Repeat("a", MaxRawResponseBytes*2)
+	ic := IncidentContext{CallID: "loop-big"}
+	ev := IncidentEvent{
+		Checkpoint:  observability.CheckpointResponseParse,
+		Outcome:     observability.OutcomeRejected,
+		RawResponse: huge,
+	}
+	incidentID := "loop-big.parse.response_parse"
+
+	triples := buildIncidentTriples(incidentID, ic, ev)
+
+	find := func(pred string) *message.Triple {
+		for i := range triples {
+			if triples[i].Predicate == pred {
+				return &triples[i]
+			}
+		}
+		return nil
+	}
+
+	rawT := find(observability.RawResponse)
+	if rawT == nil {
+		t.Fatal("missing raw_response triple")
+	}
+	rawStr, ok := rawT.Object.(string)
+	if !ok {
+		t.Fatalf("raw_response object is not a string: %T", rawT.Object)
+	}
+	if len(rawStr) > MaxRawResponseBytes {
+		t.Errorf("raw_response should be ≤%d bytes, got %d", MaxRawResponseBytes, len(rawStr))
+	}
+	truncT := find(observability.RawResponseTruncated)
+	if truncT == nil {
+		t.Fatal("missing raw_response_truncated flag")
+	}
+	if truncT.Object != true {
+		t.Errorf("raw_response_truncated = %v, want true", truncT.Object)
+	}
+}
+
+// ----- Emit — path-pin tests -------------------------------------------------
+
+// TestEmit_UsesUpsertEntity_NotWriteTriple is the genuine path pin for
+// slice #2: confirms Emit calls UpsertEntity exactly once and makes ZERO
+// WriteTriple calls. Slice #1 lacked this assertion.
+func TestEmit_UsesUpsertEntity_NotWriteTriple(t *testing.T) {
+	rw := &recordingWriter{}
+	ic := IncidentContext{CallID: "loop-pin", Role: "planner", Model: "m1"}
+	ev := IncidentEvent{
+		Checkpoint: observability.CheckpointResponseParse,
+		Outcome:    observability.OutcomeRejected,
+		Reason:     "no JSON",
+	}
+	id, err := Emit(context.Background(), rw, ic, ev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty incident ID")
+	}
+	if len(rw.upserts) != 1 {
+		t.Errorf("expected 1 UpsertEntity call, got %d", len(rw.upserts))
+	}
+	if rw.writeCalls != 0 {
+		t.Errorf("expected 0 WriteTriple calls (relation write dropped), got %d", rw.writeCalls)
+	}
+	if rw.upserts[0].entityType != ParseIncidentEntityType {
+		t.Errorf("UpsertEntity entity type = %+v, want %+v", rw.upserts[0].entityType, ParseIncidentEntityType)
+	}
+	if rw.upserts[0].entityID != id {
+		t.Errorf("UpsertEntity entity ID = %q, want %q", rw.upserts[0].entityID, id)
+	}
+}
+
+// TestEmit_UpsertEntityFails_ReturnsEmptyID confirms Emit returns ("", err)
+// when UpsertEntity fails — no partial incident ID is returned because
+// the single-call model is atomic (either the node lands or it doesn't).
+func TestEmit_UpsertEntityFails_ReturnsEmptyID(t *testing.T) {
+	rw := &recordingWriter{failUpsert: true}
+	_, err := Emit(context.Background(), rw, IncidentContext{CallID: "x"}, IncidentEvent{
+		Checkpoint: observability.CheckpointResponseParse,
+		Outcome:    observability.OutcomeRejected,
+	})
+	if err == nil {
+		t.Error("expected error when UpsertEntity fails")
+	}
+}
+
+// ----- Existing guard tests (preserved, updated to new writer shape) ---------
+
+func TestEmit_StrictOutcome_NoOp(t *testing.T) {
 	rw := &recordingWriter{}
 	ic := IncidentContext{CallID: "loop-1", Role: "planner", Model: "test"}
 	ev := IncidentEvent{
@@ -77,8 +315,8 @@ func TestEmit_StrictOutcome_NoTriples(t *testing.T) {
 	if id != "" {
 		t.Errorf("incident ID should be empty for strict outcome, got %q", id)
 	}
-	if len(rw.triples) != 0 {
-		t.Errorf("strict outcome must emit ZERO triples; got %d: %+v", len(rw.triples), rw.triples)
+	if len(rw.upserts) != 0 {
+		t.Errorf("strict outcome must call ZERO UpsertEntity; got %d", len(rw.upserts))
 	}
 }
 
@@ -107,8 +345,8 @@ func TestEmit_EmptyOutcome_NoOp(t *testing.T) {
 	if id != "" {
 		t.Errorf("empty outcome should return empty ID, got %q", id)
 	}
-	if len(rw.triples) != 0 {
-		t.Errorf("empty outcome must emit ZERO triples; got %d", len(rw.triples))
+	if len(rw.upserts) != 0 {
+		t.Errorf("empty outcome must call ZERO UpsertEntity; got %d", len(rw.upserts))
 	}
 }
 
@@ -156,20 +394,16 @@ func TestEmit_RejectedOutcome_FullTripleSet(t *testing.T) {
 		t.Errorf("incident ID = %q, want %q", id, wantID)
 	}
 
-	// Relation first.
-	if len(rw.triples) == 0 || rw.triples[0].subject != "loop-rej" || rw.triples[0].predicate != observability.Incident {
-		t.Errorf("first write must be the parse.incident relation; got %+v", rw.triples)
-	}
-
-	// All required + optional populated predicates present.
+	// All required + optional populated predicates present in the upsert.
 	checks := map[string]any{
-		observability.Checkpoint:    observability.CheckpointResponseParse,
-		observability.Outcome:       observability.OutcomeRejected,
-		observability.Reason:        "no JSON found in result",
-		observability.Role:          "planner",
-		observability.Model:         "openrouter-qwen3-moe",
-		observability.PromptVersion: "v3.2",
-		observability.RawResponse:   "I'm not sure what to do here",
+		observability.Checkpoint:     observability.CheckpointResponseParse,
+		observability.Outcome:        observability.OutcomeRejected,
+		observability.IncidentCallID: "loop-rej",
+		observability.Reason:         "no JSON found in result",
+		observability.Role:           "planner",
+		observability.Model:          "openrouter-qwen3-moe",
+		observability.PromptVersion:  "v3.2",
+		observability.RawResponse:    "I'm not sure what to do here",
 	}
 	for pred, want := range checks {
 		got := rw.findTriple(wantID, pred)
@@ -177,8 +411,8 @@ func TestEmit_RejectedOutcome_FullTripleSet(t *testing.T) {
 			t.Errorf("missing triple for predicate %q", pred)
 			continue
 		}
-		if got.object != want {
-			t.Errorf("predicate %q object = %v, want %v", pred, got.object, want)
+		if got.Object != want {
+			t.Errorf("predicate %q object = %v, want %v", pred, got.Object, want)
 		}
 	}
 
@@ -208,15 +442,14 @@ func TestEmit_ToleratedQuirk_MultipleQuirkTriples(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// One quirk triple per fired quirk — RDF-correct multi-value, NOT
-	// a concatenated string.
+	// One quirk triple per fired quirk — RDF-correct multi-value.
 	quirks := rw.findAll(id, observability.Quirk)
 	if len(quirks) != 2 {
 		t.Errorf("expected 2 quirk triples, got %d: %+v", len(quirks), quirks)
 	}
 	gotQuirks := make(map[any]bool)
 	for _, q := range quirks {
-		gotQuirks[q.object] = true
+		gotQuirks[q.Object] = true
 	}
 	if !gotQuirks["fenced_json_wrapper"] || !gotQuirks["trailing_commas"] {
 		t.Errorf("expected both fenced_json_wrapper and trailing_commas, got %v", gotQuirks)
@@ -239,8 +472,7 @@ func TestEmit_EmptyOptionalFields_SkippedNotEmptyTriples(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Required predicates: Incident relation + Checkpoint + Outcome.
-	// Optional empty fields should NOT generate empty-string triples.
+	// Optional empty fields should NOT generate triples.
 	for _, pred := range []string{
 		observability.Reason,
 		observability.Role,
@@ -259,6 +491,9 @@ func TestEmit_EmptyOptionalFields_SkippedNotEmptyTriples(t *testing.T) {
 	}
 	if rw.findTriple(id, observability.Outcome) == nil {
 		t.Error("missing required Outcome triple")
+	}
+	if rw.findTriple(id, observability.IncidentCallID) == nil {
+		t.Error("missing required call_id triple")
 	}
 }
 
@@ -280,9 +515,9 @@ func TestEmit_LargeRawResponse_TruncatedWithFlag(t *testing.T) {
 	if rawTriple == nil {
 		t.Fatal("missing raw_response triple")
 	}
-	rawString, ok := rawTriple.object.(string)
+	rawString, ok := rawTriple.Object.(string)
 	if !ok {
-		t.Fatalf("raw_response object is not a string: %T", rawTriple.object)
+		t.Fatalf("raw_response object is not a string: %T", rawTriple.Object)
 	}
 	if len(rawString) > MaxRawResponseBytes {
 		t.Errorf("raw_response should be truncated to ≤%d bytes, got %d", MaxRawResponseBytes, len(rawString))
@@ -292,8 +527,8 @@ func TestEmit_LargeRawResponse_TruncatedWithFlag(t *testing.T) {
 	if truncFlag == nil {
 		t.Fatal("missing raw_response_truncated flag on truncated response")
 	}
-	if truncFlag.object != true {
-		t.Errorf("raw_response_truncated = %v, want true", truncFlag.object)
+	if truncFlag.Object != true {
+		t.Errorf("raw_response_truncated = %v, want true", truncFlag.Object)
 	}
 }
 
@@ -306,31 +541,31 @@ func TestEmitForResult_OutcomeBranches(t *testing.T) {
 		quirks      []string
 		parseErr    error
 		wantOutcome string
-		wantTriples bool
+		wantUpsert  bool
 	}{
 		{
 			name:        "parse failure → rejected",
 			parseErr:    errors.New("invalid JSON"),
 			wantOutcome: observability.OutcomeRejected,
-			wantTriples: true,
+			wantUpsert:  true,
 		},
 		{
 			name:        "quirks fired → tolerated_quirk",
 			quirks:      []string{"fenced_json_wrapper"},
 			wantOutcome: observability.OutcomeToleratedQuirk,
-			wantTriples: true,
+			wantUpsert:  true,
 		},
 		{
-			name:        "clean parse → strict (no triples)",
+			name:        "clean parse → strict (no upsert)",
 			wantOutcome: observability.OutcomeStrict,
-			wantTriples: false,
+			wantUpsert:  false,
 		},
 		{
 			name:        "parse error wins over quirks",
 			quirks:      []string{"fenced_json_wrapper"},
 			parseErr:    errors.New("typed unmarshal failed"),
 			wantOutcome: observability.OutcomeRejected,
-			wantTriples: true,
+			wantUpsert:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -341,23 +576,26 @@ func TestEmitForResult_OutcomeBranches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if tt.wantTriples {
+			if tt.wantUpsert {
 				if id == "" {
 					t.Error("expected non-empty incident ID")
+				}
+				if len(rw.upserts) != 1 {
+					t.Fatalf("expected 1 UpsertEntity, got %d", len(rw.upserts))
 				}
 				outcome := rw.findTriple(id, observability.Outcome)
 				if outcome == nil {
 					t.Fatal("missing outcome triple")
 				}
-				if outcome.object != tt.wantOutcome {
-					t.Errorf("outcome = %v, want %s", outcome.object, tt.wantOutcome)
+				if outcome.Object != tt.wantOutcome {
+					t.Errorf("outcome = %v, want %s", outcome.Object, tt.wantOutcome)
 				}
 			} else {
 				if id != "" {
 					t.Errorf("strict outcome should produce empty incident ID, got %q", id)
 				}
-				if len(rw.triples) != 0 {
-					t.Errorf("strict outcome should produce ZERO triples, got %d", len(rw.triples))
+				if len(rw.upserts) != 0 {
+					t.Errorf("strict outcome should produce ZERO UpsertEntity calls, got %d", len(rw.upserts))
 				}
 			}
 		})
@@ -397,20 +635,6 @@ func TestEmit_IncidentID_IsNATSKVSafe(t *testing.T) {
 	// Belt-and-suspenders — explicitly forbid the historical `:`.
 	if strings.Contains(id, ":") {
 		t.Errorf("incident ID %q must not contain ':' (NATS KV rejects with 'invalid key')", id)
-	}
-}
-
-func TestEmit_RelationWriteFails_ShortCircuits(t *testing.T) {
-	rw := &recordingWriter{failOn: observability.Incident}
-	_, err := Emit(context.Background(), rw, IncidentContext{CallID: "x"}, IncidentEvent{
-		Checkpoint: observability.CheckpointResponseParse,
-		Outcome:    observability.OutcomeRejected,
-	})
-	if err == nil {
-		t.Error("expected error when relation write fails")
-	}
-	if len(rw.triples) != 0 {
-		t.Errorf("no triples should land when relation write fails, got %d", len(rw.triples))
 	}
 }
 

--- a/workflow/recoveryhint/emit.go
+++ b/workflow/recoveryhint/emit.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/observability"
 )
 
@@ -31,21 +33,34 @@ type RecoveryEvent struct {
 	Candidates    []string // empty when Outcome=not_suggested
 }
 
+// RecoveryIncidentEntityType is the message.Type for tool-recovery-incident
+// entities. Domain "tool-recovery-incident" names the entity class (the incident
+// node IDs are `<call_id>.tool-recovery.<tool>.<hash>`). Kept local to avoid
+// touching workflow/entity.go while nearby slices are editing it (issue #154); a
+// future pass may register it in workflowEntityTypes for parity with LessonEntityType.
+var RecoveryIncidentEntityType = message.Type{
+	Domain:   "tool-recovery-incident",
+	Category: "entity",
+	Version:  "v1",
+}
+
 // tripleWriter is the minimal interface Emit needs from the graph
 // write surface. graphutil.TripleWriter satisfies it implicitly.
 type tripleWriter interface {
 	WriteTriple(ctx context.Context, entityID, predicate string, object any) error
+	UpsertEntity(ctx context.Context, entityType message.Type, entityID string, triples []message.Triple) error
 }
 
-// Emit writes the tool.recovery.incident triple set for a recovery
-// event. Returns the incident node ID on success, or "" when no
-// incident was emitted (nil writer or empty outcome).
+// Emit writes the tool.recovery.incident entity for a recovery event.
+// Returns the incident node ID on success, or "" when no incident was
+// emitted (nil writer or empty outcome).
 //
-// Triple write order matters: the relation triple
-// `(call_id) -[tool.recovery.incident]-> (incident_node)` is written
-// first so a partial-write failure still leaves the relation findable
-// from the call entity. Each attribute predicate follows; individual
-// write failures bubble up after all writes are attempted.
+// The incident node is created via UpsertEntity (routes to
+// create_with_triples on first write, update_with_triples on retry),
+// which is metadata-bearing and survives the semstreams triple.add
+// must-exist change (issue #154, slice #2). call_id is carried as a
+// node attribute so the linkage to the agentic loop is preserved even
+// though the loop entity has no ENTITY_STATES graph node.
 //
 // Incident node IDs are deterministic — the suffix is a SHA-256 of
 // the OriginalQuery so retry replays of the same loop on the same
@@ -76,54 +91,50 @@ func Emit(ctx context.Context, tw tripleWriter, rc RecoveryContext, re RecoveryE
 	hash := sha256.Sum256([]byte(re.OriginalQuery))
 	incidentID := fmt.Sprintf("%s.tool-recovery.%s.%s", rc.CallID, rc.ToolName, hex.EncodeToString(hash[:8]))
 
-	// Relation first.
-	if err := tw.WriteTriple(ctx, rc.CallID, observability.ToolRecoveryIncident, incidentID); err != nil {
-		return "", fmt.Errorf("write tool.recovery.incident relation: %w", err)
-	}
-
-	// Required attribute predicates.
-	required := []predicateWrite{
-		{observability.ToolRecoveryOutcome, re.Outcome},
-		{observability.ToolRecoveryToolName, rc.ToolName},
-	}
-	for _, w := range required {
-		if err := tw.WriteTriple(ctx, incidentID, w.predicate, w.object); err != nil {
-			return incidentID, fmt.Errorf("write %s: %w", w.predicate, err)
-		}
-	}
-
-	// Optional attributes — empty values skipped so the graph doesn't
-	// accumulate sentinel triples that need a later cleanup pass.
-	optional := []predicateWrite{
-		{observability.ToolRecoveryOriginalQuery, re.OriginalQuery},
-		{observability.ToolRecoveryRole, rc.Role},
-		{observability.ToolRecoveryModel, rc.Model},
-	}
-	for _, w := range optional {
-		if w.object == "" {
-			continue
-		}
-		if err := tw.WriteTriple(ctx, incidentID, w.predicate, w.object); err != nil {
-			return incidentID, fmt.Errorf("write %s: %w", w.predicate, err)
-		}
-	}
-
-	// Multi-valued candidate predicates — one triple per suggested ID.
-	for _, c := range re.Candidates {
-		if c == "" {
-			continue
-		}
-		if err := tw.WriteTriple(ctx, incidentID, observability.ToolRecoveryCandidate, c); err != nil {
-			return incidentID, fmt.Errorf("write candidate %q: %w", c, err)
-		}
+	triples := buildIncidentTriples(incidentID, rc, re)
+	if err := tw.UpsertEntity(ctx, RecoveryIncidentEntityType, incidentID, triples); err != nil {
+		return "", fmt.Errorf("recoveryhint: upsert entity: %w", err)
 	}
 
 	return incidentID, nil
 }
 
-// predicateWrite pairs a predicate constant with its object value for
-// table-driven writes inside Emit.
-type predicateWrite struct {
-	predicate string
-	object    any
+// buildIncidentTriples constructs the full []message.Triple for a
+// tool-recovery-incident entity. It is a pure function so it can be tested
+// independently of NATS.
+//
+// Required scalars (Outcome, ToolName, CallID) are always emitted. Optional
+// fields (OriginalQuery, Role, Model) are emitted only when non-empty.
+// Multi-valued Candidates emit one triple per candidate — never JSON-encoded —
+// per feedback_no_json_in_triples.
+func buildIncidentTriples(incidentID string, rc RecoveryContext, re RecoveryEvent) []message.Triple {
+	triples := []message.Triple{
+		{Subject: incidentID, Predicate: observability.ToolRecoveryOutcome, Object: re.Outcome},
+		{Subject: incidentID, Predicate: observability.ToolRecoveryToolName, Object: rc.ToolName},
+		// call_id is carried as an attribute so the linkage to the agentic loop
+		// is preserved even though the loop has no ENTITY_STATES graph node.
+		{Subject: incidentID, Predicate: observability.IncidentCallID, Object: rc.CallID},
+	}
+
+	// Optional attribute predicates — omit empty values so the graph does
+	// not accumulate sentinel-value triples that need a later cleanup pass.
+	if re.OriginalQuery != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.ToolRecoveryOriginalQuery, Object: re.OriginalQuery})
+	}
+	if rc.Role != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.ToolRecoveryRole, Object: rc.Role})
+	}
+	if rc.Model != "" {
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.ToolRecoveryModel, Object: rc.Model})
+	}
+
+	// Multi-valued candidate predicates — one triple per suggested candidate ID.
+	for _, c := range re.Candidates {
+		if c == "" {
+			continue
+		}
+		triples = append(triples, message.Triple{Subject: incidentID, Predicate: observability.ToolRecoveryCandidate, Object: c})
+	}
+
+	return triples
 }

--- a/workflow/recoveryhint/recoveryhint_test.go
+++ b/workflow/recoveryhint/recoveryhint_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/c360studio/semstreams/message"
+
 	"github.com/c360studio/semspec/vocabulary/observability"
 )
 
@@ -16,39 +18,60 @@ import (
 // because graph-ingest stores them via CAS write.
 var natsKVKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_./=-]+$`)
 
-// recordedTriple captures a single WriteTriple invocation.
-type recordedTriple struct {
-	subject, predicate string
-	object             any
+// recordedUpsert captures a single UpsertEntity invocation.
+type recordedUpsert struct {
+	entityType message.Type
+	entityID   string
+	triples    []message.Triple
 }
 
+// recordingWriter implements tripleWriter for tests. It records UpsertEntity
+// calls in upserts and WriteTriple calls in writeCalls. Tests assert that
+// Emit uses exactly one UpsertEntity and zero WriteTriple calls — the path
+// pin that confirms the migration off graph.mutation.triple.add.
 type recordingWriter struct {
-	triples []recordedTriple
-	failOn  string
+	upserts    []recordedUpsert
+	writeCalls int  // count of WriteTriple calls — must stay 0 after migration
+	failUpsert bool // when true, UpsertEntity returns an error
 }
 
-func (rw *recordingWriter) WriteTriple(_ context.Context, subject, predicate string, object any) error {
-	if rw.failOn != "" && rw.failOn == predicate {
-		return errors.New("simulated failure")
-	}
-	rw.triples = append(rw.triples, recordedTriple{subject, predicate, object})
+func (rw *recordingWriter) WriteTriple(_ context.Context, _, _ string, _ any) error {
+	rw.writeCalls++
 	return nil
 }
 
-func (rw *recordingWriter) findAll(subject, predicate string) []recordedTriple {
-	var out []recordedTriple
-	for _, t := range rw.triples {
-		if t.subject == subject && t.predicate == predicate {
+func (rw *recordingWriter) UpsertEntity(_ context.Context, entityType message.Type, entityID string, triples []message.Triple) error {
+	if rw.failUpsert {
+		return errors.New("simulated UpsertEntity failure")
+	}
+	rw.upserts = append(rw.upserts, recordedUpsert{entityType, entityID, triples})
+	return nil
+}
+
+// findAll returns all triples matching predicate in the most recent upsert.
+func (rw *recordingWriter) findAll(_, predicate string) []message.Triple {
+	if len(rw.upserts) == 0 {
+		return nil
+	}
+	last := rw.upserts[len(rw.upserts)-1]
+	var out []message.Triple
+	for _, t := range last.triples {
+		if t.Predicate == predicate {
 			out = append(out, t)
 		}
 	}
 	return out
 }
 
-func (rw *recordingWriter) findOne(subject, predicate string) *recordedTriple {
-	for i := range rw.triples {
-		if rw.triples[i].subject == subject && rw.triples[i].predicate == predicate {
-			return &rw.triples[i]
+// findOne returns the first triple matching predicate in the most recent upsert.
+func (rw *recordingWriter) findOne(_, predicate string) *message.Triple {
+	if len(rw.upserts) == 0 {
+		return nil
+	}
+	last := rw.upserts[len(rw.upserts)-1]
+	for i := range last.triples {
+		if last.triples[i].Predicate == predicate {
+			return &last.triples[i]
 		}
 	}
 	return nil
@@ -110,7 +133,157 @@ func TestSuggest_StableOnTies(t *testing.T) {
 	}
 }
 
-// ----- Emit -----------------------------------------------------------
+// ----- buildIncidentTriples — pure unit tests --------------------------------
+
+// TestBuildIncidentTriples_FullAttributeSet verifies the pure helper emits all
+// attributes including call_id, with optional fields present when non-empty and
+// candidates emitted one-per-triple. No NATS involved.
+func TestBuildIncidentTriples_FullAttributeSet(t *testing.T) {
+	rc := RecoveryContext{
+		CallID:   "loop-build",
+		Role:     "developer",
+		Model:    "openrouter-qwen3-moe",
+		ToolName: "graph_query",
+	}
+	re := RecoveryEvent{
+		Outcome:       observability.ToolRecoveryOutcomeSuggested,
+		OriginalQuery: `{ entity(id: "semspec.semsource.code.workspace.file.main-go") }`,
+		Candidates:    []string{"semspec.semsource.golang.workspace.file.main-go", "semspec.semsource.code.workspace.folder.internal-auth"},
+	}
+	incidentID := "loop-build.tool-recovery.graph_query.deadbeef"
+
+	triples := buildIncidentTriples(incidentID, rc, re)
+
+	find := func(pred string) *message.Triple {
+		for i := range triples {
+			if triples[i].Predicate == pred {
+				return &triples[i]
+			}
+		}
+		return nil
+	}
+	findAll := func(pred string) []message.Triple {
+		var out []message.Triple
+		for _, t := range triples {
+			if t.Predicate == pred {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+
+	// Required always-present predicates.
+	required := map[string]any{
+		observability.ToolRecoveryOutcome:       observability.ToolRecoveryOutcomeSuggested,
+		observability.ToolRecoveryToolName:      "graph_query",
+		observability.IncidentCallID:            "loop-build",
+		observability.ToolRecoveryOriginalQuery: re.OriginalQuery,
+		observability.ToolRecoveryRole:          "developer",
+		observability.ToolRecoveryModel:         "openrouter-qwen3-moe",
+	}
+	for pred, want := range required {
+		got := find(pred)
+		if got == nil {
+			t.Errorf("missing triple for predicate %q", pred)
+			continue
+		}
+		if got.Object != want {
+			t.Errorf("predicate %q object = %v, want %v", pred, got.Object, want)
+		}
+	}
+
+	// Candidates — one per suggested ID.
+	cands := findAll(observability.ToolRecoveryCandidate)
+	if len(cands) != 2 {
+		t.Errorf("expected 2 candidate triples, got %d", len(cands))
+	}
+	gotCands := map[any]bool{}
+	for _, c := range cands {
+		gotCands[c.Object] = true
+	}
+	for _, want := range re.Candidates {
+		if !gotCands[want] {
+			t.Errorf("missing candidate triple %q", want)
+		}
+	}
+
+	// All subjects must equal incidentID.
+	for _, tr := range triples {
+		if tr.Subject != incidentID {
+			t.Errorf("triple subject = %q, want %q (predicate %q)", tr.Subject, incidentID, tr.Predicate)
+		}
+	}
+}
+
+// TestBuildIncidentTriples_OptionalAbsentWhenEmpty confirms empty optional
+// fields produce no triples — no sentinel-value pollution.
+func TestBuildIncidentTriples_OptionalAbsentWhenEmpty(t *testing.T) {
+	rc := RecoveryContext{CallID: "loop-min", ToolName: "graph_query"} // Role/Model empty
+	re := RecoveryEvent{Outcome: observability.ToolRecoveryOutcomeNotSuggested}
+	incidentID := "loop-min.tool-recovery.graph_query.00000000"
+
+	triples := buildIncidentTriples(incidentID, rc, re)
+
+	find := func(pred string) *message.Triple {
+		for i := range triples {
+			if triples[i].Predicate == pred {
+				return &triples[i]
+			}
+		}
+		return nil
+	}
+
+	for _, pred := range []string{
+		observability.ToolRecoveryOriginalQuery,
+		observability.ToolRecoveryRole,
+		observability.ToolRecoveryModel,
+		observability.ToolRecoveryCandidate,
+	} {
+		if t2 := find(pred); t2 != nil {
+			t.Errorf("empty optional field %q must not generate a triple; got %+v", pred, t2)
+		}
+	}
+
+	// call_id always present.
+	if t2 := find(observability.IncidentCallID); t2 == nil {
+		t.Error("call_id triple must always be present")
+	}
+}
+
+// ----- Emit — path-pin tests -------------------------------------------------
+
+// TestEmit_UsesUpsertEntity_NotWriteTriple is the genuine path pin for
+// slice #2: confirms Emit calls UpsertEntity exactly once and makes ZERO
+// WriteTriple calls. Slice #1 lacked this assertion.
+func TestEmit_UsesUpsertEntity_NotWriteTriple(t *testing.T) {
+	rw := &recordingWriter{}
+	rc := RecoveryContext{CallID: "loop-pin", Role: "developer", Model: "m1", ToolName: "graph_query"}
+	re := RecoveryEvent{
+		Outcome:       observability.ToolRecoveryOutcomeSuggested,
+		OriginalQuery: "some query",
+	}
+	id, err := Emit(context.Background(), rw, rc, re)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty incident ID")
+	}
+	if len(rw.upserts) != 1 {
+		t.Errorf("expected 1 UpsertEntity call, got %d", len(rw.upserts))
+	}
+	if rw.writeCalls != 0 {
+		t.Errorf("expected 0 WriteTriple calls (relation write dropped), got %d", rw.writeCalls)
+	}
+	if rw.upserts[0].entityType != RecoveryIncidentEntityType {
+		t.Errorf("UpsertEntity entity type = %+v, want %+v", rw.upserts[0].entityType, RecoveryIncidentEntityType)
+	}
+	if rw.upserts[0].entityID != id {
+		t.Errorf("UpsertEntity entity ID = %q, want %q", rw.upserts[0].entityID, id)
+	}
+}
+
+// ----- Existing guard tests (preserved, updated to new writer shape) ---------
 
 func TestEmit_NilWriter_NoOp(t *testing.T) {
 	id, err := Emit(context.Background(), nil, RecoveryContext{CallID: "x", ToolName: "graph_query"}, RecoveryEvent{
@@ -130,7 +303,7 @@ func TestEmit_EmptyOutcome_NoOp(t *testing.T) {
 	if err != nil {
 		t.Errorf("empty outcome should be no-op, got error: %v", err)
 	}
-	if id != "" || len(rw.triples) != 0 {
+	if id != "" || len(rw.upserts) != 0 {
 		t.Errorf("empty outcome must emit nothing")
 	}
 }
@@ -182,15 +355,11 @@ func TestEmit_Suggested_FullTripleSet(t *testing.T) {
 		t.Errorf("incident ID %q contains chars NATS KV won't accept (allowed: [a-zA-Z0-9_./=-])", id)
 	}
 
-	// Relation written FIRST (subject is the call ID).
-	if len(rw.triples) == 0 || rw.triples[0].subject != "loop-rec" || rw.triples[0].predicate != observability.ToolRecoveryIncident {
-		t.Errorf("first write must be the tool.recovery.incident relation; got %+v", rw.triples[0])
-	}
-
 	// All required + populated optional predicates present.
 	checks := map[string]any{
 		observability.ToolRecoveryOutcome:       observability.ToolRecoveryOutcomeSuggested,
 		observability.ToolRecoveryToolName:      "graph_query",
+		observability.IncidentCallID:            "loop-rec",
 		observability.ToolRecoveryOriginalQuery: re.OriginalQuery,
 		observability.ToolRecoveryRole:          "developer",
 		observability.ToolRecoveryModel:         "openrouter-qwen3-moe",
@@ -201,8 +370,8 @@ func TestEmit_Suggested_FullTripleSet(t *testing.T) {
 			t.Errorf("missing triple for %q", pred)
 			continue
 		}
-		if got.object != want {
-			t.Errorf("predicate %q object = %v, want %v", pred, got.object, want)
+		if got.Object != want {
+			t.Errorf("predicate %q object = %v, want %v", pred, got.Object, want)
 		}
 	}
 
@@ -213,7 +382,7 @@ func TestEmit_Suggested_FullTripleSet(t *testing.T) {
 	}
 	gotCands := map[any]bool{}
 	for _, c := range cands {
-		gotCands[c.object] = true
+		gotCands[c.Object] = true
 	}
 	for _, want := range re.Candidates {
 		if !gotCands[want] {
@@ -238,7 +407,7 @@ func TestEmit_NotSuggested_NoCandidateTriples(t *testing.T) {
 	}
 	// Outcome triple still written.
 	out := rw.findOne(id, observability.ToolRecoveryOutcome)
-	if out == nil || out.object != observability.ToolRecoveryOutcomeNotSuggested {
+	if out == nil || out.Object != observability.ToolRecoveryOutcomeNotSuggested {
 		t.Error("missing or wrong outcome triple")
 	}
 }
@@ -250,7 +419,7 @@ func TestEmit_DeterministicIDOnSameQuery(t *testing.T) {
 	rc := RecoveryContext{CallID: "loop-d", ToolName: "graph_query"}
 	re := RecoveryEvent{Outcome: observability.ToolRecoveryOutcomeSuggested, OriginalQuery: "same query"}
 	id1, _ := Emit(context.Background(), rw, rc, re)
-	rw.triples = nil // reset
+	rw.upserts = nil // reset
 	id2, _ := Emit(context.Background(), rw, rc, re)
 	if id1 != id2 {
 		t.Errorf("expected deterministic IDs, got %q and %q", id1, id2)
@@ -278,13 +447,11 @@ func TestEmit_DifferentQueries_DifferentIDs(t *testing.T) {
 	}
 }
 
-// Mid-write failure (e.g. on the ToolName attribute) should still
-// return the partial incident ID — the relation triple landed
-// successfully, so a graph reader can find the partial-state node.
-// Documents the partial-write contract called out in Emit's
-// godoc at emit.go:46-48.
-func TestEmit_MidAttributeWriteFails_ReturnsPartialID(t *testing.T) {
-	rw := &recordingWriter{failOn: observability.ToolRecoveryToolName}
+// TestEmit_UpsertEntityFails_ReturnsError confirms Emit propagates UpsertEntity
+// errors and returns empty ID (single-call atomic model — either the node lands
+// or it doesn't, no partial state).
+func TestEmit_UpsertEntityFails_ReturnsError(t *testing.T) {
+	rw := &recordingWriter{failUpsert: true}
 	rc := RecoveryContext{CallID: "loop-mid", ToolName: "graph_query"}
 	re := RecoveryEvent{
 		Outcome:       observability.ToolRecoveryOutcomeSuggested,
@@ -292,30 +459,10 @@ func TestEmit_MidAttributeWriteFails_ReturnsPartialID(t *testing.T) {
 	}
 	id, err := Emit(context.Background(), rw, rc, re)
 	if err == nil {
-		t.Error("expected error when mid-attribute write fails")
+		t.Error("expected error when UpsertEntity fails")
 	}
-	if id == "" {
-		t.Error("expected partial incident ID when relation already landed")
-	}
-	if !strings.HasPrefix(id, "loop-mid.tool-recovery.graph_query.") {
-		t.Errorf("partial ID prefix wrong: %q", id)
-	}
-	// Relation triple should still be in the writer's recorded set.
-	if rw.findOne("loop-mid", observability.ToolRecoveryIncident) == nil {
-		t.Error("relation triple should have landed before the mid-write failure")
-	}
-}
-
-func TestEmit_RelationWriteFails_ShortCircuits(t *testing.T) {
-	rw := &recordingWriter{failOn: observability.ToolRecoveryIncident}
-	_, err := Emit(context.Background(), rw, RecoveryContext{CallID: "x", ToolName: "graph_query"}, RecoveryEvent{
-		Outcome: observability.ToolRecoveryOutcomeSuggested,
-	})
-	if err == nil {
-		t.Error("expected error when relation write fails")
-	}
-	if len(rw.triples) != 0 {
-		t.Errorf("no triples should land when relation write fails; got %d", len(rw.triples))
+	if id != "" {
+		t.Errorf("expected empty ID on upsert failure, got %q", id)
 	}
 }
 


### PR DESCRIPTION
## What & why

semstreams is changing `graph.mutation.triple.add` to **must-exist** semantics: `AddTriple` will stop conjuring a missing entity. Four semspec subsystems currently *create* graph entities by relying on that conjure behavior (raw `WriteTriple`/`UpdateTriple`), so when must-exist lands they would **silently stop populating the graph** — errors are swallowed best-effort, so the symptom is quietly-empty mirrors (lessons, incident telemetry, project config), not a crash. This must land before the semstreams bump that ships must-exist.

The fix is uniform: convert each *creator* to a single metadata-bearing `UpsertEntity` (routes to `create_with_triples` on first write, `update_with_triples` after — both safe under must-exist, and idempotent on retry via replace-own). Everything already on the CAS path (Task/RequirementExecution, production Plan + children, Question, Cascade) was verified safe and is untouched.

Full analysis: `docs/audit/mutation-api-graphable-bypass.md` ("Impact" section). Sibling concern (dual-writer / `ExpectedRevision`) is tracked separately in #153.

Closes #154.

## Slices (one commit each)

1. **lessons** — `RecordLesson`'s `WriteTriple` loop → one `UpsertEntity` (`LessonEntityType`) via pure `buildLessonTriples`. Saves the ADR-033 lessons subsystem.
2. **incidents** — parse + recovery incident *nodes* → `UpsertEntity`; `call_id` carried as a node attribute (`observability.IncidentCallID`); the inbound loop relation is **dropped** (verified zero readers — the loop has no `ENTITY_STATES` node anyway, and the unbuilt ADR-035 detector reads incident nodes by attribute). `tripleWriter` interfaces gain `UpsertEntity` (ripples into `tools/bash`, `tools/terminal`). Also fixes a latent append-bloat bug on incident retries.
3. **project config** — `writeConfig/Checklist/StandardsTriples` → `UpsertEntity` (`projectConfigEntityType`). `ProjectConfigJSON` blob kept (reconcile reads it).
4. **plan (graph_marshal)** — `writePlanTriples` → `UpsertEntity` (`PlanEntityType`). Test-seed path only (7 `scenario-orchestrator` integration tests); production uses `planStore`.

## Verification

- `go build ./...` — OK
- `go test ./...` — **0 failures, 70 packages ok**
- `task lint` — **exit 0** (revive v1.5.1)

Each slice was implemented test-first (go-developer) and reviewed (go-reviewer): **APPROVE-WITH-NITS, zero must-fix**. Predicate-set fidelity confirmed exact; the relation drop confirmed safe; new tests pin the path (`TestEmit_UsesUpsertEntity_NotWriteTriple` asserts zero `WriteTriple` calls). Review nits fixed in-branch (a false `json.Marshal`-error comment + two imprecise type comments). The `IncidentCallID = "llm.parse.call_id"` name was intentionally **not** renamed — every observability incident predicate uses the `llm.parse.*` namespace and is already reused by recovery, so renaming only `call_id` would make it inconsistent.

## Deferred follow-ups (non-blocking)

- Register the 3 new local entity types in `workflowEntityTypes` for parity with `LessonEntityType` (kept local to avoid an `entity.go` conflict during parallel implementation; not needed for must-exist correctness).
- Incident node IDs don't follow the 6-part entity-ID convention (pre-existing; same family as the task-exec `EntityID()` orphan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
