### PR TITLE
chore(e2e): raise agentic-loop tool_result_max_bytes 32768->131072

### DIFF
--- a/configs/e2e-claude.json
+++ b/configs/e2e-claude.json
@@ -303,6 +303,7 @@
       "config": {
         "max_iterations": 50,
         "timeout": "3600s",
+        "tool_result_max_bytes": 131072,
         "consumer": {
           "ack_wait": "3900s",
           "heartbeat_interval": "240s"

--- a/configs/e2e-gemini.json
+++ b/configs/e2e-gemini.json
@@ -341,6 +341,7 @@
       "config": {
         "max_iterations": 120,
         "timeout": "1800s",
+        "tool_result_max_bytes": 131072,
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
         "content_bucket": "AGENT_CONTENT",

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -361,6 +361,7 @@
       "config": {
         "max_iterations": 120,
         "timeout": "1800s",
+        "tool_result_max_bytes": 131072,
         "consumer": {
           "ack_wait": "2100s",
           "heartbeat_interval": "240s"

--- a/configs/e2e-hybrid.json
+++ b/configs/e2e-hybrid.json
@@ -360,6 +360,7 @@
       "config": {
         "max_iterations": 120,
         "timeout": "1800s",
+        "tool_result_max_bytes": 131072,
         "consumer": {
           "ack_wait": "2100s",
           "heartbeat_interval": "240s"


### PR DESCRIPTION
## What
Raise the agentic-loop `tool_result_max_bytes` from the semstreams default **32768 (32 KB)** to **131072 (128 KB)** across all hard-tier-capable e2e configs: `e2e-gemini`, `e2e-hybrid`, `e2e-hybrid-gpt5`, `e2e-claude`.

## Why
In the 2026-06-13 paid mavlink-hard run, a 91 KB gradle output was **head-truncated to 32 KB**. Gradle/javac/test failures print at the **tail** of their output, so the head-kept 32 KB dropped the actual error → the dev loop retried the same failing build **blind** → tripped a critical `RepeatToolFailure` (loops burned 47–77 iterations before recovering), materially slowing the run. 128 KB fits the observed output with headroom.

## Scope / caveat
**Mitigation only.** The proper fix is upstream **tail-biased / error-aware truncation** in semstreams (`processor/agentic-loop/handlers.go` → `truncateToolResult`), tracked in #178. If a build still exceeds 128 KB this reverts to losing the tail, so it does **not** close #178 — it buys headroom until the upstream fix lands.

Refs #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
