### PR TITLE
fix(#151): execution-phase mock story emits one task (1-node DAG)

### DIFF
--- a/test/e2e/fixtures/mock-responses/execution-phase/mock-story-preparer.json
+++ b/test/e2e/fixtures/mock-responses/execution-phase/mock-story-preparer.json
@@ -5,7 +5,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"stories\": [{\"label\": \"api\", \"component_name\": \"api\", \"requirement_indices\": [0], \"capability_indices\": [], \"title\": \"Implement api component\", \"intent\": \"Mock fixture: implement the api component covering requirement 0.\", \"tasks\": [{\"label\": \"test-first\", \"description\": \"Write failing test for this story's behavior\", \"depends_on_labels\": []}, {\"label\": \"impl\", \"description\": \"Implement to make the failing test pass\", \"depends_on_labels\": [\"test-first\"]}, {\"label\": \"verify\", \"description\": \"Verify all scenarios pass\", \"depends_on_labels\": [\"impl\"]}]}]}"
+        "arguments": "{\"stories\": [{\"label\": \"api\", \"component_name\": \"api\", \"requirement_indices\": [0], \"capability_indices\": [], \"title\": \"Implement api component\", \"intent\": \"Mock fixture: implement the api component covering requirement 0.\", \"tasks\": [{\"label\": \"implement\", \"description\": \"Write a failing unit test for this story's behavior, then implement the code to make it pass (red->green within this single task; the dev loop retries once on the red test).\", \"depends_on_labels\": []}]}]}"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Closes #151. `task e2e:mock -- execution-phase` could never reach `complete` — it ended `rejected` on the 2nd DAG node's claim/observation mismatch.

## Root cause (confirmed with a live mock run)

The scenario asserts **"1 requirement decomposed into 1 node"** and **"mock-coder called at least 4 times"** (`execution_phase.go:345-350`), but the `mock-story-preparer` fixture had drifted to a **3-task** story (`test-first → impl → verify`), all scoped to the same file. Under ADR-043 the DAG is one node per story task → a 3-node DAG.

The first node's **red test** fails structural validation (pytest), so the dev loop **retries** and writes the impl in cycle 1 — node 1 alone consumes all four file-writing fixtures (`mock-coder.1–.4`). Node 2 then lands on the bare `submit_work` fixtures (`.5`/base) that claim files but run no bash write → worktree clean → developer-diff guard rejects ×3 → TDD budget exhausted → plan `rejected`. Nodes 2/3 had nothing new to write anyway (node 1's work was already merged into their worktree base).

## Fix

The story emits a **single** `implement` task. The dev loop does red→green within that one node (cycle 0 writes the failing test; pytest fails; cycle 1 writes the impl; pytest passes; reviewer approves) — matching the scenario's documented 1-node / ≥4-mock-coder-call expectation.

## Verification

`task e2e:mock -- execution-phase` → `plan_final_status: "complete"`, **passed 1, failed 0** (was: `rejected`).

## Follow-up (not this PR)

Genuine *multi-node* DAG mock coverage would need a story whose tasks own **distinct** files (so each node dirties its own worktree); the 3-phase-same-file shape can't work with the red-test-retry executor. Worth a separate fixture if multi-node mock coverage is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)