### PR TITLE
fix(recoveryhint): canonical 6-part entity ID + e2e architecture_revise auto-accept

### DIFF
--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -925,6 +925,7 @@
         "accepted_subject": "workflow.events.plan-decision.accepted",
         "timeout_seconds": 120,
         "auto_accept_recovery": true,
+        "max_auto_architecture_revises": 2,
         "ports": {
           "inputs": [
             {

--- a/workflow/recoveryhint/emit.go
+++ b/workflow/recoveryhint/emit.go
@@ -2,13 +2,12 @@ package recoveryhint
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 
 	"github.com/c360studio/semstreams/message"
 
 	"github.com/c360studio/semspec/vocabulary/observability"
+	"github.com/c360studio/semspec/workflow"
 )
 
 // RecoveryContext carries the per-call context that distinguishes
@@ -35,9 +34,10 @@ type RecoveryEvent struct {
 
 // RecoveryIncidentEntityType is the message.Type for tool-recovery-incident
 // entities. Domain "tool-recovery-incident" names the entity class (the incident
-// node IDs are `<call_id>.tool-recovery.<tool>.<hash>`). Kept local to avoid
-// touching workflow/entity.go while nearby slices are editing it (issue #154); a
-// future pass may register it in workflowEntityTypes for parity with LessonEntityType.
+// node IDs are the canonical 6-part form `org.platform.obs.recovery.incident.<hash>`).
+// Kept local to avoid touching workflow/entity.go while nearby slices are editing
+// it (issue #154); a future pass may register it in workflowEntityTypes for parity
+// with LessonEntityType.
 var RecoveryIncidentEntityType = message.Type{
 	Domain:   "tool-recovery-incident",
 	Category: "entity",
@@ -62,18 +62,18 @@ type tripleWriter interface {
 // node attribute so the linkage to the agentic loop is preserved even
 // though the loop entity has no ENTITY_STATES graph node.
 //
-// Incident node IDs are deterministic — the suffix is a SHA-256 of
-// the OriginalQuery so retry replays of the same loop on the same
-// failed query produce idempotent SKG state. This matters more here
-// than for parse incidents because a single loop can trigger many
-// recoveries on different IDs (today's wedge: 28 occurrences in one
-// loop), so a checkpoint-style fixed suffix would collide.
+// Incident node IDs are deterministic — the instance segment is
+// HashInstanceID(CallID, ToolName, OriginalQuery), so retry replays of
+// the same loop on the same failed query produce idempotent SKG state.
+// This matters more here than for parse incidents because a single loop
+// can trigger many recoveries on different IDs (today's wedge: 28
+// occurrences in one loop), and folding the query into the hash keeps
+// each distinct query a distinct ID rather than colliding.
 //
-// Separator is `.` (period) because NATS KV keys allow only
-// [a-zA-Z0-9_-./=]. The original `:` choice shipped alongside
-// parseincident.Emit and was caught on first real-LLM run when
-// graph-ingest CAS writes failed with "invalid key". See
-// parseincident.Emit godoc for the cross-cutting rationale.
+// The ID is the canonical 6-part entity ID
+// (org.platform.obs.recovery.incident.<hash>) so it passes
+// Component.validateEntityID and survives graph-ingest CAS writes. The
+// earlier hand-rolled 4-part form failed validation on every emit.
 func Emit(ctx context.Context, tw tripleWriter, rc RecoveryContext, re RecoveryEvent) (string, error) {
 	if tw == nil {
 		return "", nil
@@ -88,8 +88,16 @@ func Emit(ctx context.Context, tw tripleWriter, rc RecoveryContext, re RecoveryE
 		return "", fmt.Errorf("recoveryhint: ToolName required")
 	}
 
-	hash := sha256.Sum256([]byte(re.OriginalQuery))
-	incidentID := fmt.Sprintf("%s.tool-recovery.%s.%s", rc.CallID, rc.ToolName, hex.EncodeToString(hash[:8]))
+	// Canonical 6-part entity ID: org.platform.obs.recovery.incident.<instance>.
+	// Parts 1-5 are fixed; the dot-free instance segment hashes (CallID,
+	// ToolName, OriginalQuery) so retry replays of the same loop on the same
+	// failed query produce idempotent SKG state while distinct queries within a
+	// single loop get distinct IDs (a wedge can trigger many recoveries on
+	// different IDs). CallID/ToolName/query stay queryable as triples (below),
+	// not as ID segments — per the entity-ID convention (logical IDs as triples).
+	// The pre-2026-06 form `<call_id>.tool-recovery.<tool>.<hash>` was only 4
+	// parts and failed Component.validateEntityID on every emit.
+	incidentID := fmt.Sprintf("%s.obs.recovery.incident.%s", workflow.EntityPrefix(), workflow.HashInstanceID(rc.CallID, rc.ToolName, re.OriginalQuery))
 
 	triples := buildIncidentTriples(incidentID, rc, re)
 	if err := tw.UpsertEntity(ctx, RecoveryIncidentEntityType, incidentID, triples); err != nil {

--- a/workflow/recoveryhint/recoveryhint_test.go
+++ b/workflow/recoveryhint/recoveryhint_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 
 	"github.com/c360studio/semspec/vocabulary/observability"
+	"github.com/c360studio/semspec/workflow"
 )
 
 // natsKVKeyPattern matches the character set NATS JetStream KV
@@ -150,7 +151,7 @@ func TestBuildIncidentTriples_FullAttributeSet(t *testing.T) {
 		OriginalQuery: `{ entity(id: "semspec.semsource.code.workspace.file.main-go") }`,
 		Candidates:    []string{"semspec.semsource.golang.workspace.file.main-go", "semspec.semsource.code.workspace.folder.internal-auth"},
 	}
-	incidentID := "loop-build.tool-recovery.graph_query.deadbeef"
+	incidentID := "semspec.local.obs.recovery.incident.deadbeefcafe0001"
 
 	triples := buildIncidentTriples(incidentID, rc, re)
 
@@ -220,7 +221,7 @@ func TestBuildIncidentTriples_FullAttributeSet(t *testing.T) {
 func TestBuildIncidentTriples_OptionalAbsentWhenEmpty(t *testing.T) {
 	rc := RecoveryContext{CallID: "loop-min", ToolName: "graph_query"} // Role/Model empty
 	re := RecoveryEvent{Outcome: observability.ToolRecoveryOutcomeNotSuggested}
-	incidentID := "loop-min.tool-recovery.graph_query.00000000"
+	incidentID := "semspec.local.obs.recovery.incident.0000000000000000"
 
 	triples := buildIncidentTriples(incidentID, rc, re)
 
@@ -346,9 +347,11 @@ func TestEmit_Suggested_FullTripleSet(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Deterministic ID shape.
-	if !strings.HasPrefix(id, "loop-rec.tool-recovery.graph_query.") {
-		t.Errorf("incident ID prefix wrong: %q", id)
+	// Deterministic ID shape — canonical 6-part entity ID
+	// (org.platform.obs.recovery.incident.<hash>).
+	wantPrefix := workflow.EntityPrefix() + ".obs.recovery.incident."
+	if !strings.HasPrefix(id, wantPrefix) {
+		t.Errorf("incident ID prefix = %q, want prefix %q", id, wantPrefix)
 	}
 	// NATS KV key safety — see natsKVKeyPattern godoc.
 	if !natsKVKeyPattern.MatchString(id) {


### PR DESCRIPTION
## Summary

Two fixes surfaced (and the first **validated live**) by the gemini `mavlink-hard` real-LLM runs (#138):

### 1. `fix(recoveryhint)`: canonical 6-part entity ID
`workflow/recoveryhint/emit.go` built a **4-part** ID `<call_id>.tool-recovery.<tool>.<hash>`, which failed `Component.validateEntityID` (expects 6 ASCII parts `org.platform.domain.system.type.instance`) on **every** emit. Result: tool-recovery incidents (the ADR-037 wedge-recovery feedback) **never persisted** to the graph — a WARN fired on essentially every tool call.

Fix: emit the canonical 6-part `org.platform.obs.recovery.incident.<hash>` via `EntityPrefix()` + `HashInstanceID(CallID, ToolName, OriginalQuery)`. CallID / ToolName / query stay queryable as triples (per the entity-ID convention — logical IDs as triples). Updated godoc + tests.

**Validated live:** on a gemini mavlink-hard run after this change, recovery-hint emit failures dropped to **0** (was ~every tool call), and hints persisted under the new IDs.

### 2. `chore(e2e)`: auto-accept `architecture_revise` in `e2e-gemini.json`
`plan-decision-handler.config.max_auto_architecture_revises` was **unset**. The parsed component config doesn't merge `DefaultConfig()` (which is 1), so it took the JSON **zero value 0** — meaning an autonomous run **parks every `architecture_revise` recovery for human review**, and the affected requirement terminal-fails after the recovery deadline (exactly what killed mavlink-hard #138 run 1). Set it explicitly to **2** so the gemini hard e2e can auto-accept up to two architecture revisions before the human gate.

## Verification
- `go build ./...` ✓ · `go vet` ✓ · `go test ./workflow/...` (15 pkgs) ✓ · `revive` ✓
- `e2e-gemini.json` is valid (template-expanded) with the knob = 2 ✓
- Recovery-hint fix validated on a live gemini mavlink-hard run (0 emit failures)

## Notes / follow-ups
- `workflow/parseincident/emit.go` has the **same latent 4-part bug** (`<call_id>.parse.<checkpoint>`) — **not** fixed here.
- Related: debug-log volume tracking issue **#165** (DEBUG=1 dumps full LLM payloads → ~2.2GB/run), surfaced by the same runs.
- The `max_auto_architecture_revises` knob is deployed but was **not exercised** in run 2 (that run had zero restructure rejections); the next wall is the worktree-isolation merge gap (task #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
