### PR TITLE
feat(dev-loop): source_build contract-completeness gate (ADR-047) + cold-build iteration efficiency

### DIFF
--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -110,6 +110,19 @@ USER sandbox
 ENV HOME=/home/sandbox
 RUN git config --global user.email "sandbox@semspec.dev" \
     && git config --global user.name "Semspec Sandbox"
+# Gradle iteration speed (cold-build lever, 2026-06-13). A user-global build
+# cache + warm daemon so repeated dev/validator test runs reuse compiled task
+# outputs across per-task worktrees instead of recompiling unchanged upstream
+# modules (e.g. osh-core) on every cycle. GRADLE_USER_HOME defaults to
+# ~/.gradle, shared across worktrees, so the cache at
+# ~/.gradle/caches/build-cache-1 persists for the container's life. Crucially
+# org.gradle.caching helps EVEN when a build is invoked with --no-daemon (the
+# cache is independent of the daemon), which is the dominant recompilation cost
+# on large source_build projects. daemon/parallel only take effect when the
+# agent does not force --no-daemon (the developer prompt steers it that way).
+RUN mkdir -p "$HOME/.gradle" \
+    && printf 'org.gradle.caching=true\norg.gradle.daemon=true\norg.gradle.parallel=true\n' \
+       > "$HOME/.gradle/gradle.properties"
 WORKDIR /workspace
 EXPOSE 8090
 

--- a/docs/adr/ADR-047-upstream-interface-contract-completeness.md
+++ b/docs/adr/ADR-047-upstream-interface-contract-completeness.md
@@ -1,0 +1,282 @@
+# ADR-047: Upstream Interface-Contract Completeness (Method-Signature Resolution for source_build Deps)
+
+**Status:** Proposed (2026-06-13)
+**Deciders:** Coby, Claude
+**Related:** ADR-046 (dedicated dependency-resolver phase — this ADR is the *completeness* half of
+the same problem and frames where resolution should live), ADR-044 (M:N capability ↔ Story; sibling
+`architecture.component_overloaded_capabilities` rule lives in the same reviewer file), ADR-043
+(architect emits implementation files), ADR-037 (wedge recovery — the dev thrash this ADR prevents
+is the kind of recoverable-but-expensive wedge recovery exists to catch *after* the fact), ADR-035
+(strict-parse — the completeness gate is a strict, deterministic check, not a soft prompt nudge).
+**Drives:** a plan-time completeness gate (plan-reviewer rule and/or architect self-check), a scoped
+`/sources/` grant to whichever loop resolves contracts, and a decision on *where* method-contract
+resolution runs (extend the architect vs a dedicated resolution step).
+
+## Context
+
+### The thrash (verified live, 2026-06-13)
+
+In a `gemini` `WITH_EPIC` `mavlink-hard` run, the developer loop burned roughly 3.5M tokens on
+`gemini-pro` reverse-engineering OpenSensorHub's `ICommandStatus` interface contract through
+*compile errors* — even though the upstream source file was mounted at `/sources/` and the dev was
+reading it. The dev discovered, one failed compile at a time, that `getProgress()` returns `int` not
+`float`, that `getExecutionTime()` returns `TimeExtent` not `Instant`, and so on for each method a
+subclass must implement.
+
+The reactive feedback loop is *good*: the compile error reaches the model and the model acts on it.
+The gap is **proactive** — nobody handed the dev the exact method contracts up front, so the dev
+rediscovers them by trial-and-error against the compiler. Each rediscovery is a full TDD sub-cycle:
+write code → compile → read the error → re-read source → adjust. That is the most expensive possible
+way to learn a method signature, and it is learning a fact the upstream source states plainly.
+
+This is the same failure family the codebase already documents at the symbol level: take-23
+(2026-05-13) wedged at `iter=80` with 35 external file reads and 0 worktree writes because the
+architect named OSH classes without resolving their constructor + lifecycle; the 2026-06-07 mavsdk
+run burned 3.4M tokens running `javap` to find `io.mavsdk.System` because only the bare symbol
+`System` was resolved. We hardened *imports* for that case (`ValidateUpstreamImports`,
+`workflow/plan_story.go:541`). The `ICommandStatus` thrash is the next layer up: the import is
+correct, the *method contracts of the resolved type* are missing.
+
+### The maven_central vs source_build split
+
+The split is structural, by `resolution_kind` (`workflow/upstream_resolution.go`):
+
+- **`maven_central`** deps are resolved *completely*. The architect has a published jar; the prompt
+  directs it to `jar tf` / `unzip` / `javap` the artifact (`prompt/domain/software.go`), and the
+  system re-verifies the coordinate against Maven Central (`numFound>0`). The dev gets paste-ready
+  imports and signatures.
+
+- **`source_build`** deps (OSH and friends — no published jar) get only the *class declaration* plus
+  a lifecycle string. The architect names the class, satisfies `ValidateUpstreamImports` with one
+  valid import, and stops — there is no gate forcing it to enumerate the *methods a subclass must
+  implement*. The dev then thrashes on exactly those unresolved methods.
+
+`ValidateUpstreamImports` (`workflow/plan_story.go`) confirms this is the gap: it iterates the
+code-symbol import kinds and rejects any *named* surface whose `Import` is missing or bare. It does
+not check whether the *set* of named surfaces is complete for a class a subclass must extend. A
+`source_build` class with one valid import and zero method surfaces passes today.
+
+## "Mechanism exists" finding (this is population/completeness, not new plumbing)
+
+The schema and the entire injection-to-dev pipeline already carry method-level contracts end to end.
+Verified against current code (2026-06-13):
+
+- **Schema.** `workflow/types.go` `UpstreamResolution` with `ResolutionKind` and `APIs []APISurface`;
+  `APISurface` carries `Signature`, `Lifecycle`, `Import`, `Notes`, and a required `Citation`. The
+  architect can *already* emit per-class constructors, methods, and lifecycle. The schema-wiring bug
+  ADR-046 flagged was fixed (#136; `TestArchitectureSchemaStructParity` is the standing drift guard).
+
+- **Injection.** The pipeline that lands these in the dev's prompt is live and tested three ways:
+  `processor/execution-manager/component.go` sets `TaskContext.UpstreamResolutions` via
+  `prompt.ProjectUpstreams(...)`; `prompt/architecture_project.go` copies `Signature` and `Lifecycle`
+  into `UpstreamResolutionInfo`; fragment `software.task-upstream-resolutions`
+  (`prompt/domain/software.go`) calls `FormatUpstreamResolutions` → `writeUpstreamsBody`
+  (`prompt/architecture.go`), which emits `Import`, `Signature`, `Lifecycle`, and `Notes` *verbatim*;
+  covered by `prompt/domain/task_upstream_resolutions_test.go`.
+
+So a `source_build` class whose `APIs[]` *did* enumerate `getProgress() -> int`,
+`getExecutionTime() -> TimeExtent`, etc., would already reach the dev verbatim, before the first
+compile. **No new dev-prompt plumbing is needed.** The fix is to *populate* those fields and to
+*gate* on their completeness. This ADR is about completeness, not pipes.
+
+## The completeness gate (never built)
+
+The plan-reviewer (and/or an architect self-check at parse time) MUST reject a plan where a
+`source_build` class named as a component dependency lacks the subclass-required method signatures.
+Concretely, for every `UpstreamResolution` with `ResolutionKind == "source_build"` whose `APIs[]`
+names a `class` or `interface` the project *extends or implements*, the resolution must also carry,
+as paired `APISurface` entries:
+
+1. The **constructor(s)** a subclass must call (`Signature` populated).
+2. The **abstract / interface methods** a subclass must implement — each with a full `Signature`
+   (parameters + return type), not just a name.
+3. The **referenced config / parameter types** those signatures mention (e.g. `SensorConfig`,
+   `TimeExtent`) named as their own surfaces, so the dev does not have to chase a second
+   undocumented type.
+
+This is the inverse of `ValidateUpstreamImports`: that gate checks each *named* surface is
+*qualified*; this gate checks the *set* of named surfaces is *complete* for an extension point. It
+mirrors the existing sibling rule `architecture.component_overloaded_capabilities`
+(`processor/plan-reviewer/architecture_rules.go`, PR #172): a deterministic structural backstop that
+fires at plan review, surfaces one `PlanReviewFinding` per offending dependency with a concrete
+remediation, and calls `result.NormalizeVerdict()` so `approved` → `needs_changes`.
+
+Implementation shape (matching the existing rule style in `architecture_rules.go`):
+
+- New rule id `architecture.upstream_source_build_incomplete_contract`, `Severity: "error"`,
+  `Status: "violation"`, `Category: "structural"`, `Phase: "architecture"`,
+  `TargetID: <UpstreamResolution.Name>`, `Action: "add"`,
+  `TargetField: upstream_resolutions.<name>.apis`, with an `Issue` naming the class and the missing
+  contract members and a `Suggestion` pointing at the `/sources/` path to read.
+- Append it alongside `componentOverloadedCapabilityFindings` in `mergeArchitectureFindings`,
+  reusing the same skip-when-nil-architecture guards.
+
+### Goodhart-safe success measure (carry verbatim in spirit)
+
+Measure **structural completeness, not output size.** The metric is: *every `source_build` class or
+interface named as an extension point has a paired, signature-bearing `APISurface` for each
+constructor and abstract/interface method a subclass must implement, plus every config/parameter
+type those signatures reference.* Do **not** measure resolution length, API count, signature string
+length, LOC, or file count — models pad to length metrics. A class with three required methods needs
+exactly three method surfaces; ten padded ones are not "more complete," and one is incomplete.
+
+**Punish false claims of completeness, not honest incompleteness.** A resolution honestly marked
+`ResolutionKind: "unresolved"` is a reviewable gap, not a gate violation (the existing prompt already
+treats `unresolved` as a first-class honest flag — `prompt/domain/software.go`, `workflow/types.go`).
+The gate fires only when a `source_build` class is *claimed resolved* (it has at least one named
+surface and is used as an extension point) but its contract is *partial*. The Goodhart risk — a
+fabricated signature — is caught downstream when the dev's code fails to compile, a far cheaper
+failure than the 3.5M-token discovery loop. This is the same cost trade `ValidateUpstreamImports`
+already makes.
+
+**Fail fast and cheap at the architect / plan-reviewer, not slow at the dev.** The whole point is to
+move the discovery from `gemini-pro` compile-error iteration (expensive, per-method, mid-execution)
+to a plan-time read of the same source file (one pass, before any dev loop dispatches). The gate is
+the forcing function that relocates the work to where it is cheap.
+
+## Giving the resolver `/sources/` access
+
+The architect already routes `bash` through the sandbox: there is a single global bash executor
+(`tools/register.go`, `bash.NewExecutor(repoRoot, os.Getenv("SANDBOX_URL"), ...)`), and the
+architect's toolset includes `bash` and `http_request`
+(`processor/architecture-generator/component.go` `availableToolNames`). Under `WITH_EPIC`, the
+sandbox container mounts the pre-cloned upstream trees read-only at `/sources/`
+(`docker/compose/e2e-epic.yml:96`, `semsource-clones:/sources:ro`). The architect prompt already
+*instructs* reading them: `bash('ls /sources/ 2>/dev/null')`, read `pom.xml`, read raw source, run
+`javap`/`unzip`/source-tree reads (`prompt/domain/software.go`).
+
+So the access exists today **when `SANDBOX_URL` is set and `WITH_EPIC` is on** (in a non-epic run
+`/sources/` is not mounted at all — but then no actor can resolve a `source_build` dep, which is a
+separate fixture/config concern). The gap is not raw access; it is **completeness of use** — the
+architect reads `/sources/` enough to name the class and get the import, then runs out of
+budget/attention before enumerating every method (the ADR-046 plateau finding: it cannot fit N-deps ×
+M-symbols of mechanical extraction alongside its design job in one budget). Two follow-on notes:
+
+- `WITH_EPIC` also runs ast/docs indexing into the graph (~10K entities) that the agents do not query
+  (they read `/sources/` directly) — wasteful and a graph-flood confounder. A **stripped mount**
+  (clone `/sources/` for bash reads, skip the ast/docs indexing) was proposed separately and should
+  land regardless of A-vs-B; it makes the access cheap without the indexing tax.
+- Whatever loop owns contract resolution needs `/sources/` in scope as a *first-class, scoped* tool
+  grant, not an incidental side effect of the global bash sandbox. Today it is the latter.
+
+## Decision point (OPEN — both framed, one recommended, left to the human)
+
+**Where does detailed API-surface / method-contract resolution happen?**
+
+### Option A — extend the existing architect
+
+One loop does component boundaries *and* resolves every named `source_build` class's full method
+contract from `/sources/`.
+
+- **Pro:** simplest wiring — the schema, injection, and `/sources/` access are all already on the
+  architect's side; this ADR becomes "tighten the prompt + add the completeness gate," no pipeline
+  stage.
+- **Con:** overloads one mid-tier-model loop (decide boundaries + read all of `/sources/` + extract
+  every method signature) — the exact budget/attention competition ADR-046 documented as a *stable
+  plateau* on hard fixtures, not a tuning problem. The completeness gate would then reject the
+  architect repeatedly without the budget to satisfy it — recreating the unwinnable-loop shape that
+  motivated ADR-046.
+
+### Option B — a dedicated plan-phase API-surface-resolution step
+
+A focused step runs **after** the architect sets component boundaries and names its `source_build`
+dependencies, with scoped `/sources/` access, and *populates* the existing
+`UpstreamResolution.APIs[].Signature/Lifecycle` fields. This is exactly the resolver phase ADR-046
+specifies (architect emits `dependency_requests` / names symbols → resolver produces verified
+`UpstreamResolution` with its own budget). This ADR is the *completeness contract* that step must
+satisfy for `source_build` deps.
+
+- **Pro:** tractable per loop (one focused job, its own iteration budget), focused tool scope
+  (`/sources/` + bash, nothing design-y), and the completeness gate becomes the step's *done-criteria*
+  rather than an architect-rejection — the ADR-046 framing where campaign gates become loop-exit
+  contracts.
+- **Con:** adds a pipeline stage with a durable handoff (ADR-046 "Placement & durable handoff":
+  intermediate `architecture_drafted` status, per-step retry keys, restart/replay survival). More
+  moving parts than A.
+- **Critically, this is plan-time, NOT dev-time.** It does **not** reincur the shelved `research()`
+  objection (see Out of Scope), which was specifically about *dev-time* handoff latency blocking a
+  blocked dev loop. A plan-phase step runs once, before any dev dispatches, on its own budget — there
+  is no dev loop waiting on it.
+
+### Recommendation
+
+**Option B, as the `source_build`-completeness contract on ADR-046's resolver step** — but ship the
+completeness *gate* (the plan-reviewer rule) and the *stripped `/sources/` mount* first, because they
+are valuable under either option and independently testable offline. Rationale: the `ICommandStatus`
+thrash is the *exact* "N-symbols of mechanical source extraction starves the design loop" failure
+ADR-046 was written for; folding contract completeness into the architect (Option A) walks back into
+that plateau. The gate is the forcing function; the resolver step is the loop with the budget to
+satisfy it. Until the resolver step lands, the gate plus the tightened architect prompt is the
+interim (Option-A-shaped) stopgap — fail-fast at plan review beats a 3.5M-token dev thrash even if the
+architect occasionally bounces on it.
+
+This decision is **left open for the human**: the 2026-06-13 run is the re-test ADR-046 was gated on
+(post-#136 schema fix + #172 granularity fix). It showed the architect now decomposes correctly and
+*has* `/sources/` access, yet still did not resolve the `source_build` method contracts — but with no
+completeness gate in place, we cannot yet distinguish "architect can't (→ Option B)" from "architect
+was never forced to (→ Option A may suffice)." Ship the gate, re-run, and let that evidence decide:
+if the architect converges on `source_build` contracts inline once the gate forces it, Option A is
+enough and ADR-046's resolver stays deferred; if it plateaus on resolution depth, Option B is
+justified and this ADR's completeness contract becomes the resolver's `source_build` done-criterion.
+
+## Goodhart guards
+
+Carried explicitly so they survive into implementation and review:
+
+- **Structural completeness, not output size.** The pass condition is "every required contract member
+  of a claimed-resolved `source_build` extension point has a signature-bearing surface," counted
+  against the source's actual member set — never API count, signature length, LOC, or file count.
+- **Punish false claims, not honesty.** `ResolutionKind: "unresolved"` is a reviewable honest gap and
+  never trips the gate. The gate fires only on a *claimed-complete* contract that is *partial*.
+- **Fail fast and cheap, upstream.** Relocate discovery from per-method dev compile iteration
+  (expensive, mid-execution) to one plan-time source read (cheap, pre-dispatch). A fabricated
+  signature is caught at the dev's compile, the cheapest possible backstop — strictly better than the
+  unbounded discovery loop the gate exists to prevent.
+
+## Consequences
+
+- The architect (or resolver) does the source read once; the dev gets full method contracts before
+  the first compile; the `ICommandStatus`-class thrash disappears for any `source_build` dep that
+  reaches the gate.
+- `maven_central` deps are unaffected — they already resolve completely; the gate is
+  `source_build`-scoped.
+- One new deterministic plan-reviewer rule, in the same file and style as PR #172's sibling rule, with
+  one `PlanReviewFinding` per offending dependency. Offline-testable (no paid run) — predict and
+  reproduce the rejection with `go test` before any LLM burn.
+- A scoped `/sources/` grant (and the stripped mount) make the resolving loop's access first-class
+  rather than an incidental sandbox side effect.
+- Interaction with recovery (ADR-037): a plan that trips this gate is a *plan-phase* rejection
+  (architect/resolver revise), not an execution wedge — it never reaches the dev, so recovery never
+  has to diagnose it. This removes a recoverable-but-expensive wedge class from the execution tail.
+
+## Out of scope (related upstream-strengthening layers, separate ADRs/future work)
+
+- **Reviving the dev-time `research()` sub-agent.** Built and deliberately shelved (2026-05-15): it
+  shuffled context between loops without reducing it, and researcher latency (5-12 min) blew past the
+  dev's wait window. The infrastructure still exists in code (`tools/research/*`,
+  `processor/researcher-manager`, fragments in `prompt/domain/software.go`) but is granted to the dev
+  only in `configs/e2e-hybrid*.json`, not the default `configs/semspec.json`. This ADR does **not**
+  propose reviving it. The strategy lesson stands: *reduce the work (K) at the source; do not shuffle
+  it to a sub-agent.* Option B above is plan-time, not dev-time, and so does not reincur this
+  objection — that distinction is load-bearing, not a loophole.
+- **Req-gen API-surface partitioning.** Whether requirements should pre-partition external API surface
+  across requirements is a related upstream-strengthening layer — separate ADR.
+- **Graph-triple cross-cycle memory of resolved contracts** (so a resolved `source_build` contract is
+  reused across cycles / runs rather than re-resolved) is the post-MVP graph-native evolution ADR-046
+  sketches. Separate ADR; mentioned only as the eventual backend upgrade.
+- **The dedicated resolver *phase* itself** is ADR-046's decision. This ADR specifies the
+  `source_build`-completeness *contract* that phase (or the extended architect) must satisfy; it does
+  not re-decide whether the phase exists.
+
+## Cross-references
+
+- ADR-046 — dedicated dependency-resolver phase; this ADR is its `source_build`-completeness contract
+  and the framing of the A-vs-B placement decision. The 2026-06-13 run is the re-test ADR-046 is
+  gated on.
+- `processor/plan-reviewer/architecture_rules.go` — `architecture.component_overloaded_capabilities`
+  (PR #172), the sibling rule whose style the new gate mirrors.
+- `workflow/plan_story.go` — `ValidateUpstreamImports`, the symbol-level gate this layers on top of.
+- `workflow/types.go`, `prompt/architecture.go`, `prompt/architecture_project.go`,
+  `prompt/domain/task_upstream_resolutions_test.go` — the existing schema + injection pipeline this
+  ADR reuses unchanged.
+- 2026-06-13 `gemini WITH_EPIC mavlink-hard` run — the `ICommandStatus` thrash that motivated this ADR.

--- a/processor/plan-reviewer/architecture_rules.go
+++ b/processor/plan-reviewer/architecture_rules.go
@@ -2,6 +2,7 @@ package planreviewer
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/c360studio/semspec/workflow"
 )
@@ -33,16 +34,20 @@ import (
 //     caps [bootstrap, telemetry, control] mapped to 2 source files → dev
 //     built only Position+Takeoff, QA caught the gap.
 //   - architecture.upstream_source_build_incomplete_contract: a source_build
-//     UpstreamResolution that names a class/interface in its APIs but resolves
-//     ZERO method/function signatures — the dev then reverse-engineers the
-//     method contract through compile errors (ADR-047). The 2026-06-13
-//     mavlink-hard ICommandStatus fingerprint. Scoped to source_build;
-//     maven_central (jar-verified) and unresolved (honest flag) never fire.
+//     UpstreamResolution that names a class/interface/type in its APIs but
+//     resolves ZERO method/function signatures — the dev then reverse-engineers
+//     the method contract through compile errors (ADR-047). The 2026-06-13
+//     mavlink-hard ICommandStatus fingerprint. Scoped to source_build (explicit
+//     OR a VCS-source-shaped coordinate when the kind is omitted); maven_central
+//     (jar-verified) and unresolved (honest flag) never fire.
 //
-// Skipped entirely when plan.Architecture is nil (legacy plans without
-// the architecture-generator phase have no components to check), when
-// plan.Exploration is nil (no capabilities to cross-reference), or when
-// ComponentBoundaries is empty.
+// The component-boundary rules are skipped when plan.Architecture is nil (legacy
+// plans without the architecture-generator phase have no components to check),
+// when plan.Exploration is nil (no capabilities to cross-reference), or when
+// ComponentBoundaries is empty. The upstream-resolution rule is INDEPENDENT of
+// ComponentBoundaries (it reads only UpstreamResolutions) and runs whenever
+// Architecture is present, so a degenerate "resolutions but no components"
+// architecture is still gated.
 //
 // Side effect: calls result.NormalizeVerdict() so the verdict reflects the
 // merged findings ("approved" → "needs_changes" when error findings appear).
@@ -50,19 +55,23 @@ func mergeArchitectureFindings(plan *workflow.Plan, result *workflow.PlanReviewR
 	if plan == nil || plan.Architecture == nil || result == nil {
 		return
 	}
-	if len(plan.Architecture.ComponentBoundaries) == 0 {
-		return
-	}
 
 	original := len(result.Findings)
-	result.Findings = append(result.Findings,
-		architectureImplementationFileFindings(plan.Architecture.ComponentBoundaries)...)
-	result.Findings = append(result.Findings,
-		componentOverloadedCapabilityFindings(plan.Architecture.ComponentBoundaries)...)
-	result.Findings = append(result.Findings,
-		capabilityUnresolvedInArchitectureFindings(plan)...)
+
+	// Upstream-resolution rule is component-independent — it reads only
+	// UpstreamResolutions, so it runs even when ComponentBoundaries is empty.
 	result.Findings = append(result.Findings,
 		upstreamSourceBuildContractFindings(plan.Architecture.UpstreamResolutions)...)
+
+	// Component-boundary rules need at least one component to check.
+	if len(plan.Architecture.ComponentBoundaries) > 0 {
+		result.Findings = append(result.Findings,
+			architectureImplementationFileFindings(plan.Architecture.ComponentBoundaries)...)
+		result.Findings = append(result.Findings,
+			componentOverloadedCapabilityFindings(plan.Architecture.ComponentBoundaries)...)
+		result.Findings = append(result.Findings,
+			capabilityUnresolvedInArchitectureFindings(plan)...)
+	}
 
 	if len(result.Findings) > original {
 		result.NormalizeVerdict()
@@ -211,9 +220,45 @@ func capabilityUnresolvedInArchitectureFindings(plan *workflow.Plan) []workflow.
 	return findings
 }
 
+// isSourceBuildShaped reports whether a resolution should be treated as a
+// source_build for the completeness gate. It fires on an EXPLICIT source_build
+// kind, OR — because resolution_kind is omitempty and the architect prompt does
+// not hard-enforce it — on an omitted/unknown kind whose coordinate is a
+// VCS-source reference (github/gitlab/bitbucket / git@ / .git). The latter is
+// the exact "github.com/org/repo@tag" shape of the OSH dep this gate targets,
+// which EffectiveResolutionKind infers to "unknown" (NOT source_build) when the
+// field is absent — so without this widening the gate would silently miss its
+// own fingerprint. Maven GAV coordinates infer to maven_central (resolved
+// completely) and npm:/pypi: coordinates carry no VCS marker, so neither path
+// reaches here.
+func isSourceBuildShaped(r workflow.UpstreamResolution) bool {
+	switch r.EffectiveResolutionKind() {
+	case workflow.ResolutionKindSourceBuild:
+		return true
+	case "": // unknown / inferred-unverified — accept only the VCS-source shape.
+		return looksLikeVCSSource(r.Coordinate)
+	default:
+		return false
+	}
+}
+
+// looksLikeVCSSource reports whether a coordinate is a version-control source
+// reference rather than a published-registry coordinate. Deliberately narrow:
+// it must NOT match Maven GAV, npm:, or pypi: shapes (those are resolved
+// completely and are not this gate's concern).
+func looksLikeVCSSource(coordinate string) bool {
+	c := strings.ToLower(strings.TrimSpace(coordinate))
+	for _, marker := range []string{"github.com", "gitlab.com", "bitbucket.org", "git@", ".git"} {
+		if strings.Contains(c, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // upstreamSourceBuildContractFindings flags a source_build UpstreamResolution
-// that names a class/interface extension point in its APIs but resolves ZERO
-// method/function signatures (ADR-047). Without the method contract the
+// that names a class/interface/type extension point in its APIs but resolves
+// ZERO method/function signatures (ADR-047). Without the method contract the
 // developer reverse-engineers it through compile errors — the 2026-06-13
 // mavlink-hard fingerprint: OSH ICommandStatus resolved as a bare interface +
 // lifecycle string (no getProgress()/getExecutionTime() signatures), and
@@ -222,27 +267,35 @@ func capabilityUnresolvedInArchitectureFindings(plan *workflow.Plan) []workflow.
 // Deterministic floor: the reviewer has no /sources/ access at review time, so
 // it cannot verify the method SET is complete against the upstream source — only
 // that SOME callable/implementable surface exists. A source_build resolution
-// with ≥1 class/interface surface and zero method/function surfaces is therefore
-// the detectable incompleteness ("named the type, resolved no methods"). A
-// fabricated or partial method set passes this floor but is caught far more
-// cheaply at the dev's compile than by the unbounded discovery loop this rule
-// prevents — the same cost trade ValidateUpstreamImports already makes.
+// with ≥1 named-type surface (class/interface/type) and zero method/function
+// surfaces is therefore the detectable incompleteness ("named the type, resolved
+// no methods"). A fabricated or partial method set passes this floor but is
+// caught far more cheaply at the dev's compile than by the unbounded discovery
+// loop this rule prevents — the same cost trade ValidateUpstreamImports makes.
 //
-// Scoped to source_build via EffectiveResolutionKind: maven_central resolves
-// completely (jar-verified) and unresolved is a first-class honest flag —
-// neither trips this rule. Severity error to match the sibling structural rules;
-// dial to a warning if it proves noisy in practice.
+// Kind handling: the named-type set is {class, interface, type} — the shapes a
+// subclass/caller must build against; annotation/constant/config_field are
+// deliberately excluded (no method contract to resolve). Kind is normalised
+// (lower/trim) because the value originates from an LLM.
+//
+// Accepted over-fire: a CONCRETE class whose constructor lives in its own class
+// surface Signature (no separate method entry) will fire even though that
+// constructor IS its contract. The reviewer cannot tell "extends, needs abstract
+// methods" from "construct + call" without per-symbol extends/implements data,
+// so it errs toward firing — the architect adds one method entry or splits the
+// surface, cheap, vs. the discovery loop. Severity error to match the sibling
+// structural rules; dial to a warning if it proves noisy in practice.
 func upstreamSourceBuildContractFindings(resolutions []workflow.UpstreamResolution) []workflow.PlanReviewFinding {
 	var findings []workflow.PlanReviewFinding
 	for _, r := range resolutions {
-		if r.EffectiveResolutionKind() != workflow.ResolutionKindSourceBuild {
+		if !isSourceBuildShaped(r) {
 			continue
 		}
 		var hasType, hasMethod bool
 		var types []string
 		for _, api := range r.APIs {
-			switch api.Kind {
-			case "class", "interface":
+			switch strings.ToLower(strings.TrimSpace(api.Kind)) {
+			case "class", "interface", "type":
 				hasType = true
 				if api.Symbol != "" {
 					types = append(types, api.Symbol)

--- a/processor/plan-reviewer/architecture_rules.go
+++ b/processor/plan-reviewer/architecture_rules.go
@@ -32,6 +32,12 @@ import (
 //     component). The 2026-06-13 mavlink-hard MavsdkDriver fingerprint:
 //     caps [bootstrap, telemetry, control] mapped to 2 source files → dev
 //     built only Position+Takeoff, QA caught the gap.
+//   - architecture.upstream_source_build_incomplete_contract: a source_build
+//     UpstreamResolution that names a class/interface in its APIs but resolves
+//     ZERO method/function signatures — the dev then reverse-engineers the
+//     method contract through compile errors (ADR-047). The 2026-06-13
+//     mavlink-hard ICommandStatus fingerprint. Scoped to source_build;
+//     maven_central (jar-verified) and unresolved (honest flag) never fire.
 //
 // Skipped entirely when plan.Architecture is nil (legacy plans without
 // the architecture-generator phase have no components to check), when
@@ -55,6 +61,8 @@ func mergeArchitectureFindings(plan *workflow.Plan, result *workflow.PlanReviewR
 		componentOverloadedCapabilityFindings(plan.Architecture.ComponentBoundaries)...)
 	result.Findings = append(result.Findings,
 		capabilityUnresolvedInArchitectureFindings(plan)...)
+	result.Findings = append(result.Findings,
+		upstreamSourceBuildContractFindings(plan.Architecture.UpstreamResolutions)...)
 
 	if len(result.Findings) > original {
 		result.NormalizeVerdict()
@@ -198,6 +206,71 @@ func capabilityUnresolvedInArchitectureFindings(plan *workflow.Plan) []workflow.
 			TargetValue: fmt.Sprintf("capability %q on ≥1 component", cap.Name),
 			Issue:       fmt.Sprintf("Capability %q is declared in Plan.Exploration but no ComponentDef's capabilities list contains it. Winston must map every capability to at least one component.", cap.Name),
 			Suggestion:  fmt.Sprintf("Either extend an existing component_boundaries[].capabilities to include %q, or declare a new component that implements it. If the capability cannot be mapped to any component, flag it back to the analyst sub-phase rather than emitting an implementation-less abstract.", cap.Name),
+		})
+	}
+	return findings
+}
+
+// upstreamSourceBuildContractFindings flags a source_build UpstreamResolution
+// that names a class/interface extension point in its APIs but resolves ZERO
+// method/function signatures (ADR-047). Without the method contract the
+// developer reverse-engineers it through compile errors — the 2026-06-13
+// mavlink-hard fingerprint: OSH ICommandStatus resolved as a bare interface +
+// lifecycle string (no getProgress()/getExecutionTime() signatures), and
+// gemini-pro burned ~3.5M tokens rediscovering them one compile at a time.
+//
+// Deterministic floor: the reviewer has no /sources/ access at review time, so
+// it cannot verify the method SET is complete against the upstream source — only
+// that SOME callable/implementable surface exists. A source_build resolution
+// with ≥1 class/interface surface and zero method/function surfaces is therefore
+// the detectable incompleteness ("named the type, resolved no methods"). A
+// fabricated or partial method set passes this floor but is caught far more
+// cheaply at the dev's compile than by the unbounded discovery loop this rule
+// prevents — the same cost trade ValidateUpstreamImports already makes.
+//
+// Scoped to source_build via EffectiveResolutionKind: maven_central resolves
+// completely (jar-verified) and unresolved is a first-class honest flag —
+// neither trips this rule. Severity error to match the sibling structural rules;
+// dial to a warning if it proves noisy in practice.
+func upstreamSourceBuildContractFindings(resolutions []workflow.UpstreamResolution) []workflow.PlanReviewFinding {
+	var findings []workflow.PlanReviewFinding
+	for _, r := range resolutions {
+		if r.EffectiveResolutionKind() != workflow.ResolutionKindSourceBuild {
+			continue
+		}
+		var hasType, hasMethod bool
+		var types []string
+		for _, api := range r.APIs {
+			switch api.Kind {
+			case "class", "interface":
+				hasType = true
+				if api.Symbol != "" {
+					types = append(types, api.Symbol)
+				}
+			case "method", "function":
+				hasMethod = true
+			}
+		}
+		if !hasType || hasMethod {
+			continue
+		}
+		name := r.Name
+		if name == "" {
+			name = r.Coordinate
+		}
+		findings = append(findings, workflow.PlanReviewFinding{
+			SOPID:       "architecture.upstream_source_build_incomplete_contract",
+			SOPTitle:    "source_build dependency names a type but resolves no method contract (ADR-047)",
+			Severity:    "error",
+			Status:      "violation",
+			Category:    "structural",
+			Phase:       "architecture",
+			TargetID:    name,
+			Action:      "add",
+			TargetField: fmt.Sprintf("upstream_resolutions.%s.apis", name),
+			TargetValue: "≥1 method/function APISurface with a full signature for each member a subclass calls or implements",
+			Issue:       fmt.Sprintf("source_build dependency %q names type(s) %v but resolves zero method/function signatures. A subclass or caller needs each method's exact signature; without it the developer reverse-engineers the contract through compile errors (the 2026-06-13 ICommandStatus thrash burned ~3.5M tokens rediscovering getProgress()->int, getExecutionTime()->TimeExtent).", name, types),
+			Suggestion:  fmt.Sprintf("Read %q's source at its source_ref (mounted under /sources/ when WITH_EPIC) and add an apis[] entry (kind=method) with a full signature for each constructor and abstract/interface method a subclass must implement, plus any config/parameter types those signatures reference.", name),
 		})
 	}
 	return findings

--- a/processor/plan-reviewer/architecture_rules_test.go
+++ b/processor/plan-reviewer/architecture_rules_test.go
@@ -287,6 +287,126 @@ func TestMergeArchitectureFindings_CohesiveComponentNotFlagged(t *testing.T) {
 	}
 }
 
+// TestMergeArchitectureFindings_SourceBuildIncompleteContract fires
+// architecture.upstream_source_build_incomplete_contract on the 2026-06-13
+// mavlink-hard ICommandStatus shape: a source_build dependency that names an
+// interface (+ a lifecycle string) but resolves zero method signatures, so the
+// dev reverse-engineers the contract through compile errors (ADR-047).
+func TestMergeArchitectureFindings_SourceBuildIncompleteContract(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "osh-incomplete-contract",
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{Name: "control", Capabilities: []string{"control"}, ImplementationFiles: []string{"src/RawMavlinkControl.java"}},
+			},
+			UpstreamResolutions: []workflow.UpstreamResolution{
+				{
+					Name:           "OpenSensorHub Core",
+					Coordinate:     "github.com/opensensorhub/osh-core@v2.0.0",
+					SourceRef:      "/sources/osh-core",
+					ResolutionKind: "source_build",
+					UsedBy:         []string{"control"},
+					APIs: []workflow.APISurface{
+						{Symbol: "ICommandStatus", Kind: "interface", Signature: "public interface ICommandStatus", Lifecycle: "implement getProgress()/getExecutionTime()", Citation: "/sources/osh-core/.../ICommandStatus.java"},
+					},
+				},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	var f *workflow.PlanReviewFinding
+	for i := range result.Findings {
+		if result.Findings[i].SOPID == "architecture.upstream_source_build_incomplete_contract" {
+			f = &result.Findings[i]
+		}
+	}
+	if f == nil {
+		t.Fatalf("expected upstream_source_build_incomplete_contract finding, got: %+v", result.Findings)
+	}
+	if f.TargetID != "OpenSensorHub Core" {
+		t.Errorf("target = %q, want OpenSensorHub Core", f.TargetID)
+	}
+	if !strings.Contains(f.Issue, "ICommandStatus") {
+		t.Errorf("issue should name the unresolved type ICommandStatus: %q", f.Issue)
+	}
+	if result.Verdict != "needs_changes" {
+		t.Errorf("verdict = %q, want needs_changes", result.Verdict)
+	}
+}
+
+// TestMergeArchitectureFindings_SourceBuildWithMethodsNotFlagged confirms the
+// rule does NOT fire once the source_build resolution carries method signatures
+// for the interface it names — the honest complete shape.
+func TestMergeArchitectureFindings_SourceBuildWithMethodsNotFlagged(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "osh-complete-contract",
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{Name: "control", Capabilities: []string{"control"}, ImplementationFiles: []string{"src/RawMavlinkControl.java"}},
+			},
+			UpstreamResolutions: []workflow.UpstreamResolution{
+				{
+					Name: "OpenSensorHub Core", Coordinate: "github.com/opensensorhub/osh-core@v2.0.0",
+					SourceRef: "/sources/osh-core", ResolutionKind: "source_build", UsedBy: []string{"control"},
+					APIs: []workflow.APISurface{
+						{Symbol: "ICommandStatus", Kind: "interface", Signature: "public interface ICommandStatus", Citation: "c"},
+						{Symbol: "ICommandStatus.getProgress", Kind: "method", Signature: "int getProgress()", Citation: "c"},
+						{Symbol: "ICommandStatus.getExecutionTime", Kind: "method", Signature: "TimeExtent getExecutionTime()", Citation: "c"},
+					},
+				},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	for _, f := range result.Findings {
+		if f.SOPID == "architecture.upstream_source_build_incomplete_contract" {
+			t.Errorf("source_build with method signatures should not fire: %+v", f)
+		}
+	}
+	if result.Verdict != "approved" {
+		t.Errorf("verdict = %q, want approved", result.Verdict)
+	}
+}
+
+// TestMergeArchitectureFindings_NonSourceBuildContractNotFlagged confirms the
+// rule is scoped to source_build: a maven_central resolution (resolved
+// completely upstream, jar-verified) and an honest unresolved flag both carry a
+// type surface with no methods, and neither trips the gate.
+func TestMergeArchitectureFindings_NonSourceBuildContractNotFlagged(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "non-source-build",
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{Name: "driver", Capabilities: []string{"drive"}, ImplementationFiles: []string{"src/Driver.java"}},
+			},
+			UpstreamResolutions: []workflow.UpstreamResolution{
+				{Name: "MAVSDK", Coordinate: "io.mavsdk:mavsdk:3.0.0", ResolutionKind: "maven_central",
+					APIs: []workflow.APISurface{{Symbol: "System", Kind: "class", Signature: "System()", Citation: "c"}}},
+				{Name: "Mystery", Coordinate: "mystery-lib", ResolutionKind: "unresolved",
+					APIs: []workflow.APISurface{{Symbol: "Mystery", Kind: "interface", Signature: "interface Mystery", Citation: "c"}}},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	for _, f := range result.Findings {
+		if f.SOPID == "architecture.upstream_source_build_incomplete_contract" {
+			t.Errorf("only source_build should fire; got finding on %s: %+v", f.TargetID, f)
+		}
+	}
+	if result.Verdict != "approved" {
+		t.Errorf("verdict = %q, want approved", result.Verdict)
+	}
+}
+
 // TestHasSourceFile_DelegatesToWorkflowClassifier guards the
 // reviewer-side ↔ architecture-generator-side classification parity. If
 // workflow.IsDocumentationPath ever drifts from this rule's expectations,

--- a/processor/plan-reviewer/architecture_rules_test.go
+++ b/processor/plan-reviewer/architecture_rules_test.go
@@ -407,6 +407,175 @@ func TestMergeArchitectureFindings_NonSourceBuildContractNotFlagged(t *testing.T
 	}
 }
 
+// sourceBuildResolutionPlan builds a minimal plan with one clean single-cap
+// component (so no component-boundary rule fires) and the given upstream
+// resolutions, for isolating the upstream-contract rule. Exploration is nil so
+// capability.unresolved_in_architecture never fires.
+func sourceBuildResolutionPlan(resolutions ...workflow.UpstreamResolution) *workflow.Plan {
+	return &workflow.Plan{
+		Slug: "upstream-rule-iso",
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{Name: "driver", Capabilities: []string{"drive"}, ImplementationFiles: []string{"src/Driver.java"}},
+			},
+			UpstreamResolutions: resolutions,
+		},
+	}
+}
+
+func firedUpstreamContract(result *workflow.PlanReviewResult) *workflow.PlanReviewFinding {
+	for i := range result.Findings {
+		if result.Findings[i].SOPID == "architecture.upstream_source_build_incomplete_contract" {
+			return &result.Findings[i]
+		}
+	}
+	return nil
+}
+
+// TestMergeArchitectureFindings_SourceBuildByVCSShapeFiresWhenKindOmitted closes
+// the go-reviewer HIGH gap: the gate's own target shape — a github-coordinate OSH
+// dep — infers to "unknown" (NOT source_build) when resolution_kind is omitted,
+// so without the VCS-shape widening the rule would silently miss it. Also
+// exercises name-fallback to Coordinate (empty Name).
+func TestMergeArchitectureFindings_SourceBuildByVCSShapeFiresWhenKindOmitted(t *testing.T) {
+	plan := sourceBuildResolutionPlan(workflow.UpstreamResolution{
+		// No ResolutionKind set; github coordinate is the de-facto source_build shape.
+		Coordinate: "github.com/opensensorhub/osh-core@v2.0.0",
+		SourceRef:  "/sources/osh-core",
+		APIs: []workflow.APISurface{
+			{Symbol: "ICommandStatus", Kind: "interface", Signature: "public interface ICommandStatus", Citation: "c"},
+		},
+	})
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	f := firedUpstreamContract(result)
+	if f == nil {
+		t.Fatalf("VCS-shaped source_build with omitted kind should fire, got: %+v", result.Findings)
+	}
+	if f.TargetID != "github.com/opensensorhub/osh-core@v2.0.0" {
+		t.Errorf("TargetID should fall back to coordinate when Name is empty, got %q", f.TargetID)
+	}
+	if result.Verdict != "needs_changes" {
+		t.Errorf("verdict = %q, want needs_changes", result.Verdict)
+	}
+}
+
+// TestMergeArchitectureFindings_UnknownNonVCSShapeNotFlagged confirms the
+// widening stays narrow: a registry-prefixed coordinate (npm:) infers to unknown
+// but carries no VCS marker, so it is NOT treated as source_build even with a
+// type-only surface — npm/pypi packages resolve completely and are not this
+// gate's concern.
+func TestMergeArchitectureFindings_UnknownNonVCSShapeNotFlagged(t *testing.T) {
+	plan := sourceBuildResolutionPlan(workflow.UpstreamResolution{
+		Name: "Some NPM Lib", Coordinate: "npm:some-lib@1.0.0",
+		APIs: []workflow.APISurface{{Symbol: "Thing", Kind: "interface", Signature: "interface Thing", Citation: "c"}},
+	})
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	if f := firedUpstreamContract(result); f != nil {
+		t.Errorf("npm coordinate (unknown, non-VCS) should not fire: %+v", f)
+	}
+	if result.Verdict != "approved" {
+		t.Errorf("verdict = %q, want approved", result.Verdict)
+	}
+}
+
+// TestMergeArchitectureFindings_SourceBuildEmptyAPIsNotFlagged: a source_build
+// resolution with no APIs has no named type, so the rule does not fire (zero-API
+// resolutions are a separate completeness concern, not this rule's floor).
+func TestMergeArchitectureFindings_SourceBuildEmptyAPIsNotFlagged(t *testing.T) {
+	plan := sourceBuildResolutionPlan(workflow.UpstreamResolution{
+		Name: "OSH Core", Coordinate: "github.com/opensensorhub/osh-core@v2", ResolutionKind: "source_build",
+	})
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	if f := firedUpstreamContract(result); f != nil {
+		t.Errorf("source_build with empty APIs should not fire (no named type): %+v", f)
+	}
+}
+
+// TestMergeArchitectureFindings_SourceBuildTypeKindFires confirms the
+// {class,interface,type} named-type set: a source_build resolution naming only a
+// `type` surface (e.g. a protobuf message the dev builds against) with no methods
+// is incomplete and fires — closing the go-reviewer Medium-2 type-kind gap.
+func TestMergeArchitectureFindings_SourceBuildTypeKindFires(t *testing.T) {
+	plan := sourceBuildResolutionPlan(workflow.UpstreamResolution{
+		Name: "Meshtastic Proto", Coordinate: "github.com/meshtastic/protobufs@v2", ResolutionKind: "source_build",
+		APIs: []workflow.APISurface{{Symbol: "ToRadio", Kind: "type", Signature: "message ToRadio", Citation: "c"}},
+	})
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	if f := firedUpstreamContract(result); f == nil {
+		t.Fatalf("source_build naming a `type` with no methods should fire, got: %+v", result.Findings)
+	}
+}
+
+// TestMergeArchitectureFindings_UpstreamRuleRunsWithoutComponents confirms the
+// upstream rule is component-independent (go-reviewer Low): an architecture with
+// resolutions but zero ComponentBoundaries is still gated.
+func TestMergeArchitectureFindings_UpstreamRuleRunsWithoutComponents(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "no-components",
+		Architecture: &workflow.ArchitectureDocument{
+			UpstreamResolutions: []workflow.UpstreamResolution{
+				{Name: "OSH Core", Coordinate: "github.com/opensensorhub/osh-core@v2", ResolutionKind: "source_build",
+					APIs: []workflow.APISurface{{Symbol: "ICommandStatus", Kind: "interface", Signature: "interface ICommandStatus", Citation: "c"}}},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	if f := firedUpstreamContract(result); f == nil {
+		t.Fatalf("upstream rule should run even with no components, got: %+v", result.Findings)
+	}
+}
+
+// TestMergeArchitectureFindings_MultipleResolutionsIsolated confirms per-
+// resolution isolation: one incomplete source_build fires while a sibling with
+// methods stays clean (and the collected type list does not leak across loop
+// iterations).
+func TestMergeArchitectureFindings_MultipleResolutionsIsolated(t *testing.T) {
+	plan := sourceBuildResolutionPlan(
+		workflow.UpstreamResolution{
+			Name: "Incomplete", Coordinate: "github.com/x/incomplete@v1", ResolutionKind: "source_build",
+			APIs: []workflow.APISurface{{Symbol: "IFoo", Kind: "interface", Signature: "interface IFoo", Citation: "c"}},
+		},
+		workflow.UpstreamResolution{
+			Name: "Complete", Coordinate: "github.com/x/complete@v1", ResolutionKind: "source_build",
+			APIs: []workflow.APISurface{
+				{Symbol: "IBar", Kind: "interface", Signature: "interface IBar", Citation: "c"},
+				{Symbol: "IBar.run", Kind: "method", Signature: "void run()", Citation: "c"},
+			},
+		},
+	)
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	var count int
+	for _, f := range result.Findings {
+		if f.SOPID == "architecture.upstream_source_build_incomplete_contract" {
+			count++
+			if f.TargetID != "Incomplete" {
+				t.Errorf("only the incomplete resolution should fire, got TargetID %q", f.TargetID)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 upstream-contract finding, got %d", count)
+	}
+}
+
 // TestHasSourceFile_DelegatesToWorkflowClassifier guards the
 // reviewer-side ↔ architecture-generator-side classification parity. If
 // workflow.IsDocumentationPath ever drifts from this rule's expectations,

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -271,6 +271,23 @@ STOP. Do not issue a third bash call. Instead:
 - If you cannot diagnose after the scratchpad pause, call ask_question with a concrete hypothesis. Clean blockers are cheaper than 10 more iterations of bash-roulette.`,
 		},
 		{
+			ID:       "software.developer.build-efficiency",
+			Category: prompt.CategoryRoleContext,
+			Roles:    []prompt.Role{prompt.RoleDeveloper},
+			Content: `ITERATE FAST, VERIFY CLEAN — these are two phases with two different commands.
+
+Every edit→test cycle pays for whatever its command rebuilds from scratch. On a large project a cold build (fresh compiler process, full dependency resolution, recompiling unchanged modules) costs minutes — and you run many cycles, so a cold command multiplies that cost across your whole iteration budget. Build tools cache compiled output and keep a warm process for exactly this reason; defeating that cache is the single biggest avoidable time sink in the loop, and burns iterations you need for real progress.
+
+WHILE ITERATING (most of your cycles) — keep feedback fast and incremental:
+- Run the TARGETED test you are working on, not the whole suite — e.g. ` + "`./gradlew test --tests com.example.MyTest`" + `, ` + "`go test ./path/to/changed/pkg -run TestX`" + `, ` + "`mvn -pl module -Dtest=MyTest test`" + `.
+- Let the build tool reuse its warm process and cache. Do NOT stop the daemon or force a from-scratch build between edits — ` + "`gradlew --stop`" + ` and ` + "`--no-daemon`" + ` both defeat the Gradle daemon and pay full startup on every run; ` + "`clean`" + ` (gradle/maven) throws away compiled output you will immediately recompile. Incremental compilation rebuilding only what you changed is correct here, not a risk to avoid.
+
+ONCE, AS FINAL VERIFICATION before submit_work — a single clean, full run:
+- The clean / full-suite run belongs here, exactly once, to confirm the change builds and passes from a clean state. Not on every cycle.
+
+The clean-build instinct is right; the mistake is spending it on every iteration instead of the final check.`,
+		},
+		{
 			ID:       "software.developer.test-surface",
 			Category: prompt.CategoryRoleContext,
 			Roles:    []prompt.Role{prompt.RoleDeveloper},

--- a/prompt/domain/software_test.go
+++ b/prompt/domain/software_test.go
@@ -121,6 +121,26 @@ func TestSoftwareDeveloperAssembly(t *testing.T) {
 		}
 	}
 
+	// Cold-build lever pin (2026-06-13): the developer must be told to iterate
+	// with warm/incremental/targeted builds and reserve the clean cold run for
+	// a single final verification. Caught in the gemini WITH_EPIC mavlink-hard
+	// run where the dev self-ran `./gradlew --stop && ./gradlew test --no-daemon`
+	// every cycle, paying full cold-start (minutes) on a large source_build
+	// project and racing the execution clock. Language-agnostic: names gradle,
+	// go test, and maven so single-toolchain runs aren't polluted by the others.
+	wantBuildEfficiencyPins := []string{
+		"ITERATE FAST, VERIFY CLEAN", // the principle header
+		"--no-daemon",                // the specific antipattern observed live
+		"--tests",                    // targeted-test guidance (gradle)
+		"go test ./path",             // generalized to Go
+		"AS FINAL VERIFICATION",      // the verify-once-clean phase
+	}
+	for _, want := range wantBuildEfficiencyPins {
+		if !strings.Contains(result.SystemMessage, want) {
+			t.Errorf("expected build-efficiency guidance %q in developer prompt (cold-build lever)", want)
+		}
+	}
+
 	// Anti-pin: the persona must NOT name Go-specific failure modes that
 	// don't apply to Python/Node/etc projects. The user (2026-05-08)
 	// caught and rejected a Go-specific draft of this fragment that


### PR DESCRIPTION
Two **separable** dev-loop efficiency levers from the 2026-06-13 gemini WITH_EPIC `mavlink-hard` run (where #172's architect-granularity fix validated live — correct 4-component decomposition — but the dev tail ran ~2h on `gemini-pro` and we cut pre-QA on the Playwright clock). Bundled per request; two atomic commits.

## 1. Cold-build iteration efficiency (`perf`, commit 1)
**Problem:** the dev self-ran `./gradlew --stop && ./gradlew test --no-daemon` per validation — a full cold JVM+Gradle start every cycle on OSH's large build → 15-25 min/node, racing the clock. Agent-chosen (not a template), not resource starvation.

- **Sandbox** (`docker/sandbox.Dockerfile`): user-global `~/.gradle/gradle.properties` with `org.gradle.caching` + `daemon` + `parallel`. The build cache is shared across per-task worktrees (unchanged modules like osh-core compile once, reused) and **helps even under `--no-daemon`** (cache is independent of the daemon) → deterministic, agent-behavior-independent. *Verified: image builds, file lands at `/home/sandbox/.gradle/gradle.properties` owned by `sandbox:sandbox`.*
- **Developer prompt** (`prompt/domain/software.go`): new `software.developer.build-efficiency` fragment — the generalized **ITERATE FAST / VERIFY CLEAN** principle (targeted+warm+incremental while iterating; one clean cold run before submit). Names the `--stop`/`--no-daemon`/`clean` antipatterns with the reason; language-agnostic (gradle, `go test`, maven). Regression-pinned.

## 2. source_build contract-completeness gate (`feat`, commit 2 — ADR-047)
**Problem:** the dev burned ~3.5M tokens reverse-engineering OSH's `ICommandStatus` contract (`getProgress()`→`int` not `float`; `getExecutionTime()`→`TimeExtent` not `Instant`) through compile errors. The architect resolved the interface decl + lifecycle string but **no method signatures**. The schema (`UpstreamResolution.APIs[].Signature`) + inject-to-dev pipeline already carry method contracts end-to-end (tested) — the gap is *population + a forcing gate*, not plumbing.

- New deterministic plan-reviewer rule **`architecture.upstream_source_build_incomplete_contract`**: a `source_build` resolution naming a class/interface but resolving **zero** method/function surfaces → finding, `approved`→`needs_changes`. Mirrors the sibling `architecture.component_overloaded_capabilities` (#172). Scoped via `EffectiveResolutionKind` — `maven_central` (jar-verified) and `unresolved` (honest flag) never fire.
- **Goodhart-safe:** the reviewer has no `/sources/` at review time, so it checks the detectable floor (named the type, no methods), not the full method set; a fabricated/partial set is caught far more cheaply at the dev's compile than by the discovery loop this prevents.
- **ADR-047** documents this as the completeness *contract* layered on **ADR-046**'s (gated/deferred) dependency-resolver-phase decision, and frames the open **architect-does-it (A) vs dedicated-step (B)** fork. Corrects a stale assumption: the architect already **has** `/sources/` access under WITH_EPIC (global bash → `SANDBOX_URL`); the gap is completeness-of-use, not access.

## How this fits the bigger picture
The gate is the offline-shippable forcing function; once merged, a re-run distinguishes "architect can't resolve `source_build` contracts inline (→ ADR-046 Option B)" from "architect just wasn't forced to (→ Option A suffices)" — that gated evidence is left for a human decision.

## Verification
`go build ./...`, `go vet`, `revive`, `gofmt` all clean. New offline tests: build-efficiency prompt pin; gate fires / methods-present-not-flagged / non-source_build-scoping. No paid run required to validate the gate or the build-cache layer; the dev-prompt behavior change validates only on a real-LLM run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)