### PR TITLE
fix(qa): make the QA gate evaluate merged code + re-do work on rejection

### DIFF
--- a/cmd/sandbox/qa_subscriber.go
+++ b/cmd/sandbox/qa_subscriber.go
@@ -149,6 +149,22 @@ func (h *qaHandler) handleMessage(ctx context.Context, msg jetstream.Msg) {
 		"passed", completed.Passed, "duration_ms", completed.DurationMs)
 }
 
+// selectQAWorkDir resolves the directory the unit test command runs in: the
+// dedicated QA worktree when plan-manager created one and it resolves, else the
+// repo root. resolve mirrors Server.worktreeFor — it returns "" when the
+// worktree is absent. fellBack is true only when a workspace was requested but
+// could not be resolved (the caller WARN-logs so the regression to the unmerged
+// baseline is visible rather than silent).
+func selectQAWorkDir(repoPath, workspace string, resolve func(string) string) (dir string, fellBack bool) {
+	if workspace == "" {
+		return repoPath, false
+	}
+	if wt := resolve(workspace); wt != "" {
+		return wt, false
+	}
+	return repoPath, true
+}
+
 // runUnitQA executes the test command and assembles the QACompletedEvent.
 func (h *qaHandler) runUnitQA(
 	ctx context.Context,
@@ -182,9 +198,17 @@ func (h *qaHandler) runUnitQA(
 		}
 	}
 
-	// Run the test command from the workspace root (repoPath).
+	// Run the test command in the QA worktree (a checkout of the assembled plan
+	// branch, holding the merged per-requirement implementation) when plan-manager
+	// provided one; otherwise fall back to the repo root. Without this, unit QA
+	// runs against the pre-implementation main HEAD and is meaningless.
+	workDir, fellBack := selectQAWorkDir(h.srv.repoPath, evt.Workspace, h.srv.worktreeFor)
+	if fellBack {
+		h.logger.Warn("QA worktree not found — running unit tests against repo root (may be the unmerged baseline)",
+			"slug", evt.Slug, "workspace", evt.Workspace)
+	}
 	stdout, stderr, exitCode, timedOut := execCommand(
-		ctx, h.srv.repoPath, evt.TestCommand, timeout, h.srv.maxOutputBytes)
+		ctx, workDir, evt.TestCommand, timeout, h.srv.maxOutputBytes)
 
 	combined := stdout
 	if stderr != "" {

--- a/cmd/sandbox/qa_subscriber_test.go
+++ b/cmd/sandbox/qa_subscriber_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestSelectQAWorkDir(t *testing.T) {
+	const repoPath = "/repo"
+
+	// resolve mirrors Server.worktreeFor: returns the worktree path when it
+	// exists, "" otherwise.
+	resolvePresent := func(string) string { return "/repo/.semspec/worktrees/qa-auth" }
+	resolveMissing := func(string) string { return "" }
+
+	tests := []struct {
+		name         string
+		workspace    string
+		resolve      func(string) string
+		wantDir      string
+		wantFellBack bool
+	}{
+		{
+			name:         "no_workspace_uses_repo_root",
+			workspace:    "",
+			resolve:      resolveMissing, // must not even be consulted
+			wantDir:      repoPath,
+			wantFellBack: false,
+		},
+		{
+			name:         "workspace_present_uses_worktree",
+			workspace:    "qa-auth",
+			resolve:      resolvePresent,
+			wantDir:      "/repo/.semspec/worktrees/qa-auth",
+			wantFellBack: false,
+		},
+		{
+			name:         "workspace_missing_falls_back_and_flags",
+			workspace:    "qa-auth",
+			resolve:      resolveMissing,
+			wantDir:      repoPath,
+			wantFellBack: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, fellBack := selectQAWorkDir(repoPath, tt.workspace, tt.resolve)
+			if dir != tt.wantDir {
+				t.Errorf("dir = %q, want %q", dir, tt.wantDir)
+			}
+			if fellBack != tt.wantFellBack {
+				t.Errorf("fellBack = %v, want %v", fellBack, tt.wantFellBack)
+			}
+		})
+	}
+}

--- a/docs/design/qa-data-plane-fix.md
+++ b/docs/design/qa-data-plane-fix.md
@@ -1,6 +1,6 @@
 # QA Gate Data-Plane Fix — Implementation Design
 
-Status: Phase A IMPLEMENTED (branch fix/qa-data-plane-assemble-before-qa); Phase B pending
+Status: Phase A + Phase B IMPLEMENTED (branch fix/qa-data-plane-assemble-before-qa, commits 5416bfba + 3183a3be). Remaining: e2e regression scenario (depends on #151 mock-coder fixture) + stale qa-runner doc cleanup.
 Author: architect
 Scope: `processor/plan-manager`, `processor/qa-reviewer`, `processor/requirement-executor`, `cmd/sandbox`, `workflow`
 Related: ADR-045 (BMAD story gate + operator-executed tiers), `docs/audit/task-11-worktree-invariants.md` (invariant B1), CLAUDE.md (3-layer manager pattern, plan-manager single-writer)

--- a/docs/design/qa-data-plane-fix.md
+++ b/docs/design/qa-data-plane-fix.md
@@ -1,0 +1,644 @@
+# QA Gate Data-Plane Fix — Implementation Design
+
+Status: Phase A IMPLEMENTED (branch fix/qa-data-plane-assemble-before-qa); Phase B pending
+Author: architect
+Scope: `processor/plan-manager`, `processor/qa-reviewer`, `processor/requirement-executor`, `cmd/sandbox`, `workflow`
+Related: ADR-045 (BMAD story gate + operator-executed tiers), `docs/audit/task-11-worktree-invariants.md` (invariant B1), CLAUDE.md (3-layer manager pattern, plan-manager single-writer)
+
+## Problem statement
+
+The release-gate QA stage evaluates a workspace that contains **none** of the
+per-requirement implementation, and the QA-rejection recovery path is a **no-op**
+for M:N-complete Stories. Both are confirmed by prior audit and reproduced on the
+2026-06-12 mavlink-hard run #2 (reqs 3-4 stranded in unmerged branches → Murat
+correctly `needs_changes` → recovery skips because Stories are `complete`).
+
+### Problem 1 — QA inspects pre-implementation `main` HEAD
+
+- Per-requirement work lands on `semspec/requirement-<id>` branches, created at
+  `processor/requirement-executor/req_watcher.go:152` (base = `planBranch` or
+  `HEAD`, never off `main`).
+- `assembleRequirementBranches` (`processor/plan-manager/plan_merge.go:29`) merges
+  those into `semspec/plan-<slug>` — but is called ONLY in the `QAVerdictApproved`
+  arm at `processor/plan-manager/mutations.go:1368`, i.e. **after** the verdict.
+- Release-gate Murat dispatches with `Metadata["task_id"]="main"`
+  (`processor/qa-reviewer/component.go:549`). Sandbox resolves `task_id=main` →
+  `repoPath` (main repo root) via `worktreeFor` (`cmd/sandbox/server.go:68-72`).
+  So Murat inspects `main` HEAD — zero per-requirement commits.
+- Unit-QA runner runs `execCommand(ctx, h.srv.repoPath, evt.TestCommand, …)`
+  (`cmd/sandbox/qa_subscriber.go:186-187`) — also `main` HEAD. `go test` runs
+  against the pre-implementation baseline. **`qa_level=unit` is meaningless today.**
+
+The per-Story Murat gate during execution is correct because it reviews on a
+worktree off `exec.RequirementBranch`; that asymmetry is what exposed the bug.
+
+### Problem 2 — QA-rejection recovery is a no-op for M:N-complete Stories
+
+- On release-gate `needs_changes`/`rejected`, plan-manager fires
+  `RecoveryRequested` (`mutations.go:1424`) with `AffectedRequirementIDs` =
+  active reqs (`collectActiveRequirementIDsForRecovery`, `mutations.go:1056`).
+- The resume path `resumeTerminalForRecoveryLocked`
+  (`recover_completed.go:139`) → `resumeFromRecoveryLocked`
+  (`awaiting_recovery.go:166`) → `dispatchSynthesizerLocked`
+  (`component.go:1004`) → `dispatchCurrentStoryLocked` (`component.go:1067`).
+- `dispatchCurrentStoryLocked` short-circuits at `component.go:1080` when
+  `story.Status == StoryStatusComplete` ("Story already complete (M:N coverage
+  by prior requirement); skipping"). **Nothing resets `Story.Status` out of
+  `complete`**, so recovery re-marks the requirement complete without doing
+  work and bounces back to QA with identical state.
+- Contrast: per-Story FIXABLE rejection (`startFixableRetryLocked`,
+  `component.go:1763`) works because the Story is still `executing`/`failed`
+  at that altitude.
+
+## Verified mechanism facts (read before reviewing the design)
+
+| Fact | Evidence |
+| --- | --- |
+| `MergeBranches` target uses `checkout -B <target> <base>` | `cmd/sandbox/server.go:1272` — creates-or-resets target from base; idempotent for plan-manager's own re-calls, NOT against human edits (comment 1264-1271) |
+| `MergeBranchesRequest` carries `Base` (empty = HEAD) | `tools/sandbox/client.go:323-328`; server reads it `server.go:1243-1246` |
+| Merge endpoint serializes on `repoMu`, restores HEAD after | `server.go:1249-1250,1262,1299` |
+| `MergeBranches` returns descriptive `ErrMergeBranchesConflict` naming the conflicting branch | `plan_merge.go:75-78`, sentinel `tools/sandbox/client.go:348` |
+| Story DAG already legalizes `complete → ready` | `workflow/story_task.go:177-178` |
+| Story-status mutation enforces `CanTransitionTo` and re-fires orchestrator on terminal | `plan-manager/mutations.go:841-871` |
+| `ClaimStoryStatus(ctx, nc, slug, storyID, target, logger)` is the cross-component story-status setter | `workflow/kv_helpers.go:90`, used at `requirement-executor/component.go:1093,2049,2394` |
+| `dispatchSynthesizerLocked` loads the plan **fresh from KV** every call (`loadPlanFromKV`, line 1005) and reads `story.Status` from it | `component.go:1005,1019,1080` — so a KV story-status reset before resume is visible to the skip check |
+| `CurrentStoryIdx`/`SortedStoryIDs` are NOT reset on recovery resume (`resumeFromRecoveryLocked` resets DAG/node state only) | `awaiting_recovery.go:208-229`; `dispatchSynthesizerLocked` only repopulates when `len(SortedStoryIDs)==0` (line 1018) |
+| `Requirement.Status` stays `active` through execution (lifecycle field, not execution status) | `workflow/types.go:1430`, only set `deprecated`/`superseded` in http handlers; execution state lives in EXECUTION_STATES |
+| `worktreeFor(taskID)`: `"main"`→`repoPath`; else `worktreeRoot/<taskID>` (empty if absent) | `cmd/sandbox/server.go:68-77` |
+| qa-reviewer cleanup site is `handleLoopCompletion` (`component.go:586`) | confirmed; stale-loop + stale-plan guards already live there |
+| `CreateWorktree(ctx, taskID, WithBaseBranch(branch))` → `git worktree add -b agent/<taskID> <path> <base>` | `tools/sandbox/client.go:143-152` |
+
+---
+
+## Design overview
+
+Two phases, each independently shippable and testable.
+
+- **Phase A — Assemble-before-QA + single workspace-selection mechanism.**
+  Move branch assembly to the `implementing → ready_for_qa` / review transition,
+  and route BOTH the unit-QA runner and the release-gate Murat loop to the
+  assembled plan branch via ONE mechanism (a dedicated QA worktree).
+- **Phase B — Recovery resets covered Story status.** On QA-rejection recovery,
+  reset the covering Stories from `complete → ready` for the M:N owner so
+  `dispatchCurrentStoryLocked` re-does work instead of skipping.
+
+The phases are decoupled: Phase A makes QA evaluate real code (so its verdict is
+trustworthy); Phase B makes a `needs_changes` verdict actually drive rework.
+Shipping A alone already converts "QA always sees green baseline" into "QA sees
+real code and correctly rejects" — which surfaces Problem 2 deterministically,
+so A should land first.
+
+---
+
+## Phase A — Assemble before QA, one workspace-selection mechanism
+
+### A1. WHEN to assemble
+
+**Decision: assemble at the implementing-convergence transition, inside
+`checkPlanConvergence`, in the `failedCount == 0` arm, BEFORE the status flips
+to the QA target.** Concretely a new step between `targetForQALevel`
+(`execution_events.go:301`) and `setPlanStatusCached` (`execution_events.go:309`).
+
+Rationale:
+- It is the single funnel where a plan leaves `implementing` with all
+  requirements terminal-success. Both QA sub-paths (unit `QARequestedEvent` and
+  synthesis qa-reviewer dispatch) originate downstream of it
+  (`publishQARequestIfNeeded` at line 323; qa-reviewer claims `ready_for_qa`).
+- Assembling here guarantees the assembled branch exists BEFORE the
+  `QARequestedEvent` fires (unit) and BEFORE qa-reviewer transitions
+  `ready_for_qa → reviewing_qa` (synthesis).
+- It keeps plan-manager the single writer of plan state and of the assembled
+  branch (matches CLAUDE.md single-writer invariant).
+
+**Hook point (exact):** `processor/plan-manager/execution_events.go`, inside
+`checkPlanConvergence`, the `if failedCount == 0 {` block (currently lines
+298-324). Insert assembly after `target := c.targetForQALevel(...)` (line 301)
+and before `setPlanStatusCached(ctx, plan, target)` (line 309), gated on
+`target == StatusReadyForQA` (i.e. QA is actually going to run — `none`/gated
+paths that go straight to `complete`/`awaiting_review` do NOT need a pre-QA
+assemble; they keep using the approve-time assemble — see A2/A4).
+
+Pseudo-shape (NOT code — for review):
+```
+if failedCount == 0:
+    level  := plan.EffectiveQALevel()
+    target := c.targetForQALevel(level, plan, slug)
+    if target == StatusReadyForQA:
+        if err := c.assembleRequirementBranches(ctx, plan); err != nil:
+            routeAssemblyConflict(ctx, plan, err)   // A4 — does NOT proceed to QA
+            return
+        // plan.AssembledBranch / AssembledMergeCommit now populated
+    setPlanStatusCached(ctx, plan, target)
+    publishQARequestIfNeeded(ctx, plan)             // unit event now carries the branch (A3)
+    return
+```
+
+`assembleRequirementBranches` already populates `plan.AssembledBranch` /
+`plan.AssembledMergeCommit` on the in-memory plan; `setPlanStatusCached` persists
+it (write-through to KV, same as today's approve-time path).
+
+> PRODUCT CALL #1 (low stakes): the assemble-before-QA call writes the assembled
+> branch + commit onto the plan record at `ready_for_qa`. That is strictly more
+> information earlier and is backward-compatible. No new status needed for the
+> happy path. Flagged only so the reviewer is aware plan records now carry an
+> assembled branch from `ready_for_qa` onward, not just from `complete`.
+
+### A2. What the QA-approve-time call becomes
+
+**Decision: keep the `mutations.go:1368` call as an idempotent safety-net
+reconcile; do NOT remove it.**
+
+Rationale:
+- `MergeBranches` is idempotent via `checkout -B <target> <base>`
+  (`server.go:1272`): a second call discards the first attempt's partial merges
+  and re-merges from base. So calling assemble again at approve-time recomputes
+  the same branch (assuming no new req branches landed — which is the case at
+  approve-time because execution is already terminal).
+- Keeping it covers the cold-path where a plan reached `complete` via a route
+  that skipped A1 (e.g. force-complete, level transitions, or a future code path
+  that lands at approve without a `ready_for_qa` hop). Removing it would silently
+  regress B1 on those routes.
+- Cost is one extra merge round-trip on the already-assembled branch — cheap and
+  serialized by `repoMu`.
+
+**Idempotency caveat to document in-code:** the comment at `mutations.go:1355-1367`
+about an operator cherry-picking a conflict fix onto the assembled branch between
+a failed save and a retry still applies, and now also applies between the
+ready_for_qa assemble and the approve-time reassemble. That is an existing Phase-5
+reconciliation gap, NOT introduced here — call it out in the comment but do not
+attempt to fix it in this PR.
+
+### A3 + A2(workspace). ONE workspace-selection mechanism for release-gate AND unit QA
+
+Three candidate mechanisms were considered for getting QA to inspect the
+assembled branch:
+
+- **(A) Checkout the assembled branch into `repoPath` (main HEAD) before
+  dispatch.** REJECTED. It mutates the shared main working directory that every
+  other `task_id=main` consumer (planner, plan-reviewer, future read-only agents)
+  resolves to. Concurrency: a plan-reviewer or a second plan's QA running
+  concurrently would observe a drifted HEAD; `repoMu` only serializes individual
+  sandbox endpoints, not the *logical* "main is on plan-X's branch" window.
+  Restart risk: if semspec restarts mid-QA, main HEAD is left on the assembled
+  branch with no owner to restore it. This is exactly the failure class
+  `needsReconciliation` exists to prevent. Reject.
+
+- **(C) Add a `branch` field the bash tool checks out per call.** REJECTED.
+  Bash tool reads only `task_id` from call metadata (`tools/bash/executor.go`).
+  Teaching it to `git checkout <branch>` per call mutates whatever working
+  directory `task_id` resolved to (for `task_id=main`, that is `repoPath` again
+  → same shared-HEAD hazard as A). It also makes "which branch am I on" stateful
+  per-bash-call rather than per-workspace, which races against the unit runner
+  and any parallel tool calls in the same loop. Reject.
+
+- **(B) Create a dedicated QA worktree on the assembled branch and address it by
+  its own `task_id`.** CHOSEN. A worktree is an isolated checked-out tree at
+  `worktreeRoot/<taskID>`; it never touches main HEAD, survives restart as a
+  plain directory, and is the exact mechanism the per-Story Murat gate already
+  uses successfully. Both the unit runner and the release-gate loop point at the
+  SAME worktree → one mechanism, not two.
+
+**Chosen mechanism (B) — single QA worktree per plan, owned by plan-manager:**
+
+1. **plan-manager creates the QA worktree at assemble time (A1).** Immediately
+   after a successful `assembleRequirementBranches`, plan-manager calls
+   `sandbox.CreateWorktree(ctx, qaTaskID(plan), WithBaseBranch(plan.AssembledBranch))`
+   where `qaTaskID(plan)` is a deterministic id, e.g. `qa-<slug>`. Determinism
+   matters for idempotency (A6) and for the unit runner and release loop to
+   converge on the same path without extra plumbing.
+   - `CreateWorktree` → `git worktree add -b agent/qa-<slug> <path> <assembledBranch>`
+     (`client.go:143-152`). The `agent/` prefix is added server-side; the
+     worktree directory key is `qa-<slug>`, so `worktreeFor("qa-<slug>")`
+     resolves it.
+   - PRODUCT CALL #2 (mechanical): confirm the worktree branch (`agent/qa-<slug>`)
+     vs the assembled branch (`semspec/plan-<slug>`) relationship is acceptable.
+     The worktree is a throwaway checkout *of* the assembled branch; QA reads it,
+     QA does not write durable artifacts to it. The durable reviewable artifact
+     remains `semspec/plan-<slug>` (B1). If a future requirement wants Murat to be
+     able to *commit* fixes, that is a separate decision — out of scope here.
+
+2. **Unit-QA runner uses the worktree (A3).** Add `Workspace` (worktree task_id)
+   to `QARequestedEvent` (`workflow/subjects.go:116`):
+   ```
+   type QARequestedEvent struct {
+       Slug           string
+       PlanID         string
+       Mode           QALevel
+       Workspace      string   // NEW: sandbox task_id of the QA worktree; "" → legacy repoPath
+       TestCommand    string
+       TimeoutSeconds int
+       TraceID        string
+   }
+   ```
+   - Populate it in `publishQARequestIfNeeded`
+     (`execution_events.go:404-412`): `Workspace: qaTaskID(plan)`.
+   - In `cmd/sandbox/qa_subscriber.go:185-187`, replace the hardcoded
+     `h.srv.repoPath` with `h.srv.worktreeFor(evt.Workspace)`, falling back to
+     `repoPath` when `Workspace == ""` (legacy / empty) OR when `worktreeFor`
+     returns `""` (worktree missing — degrade to today's behavior but log a WARN
+     so the gap is visible rather than silent). This is the SAME
+     workspace-selection primitive the bash tool uses, so there is exactly one
+     resolution function (`worktreeFor`) in play.
+   - `QARequestedEvent.Validate()` must accept the new optional field (validate
+     it as a safe task_id token when present — no path traversal; reuse the
+     existing slug-validation discipline).
+
+3. **Release-gate Murat loop uses the worktree (A2-workspace).** In qa-reviewer
+   `dispatchReviewer` change the metadata at
+   `processor/qa-reviewer/component.go:549` from `"task_id": "main"` to
+   `"task_id": qaTaskID(plan)` (derived from `plan.Slug`; qa-reviewer already
+   has the plan). Now Murat's bash inspection resolves to the assembled-branch
+   worktree instead of main HEAD. No sandbox endpoint change is needed — the
+   worktree was created by plan-manager at A1, and `worktreeFor` already resolves
+   non-"main" ids.
+   - **Fallback:** if `worktreeFor(qa-<slug>)` returns `""` (worktree missing —
+     e.g. created before this code shipped, or pruned), qa-reviewer should detect
+     it is absent. Two options:
+     (i) qa-reviewer best-effort creates the worktree itself from
+     `plan.AssembledBranch` before dispatch (resilient, but introduces a second
+     creator → mild single-writer smell); or
+     (ii) qa-reviewer falls back to `task_id=main` with a WARN (safe, but
+     re-exposes Problem 1 on the cold path).
+     RECOMMEND (i) guarded so plan-manager remains the primary creator and
+     qa-reviewer only heals a missing worktree (idempotent: `CreateWorktree` on an
+     existing path is a benign error the client can treat as success — verify the
+     server's existing-worktree response shape before relying on it).
+     > PRODUCT CALL #3: pick (i) self-heal vs (ii) main-fallback-with-WARN. (i)
+     > is more correct; (ii) is simpler and keeps a single creator. I lean (i).
+
+4. **Cleanup hook.** The QA worktree must be deleted once the plan leaves the QA
+   gate, or worktrees accumulate (one per plan, plus stale ones across recovery
+   re-runs). Cleanup sites:
+   - **Primary:** plan-manager, when the plan transitions OUT of the QA states
+     (`reviewing_qa`/`ready_for_qa`) to a terminal-of-QA state (`complete`,
+     `awaiting_review`, `rejected`, `archived`). Add a
+     `sandbox.DeleteWorktree(ctx, qaTaskID(plan))` best-effort call in:
+     - the `QAVerdictApproved` arm (`mutations.go:1380` region, after status set),
+     - the `QAVerdictNeedsChanges/Rejected` arm (`mutations.go:1392` region),
+     - the archive path (alongside `pruneRequirementBranches`,
+       `plan_merge.go:103`).
+     Best-effort + 404-tolerant exactly like `pruneRequirementBranches`
+     (`plan_merge.go:113-130`).
+   - **Secondary (defense-in-depth):** qa-reviewer `handleLoopCompletion`
+     (`component.go:586`) already runs on every QA loop terminal and already has
+     stale-plan guards. It is a natural place to delete the worktree once the
+     verdict is in — BUT the worktree may still be needed for a recovery re-run
+     (Phase B re-runs execution, then QA re-dispatches → needs a fresh worktree
+     anyway). Because Phase B re-assembles and re-creates the worktree on the next
+     convergence (A6), it is SAFE for `handleLoopCompletion` to delete the
+     worktree after producing a verdict. RECOMMEND putting cleanup in
+     plan-manager's verdict arms (primary) and NOT in qa-reviewer, to keep a
+     single owner; list `handleLoopCompletion` only as the fallback if we observe
+     leaks.
+   - Requires a `DeleteWorktree` client method + sandbox endpoint. **VERIFY**
+     `cmd/sandbox/server.go:86` already binds `DELETE /worktree/{taskID}`
+     (`handleDeleteWorktree`) — it does (confirmed in RegisterRoutes). Confirm the
+     `tools/sandbox` client exposes a `DeleteWorktree`; if not, add the thin
+     wrapper (the endpoint exists, only the client method may be missing).
+
+**Why one mechanism, not two:** both QA sub-paths now resolve their working
+directory through `Server.worktreeFor(<qa-task-id>)`. The unit runner gets the
+id via the new `QARequestedEvent.Workspace` field; the release loop gets it via
+qa-reviewer metadata. Same worktree, same branch, same resolution function. A
+future heavier-tier executor would use the same id.
+
+### A4. Conflict handling PRE-QA
+
+Today, an assembly conflict at approve-time leaves the plan in its current state
+with `LastError` and the mutation fails (`mutations.go:1368-1379`). Pre-QA we are
+inside `checkPlanConvergence`, not a mutation handler, and we must NOT silently
+proceed to QA on a failed merge (QA would re-inspect the unmerged baseline → the
+exact bug we are fixing).
+
+**Decision: on pre-QA assembly conflict, route to RECOVERY via the existing
+`RecoveryRequested` mechanism, classified as `plan_conflict`. Do NOT invent a new
+plan status.** Keep the plan in `implementing` (it never advanced to
+`ready_for_qa`), set `LastError`/`LastErrorAt` for the UI stall signal, and emit
+`RecoveryRequested` so an architecture_revise / plan-reconcile decision can be
+generated.
+
+Routing detail:
+- `assembleRequirementBranches` already wraps the sentinel
+  (`errors.Is(err, sandbox.ErrMergeBranchesConflict)`, `plan_merge.go:75`). The
+  new `routeAssemblyConflict` helper branches on that sentinel:
+  - `ErrMergeBranchesConflict` → `RecoveryRequested` with an EscalationReason /
+    classification that Phase 5's `infra_health` vs `plan_conflict` keying maps to
+    **plan_conflict** (two requirements edited the same file — a planning-scope
+    problem, fixable by architecture_revise / re-partition, NOT an infra retry).
+  - any other error (sandbox unreachable, 503 needs_reconciliation) →
+    `infra_health` classification (transient infra), set LastError, leave plan in
+    `implementing`, bump SSE; do NOT emit a plan_conflict recovery for an infra
+    blip. (Mirror the savePlanCached stall-notify path at
+    `execution_events.go:368`.)
+- Plan stays in `implementing` in both cases (it never advanced). This reuses the
+  existing "requirements terminal but plan can't advance" stall semantics
+  operators already understand.
+
+> PRODUCT CALL #4 (the one real product decision): pre-QA conflict route.
+> Option 4a (RECOMMENDED): reuse `RecoveryRequested` + `plan_conflict`
+> classification, plan stays `implementing` + LastError. No schema change, lands
+> in the existing recovery UX. Option 4b: introduce a dedicated
+> `StatusConflictReconcile` plan status with its own UI affordance. 4b is cleaner
+> for humans but is a status-machine change (new transitions, new UI, new
+> reconcile mutation) — heavier and out of proportion to this fix. I recommend
+> 4a; flag 4b as a follow-up if conflict frequency justifies a first-class state.
+
+### A5. (covered in A1/A2) — synthesis vs unit ordering
+
+- unit: assemble (A1) → status `ready_for_qa` → `publishQARequestIfNeeded` emits
+  `QARequestedEvent{Workspace: qa-<slug>}` → sandbox runs tests on the worktree →
+  qa-reviewer claims `ready_for_qa → reviewing_qa` and inspects the same worktree.
+- synthesis: assemble (A1) → status `ready_for_qa` → qa-reviewer claims directly
+  (no test event) and inspects the worktree.
+Both are downstream of A1, so the branch + worktree exist before either runs.
+
+### A6. Idempotency & re-runs (Phase A)
+
+- **Assembly:** `MergeBranches` is `checkout -B` → re-calling reproduces the
+  branch from the same source branches. Safe to repeat on recovery re-convergence
+  and on the approve-time safety-net (A2). One caveat (already documented): a
+  human edit on the assembled branch between two assembles is destroyed — existing
+  Phase-5 gap, not introduced here.
+- **Worktree:** `qaTaskID` is deterministic (`qa-<slug>`). On a recovery re-run,
+  execution re-runs, requirements re-converge, A1 fires again: it MUST
+  delete-and-recreate the worktree (stale checkout of the previous assembled
+  commit) — mirror the stale-branch handling in
+  `req_watcher.go:165-173`/`resumeFromRecoveryLocked` (delete then create). So A1's
+  create step should be: best-effort `DeleteWorktree(qa-<slug>)` then
+  `CreateWorktree(qa-<slug>, WithBaseBranch(assembledBranch))`. This guarantees the
+  worktree reflects the freshly re-assembled branch after recovery rework.
+- **architecture_revise:** this path resets req execs (`abandonExecsForSlug`,
+  `awaiting_recovery.go:299`) and re-runs from the architect. The previously
+  assembled branch + QA worktree are now STALE (they point at the old
+  implementation). Because A1 re-runs at the next convergence (delete+recreate),
+  the stale worktree is replaced. Additionally, the stale `semspec/plan-<slug>`
+  assembled branch is force-reset by the next `checkout -B`, so no stale-commit
+  leakage into QA. ACTION: confirm `abandonExecsForSlug` / the architecture_revise
+  reset does not need to also delete the QA worktree eagerly — it does not
+  (A1 delete+recreate covers it), but add a belt-and-suspenders
+  `DeleteWorktree(qa-<slug>)` in the plan-reset path if we want the stale tree gone
+  immediately rather than at next convergence. RECOMMEND deferring that; A1
+  delete+recreate is sufficient.
+
+---
+
+## Phase B — Recovery resets covered Story status
+
+### B1. The minimal change
+
+`dispatchSynthesizerLocked` loads the plan fresh from KV (`component.go:1005`) and
+`dispatchCurrentStoryLocked` reads `story.Status` from that fresh plan
+(`component.go:1080`). Therefore: **if recovery resets the covering Stories from
+`complete → ready` in KV (via the existing story-status mutation) BEFORE the
+resume re-enters synthesis, the skip will not fire and the dev loop re-runs.**
+
+`complete → ready` is already a legal transition (`story_task.go:177-178`) and the
+story-status mutation already enforces it and re-fires the orchestrator
+(`mutations.go:841-871`). So the change reuses existing primitives — no new
+transition, no new mutation.
+
+**Where to reset:** in the QA-recovery resume entry, `resumeTerminalForRecoveryLocked`
+(`processor/requirement-executor/recover_completed.go:139`), BEFORE it calls
+`resumeFromRecoveryLocked`. Add a step that, for the requirement being resumed,
+loads the plan, finds the Stories covering it (`plan.StoriesForRequirement(reqID)`,
+`workflow/types.go:1169`), and for each Story currently `complete`, issues
+`workflow.ClaimStoryStatus(ctx, c.natsClient, slug, storyID, StoryStatusReady, logger)`.
+
+```
+// resumeTerminalForRecoveryLocked, before resumeFromRecoveryLocked:
+plan := c.loadPlanFromKV(ctx, exec.Slug)
+for _, s := range plan.StoriesForRequirement(exec.RequirementID):
+    if s.Status == StoryStatusComplete && c.ownsStoryForReset(s, exec.RequirementID):
+        workflow.ClaimStoryStatus(ctx, c.natsClient, exec.Slug, s.ID, StoryStatusReady, c.logger)
+```
+
+### B2. WHICH stories to reset — only the M:N owner, only covering stories
+
+- **Only Stories covering the affected requirement(s)**, not all plan Stories. A
+  release-gate QA rejection's `AffectedRequirementIDs` is "all active reqs"
+  (`collectActiveRequirementIDsForRecovery`), and each affected req resumes
+  independently via the consumer loop (`awaiting_recovery.go:357-459`). Resetting
+  only the resuming req's covering Stories keeps the blast radius minimal and
+  composes correctly when multiple reqs are affected (each resets its own
+  coverers; shared coverers are reset by whichever req gets there first, and the
+  mutation is idempotent — `ready → ready` is a no-op-ish CanTransitionTo=false
+  that we treat as already-reset, see B4).
+
+- **Only the deterministic M:N owner resets.** `dispatchCurrentStoryLocked`'s
+  reservation makes the lexicographically-smallest req ID in
+  `Story.RequirementIDs` the owner that actually runs the dev loop; non-owners are
+  gated behind `Story.Status == complete`
+  (`scenario-orchestrator/dag.go:101 filterByM2NStoryReservations`). If a NON-owner
+  req resets the Story to `ready`, the non-owner would then try to claim
+  `ready → executing` and run the dev loop itself — duplicating work the owner
+  should do, and inverting the M:N reservation. So the reset must be gated:
+  `ownsStoryForReset(story, reqID)` returns true only when `reqID` is the
+  deterministic owner (smallest in `story.RequirementIDs`). A non-owner resume
+  does NOT reset; it will re-skip (Story still `complete`) and fast-complete via
+  the executor's Tier-1 dedup — exactly the current happy-path M:N behavior, now
+  correctly gated behind the owner having actually re-run.
+  - VERIFY the owner-selection predicate matches `filterByM2NStoryReservations`'s
+    definition exactly (lexicographically smallest req ID in
+    `Story.RequirementIDs`) — extract a shared helper
+    (`workflow.DeterministicStoryOwner(story) string`) so the executor reset and
+    the orchestrator filter cannot drift. This is a small refactor worth doing in
+    Phase B to prevent a latent owner/non-owner mismatch bug.
+
+- **CurrentStoryIdx reset (latent bug to fix here).** On recovery resume,
+  `SortedStoryIDs` is preserved and `CurrentStoryIdx` is NOT reset
+  (`resumeFromRecoveryLocked` resets DAG/node state only,
+  `awaiting_recovery.go:208-229`; `dispatchSynthesizerLocked` only repopulates the
+  story list when `len(SortedStoryIDs)==0`, line 1018). For the QA-recovery path
+  the exec is loaded fresh from KV (`loadTerminalReqExecFromKV`,
+  `awaiting_recovery.go:422`), where `SortedStoryIDs`/`CurrentStoryIdx` may be
+  empty/zero or stale depending on what was persisted. To re-run ALL covering
+  Stories from the start, `resumeTerminalForRecoveryLocked` should reset
+  `exec.CurrentStoryIdx = 0` (and clear `exec.SortedStoryIDs` so
+  `dispatchSynthesizerLocked` re-derives the topo order from the now-reset
+  Stories). Confirm with a test that a 2-Story requirement re-runs both Stories
+  on QA-recovery, not just the cursor's current one.
+
+### B3. M:N owner/non-owner reservation interaction
+
+After reset, the owner's resume runs `dispatchCurrentStoryLocked`:
+- Story is now `ready` (not `complete`) → skip at 1080 does NOT fire.
+- `ClaimStoryStatus(... executing)` (line 1093) succeeds (ready→executing legal).
+- dev loop re-runs, Story re-reaches `complete` via the normal completion path
+  (`component.go:2049`), which re-fires the orchestrator (`mutations.go:864`),
+  releasing non-owners to fast-complete via Tier-1 dedup.
+
+This is identical to the original execution flow — Phase B simply re-opens the
+window. No change to `filterByM2NStoryReservations` itself is required; only the
+shared owner-selection helper extraction (B2).
+
+### B4. Idempotency & happy-path safety (Phase B)
+
+- **Idempotent reset:** if a Story is already `ready` (a prior affected-req reset
+  got there first, or it never completed), `ClaimStoryStatus(... ready)` fails the
+  `CanTransitionTo` check (`ready → ready` is false) and returns false — treat
+  that as "already in a re-runnable state," log Debug, continue. Do NOT fail the
+  resume on a no-op reset.
+- **Happy path untouched:** the reset is only reached from
+  `resumeTerminalForRecoveryLocked`, which is only invoked on the QA-recovery
+  branch (`awaiting_recovery.go:456`) after a `needs_changes`/`rejected` verdict
+  produced an accepted recovery PlanDecision. Normal first-pass execution never
+  enters this path, so Stories are never spuriously reset to `ready`.
+- **Budget gate already present:** the QA-recovery consumer already gates on
+  `countAcceptedRecoveryCyclesForReq > maxRecoveryRestarts`
+  (`awaiting_recovery.go:442-452`), so the reset cannot loop unboundedly.
+
+---
+
+## Risks
+
+1. **Worktree leakage.** If cleanup (A3.4) is missed on some path, QA worktrees
+   accumulate one-per-plan. Mitigation: deterministic id + delete-and-recreate at
+   A1 means at most one live `qa-<slug>` per plan; archive-path prune is the
+   final sweep. LOW.
+2. **Stale assembled branch after architecture_revise.** Addressed by A6
+   delete+recreate; residual risk if A1 is somehow not re-run before QA on a
+   recovery path. Test B-e2e covers this. MEDIUM → LOW with the test.
+3. **Owner/non-owner predicate drift (B2).** If the reset's owner predicate and
+   `filterByM2NStoryReservations` diverge, a non-owner could reset+run and
+   duplicate work. Mitigation: shared `DeterministicStoryOwner` helper. MEDIUM —
+   the reason the helper extraction is in-scope.
+4. **`CurrentStoryIdx` mis-reset (B2).** If we reset the cursor but not the story
+   list (or vice-versa), recovery could re-run the wrong subset. Mitigation:
+   reset BOTH (`CurrentStoryIdx=0`, `SortedStoryIDs=nil`) and cover with a
+   2-Story test. MEDIUM.
+5. **Unit runner fallback hides regression.** If `worktreeFor(Workspace)` returns
+   `""` and we silently fall back to `repoPath`, Problem 1 silently returns.
+   Mitigation: WARN-log the fallback and assert in the e2e that the worktree
+   resolves. MEDIUM.
+6. **Concurrent plans sharing the sandbox.** Each plan has its own `qa-<slug>`
+   worktree; merges serialize on `repoMu`. No shared-HEAD window (the whole reason
+   mechanism B beat A/C). LOW.
+
+---
+
+## Test plan
+
+### Phase A unit tests (plan-manager / sandbox)
+
+- `checkPlanConvergence` assembles before QA: given a plan with all reqs
+  terminal-success and `qa_level=unit`, assert `assembleRequirementBranches` is
+  invoked and `plan.AssembledBranch`/`AssembledMergeCommit` are populated BEFORE
+  the `QARequestedEvent` is published, and that the published event carries
+  `Workspace == "qa-<slug>"`. (fake sandbox client capturing MergeBranches +
+  CreateWorktree calls; fake NATS capturing the event.)
+- `qa_level=synthesis` assembles before status flips to `ready_for_qa`; no
+  `QARequestedEvent` published.
+- `qa_level=none`/gated path does NOT assemble at convergence (keeps approve-time
+  assemble); assert no pre-QA MergeBranches call.
+- Conflict routing (A4): fake sandbox returns `ErrMergeBranchesConflict`; assert
+  plan stays `implementing`, `LastError` set, a `RecoveryRequested` is emitted
+  with `plan_conflict` classification, and NO status advance to `ready_for_qa`,
+  NO `QARequestedEvent`.
+- Infra error (non-conflict): fake sandbox returns a generic/unreachable error;
+  assert plan stays `implementing`, LastError set, SSE bump, and NO plan_conflict
+  recovery emitted (infra_health route).
+- Idempotent re-assemble (A2/A6): calling the approve-time assemble after a
+  ready_for_qa assemble produces the same branch (checkout -B); assert no error
+  and stable `AssembledMergeCommit`.
+- `QARequestedEvent.Validate()` accepts a valid `Workspace` token and rejects a
+  path-traversal token.
+- qa_subscriber workspace selection: given `Workspace="qa-x"` and a present
+  worktree, `runUnitQA` runs the test command in `worktreeFor("qa-x")`; given
+  empty/missing worktree, it falls back to `repoPath` and WARN-logs.
+- qa-reviewer dispatch metadata: assert `Metadata["task_id"] == "qa-<slug>"`
+  (not `"main"`).
+- Cleanup: on `QAVerdictApproved` and on `QAVerdictRejected`,
+  `DeleteWorktree("qa-<slug>")` is called best-effort (404-tolerant).
+
+### Phase B unit tests (requirement-executor / workflow)
+
+- Story-reset on QA-recovery: a requirement covered by a Story currently
+  `complete`, resumed via `resumeTerminalForRecoveryLocked`, issues
+  `ClaimStoryStatus(... ready)` for that Story (owner case) BEFORE
+  `resumeFromRecoveryLocked`, and `dispatchCurrentStoryLocked` then does NOT skip
+  (re-runs the dev loop).
+- Non-owner does NOT reset: a non-owner req's resume leaves the Story `complete`
+  and re-skips (no duplicate dev loop).
+- Owner predicate parity: table test asserting `DeterministicStoryOwner(story)`
+  equals `filterByM2NStoryReservations`'s owner for representative
+  `RequirementIDs` orderings (the extracted shared helper).
+- Cursor reset: a 2-Story requirement on QA-recovery re-runs BOTH Stories
+  (`CurrentStoryIdx` reset to 0, `SortedStoryIDs` re-derived).
+- Idempotent reset: a Story already `ready` → `ClaimStoryStatus(... ready)`
+  returns false, resume continues without error.
+- Happy path untouched: first-pass execution never calls the reset (Stories not
+  spuriously moved to `ready`).
+
+### ONE new mock e2e scenario (workstream #3 — shape only)
+
+Name: `qa-data-plane` (mock LLM, Tier-2).
+
+Shape that ACTUALLY catches both bugs (must NOT use a pre-seeded green baseline
+like the current `qa-cycle`):
+- **Multi-requirement** plan (>=2 reqs) so assembly merges multiple
+  `semspec/requirement-<id>` branches, exercising B1 ordering and conflict-free
+  merge.
+- The project's unit test (`qa_level=unit`) must FAIL on the pristine `main`
+  baseline and PASS only after the agent's implementation commits land — e.g. a
+  test asserting a function/file that does not exist on `main` and is created by
+  the mock-coder fixture on the requirement branch. This is the load-bearing
+  property: if QA were (wrongly) run against `main`, the test FAILS; it can only
+  pass if QA runs against the assembled branch. Contrast with today's `qa-cycle`
+  whose test is green on the baseline, masking Problem 1 entirely.
+- Assert: plan reaches `ready_for_qa` with a populated `AssembledBranch`; the
+  `QACompletedEvent.Passed == true` ONLY because the worktree carried the
+  implementation; plan reaches `complete`/`awaiting_review`.
+- **Recovery sub-shape (Phase B):** a second variant where the mock fixture's
+  first pass leaves the unit test FAILING (or the mock Murat returns
+  `needs_changes`), and the M:N coverage is such that the failing requirement's
+  Story is `complete` (covered via M:N). Assert that recovery actually re-runs
+  the dev loop (Story reset `complete → ready`, a second dev dispatch observed)
+  rather than bouncing back to QA with identical state. This is the scenario that
+  reproduces the 2026-06-12 mavlink-hard-run-2 no-op-recovery failure
+  deterministically with a mock LLM.
+
+> Note: building this scenario depends on a mock-coder fixture that writes real
+> files on the requirement branch (the open #151 fixture limitation — "2nd DAG
+> node leaves worktree clean" — is adjacent; the new scenario needs the fixture
+> to actually produce a file the test keys off). Flag #151's fixture work as a
+> dependency of workstream #3.
+
+---
+
+## Sequencing & flags for the user
+
+1. **Land Phase A first.** It makes QA evaluate real code; it will START
+   producing correct `needs_changes` verdicts where today everything passed on the
+   baseline. Expect previously-green mock scenarios with weak tests to flip — audit
+   them (this is desirable signal, not a regression).
+2. **Land Phase B second**, once A is producing real rejections, so the recovery
+   reset has something real to act on.
+3. **PRODUCT CALLS to confirm before coding:**
+   - #1 — plan record carries `AssembledBranch` from `ready_for_qa` (vs only at
+     `complete`). Low stakes; recommend accept.
+   - #2 — QA worktree branch `agent/qa-<slug>` is a throwaway checkout of
+     `semspec/plan-<slug>`; QA reads, does not write durable artifacts. Confirm
+     Murat is read-only at the gate.
+   - #3 — qa-reviewer missing-worktree behavior: (i) self-heal create vs (ii)
+     main-fallback+WARN. Recommend (i).
+   - #4 — pre-QA conflict route: 4a reuse `RecoveryRequested`+`plan_conflict`
+     (recommended, no schema change) vs 4b a dedicated `StatusConflictReconcile`
+     status (cleaner UX, heavier). Recommend 4a, 4b as follow-up.
+
+## Other issues found (incidental, while auditing)
+
+- **Latent recovery cursor bug (pre-existing).** `resumeFromRecoveryLocked`
+  (`awaiting_recovery.go:208-229`) resets DAG/node state but NOT
+  `exec.CurrentStoryIdx`/`exec.SortedStoryIDs`. On a multi-Story requirement, a
+  recovery resume can re-enter `dispatchSynthesizerLocked` with a stale cursor and
+  re-run only a subset of Stories. Phase B fixes it for the QA-recovery path;
+  the iteration-exhaustion recovery path (`handlePlanDecisionAccepted` →
+  `resumeFromRecoveryLocked`, `awaiting_recovery.go:406`) has the same latent gap
+  and should get the same cursor reset. File: `awaiting_recovery.go:166-261`.
+- **`collectActiveRequirementIDsForRecovery` can return empty.** Because
+  `Requirement.Status` is a lifecycle field that stays `active` through execution
+  (`workflow/types.go:1430`), the function returns all reqs — correct today. But if
+  a plan ever marks reqs `deprecated`/`superseded` mid-flight, a QA rejection could
+  produce an empty `AffectedRequirementIDs` and the WARN-only path
+  (`mutations.go:1063`) leaves recovery requiring manual acceptance. Not in scope
+  here; noting the coupling. File: `processor/plan-manager/mutations.go:1056`.

--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	projectmanager "github.com/c360studio/semspec/processor/project-manager"
+	"github.com/c360studio/semspec/tools/sandbox"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/message"
@@ -296,31 +297,7 @@ func (c *Component) checkPlanConvergence(ctx context.Context, bucket jetstream.K
 
 	// All requirements are terminal.
 	if failedCount == 0 {
-		// Branch on the plan's QA level (snapshotted at plan creation).
-		level := plan.EffectiveQALevel()
-		target := c.targetForQALevel(level, plan, slug)
-
-		c.logger.Info("All requirements completed — transitioning to review",
-			"slug", slug,
-			"completed", completedCount,
-			"qa_level", level,
-			"target", target)
-
-		if err := c.setPlanStatusCached(ctx, plan, target); err != nil {
-			// Safety fallback: route to awaiting_review or complete based on config.
-			c.logger.Warn("Review transition failed, routing based on review gate config",
-				"slug", slug, "error", err)
-			fallback := workflow.StatusComplete
-			if c.shouldGateReview(plan) {
-				fallback = workflow.StatusAwaitingReview
-			}
-			if err := c.setPlanStatusCached(ctx, plan, fallback); err != nil {
-				c.logger.Error("Failed to transition plan", "slug", slug, "target", fallback, "error", err)
-			}
-			return
-		}
-		// If we routed to ready_for_qa, fire the executor dispatch.
-		c.publishQARequestIfNeeded(ctx, plan)
+		c.handleConvergenceAllSucceeded(ctx, plan, slug, completedCount)
 		return
 	}
 
@@ -370,6 +347,101 @@ func (c *Component) checkPlanConvergence(ctx context.Context, bucket jetstream.K
 	}
 }
 
+// handleConvergenceAllSucceeded runs the implementing-convergence success arm:
+// all requirements reached terminal-success, so assemble their branches, stage
+// the QA worktree, and advance the plan to its QA target. Split out of
+// checkPlanConvergence to keep each function focused (and under the length cap).
+func (c *Component) handleConvergenceAllSucceeded(ctx context.Context, plan *workflow.Plan, slug string, completedCount int) {
+	// Branch on the plan's QA level (snapshotted at plan creation).
+	level := plan.EffectiveQALevel()
+	target := c.targetForQALevel(level, plan, slug)
+
+	// Assemble the per-requirement branches into the plan branch and stage a
+	// dedicated QA worktree from it BEFORE QA runs, so both the unit-test runner
+	// and the release-gate Murat loop inspect the merged implementation instead
+	// of the pre-implementation main HEAD (the data-plane fix). Only when QA will
+	// actually run (ready_for_qa); the none/gated path goes straight to
+	// complete/awaiting_review and relies on the approve-time assemble. On
+	// conflict/failure we route to recovery or stall and do NOT advance to QA
+	// against an unmerged tree.
+	if target == workflow.StatusReadyForQA {
+		if err := c.assembleAndStageQAWorktree(ctx, plan); err != nil {
+			c.routeAssemblyConflict(ctx, plan, err)
+			return
+		}
+	}
+
+	c.logger.Info("All requirements completed — transitioning to review",
+		"slug", slug,
+		"completed", completedCount,
+		"qa_level", level,
+		"target", target,
+		"assembled_branch", plan.AssembledBranch)
+
+	if err := c.setPlanStatusCached(ctx, plan, target); err != nil {
+		// Safety fallback: route to awaiting_review or complete based on config.
+		c.logger.Warn("Review transition failed, routing based on review gate config",
+			"slug", slug, "error", err)
+		fallback := workflow.StatusComplete
+		if c.shouldGateReview(plan) {
+			fallback = workflow.StatusAwaitingReview
+		}
+		if err := c.setPlanStatusCached(ctx, plan, fallback); err != nil {
+			c.logger.Error("Failed to transition plan", "slug", slug, "target", fallback, "error", err)
+		}
+		return
+	}
+	// If we routed to ready_for_qa, fire the executor dispatch.
+	c.publishQARequestIfNeeded(ctx, plan)
+}
+
+// routeAssemblyConflict handles a failed pre-QA assemble/stage. The plan never
+// advanced out of implementing, so it stays there with a surfaced LastError —
+// we must NOT proceed to QA against an unmerged tree (the exact bug being
+// fixed). A merge conflict (two requirements edited the same file) is a
+// planning-scope problem that architecture_revise / re-partition must resolve,
+// so it fires phase-local recovery (PRODUCT CALL 4a — reuse RecoveryRequested,
+// no new plan status). Any other failure (sandbox unreachable, worktree
+// staging) is a transient stall: surface LastError and bump the SSE revision so
+// the UI shows the stall; an operator retry or the next execution event
+// re-drives convergence. We deliberately do NOT emit a plan-scope recovery for
+// an infra blip.
+func (c *Component) routeAssemblyConflict(ctx context.Context, plan *workflow.Plan, assembleErr error) {
+	// Runs from the EXECUTION_STATES watcher (checkPlanConvergence), which is
+	// lock-free like the sibling stall/infra-critical saves here. The
+	// implementing-status guard keeps the overlap with concurrent qa.start/verdict
+	// mutations narrow; a rare interleave is last-writer-wins on LastError, not
+	// state corruption.
+	now := time.Now()
+	plan.LastError = fmt.Sprintf("pre-QA assembly failed: %v", assembleErr)
+	plan.LastErrorAt = &now
+
+	if saveErr := c.savePlanCached(ctx, plan); saveErr != nil {
+		c.logger.Error("Failed to persist LastError after pre-QA assembly failure",
+			"slug", plan.Slug, "error", saveErr)
+	}
+
+	if errors.Is(assembleErr, sandbox.ErrMergeBranchesConflict) {
+		c.logger.Warn("Pre-QA plan-level merge conflict — firing recovery, plan stays implementing",
+			"slug", plan.Slug, "error", assembleErr)
+		c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
+			RecoveryID:          uuid.New().String(),
+			Layer:               payloads.RecoveryLayerPhaseLocal,
+			Slug:                plan.Slug,
+			EscalationReason:    "plan-level merge conflict assembling requirement branches before QA",
+			LastFailureFeedback: assembleErr.Error(),
+			// There is no QA verdict yet; the verdict arg only affects an
+			// internal warn-log branch (zero active reqs), which can't fire here
+			// since convergence implies active reqs.
+			AffectedRequirementIDs: c.collectActiveRequirementIDsForRecovery(plan, workflow.QAVerdictNeedsChanges),
+		})
+		return
+	}
+
+	c.logger.Error("Pre-QA assembly failed (non-conflict) — plan stalls in implementing pending retry",
+		"slug", plan.Slug, "error", assembleErr)
+}
+
 // publishQARequestIfNeeded fires when a plan is routed to ready_for_qa. For
 // unit-level QA it publishes a QARequestedEvent so the sandbox runs the
 // project's test suite before qa-reviewer interprets. synthesis/none don't
@@ -406,6 +478,7 @@ func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow
 			Slug:        plan.Slug,
 			PlanID:      plan.ID,
 			Mode:        level,
+			Workspace:   workflow.QAWorktreeID(plan.Slug),
 			TestCommand: pc.EffectiveTestCommand(),
 			TraceID:     uuid.New().String(),
 		},

--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -1077,6 +1077,9 @@ func (c *Component) handleDeletePlan(w http.ResponseWriter, r *http.Request, slu
 		// plan branch (semspec/plan-<slug>) is NOT pruned: it's the
 		// human-reviewable artifact the rest of the audit trail points at.
 		c.pruneRequirementBranches(r.Context(), plan)
+		// Also drop the per-plan QA worktree if one is still staged (e.g. archive
+		// straight from a QA state). Best-effort, same rationale as the prune.
+		c.deleteQAWorktree(r.Context(), slug)
 		c.logger.Info("Plan archived via REST API", "slug", slug)
 	} else {
 		// Hard delete — graph tombstone + cache/KV eviction.
@@ -1089,6 +1092,8 @@ func (c *Component) handleDeletePlan(w http.ResponseWriter, r *http.Request, slu
 			http.Error(w, "Failed to delete plan", http.StatusInternalServerError)
 			return
 		}
+		// Drop any staged QA worktree so a hard delete mid-QA doesn't leak it.
+		c.deleteQAWorktree(r.Context(), slug)
 		c.logger.Info("Plan deleted via REST API", "slug", slug)
 	}
 

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1275,6 +1275,11 @@ func (c *Component) handleQAStartMutation(ctx context.Context, data []byte) Muta
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 	}
 
+	// Cold-path safety net: guarantee the QA worktree (staged at convergence)
+	// exists before qa-reviewer dispatches Murat, so the release-gate loop
+	// inspects the assembled implementation rather than the repo root.
+	c.ensureQAWorktree(ctx, plan)
+
 	level := plan.EffectiveQALevel()
 	c.logger.Info("QA review started",
 		"slug", req.Slug, "level", level, "has_qa_run", req.QARun != nil)
@@ -1409,31 +1414,41 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 	}
 
-	// Fire phase-local recovery for non-approved verdicts. Mirrors the
-	// revision-cap-exhaustion path at handleRevisionEscalationMutation —
-	// every other wedge-shaped state transition published RecoveryRequested
-	// except this one until 2026-05-28 (verified on the gemini mavlink-
-	// decode run where qa-reviewer correctly diagnosed flaky time.Sleep
-	// timing but the plan terminated at rejected with no retry).
-	//
-	// EscalationReason carries the verdict kind so recovery-agent's prompt
-	// can distinguish "the tests failed and we should try again" from
-	// "the plan is structurally unsalvageable." LastFailureFeedback carries
-	// the qa-reviewer's actionable summary so the recovery agent sees the
-	// concrete diagnosis (e.g., "replace time.Sleep with active polling").
-	if req.Verdict == workflow.QAVerdictNeedsChanges || req.Verdict == workflow.QAVerdictRejected {
-		c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
-			RecoveryID:             uuid.New().String(),
-			Layer:                  payloads.RecoveryLayerPhaseLocal,
-			Slug:                   req.Slug,
-			EscalationReason:       fmt.Sprintf("QA verdict %s at level %s", req.Verdict, req.Level),
-			LastFailureFeedback:    req.Summary,
-			TraceID:                req.TraceID,
-			AffectedRequirementIDs: c.collectActiveRequirementIDsForRecovery(plan, req.Verdict),
-		})
-	}
+	// The plan has left the QA gate (approved → complete/awaiting_review, or
+	// rejected → recovery). Drop the per-plan QA worktree; a recovery re-run
+	// re-stages a fresh one at the next convergence. Best-effort.
+	c.deleteQAWorktree(ctx, req.Slug)
+
+	c.fireQAVerdictRecovery(ctx, plan, req)
 
 	return MutationResponse{Success: true}
+}
+
+// fireQAVerdictRecovery emits phase-local RecoveryRequested for non-approved QA
+// verdicts. Mirrors the revision-cap-exhaustion path at
+// handleRevisionEscalationMutation — every other wedge-shaped state transition
+// published RecoveryRequested except this one until 2026-05-28 (verified on the
+// gemini mavlink-decode run where qa-reviewer correctly diagnosed flaky
+// time.Sleep timing but the plan terminated at rejected with no retry).
+//
+// EscalationReason carries the verdict kind so recovery-agent's prompt can
+// distinguish "the tests failed and we should try again" from "the plan is
+// structurally unsalvageable." LastFailureFeedback carries the qa-reviewer's
+// actionable summary so the recovery agent sees the concrete diagnosis (e.g.,
+// "replace time.Sleep with active polling"). No-op for approved verdicts.
+func (c *Component) fireQAVerdictRecovery(ctx context.Context, plan *workflow.Plan, req workflow.QAVerdictEvent) {
+	if req.Verdict != workflow.QAVerdictNeedsChanges && req.Verdict != workflow.QAVerdictRejected {
+		return
+	}
+	c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
+		RecoveryID:             uuid.New().String(),
+		Layer:                  payloads.RecoveryLayerPhaseLocal,
+		Slug:                   req.Slug,
+		EscalationReason:       fmt.Sprintf("QA verdict %s at level %s", req.Verdict, req.Level),
+		LastFailureFeedback:    req.Summary,
+		TraceID:                req.TraceID,
+		AffectedRequirementIDs: c.collectActiveRequirementIDsForRecovery(plan, req.Verdict),
+	})
 }
 
 // handleReviewApproveMutation handles plan.mutation.review.approve — transitions

--- a/processor/plan-manager/plan_merge.go
+++ b/processor/plan-manager/plan_merge.go
@@ -92,6 +92,94 @@ func (c *Component) assembleRequirementBranches(ctx context.Context, plan *workf
 	return nil
 }
 
+// assembleAndStageQAWorktree merges the completed requirement branches into the
+// plan branch (invariant B1) and stages a fresh QA worktree checked out from it.
+// Both downstream QA paths — the sandbox unit-test runner and the release-gate
+// Murat loop — address that worktree by its deterministic id (QAWorktreeID), so
+// QA evaluates the merged implementation rather than the pre-implementation main
+// HEAD. Called at implementing convergence BEFORE the plan advances to
+// ready_for_qa.
+//
+// Idempotent for recovery re-convergence: assembleRequirementBranches uses
+// `checkout -B`, and the worktree is delete-then-create so it always reflects
+// the freshly assembled branch (a stale worktree would point at the prior
+// commit). Returns the underlying error unwrapped so the caller can
+// errors.Is-match sandbox.ErrMergeBranchesConflict to route conflicts to
+// recovery. Only the merge step (assembleRequirementBranches) can produce that
+// sentinel; a worktree-staging failure is wrapped as a plain error, so the
+// caller correctly classifies staging failures as infra (stall), not as a
+// planning-scope conflict. A no-op (no AssembledBranch) when there is no sandbox
+// or no requirements — the QA paths then fall back to repoPath, preserving
+// legacy behavior for tests that mock less of the world.
+func (c *Component) assembleAndStageQAWorktree(ctx context.Context, plan *workflow.Plan) error {
+	if err := c.assembleRequirementBranches(ctx, plan); err != nil {
+		return err
+	}
+	if c.sandbox == nil || plan.AssembledBranch == "" {
+		return nil
+	}
+
+	qaID := workflow.QAWorktreeID(plan.Slug)
+	// Best-effort delete first: the sandbox tolerates a missing worktree (returns
+	// success) and removes any stale branch, so this is safe on first convergence
+	// and required on recovery re-convergence to drop the prior commit's checkout.
+	if err := c.sandbox.DeleteWorktree(ctx, qaID); err != nil {
+		c.logger.Debug("Pre-stage QA worktree delete returned error (benign if absent)",
+			"slug", plan.Slug, "worktree", qaID, "error", err)
+	}
+	if _, err := c.sandbox.CreateWorktree(ctx, qaID, sandbox.WithBaseBranch(plan.AssembledBranch)); err != nil {
+		return fmt.Errorf("stage QA worktree %q on %q: %w", qaID, plan.AssembledBranch, err)
+	}
+	c.logger.Info("Staged QA worktree on assembled branch",
+		"slug", plan.Slug, "worktree", qaID, "branch", plan.AssembledBranch)
+	return nil
+}
+
+// ensureQAWorktree guarantees the per-plan QA worktree exists and is checked out
+// from the assembled plan branch, re-staging it if missing. Called when the plan
+// enters active review (ready_for_qa → reviewing_qa) so the release-gate Murat
+// loop's bash inspection lands on the merged implementation even on cold paths
+// where convergence-time staging did not run (e.g. a plan already at
+// ready_for_qa across a deploy). Best-effort: a sandbox failure here degrades QA
+// to the repo root (the sandbox returns 404 for the missing worktree and the
+// loop falls back) rather than blocking the verdict, and is logged. No-op
+// without a sandbox client or an assembled branch.
+func (c *Component) ensureQAWorktree(ctx context.Context, plan *workflow.Plan) {
+	if c.sandbox == nil || plan.AssembledBranch == "" {
+		return
+	}
+	qaID := workflow.QAWorktreeID(plan.Slug)
+	if exists, err := c.sandbox.WorktreeExists(ctx, qaID); err == nil && exists {
+		return
+	}
+	// Best-effort delete before create: the worktree dir is absent (checked
+	// above) but a stale "agent/qa-<slug>" branch may survive from a partial
+	// prune, and `git worktree add -b` fails if the branch already exists. The
+	// delete clears both, so the re-stage can't wedge on a leftover branch.
+	if err := c.sandbox.DeleteWorktree(ctx, qaID); err != nil {
+		c.logger.Debug("QA worktree pre-ensure delete returned error (benign if absent)",
+			"slug", plan.Slug, "worktree", qaID, "error", err)
+	}
+	if _, err := c.sandbox.CreateWorktree(ctx, qaID, sandbox.WithBaseBranch(plan.AssembledBranch)); err != nil {
+		c.logger.Warn("Failed to ensure QA worktree at review start — QA may inspect repo root",
+			"slug", plan.Slug, "worktree", qaID, "branch", plan.AssembledBranch, "error", err)
+	}
+}
+
+// deleteQAWorktree removes the per-plan QA worktree once the plan leaves the QA
+// gate (verdict in, or archive). Best-effort + idempotent: a missing worktree is
+// benign, and a recovery re-run re-stages a fresh one at the next convergence.
+// No-op without a sandbox client.
+func (c *Component) deleteQAWorktree(ctx context.Context, slug string) {
+	if c.sandbox == nil {
+		return
+	}
+	if err := c.sandbox.DeleteWorktree(ctx, workflow.QAWorktreeID(slug)); err != nil {
+		c.logger.Debug("QA worktree cleanup returned error (benign if absent)",
+			"slug", slug, "error", err)
+	}
+}
+
 // pruneRequirementBranches deletes every "semspec/requirement-<id>" branch
 // belonging to the plan. Implements invariant D3 of the Task-11 audit:
 // without explicit pruning, per-requirement branches accumulate across

--- a/processor/plan-manager/plan_qa_worktree_test.go
+++ b/processor/plan-manager/plan_qa_worktree_test.go
@@ -1,0 +1,334 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/sandbox"
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// qaSandboxStub is a recording httptest sandbox covering the endpoints the QA
+// worktree helpers touch: merge-branches, worktree create/delete/exists.
+type qaSandboxStub struct {
+	server *httptest.Server
+
+	mu          sync.Mutex
+	mergeStatus int
+	mergeBody   any
+	exists      bool // GET /worktree/{id} answer
+
+	mergeCalls  int
+	createCalls []createCall
+	deleteCalls []string
+	existsCalls []string
+}
+
+type createCall struct {
+	TaskID     string
+	BaseBranch string
+}
+
+func newQASandboxStub(t *testing.T) *qaSandboxStub {
+	t.Helper()
+	s := &qaSandboxStub{
+		mergeStatus: http.StatusOK,
+		mergeBody: map[string]any{
+			"status":        "merged",
+			"target":        "semspec/plan-demo",
+			"merge_commits": []map[string]string{{"branch": "semspec/requirement-r1", "commit": "sha1"}},
+		},
+	}
+	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/git/merge-branches":
+			s.mergeCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(s.mergeStatus)
+			_ = json.NewEncoder(w).Encode(s.mergeBody)
+		case r.Method == http.MethodPost && r.URL.Path == "/worktree":
+			var body struct {
+				TaskID     string `json:"task_id"`
+				BaseBranch string `json:"base_branch"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.createCalls = append(s.createCalls, createCall{body.TaskID, body.BaseBranch})
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "created", "path": "/wt/" + body.TaskID, "branch": "agent/" + body.TaskID,
+			})
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/worktree/"):
+			s.deleteCalls = append(s.deleteCalls, strings.TrimPrefix(r.URL.Path, "/worktree/"))
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "deleted"})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/worktree/"):
+			s.existsCalls = append(s.existsCalls, strings.TrimPrefix(r.URL.Path, "/worktree/"))
+			if s.exists {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(s.server.Close)
+	return s
+}
+
+func qaTestComponent(t *testing.T, stub *qaSandboxStub) *Component {
+	t.Helper()
+	c := &Component{name: "plan-manager"}
+	c.logger = slog.Default()
+	c.sandbox = sandbox.NewClient(stub.server.URL)
+	return c
+}
+
+func demoPlan() *workflow.Plan {
+	return &workflow.Plan{
+		Slug:         "demo",
+		Requirements: []workflow.Requirement{{ID: "r1", Title: "R1"}},
+	}
+}
+
+func TestAssembleAndStageQAWorktree_Success(t *testing.T) {
+	stub := newQASandboxStub(t)
+	c := qaTestComponent(t, stub)
+	plan := demoPlan()
+
+	if err := c.assembleAndStageQAWorktree(context.Background(), plan); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if plan.AssembledBranch != "semspec/plan-demo" {
+		t.Errorf("AssembledBranch = %q, want semspec/plan-demo", plan.AssembledBranch)
+	}
+	if stub.mergeCalls != 1 {
+		t.Errorf("merge calls = %d, want 1", stub.mergeCalls)
+	}
+	// Idempotent staging: delete-then-create on the deterministic QA worktree id.
+	if len(stub.deleteCalls) != 1 || stub.deleteCalls[0] != workflow.QAWorktreeID("demo") {
+		t.Errorf("delete calls = %v, want [%s]", stub.deleteCalls, workflow.QAWorktreeID("demo"))
+	}
+	if len(stub.createCalls) != 1 {
+		t.Fatalf("create calls = %v, want 1", stub.createCalls)
+	}
+	if got := stub.createCalls[0]; got.TaskID != workflow.QAWorktreeID("demo") || got.BaseBranch != "semspec/plan-demo" {
+		t.Errorf("create call = %+v, want {qa-demo, semspec/plan-demo}", got)
+	}
+}
+
+func TestAssembleAndStageQAWorktree_ConflictPropagatesAndDoesNotStage(t *testing.T) {
+	stub := newQASandboxStub(t)
+	stub.mergeStatus = http.StatusConflict
+	stub.mergeBody = map[string]any{
+		"status": "conflict", "target": "semspec/plan-demo",
+		"conflicting_branch": "semspec/requirement-r1",
+	}
+	c := qaTestComponent(t, stub)
+	plan := demoPlan()
+
+	err := c.assembleAndStageQAWorktree(context.Background(), plan)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !errors.Is(err, sandbox.ErrMergeBranchesConflict) {
+		t.Errorf("error must errors.Is ErrMergeBranchesConflict; got %v", err)
+	}
+	// A failed merge must NOT create a QA worktree — there's nothing assembled
+	// to check out, and QA must not run against a half-merged or empty tree.
+	if len(stub.createCalls) != 0 {
+		t.Errorf("worktree created on conflict: %v, want none", stub.createCalls)
+	}
+}
+
+func TestAssembleAndStageQAWorktree_NoSandboxIsNoop(t *testing.T) {
+	c := &Component{name: "plan-manager", logger: slog.Default()} // c.sandbox nil
+	if err := c.assembleAndStageQAWorktree(context.Background(), demoPlan()); err != nil {
+		t.Fatalf("nil sandbox should be a no-op, got: %v", err)
+	}
+}
+
+func TestEnsureQAWorktree_CreatesWhenMissing(t *testing.T) {
+	stub := newQASandboxStub(t)
+	stub.exists = false
+	c := qaTestComponent(t, stub)
+	plan := demoPlan()
+	plan.AssembledBranch = "semspec/plan-demo"
+
+	c.ensureQAWorktree(context.Background(), plan)
+
+	if len(stub.existsCalls) != 1 {
+		t.Errorf("exists checks = %d, want 1", len(stub.existsCalls))
+	}
+	if len(stub.createCalls) != 1 || stub.createCalls[0].BaseBranch != "semspec/plan-demo" {
+		t.Errorf("create calls = %v, want one on semspec/plan-demo", stub.createCalls)
+	}
+}
+
+func TestEnsureQAWorktree_NoopWhenPresent(t *testing.T) {
+	stub := newQASandboxStub(t)
+	stub.exists = true
+	c := qaTestComponent(t, stub)
+	plan := demoPlan()
+	plan.AssembledBranch = "semspec/plan-demo"
+
+	c.ensureQAWorktree(context.Background(), plan)
+
+	if len(stub.createCalls) != 0 {
+		t.Errorf("create calls = %v, want none (worktree already present)", stub.createCalls)
+	}
+}
+
+func TestEnsureQAWorktree_NoAssembledBranchIsNoop(t *testing.T) {
+	stub := newQASandboxStub(t)
+	c := qaTestComponent(t, stub)
+	plan := demoPlan() // AssembledBranch empty
+
+	c.ensureQAWorktree(context.Background(), plan)
+
+	if len(stub.existsCalls)+len(stub.createCalls) != 0 {
+		t.Errorf("made sandbox calls with no assembled branch: exists=%v create=%v",
+			stub.existsCalls, stub.createCalls)
+	}
+}
+
+func TestDeleteQAWorktree_CallsDelete(t *testing.T) {
+	stub := newQASandboxStub(t)
+	c := qaTestComponent(t, stub)
+
+	c.deleteQAWorktree(context.Background(), "demo")
+
+	if len(stub.deleteCalls) != 1 || stub.deleteCalls[0] != workflow.QAWorktreeID("demo") {
+		t.Errorf("delete calls = %v, want [qa-demo]", stub.deleteCalls)
+	}
+}
+
+// routeAssemblyConflict: a merge conflict fires phase-local recovery and keeps
+// the plan in implementing; an infra error stalls without firing recovery.
+func TestRouteAssemblyConflict_ConflictEmitsRecovery(t *testing.T) {
+	c := setupTestComponent(t)
+	var captured *payloads.RecoveryRequested
+	c.recoveryPublisher = func(_ context.Context, req *payloads.RecoveryRequested) { captured = req }
+
+	plan := setupTestPlan(t, c, "conflict-plan")
+	plan.Status = workflow.StatusImplementing
+	plan.Requirements = []workflow.Requirement{{ID: "r1"}, {ID: "r2"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	conflictErr := fmt.Errorf("branch x conflicts: %w", sandbox.ErrMergeBranchesConflict)
+	c.routeAssemblyConflict(context.Background(), plan, conflictErr)
+
+	if captured == nil {
+		t.Fatal("expected RecoveryRequested to be emitted on merge conflict")
+	}
+	if len(captured.AffectedRequirementIDs) != 2 {
+		t.Errorf("AffectedRequirementIDs = %v, want both reqs", captured.AffectedRequirementIDs)
+	}
+	if captured.Layer != payloads.RecoveryLayerPhaseLocal {
+		t.Errorf("Layer = %v, want phase-local", captured.Layer)
+	}
+	stored, _ := c.plans.get("conflict-plan")
+	if stored.Status != workflow.StatusImplementing {
+		t.Errorf("plan status = %q, want implementing (must not advance to QA)", stored.Status)
+	}
+	if stored.LastError == "" {
+		t.Error("LastError should be set so the UI can surface the stall")
+	}
+}
+
+// handleConvergenceAllSucceeded is the load-bearing early-return: on a pre-QA
+// merge conflict the plan must NOT advance to QA and must NOT stage a worktree
+// (else QA would inspect an unmerged/empty tree — the exact bug being fixed).
+func TestHandleConvergenceAllSucceeded_ConflictDoesNotAdvanceToQA(t *testing.T) {
+	stub := newQASandboxStub(t)
+	stub.mergeStatus = http.StatusConflict
+	stub.mergeBody = map[string]any{
+		"status": "conflict", "target": "semspec/plan-demo",
+		"conflicting_branch": "semspec/requirement-r2",
+	}
+	c := setupTestComponent(t)
+	c.sandbox = sandbox.NewClient(stub.server.URL)
+	var recovery *payloads.RecoveryRequested
+	c.recoveryPublisher = func(_ context.Context, r *payloads.RecoveryRequested) { recovery = r }
+
+	plan := setupTestPlan(t, c, "demo")
+	plan.Status = workflow.StatusImplementing
+	plan.QALevel = workflow.QALevelUnit
+	plan.Requirements = []workflow.Requirement{{ID: "r1"}, {ID: "r2"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	c.handleConvergenceAllSucceeded(context.Background(), plan, "demo", 2)
+
+	stored, _ := c.plans.get("demo")
+	if stored.Status != workflow.StatusImplementing {
+		t.Errorf("status = %q, want implementing (must not advance to QA on conflict)", stored.Status)
+	}
+	if recovery == nil {
+		t.Error("expected RecoveryRequested on pre-QA merge conflict")
+	}
+	if len(stub.createCalls) != 0 {
+		t.Errorf("QA worktree staged despite conflict: %v", stub.createCalls)
+	}
+}
+
+func TestHandleConvergenceAllSucceeded_SuccessStagesWorktreeAndAdvances(t *testing.T) {
+	stub := newQASandboxStub(t) // merge OK by default, target semspec/plan-demo
+	c := setupTestComponent(t)
+	c.sandbox = sandbox.NewClient(stub.server.URL)
+	// c.natsClient nil → publishQARequestIfNeeded no-ops; we assert state + staging.
+
+	plan := setupTestPlan(t, c, "demo")
+	plan.Status = workflow.StatusImplementing
+	plan.QALevel = workflow.QALevelUnit
+	plan.Requirements = []workflow.Requirement{{ID: "r1"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	c.handleConvergenceAllSucceeded(context.Background(), plan, "demo", 1)
+
+	stored, _ := c.plans.get("demo")
+	if stored.Status != workflow.StatusReadyForQA {
+		t.Errorf("status = %q, want ready_for_qa", stored.Status)
+	}
+	if stored.AssembledBranch != "semspec/plan-demo" {
+		t.Errorf("AssembledBranch = %q, want semspec/plan-demo", stored.AssembledBranch)
+	}
+	if len(stub.createCalls) != 1 || stub.createCalls[0].TaskID != workflow.QAWorktreeID("demo") {
+		t.Errorf("QA worktree not staged on success: %v", stub.createCalls)
+	}
+}
+
+func TestRouteAssemblyConflict_InfraErrorDoesNotEmitRecovery(t *testing.T) {
+	c := setupTestComponent(t)
+	recoveryFired := false
+	c.recoveryPublisher = func(_ context.Context, _ *payloads.RecoveryRequested) { recoveryFired = true }
+
+	plan := setupTestPlan(t, c, "infra-plan")
+	plan.Status = workflow.StatusImplementing
+	plan.Requirements = []workflow.Requirement{{ID: "r1"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	c.routeAssemblyConflict(context.Background(), plan, errors.New("sandbox unreachable"))
+
+	if recoveryFired {
+		t.Error("infra error must NOT fire plan-scope recovery (it's a transient stall)")
+	}
+	stored, _ := c.plans.get("infra-plan")
+	if stored.Status != workflow.StatusImplementing {
+		t.Errorf("plan status = %q, want implementing", stored.Status)
+	}
+	if stored.LastError == "" {
+		t.Error("LastError should be set on infra stall")
+	}
+}

--- a/processor/qa-reviewer/component.go
+++ b/processor/qa-reviewer/component.go
@@ -521,6 +521,19 @@ func (c *Component) dispatchReviewer(ctx context.Context, plan *workflow.Plan, p
 	// in execution-manager for rationale.
 	qaTools := prompt.FilterTools(c.availableToolNames(), prompt.RolePlanQAReviewer)
 
+	// Point Murat's bash inspection at the per-plan QA worktree (a checkout of
+	// the assembled plan branch holding the merged per-requirement
+	// implementation), staged by plan-manager at convergence and ensured at
+	// review start. Fall back to the repo root ("main") only when there is no
+	// assembled branch — a plan that reached review before the assemble-before-QA
+	// path existed. Gating on AssembledBranch avoids a 404 storm: the sandbox's
+	// exec endpoint hard-fails every command when a named worktree is absent,
+	// unlike the unit runner which degrades gracefully.
+	qaTaskID := "main"
+	if plan.AssembledBranch != "" {
+		qaTaskID = workflow.QAWorktreeID(plan.Slug)
+	}
+
 	task := &agentic.TaskMessage{
 		TaskID: taskID,
 		Role:   agentic.RoleReviewer,
@@ -546,7 +559,7 @@ func (c *Component) dispatchReviewer(ctx context.Context, plan *workflow.Plan, p
 		Metadata: map[string]any{
 			"plan_slug":        plan.Slug,
 			"qa_level":         string(plan.EffectiveQALevel()),
-			"task_id":          "main",
+			"task_id":          qaTaskID,
 			"deliverable_type": "qa-review",
 			// role + model for SKG tool.recovery.incident partitioning.
 			"role":  string(prompt.RoleQA),

--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -212,6 +212,13 @@ func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirem
 	exec.CurrentNodeTaskID = ""
 	exec.VisitedNodes = make(map[string]bool)
 	exec.NodeResults = nil
+	// Re-run the requirement's Stories from the start on recovery resume. Without
+	// this, a multi-Story requirement keeps a stale CurrentStoryIdx and re-runs
+	// only a subset; clearing SortedStoryIDs makes dispatchSynthesizerLocked
+	// re-derive the story topo order from current plan Stories. Applies to both
+	// QA-recovery (completed req) and iteration-exhaustion resumes.
+	exec.CurrentStoryIdx = 0
+	exec.SortedStoryIDs = nil
 	// KV NodeResults is append-only via handleReqNodeMutation; the in-memory
 	// wipe above must be mirrored to KV or the stale entries reappear on
 	// rebuildExecFromKV after the next restart. Closes Pass-1 H4 for the

--- a/processor/requirement-executor/recover_completed.go
+++ b/processor/requirement-executor/recover_completed.go
@@ -146,7 +146,74 @@ func (c *Component) resumeTerminalForRecoveryLocked(ctx context.Context, exec *r
 		"prior_stage", "terminal",
 		"proposal_id", proposalID,
 	)
+	// Re-open the M:N Stories this requirement owns so the resumed dev loop
+	// re-does work instead of skipping ("Story already complete"). Without this,
+	// QA-recovery on an M:N-complete plan is a no-op: the req re-dispatches, every
+	// Story is skipped, the req re-marks complete, and the plan bounces back to QA
+	// unchanged. Must run BEFORE resumeFromRecoveryLocked so the reset stories are
+	// visible when dispatchSynthesizerLocked reloads the plan from KV.
+	c.reopenOwnedStoriesForRecoveryLocked(ctx, exec)
 	c.resumeFromRecoveryLocked(ctx, exec)
+}
+
+// storiesToReopenForRecovery returns the IDs of complete Stories covering reqID
+// that reqID owns (the deterministic M:N owner). These are the Stories a
+// QA-recovery resume must reset complete → ready so the dev loop re-runs rather
+// than skipping. Non-owned Stories are excluded — resetting one would let a
+// non-owner run the dev loop, inverting the M:N reservation; the non-owner
+// instead re-skips (Story stays complete) and fast-completes via Tier-1 dedup
+// once the owner re-ships. Non-complete Stories are excluded (nothing to
+// re-open). Pure function — the side-effecting reopen lives in
+// reopenOwnedStoriesForRecoveryLocked.
+func storiesToReopenForRecovery(plan *workflow.Plan, reqID string) []string {
+	if plan == nil {
+		return nil
+	}
+	var ids []string
+	for _, s := range plan.StoriesForRequirement(reqID) {
+		if s.Status == workflow.StoryStatusComplete && workflow.DeterministicStoryOwner(s) == reqID {
+			ids = append(ids, s.ID)
+		}
+	}
+	return ids
+}
+
+// reopenOwnedStoriesForRecoveryLocked resets the owner's complete M:N Stories to
+// ready via the cross-component story-status mutation. No-op without a NATS
+// client (unit-test substrate) or when the plan can't be loaded. Idempotent
+// across recovery cycles: candidates are pre-filtered to complete Stories, so a
+// re-run reopens nothing once a Story has already moved on to ready/executing.
+func (c *Component) reopenOwnedStoriesForRecoveryLocked(ctx context.Context, exec *requirementExecution) {
+	if c.natsClient == nil {
+		return
+	}
+	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
+	if err != nil || plan == nil {
+		c.logger.Warn("QA-recovery: could not load plan to reopen owned stories",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID, "error", err)
+		return
+	}
+	ids := storiesToReopenForRecovery(plan, exec.RequirementID)
+	reopened := 0
+	for _, storyID := range ids {
+		if workflow.ClaimStoryStatus(ctx, c.natsClient, exec.Slug, storyID, workflow.StoryStatusReady, c.logger) {
+			reopened++
+		}
+	}
+	switch {
+	case len(ids) > 0 && reopened < len(ids):
+		// A reopen was expected but did not fully land (NATS error or a rejected
+		// mutation). Proceeding lets the un-reopened stories re-skip and the
+		// requirement re-complete without work — silently resurrecting the no-op
+		// this function exists to fix. Surface it so it's diagnosable.
+		c.logger.Warn("QA-recovery: not all owned stories reopened — recovery may be a partial no-op",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"reopened", reopened, "candidates", len(ids))
+	case reopened > 0:
+		c.logger.Info("QA-recovery: reopened owned M:N stories for re-execution",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"reopened", reopened, "candidates", len(ids))
+	}
 }
 
 // isKVNotFound returns true when err is the soft "no entry" shape returned

--- a/processor/requirement-executor/recover_completed_test.go
+++ b/processor/requirement-executor/recover_completed_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/c360studio/semspec/workflow"
 )
 
 // TestResumeTerminalForRecoveryLocked covers the new branch added 2026-05-28
@@ -88,4 +90,53 @@ func TestResumeTerminalForRecoveryLocked_RecordsReasonBeforeResume(t *testing.T)
 	if gotReason != want {
 		t.Errorf("recoveryReason after resume = %q, want %q", gotReason, want)
 	}
+}
+
+// TestStoriesToReopenForRecovery pins the M:N owner/complete gating: a
+// QA-recovery resume reopens only the Stories the requirement OWNS and that are
+// currently complete. Reopening a non-owned Story would invert the M:N
+// reservation (a non-owner would run the dev loop); reopening a non-complete
+// Story is meaningless.
+func TestStoriesToReopenForRecovery(t *testing.T) {
+	plan := &workflow.Plan{Stories: []workflow.Story{
+		// owner = r1 (smallest), complete → reopen candidate for r1
+		{ID: "s1", Status: workflow.StoryStatusComplete, RequirementIDs: []string{"r1", "r2"}},
+		// owner = r2, complete → reopen candidate for r2 only
+		{ID: "s2", Status: workflow.StoryStatusComplete, RequirementIDs: []string{"r2", "r3"}},
+		// owner = r1 but NOT complete → never a reopen candidate
+		{ID: "s3", Status: workflow.StoryStatusExecuting, RequirementIDs: []string{"r1"}},
+	}}
+
+	tests := []struct {
+		name  string
+		plan  *workflow.Plan
+		reqID string
+		want  []string
+	}{
+		{"owner_complete_reopens", plan, "r1", []string{"s1"}},
+		{"non_owner_excluded", plan, "r2", []string{"s2"}}, // r2 covers s1 but doesn't own it
+		{"covers_but_not_owner", plan, "r3", nil},          // r3 covers s2 but r2 owns it
+		{"nil_plan", nil, "r1", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := storiesToReopenForRecovery(tt.plan, tt.reqID)
+			if !equalStringSlices(got, tt.want) {
+				t.Errorf("storiesToReopenForRecovery(%q) = %v, want %v", tt.reqID, got, tt.want)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/processor/scenario-orchestrator/dag.go
+++ b/processor/scenario-orchestrator/dag.go
@@ -1,8 +1,6 @@
 package scenarioorchestrator
 
 import (
-	"sort"
-
 	"github.com/c360studio/semspec/workflow"
 )
 
@@ -115,7 +113,7 @@ func filterByM2NStoryReservations(ready []workflow.Requirement, stories []workfl
 	for _, req := range ready {
 		gated := false
 		for _, s := range storiesByReq[req.ID] {
-			if storyOwner(s) == req.ID {
+			if workflow.DeterministicStoryOwner(s) == req.ID {
 				continue // we own this Story — dispatch normally
 			}
 			if s.Status == workflow.StoryStatusComplete {
@@ -130,19 +128,6 @@ func filterByM2NStoryReservations(ready []workflow.Requirement, stories []workfl
 		}
 	}
 	return out
-}
-
-// storyOwner returns the deterministic "owning" requirement ID for a Story
-// under the ADR-044 M:N reservation pattern. The lexicographically smallest
-// req ID in Story.RequirementIDs wins. Stable across re-evaluations so the
-// owner picked on one orchestration sweep is the same on the next.
-func storyOwner(s workflow.Story) string {
-	if len(s.RequirementIDs) == 0 {
-		return ""
-	}
-	ids := append([]string(nil), s.RequirementIDs...)
-	sort.Strings(ids)
-	return ids[0]
 }
 
 // depsComplete returns true when every requirement listed in req.DependsOn is

--- a/tools/sandbox/client.go
+++ b/tools/sandbox/client.go
@@ -176,6 +176,30 @@ func (c *Client) DeleteWorktree(ctx context.Context, taskID string) error {
 	return nil
 }
 
+// WorktreeExists reports whether the sandbox currently has a worktree for
+// taskID. Unlike the generic do* helpers it treats 404 as a normal "absent"
+// answer rather than an error, so callers can self-heal a missing worktree.
+// Server route: GET /worktree/{taskID} → 200 present, 404 absent.
+func (c *Client) WorktreeExists(ctx context.Context, taskID string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/worktree/"+taskID, nil)
+	if err != nil {
+		return false, fmt.Errorf("build worktree-exists request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("worktree-exists http: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("worktree-exists check: server error %d", resp.StatusCode)
+	}
+}
+
 // MergeResult holds the outcome of a worktree merge.
 //
 // NothingToCommit is the typed signal that the worktree was empty AND its

--- a/workflow/payloads/qa.go
+++ b/workflow/payloads/qa.go
@@ -3,6 +3,7 @@ package payloads
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semstreams/message"
@@ -41,6 +42,15 @@ func (p *QARequestedPayload) Validate() error {
 	// heavier tiers run in the operator's CI, not via a semspec executor.
 	if p.Mode != workflow.QALevelUnit {
 		return fmt.Errorf("mode must be unit, got %q", p.Mode)
+	}
+	// Workspace, when present, is the QA worktree's sandbox task_id. Reject
+	// path-traversal-shaped values so a malformed event cannot escape the
+	// sandbox worktree root when worktreeFor joins it onto worktreeRoot.
+	if p.Workspace != "" &&
+		(strings.Contains(p.Workspace, "..") ||
+			strings.Contains(p.Workspace, "/") ||
+			strings.Contains(p.Workspace, "\\")) {
+		return fmt.Errorf("workspace contains path separators: %q", p.Workspace)
 	}
 	return nil
 }

--- a/workflow/payloads/qa_test.go
+++ b/workflow/payloads/qa_test.go
@@ -1,0 +1,54 @@
+package payloads
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestQARequestedPayloadValidate(t *testing.T) {
+	base := func() *QARequestedPayload {
+		return &QARequestedPayload{QARequestedEvent: workflow.QARequestedEvent{
+			Slug:        "auth",
+			PlanID:      "plan-1",
+			Mode:        workflow.QALevelUnit,
+			TestCommand: "go test ./...",
+		}}
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(*QARequestedPayload)
+		wantErr   bool
+		errSubstr string
+	}{
+		{"valid_no_workspace", func(*QARequestedPayload) {}, false, ""},
+		{"valid_with_workspace", func(p *QARequestedPayload) { p.Workspace = workflow.QAWorktreeID("auth") }, false, ""},
+		{"empty_slug", func(p *QARequestedPayload) { p.Slug = "" }, true, "slug"},
+		{"non_unit_mode", func(p *QARequestedPayload) { p.Mode = workflow.QALevelSynthesis }, true, "mode must be unit"},
+		{"workspace_path_traversal_dots", func(p *QARequestedPayload) { p.Workspace = "../escape" }, true, "path separators"},
+		{"workspace_slash", func(p *QARequestedPayload) { p.Workspace = "qa/auth" }, true, "path separators"},
+		{"workspace_backslash", func(p *QARequestedPayload) { p.Workspace = "qa\\auth" }, true, "path separators"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := base()
+			tt.mutate(p)
+			err := p.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() = nil, want error containing %q", tt.errSubstr)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("Validate() error = %q, want substring %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/workflow/plan.go
+++ b/workflow/plan.go
@@ -42,6 +42,18 @@ func ValidateSlug(slug string) error {
 	return nil
 }
 
+// QAWorktreeID returns the deterministic sandbox task_id of the per-plan QA
+// worktree — a throwaway checkout of the assembled plan branch
+// ("semspec/plan-<slug>") that both the unit-test runner and the release-gate
+// Murat loop inspect, so QA evaluates the merged implementation rather than the
+// pre-implementation main HEAD. Determinism lets plan-manager (creator),
+// qa-reviewer (release loop), and the sandbox unit runner converge on the same
+// worktree without extra plumbing. The slug is already path-safe (ValidateSlug),
+// so the "qa-" prefix yields a safe task_id token.
+func QAWorktreeID(slug string) string {
+	return "qa-" + slug
+}
+
 // CreatePlan creates a new plan in draft mode (Approved=false).
 // Plans are created in the default project at .semspec/projects/default/plans/{slug}/.
 func CreatePlan(ctx context.Context, tw *graphutil.TripleWriter, slug, title string) (*Plan, error) {

--- a/workflow/qa_worktree_test.go
+++ b/workflow/qa_worktree_test.go
@@ -1,0 +1,34 @@
+package workflow
+
+import "testing"
+
+func TestQAWorktreeID(t *testing.T) {
+	tests := []struct {
+		name string
+		slug string
+		want string
+	}{
+		{"simple", "auth", "qa-auth"},
+		{"hyphenated", "mavlink-hard", "qa-mavlink-hard"},
+		{"numeric", "feature-2", "qa-feature-2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := QAWorktreeID(tt.slug); got != tt.want {
+				t.Errorf("QAWorktreeID(%q) = %q, want %q", tt.slug, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQAWorktreeID_Deterministic guards the property the data-plane fix relies
+// on: plan-manager, qa-reviewer, and the sandbox unit runner must derive the
+// SAME worktree id from the slug, or they would inspect different trees.
+func TestQAWorktreeID_Deterministic(t *testing.T) {
+	if QAWorktreeID("plan-x") != QAWorktreeID("plan-x") {
+		t.Fatal("QAWorktreeID is not deterministic for the same slug")
+	}
+	if QAWorktreeID("a") == QAWorktreeID("b") {
+		t.Fatal("QAWorktreeID collides across distinct slugs")
+	}
+}

--- a/workflow/story_owner_test.go
+++ b/workflow/story_owner_test.go
@@ -1,0 +1,36 @@
+package workflow
+
+import "testing"
+
+func TestDeterministicStoryOwner(t *testing.T) {
+	tests := []struct {
+		name   string
+		reqIDs []string
+		want   string
+	}{
+		{"single", []string{"r1"}, "r1"},
+		{"smallest_wins", []string{"r3", "r1", "r2"}, "r1"},
+		// Lexicographic, NOT numeric: "r10" < "r2" because '1' < '2'. Pins the
+		// exact tie-break the scenario-orchestrator reservation also relies on.
+		{"lexicographic_not_numeric", []string{"r10", "r2"}, "r10"},
+		{"empty", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DeterministicStoryOwner(Story{RequirementIDs: tt.reqIDs}); got != tt.want {
+				t.Errorf("DeterministicStoryOwner(%v) = %q, want %q", tt.reqIDs, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeterministicStoryOwner_DoesNotMutateInput guards that owner selection
+// doesn't sort the Story's RequirementIDs in place (which would scramble the
+// M:N join order downstream).
+func TestDeterministicStoryOwner_DoesNotMutateInput(t *testing.T) {
+	s := Story{RequirementIDs: []string{"r3", "r1", "r2"}}
+	_ = DeterministicStoryOwner(s)
+	if s.RequirementIDs[0] != "r3" {
+		t.Errorf("input RequirementIDs mutated: %v", s.RequirementIDs)
+	}
+}

--- a/workflow/story_task.go
+++ b/workflow/story_task.go
@@ -1,6 +1,26 @@
 package workflow
 
-import "time"
+import (
+	"sort"
+	"time"
+)
+
+// DeterministicStoryOwner returns the "owning" requirement ID for a Story under
+// the ADR-044 M:N reservation pattern: the lexicographically smallest req ID in
+// Story.RequirementIDs. Stable across re-evaluations so the owner picked on one
+// sweep is the same on the next. The owner is the sole requirement that runs the
+// dev loop for a Story; non-owners gate behind Story.Status==complete. Shared by
+// the scenario-orchestrator reservation filter and the requirement-executor's
+// QA-recovery story reopen so the two cannot drift. Empty when the Story covers
+// no requirements.
+func DeterministicStoryOwner(s Story) string {
+	if len(s.RequirementIDs) == 0 {
+		return ""
+	}
+	ids := append([]string(nil), s.RequirementIDs...)
+	sort.Strings(ids)
+	return ids[0]
+}
 
 // Story is a Sarah-authored unit of dev-ready work anchored to a single
 // architectural component (ADR-044). Under M:N coverage, a Story covers

--- a/workflow/subjects.go
+++ b/workflow/subjects.go
@@ -114,12 +114,18 @@ type UserSignalErrorEvent struct {
 // straight to reviewing_qa) and level=none skips QA entirely. Heavier tiers
 // run in the operator's CI, not via a semspec executor.
 type QARequestedEvent struct {
-	Slug           string  `json:"slug"`
-	PlanID         string  `json:"plan_id"`
-	Mode           QALevel `json:"mode"`                   // unit (the only sandbox-executed level)
-	TestCommand    string  `json:"test_command,omitempty"` // project-configured command, e.g. "go test ./..."
-	TimeoutSeconds int     `json:"timeout_seconds,omitempty"`
-	TraceID        string  `json:"trace_id,omitempty"`
+	Slug   string  `json:"slug"`
+	PlanID string  `json:"plan_id"`
+	Mode   QALevel `json:"mode"` // unit (the only sandbox-executed level)
+	// Workspace is the sandbox task_id of the per-plan QA worktree (see
+	// QAWorktreeID) — a checkout of the assembled plan branch that holds the
+	// merged per-requirement implementation. The sandbox runs the test command
+	// there so unit QA evaluates real work, not the pre-implementation main HEAD.
+	// Empty (legacy / cold path) means run against the repo root.
+	Workspace      string `json:"workspace,omitempty"`
+	TestCommand    string `json:"test_command,omitempty"` // project-configured command, e.g. "go test ./..."
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+	TraceID        string `json:"trace_id,omitempty"`
 }
 
 // QAFailure describes a single test or job failure surfaced by qa-runner.


### PR DESCRIPTION
## Problem

An audit of the QA subsystem against ADR-045 (prompted by "don't assume QA is OK after we gutted the integration/e2e gates + removed qa-runner") found the **control plane coherent but the data plane broken**:

- **Both QA tiers evaluated unmerged `main` HEAD.** Per-requirement work lives on `semspec/requirement-<id>` branches, merged into `semspec/plan-<slug>` only by `assembleRequirementBranches` — which ran **only at QA-approve**. So the release-gate Murat loop (`task_id=main`) and the sandbox unit-test runner (`go test` in `repoPath`) both judged code they couldn't see. `qa_level=unit` was effectively meaningless.
- **QA-rejection recovery was a no-op for M:N-complete stories.** `dispatchCurrentStoryLocked` skips any Story already `complete`; recovery never reset it, so the requirement re-marked complete without work and bounced back to QA unchanged.

Together these are the **mavlink-hard run-2 QA-gate failure** (reqs 3–4 stranded in unmerged branches; Murat correctly `needs_changes`; recovery idled ~80 min as a no-op). The green `qa-cycle` e2e scenario can't catch this — it pre-seeds a passing `go test` baseline + is single-requirement, so it validates the broken behavior.

## Fix (design: `docs/design/qa-data-plane-fix.md`)

**Phase A — assemble before QA, one workspace mechanism.** Assemble requirement branches + stage a dedicated per-plan QA worktree (`qa-<slug>`, a checkout of the assembled plan branch) at the `implementing → ready_for_qa` convergence, before either QA path runs. Both QA workspaces point at it: the unit runner via a new `QARequestedEvent.Workspace` field, the release loop via qa-reviewer `task_id` (gated on `AssembledBranch` so pre-existing plans fall back to `main` instead of 404ing). Self-heal at `qa.start`; cleanup on verdict/archive/delete. Pre-QA merge conflict → phase-local recovery (plan stays `implementing`); infra error → stall with `LastError`. Never advances to QA on a failed merge. Approve-time assemble kept as an idempotent safety net.

**Phase B — recovery re-opens M:N-complete stories.** Extract shared `workflow.DeterministicStoryOwner` (reservation filter + recovery can't drift). On QA-recovery, reset the **owner's** complete stories `complete → ready` so the dev loop re-runs; non-owners re-skip + Tier-1 fast-complete (no double-run); a partial reopen WARN-logs. Also reset the story cursor in `resumeFromRecoveryLocked`, fixing a latent stale-cursor on both the QA-recovery and iteration-exhaustion paths.

## Testing

- `go build ./...`, `go vet ./...`, `task lint` (revive) all clean.
- Full suite green: **70 packages ok, 0 fail**.
- New unit tests cover: `QAWorktreeID`, `QARequestedEvent.Workspace` validation, `selectQAWorkDir` fallback, `assembleAndStageQAWorktree` (success/conflict/no-op), `ensureQAWorktree`, `deleteQAWorktree`, `routeAssemblyConflict` (conflict→recovery / infra→stall), `handleConvergenceAllSucceeded` (conflict→no-advance / success→staged), `DeterministicStoryOwner` (incl. lexicographic + no-mutation), `storiesToReopenForRecovery` (owner/non-owner/incomplete gating).
- Both phases reviewed by go-reviewer (no blockers; medium/low findings addressed).

## Not in this PR (follow-ups)
- A multi-requirement e2e regression scenario where only agent code makes the test pass (depends on the mock-coder fixture writing real files — issue #151).
- Cleanup of ~30 stale `qa-runner`/`integration`/`full` doc + comment references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)