### PR TITLE
fix(requirement-executor): surface dropped terminal task completions (QA-recovery wedge)

### DIFF
--- a/processor/requirement-executor/req_completions.go
+++ b/processor/requirement-executor/req_completions.go
@@ -174,6 +174,17 @@ func (c *Component) handleTaskStateChange(ctx context.Context, entry jetstream.K
 
 	exec := c.findExecByTaskID(taskExec.TaskID)
 	if exec == nil {
+		// A terminal task completion that matches no active execution's current
+		// node or reviewer task. Benign + common for nodes whose execution
+		// already completed and was cleaned from activeExecs — but it is ALSO
+		// the silent-drop shape that wedged the 2026-06-13 QA-recovery
+		// re-execution (a re-dispatched node completed, but routing back into
+		// the re-opened DAG found no owner, so the completion vanished and the
+		// requirement never advanced to re-QA — a permanent, invisible wedge).
+		// Log at DEBUG so the gate is visible on a debug run without flooding
+		// the normal path.
+		c.logger.Debug("terminal task completion matched no active execution — dropping",
+			"task_id", taskExec.TaskID, "stage", taskExec.Stage)
 		return
 	}
 
@@ -181,11 +192,23 @@ func (c *Component) handleTaskStateChange(ctx context.Context, entry jetstream.K
 	defer exec.mu.Unlock()
 
 	if exec.terminated {
+		c.logger.Debug("terminal task completion for terminated execution — dropping",
+			"task_id", taskExec.TaskID, "stage", taskExec.Stage,
+			"requirement_id", exec.RequirementID)
 		return
 	}
 
-	// Only handle node completions via this path.
+	// Only handle node completions via this path. A non-current-node task that
+	// still matched findExecByTaskID is the reviewer task (handled elsewhere) —
+	// or a stale node task left behind by a re-dispatch whose CurrentNodeTaskID
+	// did not get re-aligned (the QA-recovery-wedge suspect). Surface both at
+	// DEBUG so the mismatch is diagnosable instead of silent.
 	if taskExec.TaskID != exec.CurrentNodeTaskID {
+		c.logger.Debug("terminal task completion is not the current node task — dropping",
+			"task_id", taskExec.TaskID,
+			"current_node_task_id", exec.CurrentNodeTaskID,
+			"reviewer_task_id", exec.ReviewerTaskID,
+			"requirement_id", exec.RequirementID, "stage", taskExec.Stage)
 		return
 	}
 


### PR DESCRIPTION
## What happened
A gemini `mavlink-hard` run (2026-06-13) **wedged permanently and silently** during QA-recovery re-execution. The recovery worked — it re-opened the owner M:N story, re-decomposed, and re-ran node 0 (dev+review approved, 11 files merged, *broader* than the first pass). But the node's terminal completion **never routed back into the re-opened DAG**: the requirement never advanced to re-QA. 14 minutes of total silence, no error, **no watchdog** (there is no per-node watchdog — `awaiting_recovery.go:203` notes it as a future PR), so it never self-healed.

## Root
`handleTaskStateChange` (`req_completions.go`) drops a terminal completion at one of three gates — no owning exec (`:176`), exec terminated (`:183`), or `TaskID != CurrentNodeTaskID` (`:188`) — and **all three `return` silently**. A dropped node-completion is therefore an invisible permanent wedge. That silence is exactly what cost 14 minutes of blind diagnosis.

## This change
Adds **DEBUG logging at all three gates** (`task_id`, `stage`, and for the mismatch gate the current-node + reviewer task IDs). Debug runs are now usable (semstreams beta.107 summarizes payloads instead of dumping them), so the next QA-recovery run pins the exact gate + task-id mismatch.

## Scope (honest)
This is the **observability half**. The routing root-cause is **not** fixed here — static analysis shows every precondition for correct routing is met:
- recovery resume dispatches via the normal `dispatchSynthesizerLocked` path that sets `CurrentNodeTaskID` (`component.go:1435`)
- the exec is re-added to `activeExecs` (`awaiting_recovery.go:510`)
- `terminated` is reset (`awaiting_recovery.go:172`)

So the drop is a **race or a missed KV write** that needs this logging + a repro to confirm rather than a speculative fix. Follow-ups: (1) pin + fix the routing once the logging captures the gate; (2) a per-node stuck-execution **watchdog** to convert any future dropped-completion wedge into a timeout-retry instead of a permanent wedge.

Behavior-preserving (logging only); full `requirement-executor` suite, `go vet`, `revive` green. Forensics: `/tmp/qa-recovery-wedge-20260613/WEDGE_ANALYSIS.md`.

Companion to #172 (the architect/content-quality fix from the same run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)