### PR TITLE
feat(ownership): file-ownership discipline to prevent assembly wedges (#175/#176/#177, ADR-048)

### DIFF
--- a/docs/adr/ADR-048-file-ownership-discipline.md
+++ b/docs/adr/ADR-048-file-ownership-discipline.md
@@ -1,0 +1,134 @@
+# ADR-048: File-Ownership Discipline (Every Written File Must Be Owned)
+
+**Status:** Proposed (2026-06-13)
+**Deciders:** Coby, Claude
+**Related:** ADR-043 (architect emits `ComponentDef.ImplementationFiles` — the ownership source),
+ADR-044 (M:N capability ↔ Story; `Story.FilesOwned` derives from the component's
+`ImplementationFiles`, and `workflow.DeriveStoryScheduling` serializes stories that share an owned
+file), ADR-047 (sibling deterministic completeness gate in the same plan-reviewer file — Gate 1 here
+mirrors its shape), ADR-037 (wedge recovery — the assembly wedge this prevents is the kind of
+expensive-but-recoverable failure recovery exists to catch *after* the fact).
+**Drives:** a plan-time ownership-completeness gate (plan-reviewer), a dev-loop containment gate
+(structural-validator), a distinct terminal `assembly_conflict` PlanDecision kind, and scratch
+hygiene (.gitignore + developer prompt).
+
+## Context
+
+### The wedge (verified live, 2026-06-13)
+
+In a `gemini` `WITH_EPIC` `mavlink-hard` run (slug `9a5eca2f2fac`, the furthest a paid run has
+reached) all 13 execution nodes passed review and the Java **source** merged with ZERO conflicts
+across all four requirement branches — decomposition (ADR-044) was genuinely clean. Yet
+`plan-manager.assembleRequirementBranches` failed on a plan-level merge conflict over **`README.md`**
+and the run wedged before QA.
+
+Root cause, traced end to end:
+
+- Source merged clean because every source file was owned by exactly **one** component
+  (`ComponentDef.ImplementationFiles` → `Story.FilesOwned`, disjoint partition).
+- `README.md` was the **one file owned by no component at all**. The user prompt's acceptance
+  criteria mandated "README documents … the coverage matrix", so all four parallel stories' devs
+  each wrote their section of it — but it appeared in no `ImplementationFiles`.
+- `workflow.DeriveStoryScheduling.applyResourceEdges` only serializes stories whose `FilesOwned`
+  overlap. Blind to `README.md` (in zero `FilesOwned`), it ran the four stories in parallel.
+- The sandbox commits each worktree with `git add -A`, so each branch carried its own divergent
+  `README.md` (plus scratch like `patch.diff` and `*.orig`). `assembleRequirementBranches`'
+  sequential `git merge` then hit an unmergeable content conflict.
+- Recovery fired `escalate_human`, which has no unattended fallback (the auto-accept watcher only
+  handles `requirement_change`), so the plan idled at `implementing` until the Playwright timeout
+  (~65 min), failing late with no actionable signal — and the decision was misclassified as
+  `execution_exhausted` even though execution *succeeded*.
+
+### Reframing: this is ownership, not docs
+
+The first instinct was to special-case documentation. It is not a docs problem. A doc was merely the
+file type most likely to be cross-cutting and slip out of the component model. The invariant is
+general: **every file a story writes must be owned**, so the existing scheduler serializes shared
+owned files automatically. Fuzzy free-text doc-detection is the wrong tool.
+
+A complicating constraint: ADR-043's `architecture.component_implementation_files_doc_only` rule
+*rejects* a component whose `ImplementationFiles` are docs-only. So a pure-documentation deliverable
+has no clean home as its own component — it must ride as a **companion file on a source component**
+(which that rule's own text blesses: "Documentation companion files may remain alongside the source
+but never alone").
+
+## Decision
+
+Defense in depth across the three phases where the invariant can be enforced.
+
+### Gate 1 — Prevention (plan-reviewer, deterministic, pure)
+
+New rule `architecture.scoped_file_unowned` (`processor/plan-reviewer/architecture_rules.go`,
+mirroring the ADR-047 sibling). Let
+
+```
+S = NormalizeFilePaths(Scope.Create)
+    ∪ { f ∈ NormalizeFilePaths(Scope.Include) : isConcreteScopedFile(f) ∧ f ∉ Scope.DoNotTouch }
+O = ⋃ over components of NormalizeFilePaths(ImplementationFiles)
+```
+
+Every `f ∈ S \ O` emits one error finding naming the orphan and instructing the architect to declare
+it on the single source component that produces it (companion-on-source for docs), or move it to
+`scope.do_not_touch` if it is a read-only reference. `isConcreteScopedFile` requires a file
+extension *or* a well-known extensionless deliverable basename (`Dockerfile`, `Makefile`, …) and
+excludes directories and globs (a component owns concrete files, not dirs/patterns).
+
+Once a doc is owned by one component → single writer; if the architect declares it on several source
+components → `DeriveStoryScheduling` serializes those stories. Either outcome closes the wedge. The
+rule is NOT docs-specific — a doc and a source file are treated identically.
+
+### Gate 2 — Containment (structural-validator, deterministic, post-dev)
+
+New always-on check `file-ownership-containment` (`processor/structural-validator/ownership_check.go`).
+It computes the **authoritative** changed set from `git status --porcelain` in the worktree (the
+agent's self-reported `files_modified` cannot be trusted for a gate about the agent overstepping) and
+classifies each change against `Story.FilesOwned` (threaded as `TaskExecution.FileScope` →
+`ValidationRequest.FilesOwned`):
+
+- **Hard fail (Required):** a committed scratch/merge artefact (`*.orig`, `patch*.diff`, …) OR a
+  pre-existing **documentation** file modified by a non-owner — the unmergeable co-write that wedged
+  the README assembly.
+- **Advisory (surfaced, not blocking):** a pre-existing non-doc file (build/manifest/source) modified
+  by a non-owner — these usually merge cleanly and a dep bump is a routine TDD move; #176 fails
+  honestly if one does conflict. New files outside ownership (legitimate class splits) are likewise
+  advisory.
+- Skipped entirely when there is no ownership context (manual validation / E2E).
+
+The hard-fail vs advisory line is drawn at **unmergeable vs usually-mergeable**, not new-vs-modified,
+so a dev legitimately editing `build.gradle`/`go.mod`/a pre-existing test is not blocked.
+
+### Gate 3 — Honest failure (plan-manager, #176)
+
+A plan-level merge conflict is recorded as a distinct terminal `PlanDecisionKindAssemblyConflict`
+(naming the conflicting branch + files) and the plan transitions to `rejected` — fail-fast — instead
+of firing recovery's `escalate_human` (which wedges unattended runs) or mislabelling it
+`execution_exhausted`. This is the backstop when an undeclared shared file slips both gates.
+
+### Scratch hygiene (#177)
+
+- Fixture `.gitignore`s ignore `*.orig`/`patch*.diff`/etc. `git add -A` honours `.gitignore` for
+  untracked files, so ignored scratch never reaches the commit (necessary-but-not-sufficient: only
+  helps repos that *have* such a gitignore — Gate 2's junk arm is the portable fallback).
+- The developer prompt (`prompt/domain/software.go`) tells the dev that the worktree is committed
+  wholesale, so scratch belongs in `/tmp`, and to stay inside its file scope.
+
+## Consequences
+
+- A user-requested deliverable doc must be declared on a source component (single writer) or several
+  (scheduler serializes). The wedge cannot recur from an undeclared shared file.
+- A dev that oversteps ownership on a doc, or commits scratch, fails one TDD cycle with actionable
+  feedback rather than wedging the run at assembly. Non-doc overreach is surfaced, not blocked.
+- An assembly conflict that still slips through fails the plan immediately with a named, correctly
+  classified signal, retryable via the existing `/plans/{slug}/retry` endpoints.
+- All three gates are deterministic and offline-testable — validated by `go test` without a paid run.
+
+## Alternatives rejected
+
+- **Fuzzy free-text doc-detection** — this is ownership, not docs; a path classifier (used only to
+  tune Gate 2 severity) is deterministic, free-text scanning is not.
+- **Union/auto-merge of README at assembly** — no such primitive exists; treats the symptom, not the
+  unowned-file cause.
+- **Hard-failing every modified-unowned file** — false-fails legitimate build/test edits and would
+  itself wedge legitimate dev submissions; the advisory/required split avoids this.
+- **Keep firing recovery on assembly conflict** — `escalate_human` has no unattended fallback and is
+  the exact wedge being removed.

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -1918,6 +1918,7 @@ func (c *Component) runStructuralValidation(ctx context.Context, exec *taskExecu
 		WorktreePath:    exec.WorktreePath,
 		TaskID:          exec.TaskID,
 		DeveloperLoopID: exec.DeveloperLoopID,
+		FilesOwned:      exec.FileScope,
 		TraceID:         exec.TraceID,
 	}
 

--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -396,16 +396,26 @@ func (c *Component) handleConvergenceAllSucceeded(ctx context.Context, plan *wor
 }
 
 // routeAssemblyConflict handles a failed pre-QA assemble/stage. The plan never
-// advanced out of implementing, so it stays there with a surfaced LastError —
-// we must NOT proceed to QA against an unmerged tree (the exact bug being
-// fixed). A merge conflict (two requirements edited the same file) is a
-// planning-scope problem that architecture_revise / re-partition must resolve,
-// so it fires phase-local recovery (PRODUCT CALL 4a — reuse RecoveryRequested,
-// no new plan status). Any other failure (sandbox unreachable, worktree
-// staging) is a transient stall: surface LastError and bump the SSE revision so
-// the UI shows the stall; an operator retry or the next execution event
-// re-drives convergence. We deliberately do NOT emit a plan-scope recovery for
-// an infra blip.
+// advanced out of implementing — we must NOT proceed to QA against an unmerged
+// tree.
+//
+// A merge conflict (two truly-parallel branches edited the same file with no
+// DependsOn edge) is a planning-partition defect, not an execution failure: all
+// requirements passed review, the branches just can't merge. In an unattended
+// run firing recovery's escalate_human has no fallback — the decision sits
+// unhandled and the plan idles at implementing until the Playwright timeout
+// (~65 min), failing late with no actionable signal (issue #176). So we instead
+// FAIL FAST and TERMINAL: record a distinct assembly_conflict PlanDecision
+// naming the conflicting branch + files (so dashboards/recovery don't conflate
+// it with execution_exhausted) and transition the plan to rejected, where the
+// defect surfaces immediately and the operator's existing /retry endpoints
+// apply. Prevention is the file-ownership gates (#175); this is the honest
+// backstop when an undeclared shared file slips through.
+//
+// Any other failure (sandbox unreachable, worktree staging) is a transient
+// stall: surface LastError and bump the SSE revision so the UI shows the stall;
+// an operator retry or the next execution event re-drives convergence. We
+// deliberately do NOT fail the plan for an infra blip.
 func (c *Component) routeAssemblyConflict(ctx context.Context, plan *workflow.Plan, assembleErr error) {
 	// Runs from the EXECUTION_STATES watcher (checkPlanConvergence), which is
 	// lock-free like the sibling stall/infra-critical saves here. The
@@ -416,30 +426,59 @@ func (c *Component) routeAssemblyConflict(ctx context.Context, plan *workflow.Pl
 	plan.LastError = fmt.Sprintf("pre-QA assembly failed: %v", assembleErr)
 	plan.LastErrorAt = &now
 
+	if errors.Is(assembleErr, sandbox.ErrMergeBranchesConflict) {
+		c.failPlanOnAssemblyConflict(ctx, plan, assembleErr, now)
+		return
+	}
+
 	if saveErr := c.savePlanCached(ctx, plan); saveErr != nil {
 		c.logger.Error("Failed to persist LastError after pre-QA assembly failure",
 			"slug", plan.Slug, "error", saveErr)
 	}
-
-	if errors.Is(assembleErr, sandbox.ErrMergeBranchesConflict) {
-		c.logger.Warn("Pre-QA plan-level merge conflict — firing recovery, plan stays implementing",
-			"slug", plan.Slug, "error", assembleErr)
-		c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
-			RecoveryID:          uuid.New().String(),
-			Layer:               payloads.RecoveryLayerPhaseLocal,
-			Slug:                plan.Slug,
-			EscalationReason:    "plan-level merge conflict assembling requirement branches before QA",
-			LastFailureFeedback: assembleErr.Error(),
-			// There is no QA verdict yet; the verdict arg only affects an
-			// internal warn-log branch (zero active reqs), which can't fire here
-			// since convergence implies active reqs.
-			AffectedRequirementIDs: c.collectActiveRequirementIDsForRecovery(plan, workflow.QAVerdictNeedsChanges),
-		})
-		return
-	}
-
 	c.logger.Error("Pre-QA assembly failed (non-conflict) — plan stalls in implementing pending retry",
 		"slug", plan.Slug, "error", assembleErr)
+}
+
+// failPlanOnAssemblyConflict records an assembly_conflict PlanDecision and
+// transitions the plan to terminal rejected (issue #176). assembleErr already
+// names the conflicting branch + files (see assembleRequirementBranches), so its
+// message is the actionable signal carried into both LastError and the decision
+// rationale. The decision is authored by plan-manager (ProposedBy != the
+// recovery-agent gate), so the auto-accept watcher ignores it — it is a terminal
+// record, not a cascade trigger.
+func (c *Component) failPlanOnAssemblyConflict(ctx context.Context, plan *workflow.Plan, assembleErr error, now time.Time) {
+	affected := make([]string, 0, len(plan.Requirements))
+	for _, r := range plan.Requirements {
+		affected = append(affected, r.ID)
+	}
+
+	decision := workflow.PlanDecision{
+		ID:             fmt.Sprintf("plan-decision.%s.%d", plan.Slug, len(plan.PlanDecisions)+1),
+		PlanID:         workflow.PlanEntityID(plan.Slug),
+		Kind:           workflow.PlanDecisionKindAssemblyConflict,
+		Title:          "Plan-level merge conflict at branch assembly",
+		Rationale:      fmt.Sprintf("Execution succeeded but the requirement branches could not be merged: %v. This is a planning-partition defect — two parallel branches edited the same file with no ownership/DependsOn edge. Re-run with corrected file ownership (the offending file must be declared on exactly one component, or shared owners serialized).", assembleErr),
+		Status:         workflow.PlanDecisionStatusProposed,
+		ProposedBy:     "plan-manager",
+		AffectedReqIDs: affected,
+		CreatedAt:      now,
+	}
+	plan.PlanDecisions = append(plan.PlanDecisions, decision)
+
+	c.logger.Error("Pre-QA plan-level merge conflict — failing plan terminally (planning-partition defect)",
+		"slug", plan.Slug, "decision_kind", string(decision.Kind), "error", assembleErr)
+
+	if err := c.setPlanStatusCached(ctx, plan, workflow.StatusRejected); err != nil {
+		// setPlanStatusCached persists the plan (including the appended decision
+		// and LastError). On failure, fall back to a direct save so the decision
+		// and LastError are not lost even if the status transition didn't apply.
+		c.logger.Error("Failed to transition plan to rejected after assembly conflict",
+			"slug", plan.Slug, "error", err)
+		if saveErr := c.savePlanCached(ctx, plan); saveErr != nil {
+			c.logger.Error("Failed to persist assembly-conflict decision after transition failure",
+				"slug", plan.Slug, "error", saveErr)
+		}
+	}
 }
 
 // publishQARequestIfNeeded fires when a plan is routed to ready_for_qa. For

--- a/processor/plan-manager/plan_qa_worktree_test.go
+++ b/processor/plan-manager/plan_qa_worktree_test.go
@@ -217,34 +217,49 @@ func TestDeleteQAWorktree_CallsDelete(t *testing.T) {
 
 // routeAssemblyConflict: a merge conflict fires phase-local recovery and keeps
 // the plan in implementing; an infra error stalls without firing recovery.
-func TestRouteAssemblyConflict_ConflictEmitsRecovery(t *testing.T) {
+// A plan-level merge conflict is a planning-partition defect, not an execution
+// failure (issue #176). The plan must fail FAST and TERMINAL — record a distinct
+// assembly_conflict PlanDecision and transition to rejected — instead of firing
+// recovery's escalate_human, which has no unattended fallback and wedges CI/e2e
+// at implementing until timeout.
+func TestRouteAssemblyConflict_ConflictFailsPlanTerminally(t *testing.T) {
 	c := setupTestComponent(t)
-	var captured *payloads.RecoveryRequested
-	c.recoveryPublisher = func(_ context.Context, req *payloads.RecoveryRequested) { captured = req }
+	recoveryFired := false
+	c.recoveryPublisher = func(_ context.Context, _ *payloads.RecoveryRequested) { recoveryFired = true }
 
 	plan := setupTestPlan(t, c, "conflict-plan")
 	plan.Status = workflow.StatusImplementing
 	plan.Requirements = []workflow.Requirement{{ID: "r1"}, {ID: "r2"}}
 	_ = c.plans.save(context.Background(), plan)
 
-	conflictErr := fmt.Errorf("branch x conflicts: %w", sandbox.ErrMergeBranchesConflict)
+	conflictErr := fmt.Errorf("requirement branch x conflicts over files [README.md]: %w", sandbox.ErrMergeBranchesConflict)
 	c.routeAssemblyConflict(context.Background(), plan, conflictErr)
 
-	if captured == nil {
-		t.Fatal("expected RecoveryRequested to be emitted on merge conflict")
-	}
-	if len(captured.AffectedRequirementIDs) != 2 {
-		t.Errorf("AffectedRequirementIDs = %v, want both reqs", captured.AffectedRequirementIDs)
-	}
-	if captured.Layer != payloads.RecoveryLayerPhaseLocal {
-		t.Errorf("Layer = %v, want phase-local", captured.Layer)
+	if recoveryFired {
+		t.Error("merge conflict must NOT fire recovery (escalate_human has no unattended fallback — fail terminal instead)")
 	}
 	stored, _ := c.plans.get("conflict-plan")
-	if stored.Status != workflow.StatusImplementing {
-		t.Errorf("plan status = %q, want implementing (must not advance to QA)", stored.Status)
+	if stored.Status != workflow.StatusRejected {
+		t.Errorf("plan status = %q, want rejected (fail-fast terminal)", stored.Status)
 	}
-	if stored.LastError == "" {
-		t.Error("LastError should be set so the UI can surface the stall")
+	if !strings.Contains(stored.LastError, "README.md") {
+		t.Errorf("LastError = %q, want it to name the conflicting path README.md", stored.LastError)
+	}
+	// A distinct assembly_conflict decision must be recorded (not execution_exhausted).
+	var found *workflow.PlanDecision
+	for i := range stored.PlanDecisions {
+		if stored.PlanDecisions[i].Kind == workflow.PlanDecisionKindAssemblyConflict {
+			found = &stored.PlanDecisions[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected an assembly_conflict PlanDecision, got %+v", stored.PlanDecisions)
+	}
+	if !strings.Contains(found.Rationale, "README.md") {
+		t.Errorf("decision rationale = %q, want it to name README.md", found.Rationale)
+	}
+	if len(found.AffectedReqIDs) != 2 {
+		t.Errorf("decision AffectedReqIDs = %v, want both reqs", found.AffectedReqIDs)
 	}
 }
 
@@ -273,24 +288,23 @@ func TestHandleConvergenceAllSucceeded_ConflictDoesNotAdvanceToQA(t *testing.T) 
 	c.handleConvergenceAllSucceeded(context.Background(), plan, "demo", 2)
 
 	stored, _ := c.plans.get("demo")
-	if stored.Status != workflow.StatusImplementing {
-		t.Errorf("status = %q, want implementing (must not advance to QA on conflict)", stored.Status)
+	// Issue #176: a merge conflict fails the plan terminally (rejected) rather
+	// than parking at implementing — it must NOT advance to QA either way.
+	if stored.Status != workflow.StatusRejected {
+		t.Errorf("status = %q, want rejected (fail-fast terminal on conflict)", stored.Status)
 	}
-	if recovery == nil {
-		t.Fatal("expected RecoveryRequested on pre-QA merge conflict")
+	if recovery != nil {
+		t.Error("merge conflict must NOT fire recovery (fail terminal instead)")
 	}
 	if len(stub.createCalls) != 0 {
 		t.Errorf("QA worktree staged despite conflict: %v", stub.createCalls)
 	}
-	// Slice 4a end-to-end: the conflicting shared path must survive the whole
-	// chain (sandbox 409 → assembleRequirementBranches error → routeAssemblyConflict)
-	// into both the plan's LastError and the recovery feedback, so the diagnostic
-	// names the file two requirements collided on rather than a bare "merge failed".
+	// The conflicting shared path must survive the whole chain (sandbox 409 →
+	// assembleRequirementBranches error → routeAssemblyConflict) into the plan's
+	// LastError, so the diagnostic names the file two requirements collided on
+	// rather than a bare "merge failed".
 	if !strings.Contains(stored.LastError, "README.md") {
 		t.Errorf("plan.LastError = %q, want it to name the conflicting path README.md", stored.LastError)
-	}
-	if !strings.Contains(recovery.LastFailureFeedback, "README.md") {
-		t.Errorf("recovery.LastFailureFeedback = %q, want it to name the conflicting path README.md", recovery.LastFailureFeedback)
 	}
 }
 

--- a/processor/plan-reviewer/architecture_rules.go
+++ b/processor/plan-reviewer/architecture_rules.go
@@ -2,6 +2,7 @@ package planreviewer
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/c360studio/semspec/workflow"
@@ -71,6 +72,8 @@ func mergeArchitectureFindings(plan *workflow.Plan, result *workflow.PlanReviewR
 			componentOverloadedCapabilityFindings(plan.Architecture.ComponentBoundaries)...)
 		result.Findings = append(result.Findings,
 			capabilityUnresolvedInArchitectureFindings(plan)...)
+		result.Findings = append(result.Findings,
+			scopedFileOwnershipFindings(plan.Scope, plan.Architecture.ComponentBoundaries)...)
 	}
 
 	if len(result.Findings) > original {
@@ -352,4 +355,124 @@ func sourceFileCount(paths []string) int {
 		}
 	}
 	return n
+}
+
+// scopedFileOwnershipFindings emits one finding per scoped DELIVERABLE file that
+// no component owns (issue #175). The invariant: every file the build will write
+// must belong to exactly one component's implementation_files, so the scheduler
+// (workflow.DeriveStoryScheduling) serializes the stories that share an owned
+// file. A file owned by NO component is written by every parallel story and
+// produces an unmergeable conflict at assembly — the 2026-06-13 mavlink-hard
+// README wedge: README.md was a deliverable (scope.include) but appeared in no
+// component's implementation_files, so all four parallel stories wrote it and
+// assembleRequirementBranches conflicted.
+//
+// This is deliberately NOT docs-specific (a doc and a source file are treated
+// identically — both must be owned). It is the architecture-side mirror of the
+// developer-loop containment gate (structural-validator), which rejects a story
+// that MODIFIES an unowned file. Prevention here; containment there.
+//
+// Set S of scoped deliverables (the files that must be owned):
+//   - every concrete file in scope.create (creation intent ⇒ a deliverable), and
+//   - every concrete file in scope.include that is NOT in scope.do_not_touch
+//     (an in-scope existing file the plan will modify; do_not_touch marks the
+//     read-only references, which are excluded).
+//
+// "Concrete file" = a literal path with a file extension and no glob meta — this
+// excludes directory entries ("src/") and patterns ("src/**/*.java"), which a
+// component cannot own as a single path and which would otherwise false-positive.
+//
+// Composes with architecture.component_implementation_files_doc_only: a README
+// cannot satisfy this rule by becoming its own docs-only component (that rule
+// rejects it) — it must ride as a companion file on the source component that
+// produces it (single owner ⇒ single writer), or on several source components
+// (⇒ the scheduler serializes them). Either outcome closes the wedge.
+func scopedFileOwnershipFindings(scope workflow.Scope, components []workflow.ComponentDef) []workflow.PlanReviewFinding {
+	// Ownership universe: every file any component declares, regardless of the
+	// component's Name (an unnamed component is flagged elsewhere, but its files
+	// still count as owned — otherwise we'd emit spurious orphan findings).
+	owned := make(map[string]struct{})
+	for _, c := range components {
+		for _, f := range workflow.NormalizeFilePaths(c.ImplementationFiles) {
+			owned[f] = struct{}{}
+		}
+	}
+
+	doNotTouch := make(map[string]struct{})
+	for _, f := range workflow.NormalizeFilePaths(scope.DoNotTouch) {
+		doNotTouch[f] = struct{}{}
+	}
+
+	// Build S in deterministic order (create first, then include), recording the
+	// origin scope list for the finding message. First-seen origin wins so a file
+	// listed in both create and include is reported once as "create".
+	seen := make(map[string]struct{})
+	var findings []workflow.PlanReviewFinding
+
+	consider := func(raw, origin string) {
+		f := workflow.NormalizeFilePath(raw)
+		if f == "" || !isConcreteScopedFile(f) {
+			return
+		}
+		if _, dup := seen[f]; dup {
+			return
+		}
+		seen[f] = struct{}{}
+		if _, protected := doNotTouch[f]; protected {
+			return
+		}
+		if _, ok := owned[f]; ok {
+			return
+		}
+		findings = append(findings, workflow.PlanReviewFinding{
+			SOPID:       "architecture.scoped_file_unowned",
+			SOPTitle:    "Scoped deliverable file has no owning component (issue #175)",
+			Severity:    "error",
+			Status:      "violation",
+			Category:    "structural",
+			Phase:       "architecture",
+			TargetID:    f,
+			Action:      "add",
+			TargetField: "component_boundaries[].implementation_files",
+			TargetValue: fmt.Sprintf("path %q on exactly one component's implementation_files", f),
+			Issue:       fmt.Sprintf("Scoped file %q is a deliverable (scope.%s) but appears in no component's implementation_files. Every file the build writes must have exactly one owning component; an unowned file is written by every parallel story and produces an unmergeable conflict at assembly (the 2026-06-13 README wedge).", f, origin),
+			Suggestion:  fmt.Sprintf("Add %q to the implementation_files of the single source component that produces it (a README/doc may ride as a companion alongside source — it cannot be its own docs-only component). If %q is a read-only reference, move it to scope.do_not_touch instead.", f, f),
+		})
+	}
+
+	for _, f := range scope.Create {
+		consider(f, "create")
+	}
+	for _, f := range scope.Include {
+		consider(f, "include")
+	}
+	return findings
+}
+
+// wellKnownExtensionlessDeliverables are root-level deliverable files that carry
+// no extension but are real owned artifacts a parallel story can collide on the
+// same way README did. Without this set isConcreteScopedFile would exempt them
+// (path.Ext == "") and Gate 1 would miss a Dockerfile/Makefile co-write.
+var wellKnownExtensionlessDeliverables = map[string]bool{
+	"Dockerfile":  true,
+	"Makefile":    true,
+	"Jenkinsfile": true,
+	"Vagrantfile": true,
+	"Procfile":    true,
+}
+
+// isConcreteScopedFile reports whether a normalized scoped path is a single
+// literal file (not a directory entry or glob). It must either carry a file
+// extension or be a well-known extensionless deliverable, and contain no glob
+// metacharacters. Directory entries ("src") and patterns ("src/**/*.java")
+// return false — a component owns concrete files, not dirs or patterns, so
+// requiring those to be "owned" would false-positive.
+func isConcreteScopedFile(p string) bool {
+	if strings.ContainsAny(p, "*?[") {
+		return false
+	}
+	if path.Ext(p) != "" {
+		return true
+	}
+	return wellKnownExtensionlessDeliverables[path.Base(p)]
 }

--- a/processor/plan-reviewer/architecture_rules_test.go
+++ b/processor/plan-reviewer/architecture_rules_test.go
@@ -601,3 +601,167 @@ func TestHasSourceFile_DelegatesToWorkflowClassifier(t *testing.T) {
 		})
 	}
 }
+
+// --- Gate 1: scoped-file ownership (issue #175) -----------------------------
+
+// countScopedUnowned returns the scoped_file_unowned findings keyed by TargetID.
+func scopedUnownedByTarget(findings []workflow.PlanReviewFinding) map[string]workflow.PlanReviewFinding {
+	out := make(map[string]workflow.PlanReviewFinding)
+	for _, f := range findings {
+		if f.SOPID == "architecture.scoped_file_unowned" {
+			out[f.TargetID] = f
+		}
+	}
+	return out
+}
+
+// TestScopedFileOwnershipFindings tables the prevention gate that forces every
+// scoped deliverable file to be owned by some component. README.md being owned
+// by no component is the 2026-06-13 mavlink-hard wedge fingerprint.
+func TestScopedFileOwnershipFindings(t *testing.T) {
+	comp := func(name string, files ...string) workflow.ComponentDef {
+		return workflow.ComponentDef{Name: name, ImplementationFiles: files, Capabilities: []string{"c"}}
+	}
+
+	tests := []struct {
+		name       string
+		scope      workflow.Scope
+		components []workflow.ComponentDef
+		wantOrphan []string // TargetIDs expected to fire (order-independent)
+	}{
+		{
+			name:       "create file unowned",
+			scope:      workflow.Scope{Create: []string{"src/New.java"}},
+			components: []workflow.ComponentDef{comp("c1", "src/Other.java")},
+			wantOrphan: []string{"src/New.java"},
+		},
+		{
+			name:       "include README unowned (the bug)",
+			scope:      workflow.Scope{Include: []string{"build.gradle", "README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "build.gradle", "src/A.java")},
+			wantOrphan: []string{"README.md"},
+		},
+		{
+			name:       "include read-only ref in do_not_touch is excluded",
+			scope:      workflow.Scope{Include: []string{"docs/SPEC.md"}, DoNotTouch: []string{"docs/SPEC.md"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "include directory entry is not a concrete file",
+			scope:      workflow.Scope{Include: []string{"src/", "gradle/"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "include glob entry is not a concrete file",
+			scope:      workflow.Scope{Include: []string{"src/**/*.java"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "all create+include owned",
+			scope:      workflow.Scope{Create: []string{"src/A.java"}, Include: []string{"README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java"), comp("c2", "README.md", "src/B.java")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "README owned as companion on a source component",
+			scope:      workflow.Scope{Include: []string{"README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java", "README.md")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "README owned on two source components (scheduler serializes downstream)",
+			scope:      workflow.Scope{Include: []string{"README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java", "README.md"), comp("c2", "src/B.java", "README.md")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "normalization collapses ./ prefix",
+			scope:      workflow.Scope{Include: []string{"./README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "README.md")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "empty scope greenfield",
+			scope:      workflow.Scope{},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: nil,
+		},
+		{
+			name:       "well-known extensionless deliverable (Makefile) IS gated",
+			scope:      workflow.Scope{Create: []string{"Makefile"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: []string{"Makefile"}, // in the extensionless-deliverable allowlist
+		},
+		{
+			name:       "unknown extensionless entry not gated (avoids dir false positives)",
+			scope:      workflow.Scope{Include: []string{"scripts"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: nil, // no extension, not in allowlist -> treated as a dir
+		},
+		{
+			name:       "file in both create and include reported once",
+			scope:      workflow.Scope{Create: []string{"README.md"}, Include: []string{"README.md"}},
+			components: []workflow.ComponentDef{comp("c1", "src/A.java")},
+			wantOrphan: []string{"README.md"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scopedUnownedByTarget(scopedFileOwnershipFindings(tc.scope, tc.components))
+			if len(got) != len(tc.wantOrphan) {
+				t.Fatalf("got %d orphan findings %v, want %d %v", len(got), keysOf(got), len(tc.wantOrphan), tc.wantOrphan)
+			}
+			for _, want := range tc.wantOrphan {
+				f, ok := got[want]
+				if !ok {
+					t.Fatalf("expected orphan finding for %q, got %v", want, keysOf(got))
+				}
+				if f.Severity != "error" || f.Action != "add" {
+					t.Errorf("finding %q has wrong shape: severity=%q action=%q", want, f.Severity, f.Action)
+				}
+			}
+		})
+	}
+}
+
+func keysOf(m map[string]workflow.PlanReviewFinding) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestScopedFileOwnership_IntegrationVerdictFlip confirms the rule fires through
+// mergeArchitectureFindings and flips the verdict to needs_changes.
+func TestScopedFileOwnership_IntegrationVerdictFlip(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug:        "scoped-unowned",
+		Exploration: &workflow.Exploration{Capabilities: []workflow.Capability{{Name: "telemetry", Lifecycle: workflow.CapabilityNew, Description: "T."}}},
+		Scope:       workflow.Scope{Include: []string{"README.md"}, Create: []string{"src/Telemetry.java"}},
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				// Owns the source file but NOT README.md → README orphaned.
+				{Name: "cs-telemetry", ImplementationFiles: []string{"src/Telemetry.java"}, Capabilities: []string{"telemetry"}},
+			},
+		},
+	}
+	result := &workflow.PlanReviewResult{Verdict: "approved"}
+
+	mergeArchitectureFindings(plan, result)
+
+	got := scopedUnownedByTarget(result.Findings)
+	if _, ok := got["README.md"]; !ok {
+		t.Fatalf("expected README.md orphan finding through mergeArchitectureFindings, got %v", keysOf(got))
+	}
+	if _, ok := got["src/Telemetry.java"]; ok {
+		t.Errorf("src/Telemetry.java is owned; should not be flagged")
+	}
+	if result.Verdict != "needs_changes" {
+		t.Errorf("expected verdict needs_changes, got %q", result.Verdict)
+	}
+}

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -129,6 +129,16 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		results = append(results, e.runGoTestsExistOnModifiedIn(ctx, trigger.FilesModified, workDir, runner))
 	}
 
+	// Always-on gate: a story may only MODIFY files it owns, and must not commit
+	// scratch artefacts (*.orig, patch.diff, …). Computes the authoritative
+	// change set from `git status` in the worktree (the agent's self-reported
+	// FilesModified is not trustworthy for a gate about the agent overstepping).
+	// Skips when there's no ownership context (manual validation / E2E). Closes
+	// the 2026-06-13 mavlink-hard README assembly wedge upstream of merge
+	// (issues #175 / #177).
+	results = append(results,
+		e.runFileOwnershipContainment(ctx, workflow.NormalizeFilePaths(trigger.FilesOwned), workDir, runner)...)
+
 	// Advisory anti-mock governance check — only when test files are present.
 	if hasTestFiles(trigger.FilesModified) {
 		antiMockResult := CheckAntiMock(workDir, trigger.FilesModified)

--- a/processor/structural-validator/ownership_check.go
+++ b/processor/structural-validator/ownership_check.go
@@ -1,0 +1,257 @@
+package structuralvalidator
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// File-ownership containment gate (issues #175 / #177).
+//
+// A story may only MODIFY files it owns, and must not commit scratch artefacts.
+// A file owned by NO story is written by every parallel story and produces an
+// unmergeable conflict at assembly (the 2026-06-13 mavlink-hard README wedge);
+// scratch (patch.diff, *.orig) rides `git add -A` onto the branch and collides
+// the same way.
+//
+// The check computes the AUTHORITATIVE changed set from `git status` in the
+// worktree rather than trusting the agent's self-reported FilesModified — the
+// whole point of the gate is to catch the agent overstepping, so its own claim
+// can't be the source of truth. It runs BEFORE submit_work commits, so the
+// untracked scratch that `git add -A` is about to stage is still visible as `??`.
+//
+// The pure core (parsePorcelain / isJunkArtifact / decideOwnership) holds no IO
+// and is the unit-test surface.
+
+// porcelainEntry is one parsed line of `git status --porcelain=v1`.
+type porcelainEntry struct {
+	Path        string // current path (rename destination for R/C entries)
+	IndexStatus byte   // X column
+	WorkStatus  byte   // Y column
+}
+
+// isNew reports whether the entry is a file the dev CREATED (untracked or
+// index-added) rather than a modification of a pre-existing tracked file.
+func (e porcelainEntry) isNew() bool {
+	return (e.IndexStatus == '?' && e.WorkStatus == '?') || e.IndexStatus == 'A'
+}
+
+// ownershipVerdict is the classification of a worktree change set against the
+// story's owned file set.
+//
+// The hard-fail vs advisory line is drawn at MERGEABLE vs UNMERGEABLE, not
+// new-vs-modified. The assembly wedge is caused by a shared DOC co-written by
+// parallel stories (README + the coverage matrix — line-level conflicts that
+// cannot auto-merge). A non-owner bumping build.gradle / go.mod or editing a
+// pre-existing test usually merges cleanly and is a routine TDD move, so it is
+// advisory (surfaced to the reviewer; #176 fails honestly if it does conflict).
+type ownershipVerdict struct {
+	// JunkViolations are committed scratch/merge artefacts (hard fail). Each
+	// element is "path (pattern)".
+	JunkViolations []string
+	// ModifiedDocUnowned are pre-existing DOCUMENTATION files a non-owner
+	// modified (hard fail — the unmergeable co-write that wedged the
+	// 2026-06-13 README assembly).
+	ModifiedDocUnowned []string
+	// ModifiedUnowned are pre-existing non-doc files a non-owner modified
+	// (advisory — source/build edits usually merge; surfaced, not blocked).
+	ModifiedUnowned []string
+	// NewUnowned are newly-created files outside the owned set (advisory — a dev
+	// legitimately splitting a class into a new file lands here; too noisy to
+	// hard-fail).
+	NewUnowned []string
+}
+
+// clean reports whether there are no hard-fail violations.
+func (v ownershipVerdict) clean() bool {
+	return len(v.JunkViolations) == 0 && len(v.ModifiedDocUnowned) == 0
+}
+
+// parsePorcelain parses `git status --porcelain=v1` output into entries. It is
+// tolerant of trailing newlines and blank lines. Renames/copies report the
+// destination path (the part after " -> "). Double-quoted paths (git quotes
+// paths with special chars) are unquoted best-effort.
+func parsePorcelain(stdout string) []porcelainEntry {
+	var out []porcelainEntry
+	for _, line := range strings.Split(stdout, "\n") {
+		// A porcelain v1 line is "XY PATH"; minimum length 4 ("XY x").
+		if len(line) < 4 {
+			continue
+		}
+		x, y := line[0], line[1]
+		rest := line[3:] // skip the single separating space at index 2
+		if i := strings.Index(rest, " -> "); i >= 0 {
+			rest = rest[i+len(" -> "):]
+		}
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(rest, `"`) && strings.HasSuffix(rest, `"`) && len(rest) >= 2 {
+			rest = rest[1 : len(rest)-1]
+		}
+		if rest == "" {
+			continue
+		}
+		out = append(out, porcelainEntry{Path: rest, IndexStatus: x, WorkStatus: y})
+	}
+	return out
+}
+
+// isJunkArtifact reports whether a path is a scratch/merge artefact that must
+// never be committed (issue #177). Matched on the basename. Deliberately narrow
+// — only non-source artefact shapes — so it never collides with a legitimate
+// source or test file (those are handled by the modified/new-unowned rules).
+func isJunkArtifact(p string) (pattern string, ok bool) {
+	base := path.Base(strings.ReplaceAll(p, "\\", "/"))
+	switch {
+	case strings.HasSuffix(base, ".orig"):
+		return "*.orig", true
+	case strings.HasSuffix(base, ".rej"):
+		return "*.rej", true
+	case strings.HasSuffix(base, ".patch"):
+		return "*.patch", true
+	case strings.HasSuffix(base, ".bak"):
+		return "*.bak", true
+	case strings.HasSuffix(base, ".tmp"):
+		return "*.tmp", true
+	case strings.HasSuffix(base, ".swp"):
+		return "*.swp", true
+	case strings.HasSuffix(base, "~"):
+		return "*~", true
+	case strings.HasPrefix(base, "patch") && strings.HasSuffix(base, ".diff"):
+		// patch.diff, patch2.diff — saved `git diff` output committed at root.
+		return "patch*.diff", true
+	default:
+		return "", false
+	}
+}
+
+// decideOwnership classifies a worktree change set against the owned file set.
+// Pure: no git, no IO. owned is the normalized set of Story.FilesOwned.
+func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) ownershipVerdict {
+	var v ownershipVerdict
+	for _, c := range changes {
+		norm := workflow.NormalizeFilePath(c.Path)
+		if norm == "" {
+			continue
+		}
+		if pattern, ok := isJunkArtifact(norm); ok {
+			v.JunkViolations = append(v.JunkViolations, fmt.Sprintf("%s (%s)", norm, pattern))
+			continue
+		}
+		if _, isOwned := owned[norm]; isOwned {
+			continue
+		}
+		switch {
+		case c.isNew():
+			v.NewUnowned = append(v.NewUnowned, norm)
+		case workflow.IsDocumentationPath(norm):
+			// A non-owner co-writing a shared doc is the unmergeable shape.
+			v.ModifiedDocUnowned = append(v.ModifiedDocUnowned, norm)
+		default:
+			v.ModifiedUnowned = append(v.ModifiedUnowned, norm)
+		}
+	}
+	return v
+}
+
+// runFileOwnershipContainment computes the worktree's actual change set via
+// `git status --porcelain` (run in workDir via runner) and returns up to two
+// CheckResults: a Required containment verdict (junk + modified-unowned) and an
+// advisory new-files list. When owned is empty the gate is skipped (manual
+// validation / E2E / any dispatch without story context). A git failure is
+// surfaced as a non-blocking advisory rather than a hard fail — the gate must
+// not wedge a run on a plumbing hiccup.
+func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []string, workDir string, runner CommandRunner) []payloads.CheckResult {
+	const checkName = "file-ownership-containment"
+
+	// No story ownership context (manual validation / E2E / any dispatch
+	// without FilesOwned) — the gate does not apply. Return no check row so it
+	// is invisible to ChecksRun rather than a spurious always-pass result.
+	if len(owned) == 0 {
+		return nil
+	}
+
+	ownedSet := make(map[string]struct{}, len(owned))
+	for _, f := range owned {
+		ownedSet[f] = struct{}{}
+	}
+
+	start := time.Now()
+	// --untracked-files=all reports untracked-but-not-ignored files. Scratch
+	// that a repo's .gitignore already covers (the fixtures' *.orig/patch.diff
+	// patterns) is therefore invisible here — which is correct: git add -A also
+	// honours .gitignore, so that scratch never reaches the commit. The junk arm
+	// below is thus the PORTABLE FALLBACK for repos that lack such a .gitignore
+	// (e.g. a fresh user project), not a duplicate of the fixture gitignore.
+	cmd := "git status --porcelain=v1 --untracked-files=all"
+	stdout, stderr, exitCode, err := runner.Run(ctx, cmd, workDir, 15*time.Second)
+	duration := time.Since(start).String()
+
+	if err != nil || exitCode != 0 {
+		// Don't block on a git plumbing failure — advisory only.
+		detail := strings.TrimSpace(stderr)
+		if err != nil {
+			detail = err.Error()
+		}
+		return []payloads.CheckResult{{
+			Name:     checkName,
+			Passed:   true,
+			Required: false,
+			Command:  cmd,
+			ExitCode: exitCode,
+			Stdout:   fmt.Sprintf("could not compute change set (git status failed): %s — containment gate skipped", detail),
+			Duration: duration,
+		}}
+	}
+
+	verdict := decideOwnership(parsePorcelain(stdout), ownedSet)
+
+	var results []payloads.CheckResult
+
+	// Required gate: scratch artefacts + a non-owner co-writing a shared doc
+	// (the unmergeable shapes that wedge assembly).
+	containment := payloads.CheckResult{
+		Name:     checkName,
+		Passed:   verdict.clean(),
+		Required: true,
+		Command:  cmd,
+		Duration: duration,
+	}
+	if verdict.clean() {
+		containment.Stdout = fmt.Sprintf("no scratch artefacts committed and no shared docs co-written outside the story's %d owned path(s)", len(owned))
+	} else {
+		var b strings.Builder
+		if len(verdict.JunkViolations) > 0 {
+			fmt.Fprintf(&b, "Scratch/merge artefacts must not be committed (write scratch to /tmp, not the worktree): %s. ", strings.Join(verdict.JunkViolations, ", "))
+		}
+		if len(verdict.ModifiedDocUnowned) > 0 {
+			fmt.Fprintf(&b, "Modified shared documentation this story does not own: %s. A doc owned by no story (or by another story) is co-written by parallel stories and cannot be merged at assembly — only edit docs in your file scope; if a deliverable doc isn't yours, surface it as a planning gap. ", strings.Join(verdict.ModifiedDocUnowned, ", "))
+		}
+		fmt.Fprintf(&b, "Owned paths: %s.", strings.Join(owned, ", "))
+		containment.ExitCode = 1
+		containment.Stderr = b.String()
+	}
+	results = append(results, containment)
+
+	// Advisory: non-doc files modified outside ownership (usually mergeable
+	// build/source edits) + new files outside the owned set (legitimate class
+	// splits). Surfaced to the reviewer, never hard-fails.
+	advisory := append(append([]string(nil), verdict.ModifiedUnowned...), verdict.NewUnowned...)
+	if len(advisory) > 0 {
+		results = append(results, payloads.CheckResult{
+			Name:     "file-ownership-advisory",
+			Passed:   false,
+			Required: false,
+			Command:  cmd,
+			Stdout: fmt.Sprintf("touched %d file(s) outside the declared file scope (advisory — confirm these belong to this story; a conflict at assembly will fail the plan honestly): %s",
+				len(advisory), strings.Join(advisory, ", ")),
+			Duration: duration,
+		})
+	}
+
+	return results
+}

--- a/processor/structural-validator/ownership_check_test.go
+++ b/processor/structural-validator/ownership_check_test.go
@@ -1,0 +1,419 @@
+package structuralvalidator
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+func sortedCopy(s []string) []string {
+	out := append([]string(nil), s...)
+	sort.Strings(out)
+	return out
+}
+
+func ownedSetOf(paths ...string) map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, p := range workflow.NormalizeFilePaths(paths) {
+		m[p] = struct{}{}
+	}
+	return m
+}
+
+func TestParsePorcelain(t *testing.T) {
+	in := " M src/A.java\n" +
+		"?? patch.diff\n" +
+		"A  src/New.java\n" +
+		"R  old/Old.java -> src/Renamed.java\n" +
+		"\n" + // blank line tolerated
+		"M  build.gradle\n"
+	got := parsePorcelain(in)
+
+	want := []porcelainEntry{
+		{Path: "src/A.java", IndexStatus: ' ', WorkStatus: 'M'},
+		{Path: "patch.diff", IndexStatus: '?', WorkStatus: '?'},
+		{Path: "src/New.java", IndexStatus: 'A', WorkStatus: ' '},
+		{Path: "src/Renamed.java", IndexStatus: 'R', WorkStatus: ' '},
+		{Path: "build.gradle", IndexStatus: 'M', WorkStatus: ' '},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parsePorcelain returned %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestIsJunkArtifact(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"src/A.java.orig", true},
+		{"A.rej", true},
+		{"foo.patch", true},
+		{"patch.diff", true},
+		{"patch2.diff", true},
+		{"deep/dir/patch3.diff", true},
+		{"backup.bak", true},
+		{"x.tmp", true},
+		{".file.swp", true},
+		{"foo~", true},
+		{"src/Main.java", false},
+		{"README.md", false},
+		{"build.gradle", false},
+		{"data.diff", false}, // .diff without patch prefix is not junk
+		{"src/test/AppTest.java", false},
+	}
+	for _, tc := range tests {
+		if _, ok := isJunkArtifact(tc.path); ok != tc.want {
+			t.Errorf("isJunkArtifact(%q) = %v, want %v", tc.path, ok, tc.want)
+		}
+	}
+}
+
+func TestDecideOwnership(t *testing.T) {
+	tests := []struct {
+		name              string
+		porcelain         string
+		owned             map[string]struct{}
+		wantJunk          []string // matched by path prefix (pattern suffix ignored)
+		wantModDocUnowned []string // hard-fail: non-owner co-writing a shared doc
+		wantModUnowned    []string // advisory: non-owner editing non-doc
+		wantNewUnowned    []string // advisory: new file outside ownership
+	}{
+		{
+			name:              "modified non-owned DOC (README wedge) hard-fails",
+			porcelain:         " M README.md",
+			owned:             ownedSetOf("src/A.java"),
+			wantModDocUnowned: []string{"README.md"},
+		},
+		{
+			name:           "modified non-owned BUILD file is advisory (usually mergeable)",
+			porcelain:      " M build.gradle",
+			owned:          ownedSetOf("src/A.java"),
+			wantModUnowned: []string{"build.gradle"},
+		},
+		{
+			name:           "modified non-owned source file is advisory",
+			porcelain:      " M src/Other.java",
+			owned:          ownedSetOf("src/A.java"),
+			wantModUnowned: []string{"src/Other.java"},
+		},
+		{
+			name:      "modified owned file is clean",
+			porcelain: " M src/A.java",
+			owned:     ownedSetOf("src/A.java"),
+		},
+		{
+			name:      "new owned source file is clean",
+			porcelain: "A  src/A.java",
+			owned:     ownedSetOf("src/A.java"),
+		},
+		{
+			name:           "new unowned source (class split) is advisory",
+			porcelain:      "?? src/FooHelper.java",
+			owned:          ownedSetOf("src/Foo.java"),
+			wantNewUnowned: []string{"src/FooHelper.java"},
+		},
+		{
+			name:      "patch.diff committed is junk",
+			porcelain: "?? patch.diff",
+			owned:     ownedSetOf("src/A.java"),
+			wantJunk:  []string{"patch.diff"},
+		},
+		{
+			name:      "patch2.diff is junk",
+			porcelain: "?? patch2.diff",
+			owned:     ownedSetOf("src/A.java"),
+			wantJunk:  []string{"patch2.diff"},
+		},
+		{
+			name:      "orig file is junk",
+			porcelain: "?? src/A.java.orig",
+			owned:     ownedSetOf("src/A.java"),
+			wantJunk:  []string{"src/A.java.orig"},
+		},
+		{
+			name:      "staged-modified owned is clean",
+			porcelain: "M  src/A.java",
+			owned:     ownedSetOf("src/A.java"),
+		},
+		{
+			name:      "renamed to owned path is clean",
+			porcelain: "R  old.java -> src/A.java",
+			owned:     ownedSetOf("src/A.java"),
+		},
+		{
+			name:           "renamed to unowned non-doc path is advisory",
+			porcelain:      "R  old.java -> src/B.java",
+			owned:          ownedSetOf("src/A.java"),
+			wantModUnowned: []string{"src/B.java"},
+		},
+		{
+			name:           "deleted unowned non-doc file is advisory",
+			porcelain:      " D shared/Config.java",
+			owned:          ownedSetOf("src/A.java"),
+			wantModUnowned: []string{"shared/Config.java"},
+		},
+		{
+			name:      "normalization matches owned with ./ prefix",
+			porcelain: " M ./README.md",
+			owned:     ownedSetOf("README.md"),
+		},
+		{
+			name:              "normalization flags modified ./ unowned doc",
+			porcelain:         " M ./README.md",
+			owned:             ownedSetOf("src/A.java"),
+			wantModDocUnowned: []string{"README.md"},
+		},
+		{
+			name:      "junk takes precedence over ownership classification",
+			porcelain: "?? README.md.orig",
+			owned:     ownedSetOf("README.md"),
+			wantJunk:  []string{"README.md.orig"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := decideOwnership(parsePorcelain(tc.porcelain), tc.owned)
+
+			// Junk findings carry a "(pattern)" suffix; compare on the path prefix.
+			gotJunkPaths := make([]string, len(v.JunkViolations))
+			for i, j := range v.JunkViolations {
+				gotJunkPaths[i] = strings.SplitN(j, " (", 2)[0]
+			}
+			if !equalSets(gotJunkPaths, tc.wantJunk) {
+				t.Errorf("junk = %v, want %v", sortedCopy(gotJunkPaths), sortedCopy(tc.wantJunk))
+			}
+			if !equalSets(v.ModifiedDocUnowned, tc.wantModDocUnowned) {
+				t.Errorf("modifiedDocUnowned = %v, want %v", sortedCopy(v.ModifiedDocUnowned), sortedCopy(tc.wantModDocUnowned))
+			}
+			if !equalSets(v.ModifiedUnowned, tc.wantModUnowned) {
+				t.Errorf("modifiedUnowned = %v, want %v", sortedCopy(v.ModifiedUnowned), sortedCopy(tc.wantModUnowned))
+			}
+			if !equalSets(v.NewUnowned, tc.wantNewUnowned) {
+				t.Errorf("newUnowned = %v, want %v", sortedCopy(v.NewUnowned), sortedCopy(tc.wantNewUnowned))
+			}
+		})
+	}
+}
+
+func equalSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as, bs := sortedCopy(a), sortedCopy(b)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// fakeRunner returns canned output for the containment integration test.
+type fakeRunner struct {
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+	gotCmd   string
+}
+
+func (f *fakeRunner) Run(_ context.Context, command, _ string, _ time.Duration) (string, string, int, error) {
+	f.gotCmd = command
+	return f.stdout, f.stderr, f.exitCode, f.err
+}
+
+func TestRunFileOwnershipContainment(t *testing.T) {
+	e := &Executor{}
+
+	t.Run("empty owned skips gate (no check row)", func(t *testing.T) {
+		runner := &fakeRunner{stdout: " M README.md"}
+		results := e.runFileOwnershipContainment(context.Background(), nil, "/wt", runner)
+		if len(results) != 0 {
+			t.Fatalf("expected no check rows when owned is empty, got %+v", results)
+		}
+		if runner.gotCmd != "" {
+			t.Errorf("git should not run when owned is empty, ran %q", runner.gotCmd)
+		}
+	})
+
+	t.Run("modified-unowned DOC hard fails the required gate", func(t *testing.T) {
+		runner := &fakeRunner{stdout: " M README.md\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		c := findResult(t, results, "file-ownership-containment")
+		if c.Passed || !c.Required {
+			t.Fatalf("expected required FAIL, got %+v", c)
+		}
+		if !strings.Contains(c.Stderr, "README.md") {
+			t.Errorf("expected README.md named in failure, got %q", c.Stderr)
+		}
+	})
+
+	t.Run("modified-unowned non-doc (build.gradle) is advisory, gate passes", func(t *testing.T) {
+		runner := &fakeRunner{stdout: " M build.gradle\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		c := findResult(t, results, "file-ownership-containment")
+		if !c.Passed {
+			t.Fatalf("build-file edit by a non-owner must NOT hard-fail (usually mergeable), got %+v", c)
+		}
+		adv := findResult(t, results, "file-ownership-advisory")
+		if adv.Required || !strings.Contains(adv.Stdout, "build.gradle") {
+			t.Errorf("expected build.gradle in advisory result, got %+v", adv)
+		}
+	})
+
+	t.Run("junk hard fails the required gate", func(t *testing.T) {
+		runner := &fakeRunner{stdout: "?? patch.diff\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		c := findResult(t, results, "file-ownership-containment")
+		if c.Passed {
+			t.Fatalf("expected required FAIL on patch.diff, got %+v", c)
+		}
+		if !strings.Contains(c.Stderr, "patch.diff") {
+			t.Errorf("expected patch.diff named, got %q", c.Stderr)
+		}
+	})
+
+	t.Run("new-unowned is advisory, gate passes", func(t *testing.T) {
+		runner := &fakeRunner{stdout: "?? src/Helper.java\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		c := findResult(t, results, "file-ownership-containment")
+		if !c.Passed {
+			t.Fatalf("required gate should pass when only new-unowned present, got %+v", c)
+		}
+		adv := findResult(t, results, "file-ownership-advisory")
+		if adv.Required {
+			t.Errorf("advisory result must be advisory (Required=false), got %+v", adv)
+		}
+		if !strings.Contains(adv.Stdout, "src/Helper.java") {
+			t.Errorf("expected Helper.java named in advisory, got %q", adv.Stdout)
+		}
+	})
+
+	t.Run("all owned and clean passes with no advisory", func(t *testing.T) {
+		runner := &fakeRunner{stdout: " M src/A.java\nA  src/B.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java", "src/B.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		if len(results) != 1 {
+			t.Fatalf("expected only the required result, got %+v", results)
+		}
+		if !results[0].Passed || !results[0].Required {
+			t.Errorf("expected passing required result, got %+v", results[0])
+		}
+	})
+
+	t.Run("git failure is advisory not a hard fail", func(t *testing.T) {
+		runner := &fakeRunner{exitCode: 128, stderr: "not a git repository"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		if len(results) != 1 || !results[0].Passed || results[0].Required {
+			t.Fatalf("git failure must not hard-fail, got %+v", results)
+		}
+	})
+}
+
+func findResult(t *testing.T, results []payloads.CheckResult, name string) payloads.CheckResult {
+	t.Helper()
+	for _, r := range results {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("no CheckResult named %q in %+v", name, results)
+	return payloads.CheckResult{}
+}
+
+// gitRun runs a git command in dir, failing the test on error.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestRunFileOwnershipContainment_RealGit validates parsePorcelain against the
+// ACTUAL `git status --porcelain` output (not synthetic blobs) — the CLAUDE.md
+// "real fixture not guessed" discipline. It also pins the H1 interaction: a
+// gitignored scratch file is invisible to --untracked-files=all (so the junk arm
+// is the fallback for repos lacking a gitignore), while a NON-ignored patch.diff
+// is caught.
+func TestRunFileOwnershipContainment_RealGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-q")
+
+	write := func(rel, content string) {
+		t.Helper()
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Base commit: an owned source file + a shared README + a .gitignore.
+	write("src/A.java", "class A {}\n")
+	write("README.md", "# base\n")
+	write(".gitignore", "*.orig\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-qm", "base")
+
+	// Dev changes: modify owned source (clean), co-write the shared README
+	// (hard-fail doc), drop a non-ignored patch.diff (hard-fail junk), drop a
+	// gitignored A.java.orig (invisible — fallback only), add a new helper
+	// (advisory).
+	write("src/A.java", "class A { int x; }\n")
+	write("README.md", "# base\nmy section\n")
+	write("patch.diff", "diff --git ...\n")
+	write("src/A.java.orig", "leftover\n")
+	write("src/Helper.java", "class Helper {}\n")
+
+	owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+	results := (&Executor{}).runFileOwnershipContainment(context.Background(), owned, dir, &localRunner{})
+
+	c := findResult(t, results, "file-ownership-containment")
+	if c.Passed {
+		t.Fatalf("expected required FAIL (README doc co-write + patch.diff junk), got pass: %+v", c)
+	}
+	if !strings.Contains(c.Stderr, "README.md") {
+		t.Errorf("expected README.md (doc co-write) named, got %q", c.Stderr)
+	}
+	if !strings.Contains(c.Stderr, "patch.diff") {
+		t.Errorf("expected patch.diff (junk) named, got %q", c.Stderr)
+	}
+	// The gitignored *.orig must NOT appear (it's invisible to --untracked-files=all).
+	if strings.Contains(c.Stderr, ".orig") {
+		t.Errorf("gitignored .orig should be invisible to the gate, but appeared: %q", c.Stderr)
+	}
+	adv := findResult(t, results, "file-ownership-advisory")
+	if !strings.Contains(adv.Stdout, "src/Helper.java") {
+		t.Errorf("expected new Helper.java in advisory, got %q", adv.Stdout)
+	}
+}

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -195,6 +195,10 @@ What you don't need to do:
 - Don't create branches or stash. The worktree IS your branch.
 - Don't worry about merging — that happens after submit_work, on a different lock.
 
+Scratch files go to /tmp, never the worktree. Because the system commits EVERYTHING in your worktree wholesale (git add -A), any temporary file you leave behind gets committed as part of your contribution and then collides when your branch is merged with your siblings' branches at assembly. This is a real failure mode: a patch.diff saved from ` + "`git apply`" + `, a *.orig/*.rej left by a conflict, a throwaway Inspect.java or test_*.java probe — all rode git add -A onto the branch and wedged a real run (2026-06-13 mavlink-hard). Write all scratch, experiments, and one-off probes under /tmp/. The only files in your worktree at submit time should be the deliverables in your file scope; if you created a scratch file in the worktree, ` + "`rm`" + ` it before you submit.
+
+Stay inside your file scope. Only create or modify the files you own (your file scope / the component's implementation files). Do NOT edit a shared file you don't own — e.g. a README/coverage doc, a build file, or another component's source — to "document your part" or wire something up. A file owned by no story, written by every story, cannot be merged. If a deliverable you need isn't in your scope, that's a planning gap to surface, not a file to grab.
+
 If a file write seems to have succeeded but git status shows nothing, you wrote outside the worktree. Re-read the path you used and try again from the worktree root.
 
 VERIFY, DON'T INVENT — anti-fabrication rules:

--- a/test/e2e/fixtures/osh-driver-mavsdk/.gitignore
+++ b/test/e2e/fixtures/osh-driver-mavsdk/.gitignore
@@ -18,3 +18,16 @@ build/
 .classpath
 .project
 .settings/
+
+# Scratch / merge artefacts — never commit (issue #177). The sandbox commits
+# the worktree with `git add -A`, which honours .gitignore for UNTRACKED files,
+# so ignoring these keeps a dev's throwaway probes and merge leftovers out of
+# the per-requirement branch (a root cause of the 2026-06-13 mavlink-hard
+# assembly wedge: patch.diff/*.orig committed on parallel branches collided).
+*.orig
+*.rej
+*.patch
+patch.diff
+patch*.diff
+*.bak
+*~

--- a/test/e2e/fixtures/osh-driver-meshtastic/.gitignore
+++ b/test/e2e/fixtures/osh-driver-meshtastic/.gitignore
@@ -18,3 +18,16 @@ build/
 .classpath
 .project
 .settings/
+
+# Scratch / merge artefacts — never commit (issue #177). The sandbox commits
+# the worktree with `git add -A`, which honours .gitignore for UNTRACKED files,
+# so ignoring these keeps a dev's throwaway probes and merge leftovers out of
+# the per-requirement branch (a root cause of the 2026-06-13 mavlink-hard
+# assembly wedge: patch.diff/*.orig committed on parallel branches collided).
+*.orig
+*.rej
+*.patch
+patch.diff
+patch*.diff
+*.bak
+*~

--- a/workflow/cascade/cascade.go
+++ b/workflow/cascade/cascade.go
@@ -95,10 +95,13 @@ func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, sce
 			}
 		}
 
-	case workflow.PlanDecisionKindExecutionExhausted:
-		// Terminal kind — cascade is a no-op beyond recording the
+	case workflow.PlanDecisionKindExecutionExhausted,
+		workflow.PlanDecisionKindAssemblyConflict:
+		// Terminal kinds — cascade is a no-op beyond recording the
 		// AffectedRequirementIDs already populated above for caller
-		// telemetry. Stories + Scenarios stay empty.
+		// telemetry. Stories + Scenarios stay empty. assembly_conflict
+		// (issue #176) is informational: the plan is already failed to
+		// rejected, so there is nothing to dirty-cascade.
 
 	case workflow.PlanDecisionKindArchitectureRevise:
 		// The plan-manager accept handler already wiped Architecture +

--- a/workflow/derive_story_scheduling_test.go
+++ b/workflow/derive_story_scheduling_test.go
@@ -356,3 +356,49 @@ func TestDeriveStoryScheduling_Pass2_NoEdgeWhenDisjointFiles(t *testing.T) {
 		t.Errorf("s2 DependsOn should be empty, got %v", stories[1].DependsOn)
 	}
 }
+
+// TestDeriveStoryScheduling_SharedDeliverableDocSerializes pins the issue #175
+// invariant that the prevention gate enables: when two stories on DIFFERENT
+// components both own a shared deliverable file (e.g. README.md declared as a
+// companion on each source component), the resource-edge pass serializes them
+// (lower Story.ID first) instead of running them parallel — which is exactly
+// what prevents the 2026-06-13 mavlink-hard README assembly conflict.
+func TestDeriveStoryScheduling_SharedDeliverableDocSerializes(t *testing.T) {
+	stories := []Story{
+		{ID: "s1", ComponentName: "comp-a", RequirementIDs: []string{"req.1"},
+			FilesOwned: []string{"src/a.java", "README.md"}},
+		{ID: "s2", ComponentName: "comp-b", RequirementIDs: []string{"req.2"},
+			FilesOwned: []string{"src/b.java", "README.md"}},
+	}
+	reqs := []Requirement{{ID: "req.1"}, {ID: "req.2"}}
+
+	if err := DeriveStoryScheduling(stories, reqs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// s2 (higher ID) must depend on s1 (lower ID); s1 must have no deps.
+	if got := sortedDeps(stories[1]); len(got) != 1 || got[0] != "s1" {
+		t.Errorf("expected s2.DependsOn=[s1] (serialized on shared README.md), got %v", got)
+	}
+	if got := sortedDeps(stories[0]); len(got) != 0 {
+		t.Errorf("expected s1.DependsOn=[] (runs first), got %v", got)
+	}
+}
+
+// TestDeriveStoryScheduling_SameComponentSharedDocRejected confirms two stories
+// on the SAME component sharing the doc is still the collapse-to-one error
+// (ErrSameComponentFileConflict) — the doc doesn't get a special pass.
+func TestDeriveStoryScheduling_SameComponentSharedDocRejected(t *testing.T) {
+	stories := []Story{
+		{ID: "s1", ComponentName: "comp-a", RequirementIDs: []string{"req.1"},
+			FilesOwned: []string{"src/a.java", "README.md"}},
+		{ID: "s2", ComponentName: "comp-a", RequirementIDs: []string{"req.2"},
+			FilesOwned: []string{"src/b.java", "README.md"}},
+	}
+	reqs := []Requirement{{ID: "req.1"}, {ID: "req.2"}}
+
+	err := DeriveStoryScheduling(stories, reqs)
+	if !errors.Is(err, ErrSameComponentFileConflict) {
+		t.Fatalf("expected ErrSameComponentFileConflict for same-component shared README.md, got %v", err)
+	}
+}

--- a/workflow/payloads/types.go
+++ b/workflow/payloads/types.go
@@ -424,6 +424,14 @@ type ValidationRequest struct {
 	// the trajectory is the developer agent's path to that worktree.
 	DeveloperLoopID string `json:"developer_loop_id,omitempty"`
 
+	// FilesOwned is the story's declared ownership set (Story.FilesOwned,
+	// threaded via TaskExecution.FileScope). The structural-validator's
+	// file-ownership-containment gate (issue #175/#177) uses it to reject a
+	// submission that MODIFIES an existing file outside this set or commits a
+	// scratch artifact. Empty means the gate is skipped (manual validation,
+	// E2E, or any dispatch without story context).
+	FilesOwned []string `json:"files_owned,omitempty"`
+
 	// Trace context
 	TraceID string `json:"trace_id,omitempty"`
 }

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -1789,6 +1789,21 @@ const (
 	// accept handler already performed the wipe inline. Emitted by the
 	// recovery-agent for the architecture_revise action.
 	PlanDecisionKindArchitectureRevise PlanDecisionKind = "architecture_revise"
+
+	// PlanDecisionKindAssemblyConflict marks a decision recording a plan-level
+	// merge conflict at branch assembly (issue #176). Execution SUCCEEDED — all
+	// requirements passed review — but assembleRequirementBranches could not
+	// merge their branches because two truly-parallel branches edited the same
+	// file with no DependsOn edge: a planning-partition defect, NOT an execution
+	// failure. Distinct from execution_exhausted (which means code couldn't
+	// converge) so dashboards and recovery don't conflate "code couldn't
+	// converge" with "branches couldn't merge". plan-manager records this
+	// directly and fails the plan terminally (→ rejected), naming the
+	// conflicting branch + files, rather than firing recovery's escalate_human
+	// (which has no unattended fallback and wedges CI/e2e at implementing until
+	// timeout). The prevention is the file-ownership gates (#175); this is the
+	// honest backstop when an undeclared shared file slips through.
+	PlanDecisionKindAssemblyConflict PlanDecisionKind = "assembly_conflict"
 )
 
 // String returns the string representation of the plan decision kind.
@@ -1802,7 +1817,8 @@ func (k PlanDecisionKind) IsValid() bool {
 	case PlanDecisionKindRequirementChange,
 		PlanDecisionKindExecutionExhausted,
 		PlanDecisionKindStoryReprepare,
-		PlanDecisionKindArchitectureRevise:
+		PlanDecisionKindArchitectureRevise,
+		PlanDecisionKindAssemblyConflict:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

Closes the 2026-06-13 mavlink-hard **README assembly wedge** (slug `9a5eca2f2fac`, furthest a paid run has reached). All 13 nodes passed review and the Java **source merged with ZERO conflicts** — but `README.md`, owned by **no component**, was co-written by all 4 parallel stories and could not be merged at assembly, wedging the run pre-QA for ~65 min.

Reframed (per review) as a **general file-ownership invariant**, not a docs special-case: *every file a story writes must be owned*, so the existing `DeriveStoryScheduling` serializes shared owned files. Defense in depth across the three enforceable phases. See **ADR-048**.

## Changes

### #175 — Prevention (plan-reviewer, deterministic, pure)
- New rule `architecture.scoped_file_unowned`: every concrete scoped deliverable (`Scope.Create ∪ Scope.Include` minus `DoNotTouch`) must be in some `ComponentDef.ImplementationFiles`, else reject naming the orphan. Composes with the docs-only rule — a README rides as a **companion on a source component** (single writer) or several (scheduler serializes). Mirrors the ADR-047 gate.

### #175/#177 — Containment (structural-validator, deterministic, post-dev)
- New always-on `file-ownership-containment` check computes the **authoritative** changed set from `git status --porcelain` in the worktree (not the agent's self-report) and classifies against `Story.FilesOwned` (threaded via `TaskExecution.FileScope` → `ValidationRequest.FilesOwned`).
- **Hard-fail:** scratch artefacts (`*.orig`, `patch*.diff`, …) + a non-owner co-writing a shared **doc** (the unmergeable shape). **Advisory:** non-doc build/source edits (usually mergeable; #176 backstops) + new files. Skipped without ownership context. The hard-fail line is drawn at *unmergeable vs usually-mergeable* so a dev bumping `build.gradle`/`go.mod` isn't blocked.

### #176 — Honest failure (plan-manager)
- A plan-level merge conflict now records a distinct terminal `PlanDecisionKindAssemblyConflict` (naming branch + files) and fails the plan to `rejected`, instead of recovery's `escalate_human` (no unattended fallback → wedge) or the `execution_exhausted` mislabel (execution *succeeded*; assembly failed).

### #177 — Scratch hygiene
- Ignore `*.orig`/`patch*.diff` in the osh fixtures (`git add -A` honours `.gitignore` for untracked files); developer-prompt nudge (scratch → `/tmp`, stay in file scope).

## Testing
- Fully **offline-testable** — `go test ./processor/plan-reviewer/... ./processor/structural-validator/... ./processor/plan-manager/... ./workflow/...` all green, plus a **real-`git`** integration test (`t.TempDir()`) validating `parsePorcelain` against actual `git status` output (not synthetic blobs).
- `go build ./...`, `go vet`, `task lint` clean.
- go-reviewer pass applied: fixed H2 (build/test edits no longer hard-fail), H1 (documented gitignore/junk-arm interaction), L1 (extensionless-deliverable allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)