### PR TITLE
feat(architecture): component = unit of execution + reviewer flags overloaded components

### DIFF
--- a/processor/plan-reviewer/architecture_rules.go
+++ b/processor/plan-reviewer/architecture_rules.go
@@ -24,6 +24,14 @@ import (
 //   - capability.unresolved_in_architecture: a Capability.Name from
 //     plan.Exploration whose name doesn't appear in any ComponentDef's
 //     Capabilities list. Winston didn't map this capability to a component.
+//   - architecture.component_overloaded_capabilities: ComponentDef mapping
+//     ≥2 capabilities but declaring fewer SOURCE (non-doc) implementation
+//     files than capabilities — it has no distinct implementation surface per
+//     capability, so one dev loop implements one and stubs the rest. The
+//     inverse of the missing-files / docs-only rules (an OVER-loaded
+//     component). The 2026-06-13 mavlink-hard MavsdkDriver fingerprint:
+//     caps [bootstrap, telemetry, control] mapped to 2 source files → dev
+//     built only Position+Takeoff, QA caught the gap.
 //
 // Skipped entirely when plan.Architecture is nil (legacy plans without
 // the architecture-generator phase have no components to check), when
@@ -43,6 +51,8 @@ func mergeArchitectureFindings(plan *workflow.Plan, result *workflow.PlanReviewR
 	original := len(result.Findings)
 	result.Findings = append(result.Findings,
 		architectureImplementationFileFindings(plan.Architecture.ComponentBoundaries)...)
+	result.Findings = append(result.Findings,
+		componentOverloadedCapabilityFindings(plan.Architecture.ComponentBoundaries)...)
 	result.Findings = append(result.Findings,
 		capabilityUnresolvedInArchitectureFindings(plan)...)
 
@@ -102,6 +112,55 @@ func architectureImplementationFileFindings(components []workflow.ComponentDef) 
 	return findings
 }
 
+// componentOverloadedCapabilityFindings flags a ComponentDef that claims more
+// independently-testable capabilities than it has SOURCE (non-doc)
+// implementation files — it has no distinct implementation surface per
+// capability, so a single developer loop will implement one capability and stub
+// the rest. This is the inverse of the missing-files / docs-only rules: those
+// catch a component with too LITTLE, this catches one asked to do too MUCH.
+//
+// Heuristic: a component mapping N capabilities needs at least N source files
+// (one surface per capability). Fewer source files than capabilities means the
+// architect collapsed distinct behavior surfaces behind a facade. The
+// 2026-06-13 mavlink-hard MavsdkDriver fingerprint: capabilities
+// [mavsdk-bootstrap, mavsdk-telemetry, mavsdk-control] mapped to two source
+// files (UnmannedSystem.java + UnmannedConfig.java) → the dev built only
+// Position telemetry + Takeoff and stubbed the rest; QA (Murat) caught it but
+// only after a full execution + assembly. This rule catches it at plan review.
+//
+// Single-capability components are never flagged (the common, healthy shape).
+func componentOverloadedCapabilityFindings(components []workflow.ComponentDef) []workflow.PlanReviewFinding {
+	var findings []workflow.PlanReviewFinding
+	for _, c := range components {
+		if c.Name == "" {
+			continue
+		}
+		capCount := len(c.Capabilities)
+		if capCount < 2 {
+			continue
+		}
+		src := sourceFileCount(c.ImplementationFiles)
+		if src >= capCount {
+			continue
+		}
+		findings = append(findings, workflow.PlanReviewFinding{
+			SOPID:       "architecture.component_overloaded_capabilities",
+			SOPTitle:    "Component maps more capabilities than it has implementation surfaces (ADR-044)",
+			Severity:    "error",
+			Status:      "violation",
+			Category:    "structural",
+			Phase:       "architecture",
+			TargetID:    c.Name,
+			Action:      "split",
+			TargetField: fmt.Sprintf("component_boundaries.%s", c.Name),
+			TargetValue: "one component per independently-testable capability (or ≥1 source file per capability)",
+			Issue:       fmt.Sprintf("Component %q maps %d capabilities (%v) but declares only %d source implementation file(s) — it has no distinct implementation surface per capability, so a single dev loop will build one and stub the rest.", c.Name, capCount, c.Capabilities, src),
+			Suggestion:  fmt.Sprintf("Split component %q into one component per independently-testable capability, each with its own implementation_files. If the capabilities genuinely share one implementation surface, add a distinct source file per capability so the mapping is honest.", c.Name),
+		})
+	}
+	return findings
+}
+
 // capabilityUnresolvedInArchitectureFindings emits one finding per Capability
 // declared by Mary's analyst sub-phase that has no implementing component.
 // The architect-side mirror of capability.orphan (which flags capabilities
@@ -151,13 +210,20 @@ func capabilityUnresolvedInArchitectureFindings(plan *workflow.Plan) []workflow.
 // downstream phases while the reviewer-side rule rejected it (or vice
 // versa). Both sides delegate to workflow.IsDocumentationPath.
 func hasSourceFile(paths []string) bool {
-	if len(paths) == 0 {
-		return false
-	}
+	return sourceFileCount(paths) > 0
+}
+
+// sourceFileCount returns the number of source-code (non-documentation) files
+// in the given workspace-relative paths, delegating to the same
+// workflow.IsDocumentationPath classifier as hasSourceFile. Used by
+// componentOverloadedCapabilityFindings to compare a component's source-surface
+// count against the number of capabilities it claims.
+func sourceFileCount(paths []string) int {
+	n := 0
 	for _, p := range paths {
 		if !workflow.IsDocumentationPath(p) {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
 }

--- a/processor/plan-reviewer/architecture_rules_test.go
+++ b/processor/plan-reviewer/architecture_rules_test.go
@@ -204,6 +204,89 @@ func TestMergeArchitectureFindings_HappyPath(t *testing.T) {
 	}
 }
 
+// TestMergeArchitectureFindings_OverloadedComponent fires
+// architecture.component_overloaded_capabilities on the 2026-06-13 mavlink-hard
+// MavsdkDriver shape: three independently-testable capabilities collapsed onto
+// one component backed by two source files (+ two doc files). A single dev loop
+// built only one capability's surface and stubbed the rest; this rule catches
+// the collapse at plan review instead of at the QA gate.
+func TestMergeArchitectureFindings_OverloadedComponent(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "mavsdk-overloaded",
+		Exploration: &workflow.Exploration{Capabilities: []workflow.Capability{
+			{Name: "mavsdk-bootstrap", Lifecycle: workflow.CapabilityNew, Description: "B."},
+			{Name: "mavsdk-telemetry", Lifecycle: workflow.CapabilityNew, Description: "T."},
+			{Name: "mavsdk-control", Lifecycle: workflow.CapabilityNew, Description: "C."},
+		}},
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{
+					Name:                "MavsdkDriver",
+					Capabilities:        []string{"mavsdk-bootstrap", "mavsdk-telemetry", "mavsdk-control"},
+					ImplementationFiles: []string{"src/UnmannedSystem.java", "src/UnmannedConfig.java", "README.md", "CoverageMatrix.md"},
+				},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	var f *workflow.PlanReviewFinding
+	for i := range result.Findings {
+		if result.Findings[i].SOPID == "architecture.component_overloaded_capabilities" {
+			f = &result.Findings[i]
+		}
+	}
+	if f == nil {
+		t.Fatalf("expected component_overloaded_capabilities finding, got: %+v", result.Findings)
+	}
+	if f.TargetID != "MavsdkDriver" {
+		t.Errorf("target = %q, want MavsdkDriver", f.TargetID)
+	}
+	if !strings.Contains(f.Issue, "3 capabilities") || !strings.Contains(f.Issue, "2 source") {
+		t.Errorf("issue should name 3 capabilities / 2 source files: %q", f.Issue)
+	}
+	if result.Verdict != "needs_changes" {
+		t.Errorf("verdict = %q, want needs_changes", result.Verdict)
+	}
+}
+
+// TestMergeArchitectureFindings_CohesiveComponentNotFlagged confirms the rule
+// does NOT fire when a multi-capability component declares one source file per
+// capability — the honest exceptional shape (real shared module, distinct
+// surface per capability).
+func TestMergeArchitectureFindings_CohesiveComponentNotFlagged(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "cohesive-ok",
+		Exploration: &workflow.Exploration{Capabilities: []workflow.Capability{
+			{Name: "auth", Lifecycle: workflow.CapabilityNew, Description: "A."},
+			{Name: "session", Lifecycle: workflow.CapabilityNew, Description: "S."},
+		}},
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{
+					Name:                "identity",
+					Capabilities:        []string{"auth", "session"},
+					ImplementationFiles: []string{"src/auth.go", "src/session.go", "README.md"},
+				},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	for _, f := range result.Findings {
+		if f.SOPID == "architecture.component_overloaded_capabilities" {
+			t.Errorf("2 caps + 2 source files should not fire overloaded rule, got: %+v", f)
+		}
+	}
+	if result.Verdict != "approved" {
+		t.Errorf("verdict = %q, want approved (no findings)", result.Verdict)
+	}
+}
+
 // TestHasSourceFile_DelegatesToWorkflowClassifier guards the
 // reviewer-side ↔ architecture-generator-side classification parity. If
 // workflow.IsDocumentationPath ever drifts from this rule's expectations,

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -794,7 +794,7 @@ Below is the architecture you produced last round. Start from it and make the MI
 - Focus on structure and boundaries, not implementation details
 - Justify every decision with a rationale
 - Flag architectural risks or trade-offs
-- Component boundaries should reflect natural module/service divisions in the codebase
+- Component boundaries are the planning system's UNIT OF EXECUTION — each component is built and verified by ONE developer loop / ONE story, not just a runtime or deployment module. Default to ONE independently-testable capability per component. Map multiple capabilities onto one component ONLY when the same classes genuinely implement them — never when a facade/config class fronts several distinct behavior surfaces. When capabilities have independent behavior (separate plugins, streams, command handlers, protocols), give each its own component with its own implementation_files
 
 ## Deliverable Structure
 
@@ -811,7 +811,7 @@ Below is the architecture you produced last round. Start from it and make the MI
 **Optional fields** — human documentation in plan.md; only include when they add real value:
 
 - **technology_choices**: array of {category, choice, rationale} — when introducing or formally endorsing a stack choice. Skip when reusing whatever the project already has.
-- **component_boundaries**: array of {name, responsibility, dependencies[], implementation_files[], capability_indices[]} — every component maps to capabilities via capability_indices (0-based indices into the Capabilities list above), NOT re-typed names. Every analyst capability must appear in at least one component's capability_indices.
+- **component_boundaries**: array of {name, responsibility, dependencies[], implementation_files[], capability_indices[]} — every component maps to capabilities via capability_indices (0-based indices into the Capabilities list above), NOT re-typed names. Every analyst capability must appear in at least one component's capability_indices. GRANULARITY: prefer one capability per component. A component that maps N capabilities MUST declare at least one distinct, substantive implementation_file per capability (a real source file — not README/CoverageMatrix/a single *Config facade). You cannot implement N independently-testable capabilities from one class; if you cannot name a distinct implementation surface for each capability, split the component.
 - **data_flow**: string — when data movement between components is non-obvious. Skip for trivial flows.
 - **decisions**: array of {id, title, decision, rationale} — architecture decision records (use IDs like ARCH-001) for trade-offs future contributors will want to understand. Skip for routine choices.
 


### PR DESCRIPTION
## Why
A gemini `mavlink-hard` run (2026-06-13) reached the QA gate but got `needs_changes` — the implementation built only **Position telemetry + Takeoff** instead of the required plugin suite. Root cause traced to the **architect under-decomposing**: component `MavsdkDriver` mapped three independently-testable capabilities (`mavsdk-bootstrap` + `mavsdk-telemetry` + `mavsdk-control`) onto one component backed by two source files (`UnmannedSystem.java`, `UnmannedConfig.java`).

The downstream collapse was all *correct obedience* to that boundary: Sarah emits one story per component → reqs 2/3 become M:N non-owners and skip → Bob's scenarios scope to the two facade files and come out shallow → one dev loop builds one capability and stubs the rest. **QA was the only gate that caught it**, after a full execution + assembly.

## Changes
1. **Architect contract** (`prompt/domain/software_render.go`) — reframe component boundaries as the planning system's **unit of execution** (one dev loop / one story), default to one independently-testable capability per component, and require a distinct substantive `implementation_file` per capability when a component maps several. No facade/config class fronting N behaviors.
2. **Reviewer backstop** (`processor/plan-reviewer/architecture_rules.go`) — new rule `architecture.component_overloaded_capabilities`: a component mapping ≥2 capabilities with fewer **source (non-doc)** implementation files than capabilities has no distinct surface per capability. The inverse of the existing missing-files / docs-only rules; reuses `workflow.IsDocumentationPath` for classification parity. Single-capability components never fire.

## Tests
- `MavsdkDriver` shape (3 caps / 2 source files + 2 docs) → fires, verdict `needs_changes`
- cohesive 2-cap / 2-source-file component → does **not** fire
- existing happy-path (1 cap per component) stays clean
- `go build`, `go vet`, `revive`, full `plan-reviewer` + `prompt` suites green

## Notes
- Heuristic is "≥1 source file per claimed capability." Drafted as `error` to match sibling structural rules; can dial to a completeness/warning finding if it proves too aggressive in practice.
- This is the **content-quality** lever. The companion PR fixes a separate plumbing wedge in the QA-recovery re-execution path found in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)