### PR TITLE
chore(qa): remove stale qa-runner / integration-tier references

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [Project Setup](docs/project-setup.md) for config details.
 
 Requires Go 1.25+, Docker, and [Task](https://taskfile.dev/).
 
-Semspec runs alongside 6 services (NATS, sandbox, semsource, qa-runner, UI, gateway).
+Semspec runs alongside 5 services (NATS, sandbox, semsource, UI, gateway).
 The simplest way to build from source is `task local:up`, which compiles the
 Go binary inside Docker and starts the full stack:
 
@@ -188,8 +188,9 @@ the full changeset and returns per-scenario verdicts: `approved`, `needs_changes
 into a final release-readiness verdict. The plan transitions through `reviewing_qa` (or directly
 to `complete` when `qa_level=none`) before reaching `complete`. The gate counts completed
 requirements, not scenarios. Inputs vary by `qa_level`: `synthesis` reads plan+impl only;
-`unit`/`integration`/`full` first route through `ready_for_qa` so sandbox or qa-runner can run
-project tests, then feed results into the reviewer.
+`unit` first routes through `ready_for_qa` so the sandbox can run project tests, then feeds
+results into the reviewer. Heavier tiers (`integration`/`full`) run in the operator's CI via
+the emitted `qa.yml` — semspec designs and gates, the operator's CI executes.
 
 > Older plans may show a `reviewing_rollup` status. That stage is kept for in-flight plans on
 > upgrade but no new code emits it.

--- a/configs/presets/bmad.json
+++ b/configs/presets/bmad.json
@@ -85,7 +85,7 @@
     },
     "qa": {
       "display_name": "Murat",
-      "system_prompt": "You are Murat, a master test architect who designs and executes integration and end-to-end test strategies. You verify cross-requirement interactions and catch issues that unit tests miss.",
+      "system_prompt": "You are Murat, a master test architect who designs integration and end-to-end test strategies and gates release readiness. Semspec emits qa.yml for the operator's CI to execute heavier tiers; you evaluate the evidence and produce verdicts. You verify cross-requirement interactions and catch issues that unit tests miss.",
       "traits": ["systematic", "adversarial-thinker", "thorough"],
       "style": "analytical"
     },

--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -135,9 +135,9 @@ services:
     depends_on:
       nats:
         condition: service_healthy
-      # Same WORKFLOW-stream race as qa-runner — sandbox's qa-unit subscriber
-      # exits with code 1 if the stream isn't ready within ~60s of NATS
-      # connect. Gate on semspec health so the stream exists by then.
+      # sandbox's qa-unit subscriber exits with code 1 if the WORKFLOW stream
+      # isn't ready within ~60s of NATS connect. Gate on semspec health so
+      # the stream exists by then.
       semspec:
         condition: service_healthy
     deploy:

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -137,8 +137,8 @@ plan at creation so policy changes don't retroactively affect in-flight work.
 | `none` | — | No QA gate; plan goes straight to `complete` | Doc-only hotfixes |
 | `synthesis` | qa-reviewer only | LLM verdict on plan artifacts, no test execution | Default; fast, content-based check |
 | `unit` | sandbox | `go test ./...` (or language default) against the merged worktree | Most projects |
-| `integration` | qa-runner + `act` | `.github/workflows/qa.yml` job `integration` — tagged integration tests against real service dependencies. Per ADR-039 the catalog `services`-class profiles render as qa.yml `services:` blocks brought up by qa-runner; `testcontainers` and `pure-fixture` profiles are started by the test code itself. | Projects with integration suites |
-| `full` | qa-runner + `act` | Both `integration` + `e2e` jobs — adds Playwright browser flows | Projects with UI + browser tests |
+| `integration` | operator's CI | `.github/workflows/qa.yml` job `integration` — tagged integration tests against real service dependencies. Per ADR-039 the catalog `services`-class profiles render as qa.yml `services:` blocks; the operator's CI brings the stack up. `testcontainers` and `pure-fixture` profiles are started by the test code itself. Semspec emits the qa.yml; it does not execute it (ADR-045). Values of `integration` in `qa_level` are coerced to `synthesis` at runtime. | Projects with integration suites (operator-CI-only) |
+| `full` | operator's CI | Both `integration` + `e2e` jobs — adds Playwright browser flows. Semspec emits the qa.yml; the operator's CI executes it (ADR-045). Values of `full` in `qa_level` are coerced to `synthesis` at runtime. | Projects with UI + browser tests (operator-CI-only) |
 
 **MVP scope:** use `synthesis` for hard-scenario demos unless the project already owns a reliable integration command.
 Scenario tags and harness profile IDs remain planning/review metadata, but semspec-managed harness routing and full/e2e
@@ -164,11 +164,9 @@ curl -X PATCH http://localhost:8080/project-manager/config \
 ```
 
 **Sandbox** (level=unit) runs the project's native test command in the same
-container semspec uses for per-task structural validation. **qa-runner**
-(level=integration/full) invokes nektos/act against `.github/workflows/qa.yml`
-using the host Docker daemon via a mounted socket — tests run in real GitHub
-Actions runner images (catthehacker/ubuntu:act-latest). The qa.yml template is
-scaffolded by `POST /project-manager/init` when missing.
+container semspec uses for per-task structural validation. The qa.yml template is
+scaffolded by `POST /project-manager/init` when missing, for the operator's CI
+to consume. Semspec does not execute `qa.yml` itself (ADR-045).
 
 Catalog-backed **test environment profiles** split into three orchestration
 types (`harnesscatalog.Profile.Orchestration` in code, per ADR-039):
@@ -176,9 +174,9 @@ types (`harnesscatalog.Profile.Orchestration` in code, per ADR-039):
 - **`services`** — heavy or persistent integration peers (e.g. PX4 SITL via
   `mavlink.px4-sitl.mavsdk-smoke`). Plan-manager renders `services:` blocks
   into qa.yml from the catalog entry's `images`, `ports`, `env`, and
-  `readiness` fields. qa-runner brings the stack up; **tests are consumers**
-  that read the endpoint from the env qa-runner injects and never start the
-  service themselves.
+  `readiness` fields. The operator's CI brings the stack up; **tests are
+  consumers** that read the endpoint from the env the CI injects and never
+  start the service themselves.
 - **`testcontainers`** — lightweight per-test fixtures the test code spins
   up via the Testcontainers library (uses the docker socket act mounts into
   runner containers). No qa.yml-level `services:` blocks needed.

--- a/processor/execution-manager/harness_prompt_seam_test.go
+++ b/processor/execution-manager/harness_prompt_seam_test.go
@@ -11,8 +11,9 @@ import (
 // catalog→prompt-context seam. A regression that dropped Profile.Orchestration
 // from the constructed ResolvedHarnessProfileContext would silently feed the
 // developer agent profiles without the orchestration directive, leaving the
-// agent to guess whether qa-runner brings services up or the test fixture
-// owns the stack. ADR-039 Phase 1a depends on this propagating end-to-end.
+// agent to guess whether the operator's CI brings services up or the test
+// fixture owns the stack. ADR-039 Phase 1a depends on this propagating
+// end-to-end.
 func TestResolvedHarnessProfilesToPromptPropagatesOrchestration(t *testing.T) {
 	cat, err := harnesscatalog.LoadBuiltIn()
 	if err != nil {

--- a/processor/plan-manager/qa_workflow_render.go
+++ b/processor/plan-manager/qa_workflow_render.go
@@ -16,9 +16,9 @@ import (
 // selections, operator opt-out, catalog load failure) so the caller writes
 // the language-aware scaffold instead.
 //
-// Render failures log a warning and return false — qa-runner will surface a
-// clearer error against whichever qa.yml is on disk than a silent partial
-// write would.
+// Render failures log a warning and return false — the operator's CI will
+// surface a clearer error against whichever qa.yml is on disk than a silent
+// partial write would.
 func (c *Component) maybeRenderQAWithServices(plan *workflow.Plan, pc *workflow.ProjectConfig) bool {
 	if plan == nil || plan.Architecture == nil || len(plan.Architecture.HarnessProfiles) == 0 {
 		return false

--- a/processor/project-manager/qa_workflow.go
+++ b/processor/project-manager/qa_workflow.go
@@ -20,9 +20,9 @@ import (
 // Called from:
 //   - processor/project-manager HTTP /init: at project initialization.
 //   - processor/plan-manager.publishQARequestIfNeeded: just before
-//     publishing a QARequestedEvent so qa-runner finds the workflow even
-//     when the project was hand-authored (e2e fixtures) rather than
-//     init-ed via project-manager.
+//     publishing a QARequestedEvent so the operator's CI finds the
+//     workflow even when the project was hand-authored (e2e fixtures)
+//     rather than init-ed via project-manager.
 func EnsureQAWorkflow(workspacePath string, projectConfig *workflow.ProjectConfig, logger Logger) error {
 	workflowPath := filepath.Join(workspacePath, ".github", "workflows", "qa.yml")
 	if fileExists(workflowPath) {
@@ -57,16 +57,15 @@ type Logger interface {
 // most build tools available, so the wrong language template at worst
 // produces a "no tests found" rather than a hard fail).
 //
-// All variants emit two jobs: `integration` (run at qa_level=integration
-// AND qa_level=full) and `e2e` (run at qa_level=full only via the
-// absence of --job filter). qa-runner uses --job integration at
-// qa_level=integration to skip the e2e job for faster feedback.
+// All variants emit two jobs: `integration` and `e2e`. These jobs are
+// executed by the operator's CI (e.g. GitHub Actions), not by semspec.
+// Semspec only emits this file; the operator's CI runs it (ADR-045).
 //
 // Note: harness profiles split into three orchestration types (see
 // prompt/domain/software_render.go:harnessProfilesIntro and ADR-039):
-//   - services: qa-runner renders services: blocks into qa.yml from
+//   - services: plan-manager renders services: blocks into qa.yml from
 //     the catalog (images/ports/env/readiness). Tests are consumers
-//     that read the endpoint from the env qa-runner injects.
+//     that read the endpoint from the env the operator's CI injects.
 //   - testcontainers: dev's test code spins up containers via the
 //     Testcontainers library, which uses the docker socket act mounts
 //     into runner containers. No qa.yml-level services: needed.
@@ -283,25 +282,22 @@ func goQAWorkflow(pc *workflow.ProjectConfig) string {
 	cmd := testCommand(pc, "go test ./... -tags=integration -v")
 	return fmt.Sprintf(`name: QA
 # Default QA workflow scaffolded by semspec project-manager.
+# Run by YOUR CI (e.g. GitHub Actions) — semspec emits this file but
+# does not execute it (ADR-045).
 #
 # Two jobs:
-#   - integration: run at qa_level=integration and qa_level=full
-#   - e2e:        run at qa_level=full (Playwright browser flows)
-#
-# qa-runner invokes this file via nektos/act, passing --job integration at
-# qa_level=integration so the e2e job is skipped for faster feedback. At
-# qa_level=full act runs the full workflow, exercising both jobs.
+#   - integration: tagged integration tests, run by your CI
+#   - e2e:         Playwright browser flows, run by your CI
 #
 # Harness profiles split into three orchestration types (ADR-039):
-#   - services: qa-runner renders services: blocks into this file from
+#   - services: plan-manager renders services: blocks into this file from
 #     the catalog (e.g. PX4 SITL via mavlink.px4-sitl.mavsdk-smoke).
-#     Tests are consumers; they read the endpoint from the env qa-runner
+#     Tests are consumers; they read the endpoint from the env your CI
 #     injects, never start the service themselves.
 #   - testcontainers: tests spawn containers via the Testcontainers
 #     library (uses the docker socket act mounts into runner containers).
 #   - pure-fixture: tests hold the fixture directly.
-# qa-runner, act, and GitHub-hosted runners all execute the same rendered
-# file — services-class blocks come from plan-manager rendering the
+# Services-class blocks come from plan-manager rendering the
 # architecture's harness_profiles[]; testcontainers and pure-fixture stay
 # in the project test suite.
 on: [push, pull_request]

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -142,8 +142,9 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// verifies only that the architect's harness_profile_selections
 	// resolve in the catalog. Binding correctness (the test actually
 	// exercises the bound harness) is enforced by the LLM reviewer +
-	// qa-runner runtime — see ADR-041 Move 5 amendment for why the
-	// literal-substring sub-checks were retired.
+	// operator's CI runtime — see ADR-041 Move 5 amendment for why the
+	// literal-substring sub-checks were retired (qa-runner enforcement
+	// removed ADR-045).
 	// Loads selections from .semspec/plans/<slug>/plan.json on disk;
 	// greenfield projects (no architecture) trivially pass.
 	if len(filterTestFiles(trigger.FilesModified)) > 0 {
@@ -163,7 +164,7 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 			// checks were retired (goodhart-able); the simplified check
 			// just verifies the architect's selections resolve in the
 			// catalog. Binding correctness is enforced by LLM reviewer +
-			// qa-runner runtime.
+			// operator's CI runtime (ADR-045).
 			results = append(results, CheckHarnessProfileDiscipline(selections, catalog))
 		}
 	}

--- a/processor/structural-validator/stub_artifact_detector.go
+++ b/processor/structural-validator/stub_artifact_detector.go
@@ -42,9 +42,9 @@ const stubJarSizeThreshold = 2048
 //
 // Closes deferred item (c) from take-19 forensics. Item d-equivalent
 // (test-body mismatch / faked implementations) is now owned by the
-// LLM reviewer + qa-runner runtime after issue #113 retired the
+// LLM reviewer + operator's CI runtime after issue #113 retired the
 // literal-substring harness-discipline checks; see ADR-041 Move 5
-// amendment.
+// amendment (qa-runner integration-tier enforcement removed ADR-045).
 func CheckStubArtifacts(workDir string, filesModified []string) payloads.CheckResult {
 	jars := filterJarFiles(filesModified)
 	if len(jars) == 0 {

--- a/processor/structural-validator/testcontainers_discipline.go
+++ b/processor/structural-validator/testcontainers_discipline.go
@@ -26,9 +26,10 @@ import (
 //   - **LLM reviewer** — judges whether the test actually exercises the
 //     bound harness (catches "UDP probe facade is not real mavsdk_server
 //     lifecycle" — the smoke-9 reviewer's call).
-//   - **qa-runner runtime** — actually starts the bound service stack
+//   - **Operator's CI runtime** — actually starts the bound service stack
 //     and runs the @integration test against it. A test that just
 //     references the literal but doesn't open the service fails here.
+//     (qa-runner integration-tier enforcement removed — ADR-045)
 //
 // This check now does one thing: verify that the architect didn't name
 // a profile that doesn't exist in the catalog. That's a plan-time
@@ -38,7 +39,7 @@ import (
 // Future direction: see issue #113 for the path to AST-aware or
 // behavioral evidence (Option B / Option C). This commit ships
 // Option A — delete the literal checks; rely on LLM reviewer +
-// qa-runner runtime.
+// operator's CI runtime (ADR-045).
 func CheckHarnessProfileDiscipline(selections []workflow.HarnessProfileSelection, catalog *harnesscatalog.Catalog) payloads.CheckResult {
 	if len(selections) == 0 {
 		return passHarnessResult("no test environment profiles selected — nothing to enforce")
@@ -48,7 +49,7 @@ func CheckHarnessProfileDiscipline(selections []workflow.HarnessProfileSelection
 		return failHarnessResult(err.Error())
 	}
 	return passHarnessResult(fmt.Sprintf(
-		"required test environment profiles resolve in catalog: %d (binding correctness enforced by LLM reviewer + qa-runner runtime, not literal-grep — see issue #113)",
+		"required test environment profiles resolve in catalog: %d (binding correctness enforced by LLM reviewer + operator's CI runtime, not literal-grep — see issue #113; qa-runner integration-tier enforcement removed ADR-045)",
 		len(required)))
 }
 

--- a/processor/structural-validator/testcontainers_discipline_test.go
+++ b/processor/structural-validator/testcontainers_discipline_test.go
@@ -15,7 +15,8 @@ import (
 // retired (evidence-anchor presence, @integration binding string,
 // env-key consumption). What remains is "do the architect's
 // selections resolve in the catalog?" — a plan-time validity check.
-// Binding correctness is enforced by LLM reviewer + qa-runner runtime.
+// Binding correctness is enforced by LLM reviewer + operator's CI
+// runtime (qa-runner integration-tier enforcement removed ADR-045).
 
 func TestCheckHarnessProfileDiscipline_NoSelections(t *testing.T) {
 	catalog := mustCatalog(t)

--- a/test/e2e/scenarios/qa_cycle.go
+++ b/test/e2e/scenarios/qa_cycle.go
@@ -37,18 +37,12 @@ type QACycleScenario struct {
 	nats    *client.NATSClient
 	mockLLM *client.MockLLMClient
 
-	// qaLevel selects the executor path: "unit" routes to sandbox (go test),
-	// "integration" routes to qa-runner (act on .github/workflows/qa.yml).
+	// qaLevel is always "unit" — the only sandbox-executed QA level.
+	// Heavier tiers (integration, full) run in the operator's CI via the
+	// emitted qa.yml and have no in-process e2e scenario (ADR-045).
 	qaLevel string
 	// name is the scenario name; also the mock-llm fixture subdirectory.
 	name string
-	// customQAYAML, when non-empty, pre-seeds the workspace qa.yml during
-	// stageSetupWorkspace so the project-manager auto-scaffold leaves it
-	// untouched (EnsureQAWorkflow only writes when no file exists). Used by
-	// the qa-cycle-services variant to ship a services-enriched qa.yml that
-	// exercises act's sibling-container spawn via the mounted Docker socket
-	// (ADR-039 Phase 1b).
-	customQAYAML string
 }
 
 // NewQACycleScenario creates a new QA cycle scenario at qa_level=unit.
@@ -58,64 +52,9 @@ func NewQACycleScenario(cfg *config.Config) *QACycleScenario {
 }
 
 // NOTE: the qa-cycle-integration and qa-cycle-services scenarios were removed
-// with the qa-runner executor (BMAD realignment Phase 3). Integration/services
+// with the qa-runner executor (BMAD realignment / ADR-045). Integration/services
 // tiers now run in the operator's CI, not via a semspec executor, so there is
-// no in-process path for an e2e scenario to exercise. The remaining
-// customQAYAML / servicesEnrichedQAYAML plumbing below is dead and is swept in
-// Phase 4.
-
-// servicesEnrichedQAYAML is the Phase 1b proof workflow. It declares one
-// service (nginx:alpine, port 80) and probes its reachability before running
-// integration tests. If qa-runner's Docker socket mount or act's services
-// support is broken, the readiness probe fails and the workflow exits non-
-// zero — qa-runner reports QACompletedEvent.Passed=false and the scenario
-// fails in stageAssertQACompleted with diagnostic logs in the act archive.
-//
-// Why the `container:` block: nektos/act creates a per-job bridge network
-// for service containers but only attaches the JOB container to that
-// network when the job declares a `container:` block (see act
-// pkg/runner/run_context.go networkName()/jobContainer() — the
-// `containerImage(ctx) != ""` branch). Without it, the job falls back to
-// `network=host` and can't resolve service names by DNS. Empirically
-// validated 2026-05-28 during ADR-039 Phase 1b: omitting `container:` made
-// `wget --spider http://nginx-service:80` time out from inside the job.
-// This is a load-bearing finding for Phase 1c — the catalog renderer must
-// emit a `container:` block alongside any `services:` block.
-//
-// Phase 1c will replace this hand-authored yaml with output from
-// workflow/harnesscatalog/qarender; for now the literal yaml stays in scope.
-const servicesEnrichedQAYAML = `name: QA
-on: [push, pull_request]
-jobs:
-  integration:
-    runs-on: ubuntu-latest
-    container:
-      image: catthehacker/ubuntu:act-latest
-    services:
-      nginx-service:
-        image: nginx:alpine
-        ports:
-          - 80
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-          cache: false
-      - name: Wait for nginx-service sibling container
-        run: |
-          for i in $(seq 1 30); do
-            if wget -q --spider http://nginx-service:80; then
-              echo "[OK] nginx-service reachable on attempt $i"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "[FAIL] nginx-service unreachable after 30 attempts"
-          exit 1
-      - name: Integration tests
-        run: go test ./... -tags=integration -v
-`
+// no in-process path for an e2e scenario to exercise them.
 
 // Name implements Scenario.
 func (s *QACycleScenario) Name() string { return s.name }
@@ -167,15 +106,10 @@ func (s *QACycleScenario) Execute(ctx context.Context) (*Result, error) {
 		return time.Duration(normalSec) * time.Second
 	}
 
-	// qaBudget is the per-stage timeout for stages that wait on the executor
-	// (reviewing_qa / qa.completed assertions / complete). Integration runs go
-	// through act which pulls a ~1GB runner image on first invocation and
-	// spawns a test container — a couple orders of magnitude slower than the
-	// sandbox unit path.
+	// qaBudget is the per-stage timeout for stages that wait on the QA executor
+	// (reviewing_qa / qa.completed assertions / complete). Only unit is executed
+	// in-process via the sandbox; heavier tiers run in the operator's CI.
 	qaBudget := func(unitNormal, unitFast int) time.Duration {
-		if s.qaLevel == "integration" {
-			return t(600, 600)
-		}
 		return t(unitNormal, unitFast)
 	}
 
@@ -248,25 +182,6 @@ func (s *QACycleScenario) stageSetupWorkspace(_ context.Context, result *Result)
 		"cmd/server/main.go": "// Package main is the QA cycle project entry point.\npackage main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"QA cycle server\") }\n",
 		// Makefile satisfies structural-validator make-based checks.
 		"Makefile": "test:\n\tgo test ./...\n\nbuild:\n\tgo build ./...\n\nlint:\n\tgo vet ./...\n",
-	}
-
-	if s.qaLevel == "integration" {
-		// integration-tagged test so `go test ./... -tags=integration -v` finds
-		// at least one test and returns zero. Without the tag the default
-		// qa.yml integration job would report "no tests to run".
-		files["pkg/math/math_integration_test.go"] = "//go:build integration\n\npackage math\n\nimport \"testing\"\n\nfunc TestAddIntegration(t *testing.T) {\n\tif got := Add(10, 20); got != 30 {\n\t\tt.Errorf(\"Add(10, 20) = %d; want 30\", got)\n\t}\n}\n"
-		// qa.yml is auto-scaffolded by plan-manager.publishQARequestIfNeeded
-		// before the QARequestedEvent is published (project-manager.EnsureQAWorkflow
-		// templates a Go workflow because project.json's primary language is Go).
-		// The scenario relies on that auto-scaffold — pre-seeding here was the
-		// pre-2026-05-15 shape, removed to exercise the real wiring end-to-end.
-	}
-
-	// qa-cycle-services pre-seeds a services-enriched qa.yml so the auto-
-	// scaffold leaves it alone (EnsureQAWorkflow respects existing files).
-	// See servicesEnrichedQAYAML for the substrate-proof rationale.
-	if s.customQAYAML != "" {
-		files[".github/workflows/qa.yml"] = s.customQAYAML
 	}
 
 	for path, content := range files {
@@ -343,9 +258,9 @@ func (s *QACycleScenario) stageInitProject(ctx context.Context, result *Result) 
 // Stage: set-qa-level
 // ---------------------------------------------------------------------------
 
-// stageSetQALevel patches the project config to set the scenario's qa_level.
-// Plans created after this point snapshot the level and trigger the matching
-// executor (sandbox at unit, qa-runner at integration/full).
+// stageSetQALevel patches the project config to set qa_level=unit.
+// Plans created after this point snapshot the level and trigger the sandbox
+// executor at implementing convergence.
 func (s *QACycleScenario) stageSetQALevel(ctx context.Context, result *Result) error {
 	qaLevel := s.qaLevel
 	reqBody := map[string]*string{"qa_level": &qaLevel}

--- a/ui/docker-compose.e2e.yml
+++ b/ui/docker-compose.e2e.yml
@@ -8,13 +8,13 @@ services:
   # the parent semspec repo as drift.
   #
   # The intermediate WORKSPACE_HOST_PATH tmpdir is a host bind-mount (not a
-  # Docker named volume) for one specific reason: qa-runner spawns `act`
-  # sibling containers via the docker socket, and act --bind needs a HOST
-  # filesystem path that the docker daemon recognizes for sibling-container
-  # mounts. Named volumes have no usable host path on Docker Desktop. The
+  # Docker named volume) so that act (when invoked by the operator's CI or
+  # Testcontainers tests via the docker socket) can use a HOST filesystem
+  # path that the docker daemon recognizes for sibling-container mounts.
+  # Named volumes have no usable host path on Docker Desktop. The
   # bind-mount tmpdir gives us snapshot isolation (init container cp's
   # fixture → tmpdir, agents and project-manager write to tmpdir not
-  # fixture) AND a host path qa-runner / act can use.
+  # fixture) AND a host path act can use.
   #
   # `find -delete; cp -a` makes the snapshot deterministic per stack-up so
   # the fixture-as-snapshot invariant holds regardless of what agents (or
@@ -23,9 +23,9 @@ services:
     image: alpine:3.19
     # chown after cp so the sandbox user (uid SANDBOX_UID:1000 — runs git
     # ops in /workspace and trips git's "dubious ownership" guard otherwise)
-    # owns the snapshot. semspec + qa-runner run as root and can rw any
-    # uid via root's normal access; only the sandbox user needs to be the
-    # nominal owner for git to operate.
+    # owns the snapshot. semspec runs as root and can rw any uid via root's
+    # normal access; only the sandbox user needs to be the nominal owner
+    # for git to operate.
     command:
       - sh
       - -c

--- a/workflow/harnesscatalog/catalog.go
+++ b/workflow/harnesscatalog/catalog.go
@@ -31,8 +31,9 @@ const (
 )
 
 const (
-	// OrchestrationServices profiles declare an invariant integration stack the
-	// qa-runner renders into qa.yml services from images/ports/env/readiness.
+	// OrchestrationServices profiles declare an invariant integration stack that
+	// semspec renders into qa.yml services from images/ports/env/readiness for
+	// the operator's CI to bring up.
 	OrchestrationServices = "services"
 	// OrchestrationTestcontainers profiles need per-test or dynamic stack
 	// orchestration the dev agent expresses with testcontainers-go (or an
@@ -67,10 +68,11 @@ type Profile struct {
 	Env                map[string]string   `yaml:"env" json:"env,omitempty"`
 	Readiness          []string            `yaml:"readiness" json:"readiness,omitempty"`
 	TestGuidance       []string            `yaml:"test_guidance" json:"test_guidance,omitempty"`
-	// Orchestration declares how the qa-runner brings up this profile's
-	// integration stack. Empty defaults to OrchestrationServices when Images
-	// is non-empty and OrchestrationPureFixture otherwise; callers should read
-	// EffectiveOrchestration() rather than this raw field.
+	// Orchestration declares how the operator's CI (via the emitted qa.yml)
+	// brings up this profile's integration stack. Empty defaults to
+	// OrchestrationServices when Images is non-empty and OrchestrationPureFixture
+	// otherwise; callers should read EffectiveOrchestration() rather than this
+	// raw field.
 	Orchestration string `yaml:"orchestration" json:"orchestration,omitempty"`
 }
 

--- a/workflow/harnesscatalog/catalog/mavlink.yaml
+++ b/workflow/harnesscatalog/catalog/mavlink.yaml
@@ -30,7 +30,7 @@ profiles:
       - act
     cost: medium
     constraints:
-      - qa-runner brings up px4io/px4-sitl as a qa.yml service from this profile; tests connect to mavlink-udp at the rendered host port.
+      - The operator's CI brings up px4io/px4-sitl as a qa.yml service from this profile; tests connect to mavlink-udp at the rendered host port.
       - Tests must not start their own SITL container — the rendered service is authoritative for this profile.
       - Gate control assertions on MAVSDK health/connection state before issuing commands.
     required_assertions:
@@ -57,7 +57,7 @@ profiles:
       - Wait for MAVLink HEARTBEAT frames on UDP 14540.
       - Wait for MAVSDK connection state to become connected.
     test_guidance:
-      - Read the SITL endpoint from the env/host the qa-runner injects rather than hard-coding localhost or a fixed port.
+      - Read the SITL endpoint from the env/host the operator's CI injects rather than hard-coding localhost or a fixed port.
       - Record the profile ID near the integration test setup so structural validation can bind evidence to the catalog entry.
 
   - id: mavlink.ardupilot-sitl.compat
@@ -80,7 +80,7 @@ profiles:
       - act
     cost: medium
     constraints:
-      - qa-runner brings up ardupilot/ardupilot as a qa.yml service from this profile; tests connect to the rendered endpoint.
+      - The operator's CI brings up ardupilot/ardupilot as a qa.yml service from this profile; tests connect to the rendered endpoint.
       - Run as an optional compatibility suite unless the architecture explicitly depends on ArduPilot behavior.
     required_assertions:
       - Observe an ArduPilot MAVLink heartbeat.
@@ -127,7 +127,7 @@ profiles:
       - pure-unit-fixture
     cost: low
     constraints:
-      - qa-runner renders no services for this profile; the test fixture owns the MAVLink peer (captured frames or an in-process peer).
+      - No services are rendered in qa.yml for this profile; the test fixture owns the MAVLink peer (captured frames or an in-process peer).
       - If a test needs a live SITL peer for autopilot-state-dependent behavior, select a services-orchestrated profile instead of widening this one.
     required_assertions:
       - Decode HEARTBEAT from a real or captured MAVLink frame.
@@ -150,7 +150,7 @@ profiles:
     orchestration: services
     proves:
       - Peripheral-heavy plugins behave with simulator-backed camera/gimbal/sensor traffic.
-      - Higher-cost data streams can be exercised without changing qa-runner orchestration.
+      - Higher-cost data streams can be exercised without changing the qa.yml services orchestration.
     covers:
       integration_targets:
         - PX4 SITL
@@ -165,7 +165,7 @@ profiles:
       - dedicated-ci-runner
     cost: high
     constraints:
-      - qa-runner brings up px4io/px4-sitl with peripheral support as a qa.yml service from this profile.
+      - The operator's CI brings up px4io/px4-sitl with peripheral support as a qa.yml service from this profile.
       - Requires substantially more CPU/GPU and wall-clock than the default smoke profile.
       - Do not require this profile by default for ordinary MAVLink driver work.
     required_assertions:

--- a/workflow/harnesscatalog/qarender/qarender.go
+++ b/workflow/harnesscatalog/qarender/qarender.go
@@ -6,8 +6,9 @@
 // larger qa.yml document. The renderer reads catalog metadata only (no docker,
 // no plan state, no filesystem). Profiles whose Orchestration is anything other
 // than `services` are intentionally skipped — testcontainers and pure-fixture
-// profiles do not get qa-runner service blocks; their integration concerns live
+// profiles do not get services blocks in qa.yml; their integration concerns live
 // in agent test code (testcontainers) or in-process fixtures (pure-fixture).
+// The emitted qa.yml is consumed by the operator's CI, not by semspec itself.
 package qarender
 
 import (
@@ -102,7 +103,7 @@ func profileHeadComment(p harnesscatalog.Profile) string {
 	b.WriteString("Profile: ")
 	b.WriteString(strings.TrimSpace(p.ID))
 	if len(p.Readiness) > 0 {
-		b.WriteString("\nReadiness (operator must enforce in qa-runner; not emitted as docker healthcheck):")
+		b.WriteString("\nReadiness (operator's CI must enforce; not emitted as docker healthcheck):")
 		for _, r := range p.Readiness {
 			b.WriteString("\n  - ")
 			b.WriteString(strings.TrimSpace(r))

--- a/workflow/harnesscatalog/qarender/qarender_test.go
+++ b/workflow/harnesscatalog/qarender/qarender_test.go
@@ -55,7 +55,7 @@ func TestRenderServicesProfileWithoutPortOffset(t *testing.T) {
 		t.Fatalf("RenderYAML() error = %v", err)
 	}
 	const want = `# Profile: mavlink.px4-sitl.mavsdk-smoke
-# Readiness (operator must enforce in qa-runner; not emitted as docker healthcheck):
+# Readiness (operator's CI must enforce; not emitted as docker healthcheck):
 #   - Wait for MAVLink HEARTBEAT frames on UDP 14540.
 #   - Wait for MAVSDK connection state to become connected.
 mavlink-px4-sitl-mavsdk-smoke:

--- a/workflow/kv_helpers.go
+++ b/workflow/kv_helpers.go
@@ -32,9 +32,9 @@ func WaitForKVBucket(ctx context.Context, js jetstream.JetStream, bucket string)
 
 // WaitForStream retries looking up a JetStream stream until it exists or ctx
 // is cancelled. Use this before setting up a consumer on a stream owned by
-// another component (e.g., sandbox / qa-runner subscribing to WORKFLOW which
-// plan-manager creates). Same retry budget as WaitForKVBucket — ~30 attempts,
-// exponential backoff capped at 2s — so the caller blocks at most ~45s.
+// another component (e.g., sandbox subscribing to WORKFLOW which plan-manager
+// creates). Same retry budget as WaitForKVBucket — ~30 attempts, exponential
+// backoff capped at 2s — so the caller blocks at most ~45s.
 func WaitForStream(ctx context.Context, js jetstream.JetStream, name string) (jetstream.Stream, error) {
 	return retry.DoWithResult(ctx, retry.Config{
 		MaxAttempts:  30,

--- a/workflow/payloads/registry.go
+++ b/workflow/payloads/registry.go
@@ -72,8 +72,8 @@ func registerRequestPayloads(reg *payloadregistry.Registry) error {
 		{GitHubPRCreatedEventType, "GitHub PR created event", func() any { return &GitHubPRCreatedEvent{} }},
 		{GitHubPRFeedbackRequestType, "GitHub PR feedback request from review", func() any { return &GitHubPRFeedbackRequest{} }},
 		// QA phase payloads
-		{QARequestedType, "QA execution request dispatched to sandbox (unit) or qa-runner (integration/full)", func() any { return &QARequestedPayload{} }},
-		{QACompletedType, "QA execution result event published by sandbox or qa-runner", func() any { return &QACompletedPayload{} }},
+		{QARequestedType, "QA execution request dispatched to sandbox (unit); integration/full run in the operator's CI via the emitted qa.yml", func() any { return &QARequestedPayload{} }},
+		{QACompletedType, "QA execution result event published by the sandbox (unit) or operator's CI (integration/full)", func() any { return &QACompletedPayload{} }},
 		// Lesson decomposition (ADR-033 Phase 2+)
 		{LessonDecomposeRequestedType, "Reviewer rejection signalled to lesson-decomposer for evidence-cited lesson production", func() any { return &LessonDecomposeRequested{} }},
 		// Wedge recovery (ADR-037 stage 1)

--- a/workflow/subjects.go
+++ b/workflow/subjects.go
@@ -104,9 +104,10 @@ type UserSignalErrorEvent struct {
 }
 
 // QA phase events — target-project test execution gate between implementing
-// and complete. Executor is selected by Mode: sandbox for unit, qa-runner
-// (act-based) for integration and full. qa-reviewer is always the verdict
-// gate, consuming QACompletedEvent and emitting QAVerdictEvent.
+// and complete. The sandbox executes unit-level tests; heavier tiers
+// (integration, full) run in the operator's CI via the emitted qa.yml
+// (ADR-045). qa-reviewer is always the verdict gate, consuming
+// QACompletedEvent and emitting QAVerdictEvent.
 
 // QARequestedEvent is published by plan-manager when a unit-level plan enters
 // ready_for_qa, so the sandbox runs the project's test suite before
@@ -122,7 +123,7 @@ type QARequestedEvent struct {
 	TraceID        string  `json:"trace_id,omitempty"`
 }
 
-// QAFailure describes a single test or job failure surfaced by qa-runner.
+// QAFailure describes a single test or job failure surfaced by the QA executor.
 // qa-reviewer consumes these to produce targeted PlanDecisions.
 type QAFailure struct {
 	JobName    string `json:"job_name"`
@@ -140,10 +141,10 @@ type QAArtifactRef struct {
 	Purpose string `json:"purpose,omitempty"` // e.g., "playwright flow X failure"
 }
 
-// QACompletedEvent is published by the QA executor (sandbox for unit mode,
-// qa-runner for integration/full) after test execution. qa-reviewer consumes
-// it and produces a QAVerdictEvent. plan-manager does NOT consume this event
-// directly.
+// QACompletedEvent is published by the QA executor (sandbox for unit mode;
+// integration/full run in the operator's CI via the emitted qa.yml) after
+// test execution. qa-reviewer consumes it and produces a QAVerdictEvent.
+// plan-manager does NOT consume this event directly.
 type QACompletedEvent struct {
 	Slug        string          `json:"slug"`
 	PlanID      string          `json:"plan_id"`
@@ -229,9 +230,10 @@ var (
 	UserSignalError = natsclient.NewSubject[UserSignalErrorEvent](
 		"user.signal.error")
 
-	// QA phase events — qa-runner / sandbox publish QACompletedEvent; qa-reviewer
-	// delivers its verdict via request/reply mutation plan.mutation.qa.verdict
-	// (see processor/plan-manager/mutations.go) rather than a fire-and-forget event.
+	// QA phase events — the sandbox (unit) or operator's CI (integration/full)
+	// publishes QACompletedEvent; qa-reviewer delivers its verdict via
+	// request/reply mutation plan.mutation.qa.verdict (see
+	// processor/plan-manager/mutations.go) rather than a fire-and-forget event.
 	QARequested = natsclient.NewSubject[QARequestedEvent](
 		"workflow.events.qa.requested")
 	QACompleted = natsclient.NewSubject[QACompletedEvent](

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -48,14 +48,15 @@ const (
 	// StatusChanged indicates requirements were deprecated via a change proposal
 	// and the plan is awaiting partial requirement regeneration.
 	StatusChanged Status = "changed"
-	// StatusReadyForQA indicates the plan is waiting for the QA executor (sandbox at
-	// level=unit, qa-runner at level=integration or full) to run project tests.
-	// Entered at implementing convergence when qa.level ≥ unit; skipped for
-	// level=synthesis (which goes straight to reviewing_qa) and level=none.
+	// StatusReadyForQA indicates the plan is waiting for the sandbox to run
+	// project tests at level=unit. Entered at implementing convergence when
+	// qa.level=unit; skipped for level=synthesis (which goes straight to
+	// reviewing_qa) and level=none. Integration/full tiers run in the
+	// operator's CI via the emitted qa.yml and do not use this status.
 	StatusReadyForQA Status = "ready_for_qa"
 	// StatusReviewingQA indicates qa-reviewer is producing the release-readiness
 	// verdict. Entered for all non-"none" levels. Inputs vary by level:
-	// synthesis reads plan+impl only; unit/integration/full add test results.
+	// synthesis reads plan+impl only; unit adds sandbox test results.
 	StatusReviewingQA Status = "reviewing_qa"
 
 	// In-progress statuses — claimed by watchers via plan.mutation.claim before
@@ -329,8 +330,8 @@ func (s Status) CanTransitionTo(target Status) bool {
 		return target == StatusAwaitingReview ||
 			target == StatusComplete || target == StatusRejected
 	case StatusReadyForQA:
-		// ready_for_qa → reviewing_qa (qa-runner claims the plan)
-		// ready_for_qa → rejected (qa-runner cannot execute — missing workflow, infrastructure error)
+		// ready_for_qa → reviewing_qa (sandbox completes unit tests)
+		// ready_for_qa → rejected (sandbox cannot execute — infrastructure error)
 		return target == StatusReviewingQA || target == StatusRejected
 	case StatusReviewingQA:
 		// reviewing_qa → complete (QA passed, auto_approve_review=true, no GitHub)


### PR DESCRIPTION
## What

Janitorial sweep of stale references to the **removed** `qa-runner` act-executor and the removed `integration`/`full` qa_levels. Per **ADR-045**, the sandbox runs `unit` only; heavier tiers run in the **operator's CI** against the **retained** `.github/workflows/qa.yml` emitter; `qa_level` is `none/synthesis/unit`.

Surfaced by the QA-subsystem audit that produced #167 — the data-plane fix there is the substance; this is the follow-up doc/comment cleanup so the codebase stops describing qa-runner as a live executor.

## Changes (comment / doc / dead-code only — no behavior change)

- **Docs:** `README.md` service count (6 → 5) + QA routing paragraph; `docs/project-setup.md` `integration`/`full` rows now reflect operator-CI execution (values coerce to `synthesis` at runtime).
- **Code comments:** `workflow/{subjects,types,kv_helpers,payloads/registry}.go`, `workflow/harnesscatalog/{catalog.go,qarender/qarender.go,catalog/mavlink.yaml}`, `processor/project-manager/qa_workflow.go` + `processor/plan-manager/qa_workflow_render.go` (the retained qa.yml renderers), `processor/structural-validator/*` (comments + one message string), `processor/execution-manager/harness_prompt_seam_test.go`, `docker/compose/e2e.yml`, `ui/docker-compose.e2e.yml` — all "qa-runner executes/brings up/injects" → "the operator's CI".
- **Persona:** `configs/presets/bmad.json` Murat — "designs and **executes** integration/e2e" → "designs + gates; the operator's CI executes heavier tiers".
- **Dead code:** `test/e2e/scenarios/qa_cycle.go` — remove the `servicesEnrichedQAYAML` const, the `customQAYAML` field + usages, and the `integration`-only branches (`qa_level` is unit-only now; the file's own comment flagged this as the Phase-4 sweep). Scenario still runs at `unit`.

## Explicitly NOT touched
- `docs/adr/*` (ADR-039/041/043/045 legitimately discuss qa-runner as the old/superseded design), `docs/sponsor-packages/*` (run evidence), `docs/proposals/*`.
- Accurate "qa-runner was removed" notes.
- The qa.yml emitter itself (retained operator-CI contract).

## Testing
- `go build ./...`, `task lint` (vet/fmt/revive), and `go test` on all touched packages + `test/...` — **green, 21 packages, 0 failures**. Net −80 lines.

## Follow-up (left for review, not in this PR)
- `prompt/domain/software_render.go` has a `qa-runner` mention in LLM prompt content (a harness-profiles fragment). Left untouched here since it's prompt content, not a doc/comment — worth a separate look at whether it still frames qa-runner as the executor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)