### PR TITLE
fix(e2e): qa-cycle mock story emits one task (3-task fixture drift, sibling of #151)

### DIFF
--- a/test/e2e/fixtures/mock-responses/qa-cycle/mock-story-preparer.json
+++ b/test/e2e/fixtures/mock-responses/qa-cycle/mock-story-preparer.json
@@ -5,7 +5,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"stories\": [{\"label\": \"math\", \"component_name\": \"math\", \"requirement_indices\": [0], \"capability_indices\": [], \"title\": \"Implement math component\", \"intent\": \"Mock fixture: implement the math component covering requirement 0.\", \"tasks\": [{\"label\": \"test-first\", \"description\": \"Write failing test for this story's behavior\", \"depends_on_labels\": []}, {\"label\": \"impl\", \"description\": \"Implement to make the failing test pass\", \"depends_on_labels\": [\"test-first\"]}, {\"label\": \"verify\", \"description\": \"Verify all scenarios pass\", \"depends_on_labels\": [\"impl\"]}]}]}"
+        "arguments": "{\"stories\": [{\"label\": \"math\", \"component_name\": \"math\", \"requirement_indices\": [0], \"capability_indices\": [], \"title\": \"Implement math component\", \"intent\": \"Mock fixture: implement the math component covering requirement 0.\", \"tasks\": [{\"label\": \"implement\", \"description\": \"Write a failing unit test for this story's behavior, then implement the code to make it pass (red->green within this single task).\", \"depends_on_labels\": []}]}]}"
       }
     }
   ],


### PR DESCRIPTION
## Summary

`task e2e:mock -- qa-cycle` failed on clean main — `plan reached terminal failure before QA: rejected` — the **same root cause** fixed for execution-phase in #160.

## Root cause

The qa-cycle story-preparer emits a 3-task story (`test-first/impl/verify`), all scoped to one file → a 3-node DAG under ADR-043. The later `mock-coder` fixtures (`.4`/`.5`/base) claim files without writing them, so the 2nd/3rd node trips the developer-diff guard → execution rejects → never reaches QA.

## Fix

Single `implement` task (the proven #160 fix). Verified: `qa_completed_passed=true`, plan reaches `complete`.

## Systematic finding (for follow-up)

A census shows **~20 story-preparer fixtures carry this 3-task shape** — a leftover from the ADR-043/044 `story.tasks` introduction. It only breaks scenarios that **run execution to completion AND have claim-without-write late coder fixtures**; `hello-world` survives because its `.4`/`.5` claim *empty* `files_modified`.

**This drift is mock-fixture-only** — real LLM writes real files per node, so the multi-node DAG is unaffected. It does **not** indicate a pipeline bug and does **not** gate real-LLM runs.

**Still at-risk (not swept here, need per-scenario judgment):** `plan-stall-{complete,reject,retry}` (may *use* the node failure as the stall they test), `qa-cycle-{integration,services}` (heavier `act`-based CI).

## Mock ladder status (clean main, this session)

Core pipeline now green: **plan-phase ✅, hello-world ✅, execution-phase ✅, qa-cycle ✅**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)