### PR TITLE
feat(ownership): ADR-049 component ownership topology + dev-gate recovery fix

### DIFF
--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -152,18 +152,77 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 // guidance reaches the wedged role through the existing channel.
 //
 // Two callers as of 2026-05-28:
-//   - handlePlanDecisionAccepted via the existing iteration-exhaustion
-//     path (exec was mid-cycle when markEscalatedLocked deferred it).
+//   - handlePlanDecisionAccepted via the existing iteration-exhaustion /
+//     dev-gate fast-fail path (exec was mid-cycle when markEscalatedLocked
+//     deferred it — ADR-049 Move-3 lands here too).
 //   - resumeTerminalForRecoveryLocked via the QA-recovery path (exec was
 //     terminal-stage in KV when the plan-level QA verdict rejected; the
 //     wrapper re-marks it awaiting before calling here).
 //
-// The function is identical for both — the only difference upstream is
-// how the exec got into activeExecs (cache-resident vs. KV-loaded then
+// The function is identical for both callers — the only difference upstream
+// is how the exec got into activeExecs (cache-resident vs. KV-loaded then
 // reinserted).
+//
+// Story reset (ADR-049 / #167/#168 analogue for the dev-gate path): this
+// function calls reopenOwnedStoriesForRecoveryLocked at the TOP — before
+// branch recreation and re-decompose — so ANY owned story left in a non-
+// ready state (Complete, Executing, Failed, Pending) is walked back to Ready.
+// This mirrors the lesson learned on the QA-recovery path: without the reopen,
+// dispatchCurrentStoryLocked's ClaimStoryStatus(→Executing) is rejected for
+// a story not at Ready (invalid transition), the executor misreads the rejection
+// as "M:N reservation held by another executor", skips, and false-completes the
+// requirement with nodes_completed=0. The dev-gate fast-fail (ADR-049 Move-3)
+// is the primary producer of Executing-stranded stories.
+//
+// If the reopen was attempted (natsClient present) but not all owned stories
+// reached Ready (transient NATS error, partial walk), this function re-arms
+// awaiting-recovery and returns WITHOUT incrementing recoveryRestarts — so the
+// next PlanDecision-accepted event retries the walk from wherever the story
+// currently sits (self-healing across cycles). The outer recovery timer still
+// bounds total wait time.
 //
 // Caller must hold exec.mu.
 func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirementExecution) {
+	// Reset any owned stories that are not in a dispatchable state BEFORE the
+	// branch recreation and re-decompose. This must happen first so the reset
+	// stories are visible in PLAN_STATES when dispatchSynthesizerLocked reloads
+	// the plan. Both the dev-gate / iteration-exhaustion path (new) and the
+	// QA-recovery path (existing via resumeTerminalForRecoveryLocked) need this.
+	// The call is idempotent: stories already at Ready are excluded.
+	reopenResult := c.reopenOwnedStoriesForRecoveryLocked(ctx, exec)
+
+	// C1: if the walk was attempted but did not fully land, do NOT proceed to
+	// dispatchSynthesizerLocked — dispatching now would produce the same
+	// false-complete this function exists to prevent (story still non-Ready,
+	// ClaimStoryStatus(→Executing) rejected, executor skips, req marks complete
+	// with nodes_completed=0). Instead, re-arm awaiting-recovery WITHOUT burning
+	// a recoveryRestarts slot so the next cycle retries the walk from the story's
+	// current status (self-healing). The outer recovery timer still fires if no
+	// progress is made, so this path cannot loop forever within a single exec.
+	//
+	// natsClient==nil means unit-test / no-NATS mode: reopenResult.candidates==0
+	// regardless of story states, so we always proceed — keeping the nil-client
+	// path a clean no-op and not disrupting existing unit tests.
+	if c.natsClient != nil && !reopenResult.allReady() {
+		// Re-mark awaiting-recovery (without incrementing recoveryRestarts — this
+		// was not a real restart attempt, only a story-walk attempt). Re-arm the
+		// timer so the outer budget fires if the walk keeps failing.
+		exec.awaitingRecovery = true
+		timeout := c.recoveryTimeout()
+		timer := time.AfterFunc(timeout, func() {
+			c.handleRecoveryTimeout(exec, timeout)
+		})
+		exec.recoveryTimer = &timeoutHandle{stop: func() { timer.Stop() }}
+		c.logger.Warn("recovery: story walk incomplete — re-arming awaiting-recovery to retry on next PlanDecision",
+			"entity_id", exec.EntityID,
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"reopened", reopenResult.reopened,
+			"candidates", reopenResult.candidates,
+		)
+		return
+	}
+
 	if exec.recoveryTimer != nil {
 		exec.recoveryTimer.stop()
 		exec.recoveryTimer = nil

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -129,6 +129,13 @@ func newSandboxClient(url string) sandboxClient {
 	return c
 }
 
+// storyStatusClaimerFunc is the function signature for atomically transitioning
+// a Story's status via plan-manager. The default implementation calls
+// workflow.ClaimStoryStatus; tests inject a fake that enforces CanTransitionTo
+// so the Executing→Failed→Pending→Ready walk can be asserted without a live
+// NATS substrate. See reopenOwnedStoriesForRecoveryLocked.
+type storyStatusClaimerFunc func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool
+
 // Component orchestrates per-requirement execution.
 type Component struct {
 	config        Config
@@ -140,6 +147,12 @@ type Component struct {
 	tripleWriter  *graphutil.TripleWriter
 	sandbox       sandboxClient     // nil when sandbox is disabled
 	assembler     *prompt.Assembler // composes system prompts for requirement-level review
+
+	// storyStatusClaimer is the seam for story-status transitions used by
+	// reopenOwnedStoriesForRecoveryLocked. Defaults to a wrapper around
+	// workflow.ClaimStoryStatus; tests inject a fake that enforces
+	// CanTransitionTo so the full walk chain is exercisable without NATS.
+	storyStatusClaimer storyStatusClaimerFunc
 
 	// Story-gate (Murat) review knowledge — symmetric with the per-task
 	// reviewer in execution-manager so the requirement-level gate sees the
@@ -202,9 +215,10 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	registry.Register(prompt.ToolGuidanceFragment(prompt.DefaultToolGuidance()))
 	registry.Register(prompt.GraphManifestFragment(workflowtools.RegistrySummaryFetchFn()))
 
+	nc := deps.NATSClient
 	c := &Component{
 		config:        cfg,
-		natsClient:    deps.NATSClient,
+		natsClient:    nc,
 		logger:        logger,
 		platform:      deps.Platform,
 		toolRegistry:  deps.ToolRegistry,
@@ -212,9 +226,14 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 		sandbox:       newSandboxClient(cfg.SandboxURL),
 		assembler:     prompt.NewAssembler(registry),
 		tripleWriter: &graphutil.TripleWriter{
-			NATSClient:    deps.NATSClient,
+			NATSClient:    nc,
 			Logger:        logger,
 			ComponentName: componentName,
+		},
+		// Default story-status claimer wraps the real NATS round-trip.
+		// Tests may replace this with a fake that enforces CanTransitionTo.
+		storyStatusClaimer: func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool {
+			return workflow.ClaimStoryStatus(ctx, nc, slug, storyID, target, logger)
 		},
 	}
 	c.initReviewKnowledge()

--- a/processor/requirement-executor/recover_completed.go
+++ b/processor/requirement-executor/recover_completed.go
@@ -146,13 +146,15 @@ func (c *Component) resumeTerminalForRecoveryLocked(ctx context.Context, exec *r
 		"prior_stage", "terminal",
 		"proposal_id", proposalID,
 	)
-	// Re-open the M:N Stories this requirement owns so the resumed dev loop
-	// re-does work instead of skipping ("Story already complete"). Without this,
-	// QA-recovery on an M:N-complete plan is a no-op: the req re-dispatches, every
-	// Story is skipped, the req re-marks complete, and the plan bounces back to QA
-	// unchanged. Must run BEFORE resumeFromRecoveryLocked so the reset stories are
-	// visible when dispatchSynthesizerLocked reloads the plan from KV.
-	c.reopenOwnedStoriesForRecoveryLocked(ctx, exec)
+	// resumeFromRecoveryLocked now calls reopenOwnedStoriesForRecoveryLocked
+	// at its own top (before branch recreation + re-decompose), so both the
+	// QA-recovery path (here) and the dev-gate / iteration-exhaustion path
+	// (handlePlanDecisionAccepted) reset owned stories. The explicit
+	// reopenOwnedStoriesForRecoveryLocked call that previously appeared here
+	// was moved into resumeFromRecoveryLocked to close the ADR-049 dev-gate
+	// fast-fail gap — the ordering invariant (reset before plan reload) is
+	// preserved because the reopen is the first thing resumeFromRecoveryLocked
+	// does.
 	c.resumeFromRecoveryLocked(ctx, exec)
 	// Invalidate the dependent branch subtree AFTER resumeFromRecoveryLocked has
 	// moved this requirement off "completed" (sendReqPhase → decomposing). That
@@ -258,64 +260,227 @@ func (c *Component) resetDependentBranchSubtree(ctx context.Context, slug, reope
 		"slug", slug, "reopened", reopenedID, "dependents", deps)
 }
 
-// storiesToReopenForRecovery returns the IDs of complete Stories covering reqID
-// that reqID owns (the deterministic M:N owner). These are the Stories a
-// QA-recovery resume must reset complete → ready so the dev loop re-runs rather
-// than skipping. Non-owned Stories are excluded — resetting one would let a
-// non-owner run the dev loop, inverting the M:N reservation; the non-owner
-// instead re-skips (Story stays complete) and fast-completes via Tier-1 dedup
-// once the owner re-ships. Non-complete Stories are excluded (nothing to
-// re-open). Pure function — the side-effecting reopen lives in
-// reopenOwnedStoriesForRecoveryLocked.
+// storyStatusWalkToReady returns the sequence of StoryStatus transitions
+// required to walk from `from` to StoryStatusReady via the valid state machine
+// edges. Used by reopenOwnedStoriesForRecoveryLocked to reset in-flight owned
+// stories that a recovery resume must reclaim.
+//
+// Transition chains (smallest to largest):
+//
+//	Complete  → Ready
+//	Pending   → Ready
+//	Failed    → Pending → Ready
+//	Executing → Failed  → Pending → Ready
+//
+// Returns nil when `from` is already Ready (no steps needed). The steps are
+// applied in order via sequential ClaimStoryStatus calls; each step must
+// succeed before the next is attempted. This avoids inventing a new state-
+// machine shortcut transition and instead threads through existing valid edges —
+// keeping the plan-manager handler (handleStoryStatusMutation) unchanged.
+//
+// Pure function — no side effects.
+func storyStatusWalkToReady(from workflow.StoryStatus) []workflow.StoryStatus {
+	switch from {
+	case workflow.StoryStatusReady:
+		return nil // already dispatchable, nothing to do
+	case workflow.StoryStatusPending:
+		return []workflow.StoryStatus{workflow.StoryStatusReady}
+	case workflow.StoryStatusComplete:
+		return []workflow.StoryStatus{workflow.StoryStatusReady}
+	case workflow.StoryStatusFailed:
+		return []workflow.StoryStatus{workflow.StoryStatusPending, workflow.StoryStatusReady}
+	case workflow.StoryStatusExecuting:
+		return []workflow.StoryStatus{
+			workflow.StoryStatusFailed,
+			workflow.StoryStatusPending,
+			workflow.StoryStatusReady,
+		}
+	default:
+		return nil
+	}
+}
+
+// storiesToReopenForRecovery returns the IDs of Stories covering reqID that
+// reqID owns (the deterministic M:N owner) and that need to be walked back to
+// Ready before a recovery resume. This covers all non-ready states that would
+// cause false-completion on re-dispatch:
+//
+//   - Complete: QA-recovery shape — req completed + plan-level QA rejected.
+//   - Executing: dev-gate fast-fail shape (ADR-049 Move-3) — the executor
+//     transitioned the req to awaiting-recovery while the Story was mid-
+//     dispatch. Without resetting, ClaimStoryStatus(→Executing) is rejected on
+//     resume (Executing→Executing is invalid), causing false-skip/false-complete.
+//   - Failed: story failed before the requirement reached terminal state.
+//   - Pending: Pending→Executing is also an invalid transition per CanTransitionTo
+//     (Pending→{Ready,Failed} only). A story stranded at Pending — e.g. by a
+//     partial walk from a prior recovery attempt — must be walked to Ready so the
+//     executor can claim it.
+//
+// Only Ready stories are excluded — they are already dispatchable (Ready→Executing
+// is the expected claim). Non-owned Stories are also excluded — resetting one would
+// let a non-owner run the dev loop, inverting the M:N reservation.
+//
+// Pure function — the side-effecting walk lives in reopenOwnedStoriesForRecoveryLocked.
 func storiesToReopenForRecovery(plan *workflow.Plan, reqID string) []string {
 	if plan == nil {
 		return nil
 	}
 	var ids []string
 	for _, s := range plan.StoriesForRequirement(reqID) {
-		if s.Status == workflow.StoryStatusComplete && workflow.DeterministicStoryOwner(s) == reqID {
+		if workflow.DeterministicStoryOwner(s) != reqID {
+			continue // non-owner: M:N reservation must not be violated
+		}
+		switch s.Status {
+		case workflow.StoryStatusComplete,
+			workflow.StoryStatusExecuting,
+			workflow.StoryStatusFailed,
+			workflow.StoryStatusPending:
 			ids = append(ids, s.ID)
+			// Ready is the only dispatchable state; no walk needed.
 		}
 	}
 	return ids
 }
 
-// reopenOwnedStoriesForRecoveryLocked resets the owner's complete M:N Stories to
-// ready via the cross-component story-status mutation. No-op without a NATS
-// client (unit-test substrate) or when the plan can't be loaded. Idempotent
-// across recovery cycles: candidates are pre-filtered to complete Stories, so a
-// re-run reopens nothing once a Story has already moved on to ready/executing.
-func (c *Component) reopenOwnedStoriesForRecoveryLocked(ctx context.Context, exec *requirementExecution) {
-	if c.natsClient == nil {
-		return
-	}
-	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
-	if err != nil || plan == nil {
-		c.logger.Warn("QA-recovery: could not load plan to reopen owned stories",
-			"slug", exec.Slug, "requirement_id", exec.RequirementID, "error", err)
-		return
-	}
-	ids := storiesToReopenForRecovery(plan, exec.RequirementID)
-	reopened := 0
+// storyReopenResult summarises whether the reopen walk succeeded for all
+// candidate stories owned by a requirement.
+type storyReopenResult struct {
+	// candidates is the number of stories that needed a walk (len(ids) from
+	// storiesToReopenForRecovery). Zero means no walk was needed.
+	candidates int
+	// reopened is the number that reached StoryStatusReady.
+	reopened int
+}
+
+// allReady reports whether every candidate story reached Ready.
+func (r storyReopenResult) allReady() bool {
+	return r.candidates == 0 || r.reopened == r.candidates
+}
+
+// reopenStoriesFromPlan is the pure inner kernel of the story-walk logic. It
+// walks each story in `ids` from its current status to Ready using the supplied
+// claimer, and returns how many reached Ready. Extracted so tests can call it
+// directly with a fake claimer and a synthetic plan — without needing a live
+// NATS substrate or loadPlanFromKV. The method reopenOwnedStoriesForRecoveryLocked
+// is the production entry-point that adds plan-loading and logging.
+//
+// Self-healing across cycles (C1): the walk for each story is derived from the
+// status read out of `plan` on THIS call. Production reloads the plan from KV on
+// every recovery cycle (reopenOwnedStoriesForRecoveryLocked), so a prior partial
+// walk that stranded a story at e.g. Pending is re-derived from Pending and
+// resumed on the next call — no in-loop state is carried between calls.
+func reopenStoriesFromPlan(
+	ctx context.Context,
+	slug string,
+	plan *workflow.Plan,
+	ids []string,
+	claimer func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool,
+) (reopened, candidates int) {
+	candidates = len(ids)
 	for _, storyID := range ids {
-		if workflow.ClaimStoryStatus(ctx, c.natsClient, exec.Slug, storyID, workflow.StoryStatusReady, c.logger) {
+		story, ok := findStoryByID(plan, storyID)
+		if !ok {
+			continue
+		}
+		walkedOK := true
+		for _, step := range storyStatusWalkToReady(story.Status) {
+			if !claimer(ctx, slug, storyID, step) {
+				walkedOK = false
+				break
+			}
+		}
+		if walkedOK {
 			reopened++
 		}
 	}
-	switch {
-	case len(ids) > 0 && reopened < len(ids):
-		// A reopen was expected but did not fully land (NATS error or a rejected
-		// mutation). Proceeding lets the un-reopened stories re-skip and the
-		// requirement re-complete without work — silently resurrecting the no-op
-		// this function exists to fix. Surface it so it's diagnosable.
-		c.logger.Warn("QA-recovery: not all owned stories reopened — recovery may be a partial no-op",
-			"slug", exec.Slug, "requirement_id", exec.RequirementID,
-			"reopened", reopened, "candidates", len(ids))
-	case reopened > 0:
-		c.logger.Info("QA-recovery: reopened owned M:N stories for re-execution",
-			"slug", exec.Slug, "requirement_id", exec.RequirementID,
-			"reopened", reopened, "candidates", len(ids))
+	return reopened, candidates
+}
+
+// reopenOwnedStoriesForRecoveryLocked walks the owner's non-ready Stories back
+// to Ready via sequential claim mutations. Covers four shapes:
+//
+//   - Pending   → Ready (1 hop — e.g. stranded by prior partial walk; C2 fix)
+//   - Complete  → Ready (1 hop — QA-recovery)
+//   - Failed    → Pending → Ready (2 hops)
+//   - Executing → Failed → Pending → Ready (3 hops — dev-gate fast-fail shape)
+//
+// Self-healing across cycles (C1 fix): delegates to reopenStoriesFromPlan which
+// tracks the story's evolving status locally so subsequent hops start from where
+// the last one landed. A prior partial walk that stranded a story at Pending is
+// resumed from Pending→Ready rather than re-attempting the full original chain.
+//
+// No-op without a NATS client (unit-test substrate) — returns allReady so
+// resumeFromRecoveryLocked proceeds normally in tests. The walk logic is
+// exercised separately via reopenStoriesFromPlan tests with an injected fake
+// claimer. When a NATS client is present and not all stories reached Ready,
+// returns the counts so resumeFromRecoveryLocked can defer instead of dispatching
+// into a guaranteed false-complete.
+//
+// Uses c.storyStatusClaimer (seam) rather than workflow.ClaimStoryStatus
+// directly so tests can inject a fake that enforces CanTransitionTo and asserts
+// the full walk sequence without a live plan-manager.
+//
+// Called from resumeFromRecoveryLocked (which serves BOTH the
+// iteration-exhaustion / dev-gate path AND the QA-recovery path).
+//
+// TODO(R2): a persistent story walk failure (e.g. plan-manager rejects the
+// transition because it already moved on) can strand the exec indefinitely
+// unless the outer recovery-timeout fires. A future improvement is to detect
+// N consecutive plan-load-or-walk failures for the same exec and fall through
+// to markFailedLocked. Track with a per-exec counter; N=3 is a reasonable
+// starting point. Low urgency: the recovery timer already caps the max wait.
+//
+// TODO(ps.save): handleStoryStatusMutation in plan-manager saves the plan on
+// every story transition (mutations.go:848). For the 3-hop Executing walk this
+// means 3 consecutive KV writes to PLAN_STATES within milliseconds. A future
+// optimisation is to batch the walk steps into a single mutation request (e.g. a
+// "walk_to_ready" mutation kind) so plan-manager applies all transitions
+// atomically. Low urgency: the current 3-hop path is correct and plan-manager's
+// per-write latency is negligible relative to LLM dispatch.
+func (c *Component) reopenOwnedStoriesForRecoveryLocked(ctx context.Context, exec *requirementExecution) storyReopenResult {
+	if c.natsClient == nil {
+		// Unit-test path: no NATS, no story state to reset. Report allReady
+		// so the caller proceeds to re-decompose. The walk logic is exercised
+		// separately via reopenStoriesFromPlan tests with an injected fake claimer.
+		return storyReopenResult{}
 	}
+	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
+	if err != nil || plan == nil {
+		c.logger.Warn("recovery: could not load plan to reopen owned stories",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID, "error", err)
+		// Plan-load failure: treat as no candidates so caller can still proceed
+		// (degraded mode — better than wedging the exec permanently).
+		return storyReopenResult{}
+	}
+	ids := storiesToReopenForRecovery(plan, exec.RequirementID)
+	if len(ids) == 0 {
+		return storyReopenResult{}
+	}
+
+	slug := exec.Slug
+	reqID := exec.RequirementID
+	reopened, candidates := reopenStoriesFromPlan(ctx, slug, plan, ids, func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool {
+		ok := c.storyStatusClaimer(ctx, slug, storyID, target)
+		if !ok {
+			c.logger.Warn("recovery: story status walk step rejected — will defer resume to retry",
+				"slug", slug, "requirement_id", reqID,
+				"story_id", storyID, "target", target)
+		}
+		return ok
+	})
+	result := storyReopenResult{candidates: candidates, reopened: reopened}
+
+	switch {
+	case result.reopened < result.candidates:
+		c.logger.Warn("recovery: not all owned stories walked to ready — deferring resume to next cycle",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"reopened", result.reopened, "candidates", result.candidates)
+	default:
+		c.logger.Info("recovery: owned stories walked to ready for re-execution",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"reopened", result.reopened, "candidates", result.candidates)
+	}
+	return result
 }
 
 // isKVNotFound returns true when err is the soft "no entry" shape returned

--- a/processor/requirement-executor/recover_completed_test.go
+++ b/processor/requirement-executor/recover_completed_test.go
@@ -2,6 +2,7 @@ package requirementexecutor
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -202,19 +203,28 @@ func TestResumeTerminalForRecoveryLocked_RecordsReasonBeforeResume(t *testing.T)
 	}
 }
 
-// TestStoriesToReopenForRecovery pins the M:N owner/complete gating: a
-// QA-recovery resume reopens only the Stories the requirement OWNS and that are
-// currently complete. Reopening a non-owned Story would invert the M:N
-// reservation (a non-owner would run the dev loop); reopening a non-complete
-// Story is meaningless.
+// TestStoriesToReopenForRecovery pins the M:N owner/complete+executing+failed
+// gating: recovery resumes must reset ALL non-ready owned Stories so the dev
+// loop can re-claim them. This includes Executing stories left in flight when a
+// dev-gate fast-fail (ADR-049 Move-3) transitions the requirement to
+// awaiting-recovery — the ADR-049 / #167/#168 fix extends the original
+// QA-recovery logic (complete-only) to the iteration-exhaustion path. Reopening
+// a non-owned Story would invert the M:N reservation; a non-owner re-skips and
+// fast-completes via Tier-1 dedup once the owner re-ships.
 func TestStoriesToReopenForRecovery(t *testing.T) {
 	plan := &workflow.Plan{Stories: []workflow.Story{
 		// owner = r1 (smallest), complete → reopen candidate for r1
 		{ID: "s1", Status: workflow.StoryStatusComplete, RequirementIDs: []string{"r1", "r2"}},
 		// owner = r2, complete → reopen candidate for r2 only
 		{ID: "s2", Status: workflow.StoryStatusComplete, RequirementIDs: []string{"r2", "r3"}},
-		// owner = r1 but NOT complete → never a reopen candidate
+		// owner = r1, executing → reopen candidate (dev-gate fast-fail leaves story here)
 		{ID: "s3", Status: workflow.StoryStatusExecuting, RequirementIDs: []string{"r1"}},
+		// owner = r1, failed → reopen candidate
+		{ID: "s4", Status: workflow.StoryStatusFailed, RequirementIDs: []string{"r1"}},
+		// owner = r1, already ready → NOT a candidate (nothing to reset)
+		{ID: "s5", Status: workflow.StoryStatusReady, RequirementIDs: []string{"r1"}},
+		// owner = r1, pending → NOT a candidate (nothing to reset)
+		{ID: "s6", Status: workflow.StoryStatusPending, RequirementIDs: []string{"r1"}},
 	}}
 
 	tests := []struct {
@@ -223,7 +233,12 @@ func TestStoriesToReopenForRecovery(t *testing.T) {
 		reqID string
 		want  []string
 	}{
-		{"owner_complete_reopens", plan, "r1", []string{"s1"}},
+		// r1 owns s1 (complete), s3 (executing), s4 (failed), s6 (pending) — all
+		// are walk candidates (C2 fix adds Pending: Pending→Executing is invalid,
+		// so Pending must be walked to Ready before re-dispatch).
+		// s5 (ready) is the only excluded status — Ready→Executing is the valid
+		// re-claim path; no walk needed.
+		{"owner_complete_executing_failed_pending", plan, "r1", []string{"s1", "s3", "s4", "s6"}},
 		{"non_owner_excluded", plan, "r2", []string{"s2"}}, // r2 covers s1 but doesn't own it
 		{"covers_but_not_owner", plan, "r3", nil},          // r3 covers s2 but r2 owns it
 		{"nil_plan", nil, "r1", nil},
@@ -237,6 +252,291 @@ func TestStoriesToReopenForRecovery(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStoryStatusWalkToReady pins the walk helper used by the
+// reopenOwnedStoriesForRecoveryLocked side-effecting path. A single-hop target
+// (Complete→Ready) must emit exactly one step; multi-hop targets (Executing→
+// Failed→Pending→Ready) must emit the full intermediate chain.
+func TestStoryStatusWalkToReady(t *testing.T) {
+	tests := []struct {
+		name string
+		from workflow.StoryStatus
+		want []workflow.StoryStatus
+	}{
+		{
+			name: "complete_single_hop",
+			from: workflow.StoryStatusComplete,
+			want: []workflow.StoryStatus{workflow.StoryStatusReady},
+		},
+		{
+			name: "failed_two_hops",
+			from: workflow.StoryStatusFailed,
+			want: []workflow.StoryStatus{workflow.StoryStatusPending, workflow.StoryStatusReady},
+		},
+		{
+			name: "executing_three_hops",
+			from: workflow.StoryStatusExecuting,
+			want: []workflow.StoryStatus{
+				workflow.StoryStatusFailed,
+				workflow.StoryStatusPending,
+				workflow.StoryStatusReady,
+			},
+		},
+		// Already-ready: no steps needed (no-op path).
+		{name: "ready_no_steps", from: workflow.StoryStatusReady, want: nil},
+		// Pending: one step to ready.
+		{name: "pending_one_step", from: workflow.StoryStatusPending, want: []workflow.StoryStatus{workflow.StoryStatusReady}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := storyStatusWalkToReady(tt.from)
+			if len(got) != len(tt.want) {
+				t.Fatalf("storyStatusWalkToReady(%q) = %v, want %v", tt.from, got, tt.want)
+			}
+			for i, w := range tt.want {
+				if got[i] != w {
+					t.Errorf("step[%d] = %q, want %q", i, got[i], w)
+				}
+			}
+		})
+	}
+}
+
+// fakeStoryStatusClaimer is an in-process fake for the story-status claim
+// round-trip. It maintains authoritative per-story status and enforces
+// CanTransitionTo so tests can assert the full walk chain without a live
+// plan-manager or NATS substrate.
+//
+// Thread-safe: tests that drive claims from a single goroutine don't need extra
+// locking; the mu protects against concurrent accesses in future tests.
+type fakeStoryStatusClaimer struct {
+	mu       sync.Mutex
+	statuses map[string]workflow.StoryStatus // storyID → current status
+	// calls records (storyID, target) pairs in the order they were made.
+	calls []struct {
+		storyID string
+		target  workflow.StoryStatus
+	}
+	// failOn, when set, causes the first call matching (storyID, target) to
+	// return false (simulating a transient NATS failure).
+	failOn *struct {
+		storyID string
+		target  workflow.StoryStatus
+	}
+}
+
+func newFakeClaimer(initial map[string]workflow.StoryStatus) *fakeStoryStatusClaimer {
+	return &fakeStoryStatusClaimer{statuses: initial}
+}
+
+func (f *fakeStoryStatusClaimer) claim(_ context.Context, _ string, storyID string, target workflow.StoryStatus) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, struct {
+		storyID string
+		target  workflow.StoryStatus
+	}{storyID, target})
+	if f.failOn != nil && f.failOn.storyID == storyID && f.failOn.target == target {
+		f.failOn = nil // one-shot
+		return false
+	}
+	current, ok := f.statuses[storyID]
+	if !ok {
+		return false
+	}
+	if !current.CanTransitionTo(target) {
+		return false
+	}
+	f.statuses[storyID] = target
+	return true
+}
+
+func (f *fakeStoryStatusClaimer) statusOf(storyID string) workflow.StoryStatus {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.statuses[storyID]
+}
+
+// TestReopenStoriesFromPlan_ExecutingWalk is the honest end-to-end regression
+// for the ADR-049 dev-gate false-completion bug (slug a6819e22bb85).
+//
+// It proves the complete Executing→Failed→Pending→Ready walk using a
+// fakeStoryStatusClaimer that enforces CanTransitionTo — so the test fails if
+// the walk tries an invalid hop (e.g. Executing→Ready directly) or if the
+// selection omits an Executing story. This is the test the go-reviewer flagged
+// as missing: it is genuinely RED against pre-fix code and GREEN after the fix.
+//
+// Red evidence (pre-fix behavior): before the ADR-049 fix,
+// storiesToReopenForRecovery excluded Executing and Pending stories, so
+// reopenStoriesFromPlan received an empty `ids` slice and returned
+// reopened=0, candidates=0. The test asserts candidates==1 and
+// statusOf("story-exec")=="ready", which fails when candidates==0.
+//
+// See also TestStoriesToReopenForRecovery (selection) and
+// TestStoryStatusWalkToReady (hop sequence) which pin the building blocks.
+func TestReopenStoriesFromPlan_ExecutingWalk(t *testing.T) {
+	t.Run("executing_story_walks_to_ready_via_three_hops", func(t *testing.T) {
+		plan := &workflow.Plan{Stories: []workflow.Story{
+			{ID: "story-exec", Status: workflow.StoryStatusExecuting, RequirementIDs: []string{"req-1"}},
+		}}
+		fake := newFakeClaimer(map[string]workflow.StoryStatus{
+			"story-exec": workflow.StoryStatusExecuting,
+		})
+		ids := storiesToReopenForRecovery(plan, "req-1")
+		if len(ids) != 1 {
+			t.Fatalf("storiesToReopenForRecovery returned %v; pre-fix code returns [] — "+
+				"this is the selection half of the regression", ids)
+		}
+
+		reopened, candidates := reopenStoriesFromPlan(context.Background(), "plan-x", plan, ids, fake.claim)
+
+		if candidates != 1 {
+			t.Errorf("candidates = %d, want 1", candidates)
+		}
+		if reopened != 1 {
+			t.Errorf("reopened = %d, want 1 (walk must complete)", reopened)
+		}
+		if got := fake.statusOf("story-exec"); got != workflow.StoryStatusReady {
+			t.Errorf("final story status = %q, want %q", got, workflow.StoryStatusReady)
+		}
+		// Assert the exact 3-hop sequence enforced by the state machine.
+		wantCalls := []struct {
+			storyID string
+			target  workflow.StoryStatus
+		}{
+			{"story-exec", workflow.StoryStatusFailed},
+			{"story-exec", workflow.StoryStatusPending},
+			{"story-exec", workflow.StoryStatusReady},
+		}
+		if len(fake.calls) != len(wantCalls) {
+			t.Fatalf("claimer calls = %v, want %v", fake.calls, wantCalls)
+		}
+		for i, w := range wantCalls {
+			if fake.calls[i] != w {
+				t.Errorf("call[%d] = %v, want %v", i, fake.calls[i], w)
+			}
+		}
+	})
+
+	t.Run("pending_story_walks_to_ready_in_one_hop", func(t *testing.T) {
+		// C2 regression: a Pending story was excluded by the pre-fix selection
+		// (only Complete/Executing/Failed were included). Pending→Executing is
+		// invalid per CanTransitionTo, so an unreseted Pending story causes the
+		// same false-complete path as Executing.
+		plan := &workflow.Plan{Stories: []workflow.Story{
+			{ID: "story-pend", Status: workflow.StoryStatusPending, RequirementIDs: []string{"req-2"}},
+		}}
+		fake := newFakeClaimer(map[string]workflow.StoryStatus{
+			"story-pend": workflow.StoryStatusPending,
+		})
+		ids := storiesToReopenForRecovery(plan, "req-2")
+		if len(ids) != 1 {
+			t.Fatalf("storiesToReopenForRecovery returned %v for Pending story; "+
+				"pre-fix code excludes Pending — C2 regression", ids)
+		}
+
+		reopened, candidates := reopenStoriesFromPlan(context.Background(), "plan-x", plan, ids, fake.claim)
+
+		if candidates != 1 || reopened != 1 {
+			t.Errorf("reopened=%d, candidates=%d; want both 1", reopened, candidates)
+		}
+		if got := fake.statusOf("story-pend"); got != workflow.StoryStatusReady {
+			t.Errorf("final story status = %q, want ready", got)
+		}
+		// Exactly one hop: Pending→Ready.
+		if len(fake.calls) != 1 || fake.calls[0].target != workflow.StoryStatusReady {
+			t.Errorf("claimer calls = %v, want [{story-pend ready}]", fake.calls)
+		}
+	})
+
+	t.Run("partial_walk_reports_incomplete_and_is_self_healing_on_retry", func(t *testing.T) {
+		// C1 regression: a partial walk (Executing→Failed succeeds, Failed→Pending
+		// fails) left the story at Failed. On the next call the story is re-selected
+		// (Failed is a candidate) and the walk restarts from its CURRENT status
+		// (Failed), not from the original Executing, so it only needs 2 more hops.
+		plan := &workflow.Plan{Stories: []workflow.Story{
+			{ID: "story-partial", Status: workflow.StoryStatusExecuting, RequirementIDs: []string{"req-3"}},
+		}}
+		fake := newFakeClaimer(map[string]workflow.StoryStatus{
+			"story-partial": workflow.StoryStatusExecuting,
+		})
+		// First call: fail at Failed→Pending so the walk strands at Failed.
+		fake.failOn = &struct {
+			storyID string
+			target  workflow.StoryStatus
+		}{"story-partial", workflow.StoryStatusPending}
+
+		ids := storiesToReopenForRecovery(plan, "req-3")
+		reopened, candidates := reopenStoriesFromPlan(context.Background(), "plan-x", plan, ids, fake.claim)
+
+		if candidates != 1 || reopened != 0 {
+			t.Errorf("first call: reopened=%d candidates=%d; want 0/1", reopened, candidates)
+		}
+		if got := fake.statusOf("story-partial"); got != workflow.StoryStatusFailed {
+			t.Errorf("after partial walk story status = %q, want failed", got)
+		}
+
+		// Simulate second recovery cycle: plan is updated to reflect the new status.
+		plan2 := &workflow.Plan{Stories: []workflow.Story{
+			{ID: "story-partial", Status: workflow.StoryStatusFailed, RequirementIDs: []string{"req-3"}},
+		}}
+		ids2 := storiesToReopenForRecovery(plan2, "req-3")
+		if len(ids2) != 1 {
+			t.Fatalf("second cycle: storiesToReopenForRecovery(%q) = %v; "+
+				"Failed must still be selected for self-healing", "req-3", ids2)
+		}
+
+		fake.calls = nil // reset call log for second cycle
+		reopened2, candidates2 := reopenStoriesFromPlan(context.Background(), "plan-x", plan2, ids2, fake.claim)
+
+		if candidates2 != 1 || reopened2 != 1 {
+			t.Errorf("second call: reopened=%d candidates=%d; want 1/1", reopened2, candidates2)
+		}
+		if got := fake.statusOf("story-partial"); got != workflow.StoryStatusReady {
+			t.Errorf("after self-heal story status = %q, want ready", got)
+		}
+		// Self-healing: only 2 hops needed (Failed→Pending→Ready), not 3.
+		wantCalls := []struct {
+			storyID string
+			target  workflow.StoryStatus
+		}{
+			{"story-partial", workflow.StoryStatusPending},
+			{"story-partial", workflow.StoryStatusReady},
+		}
+		if len(fake.calls) != len(wantCalls) {
+			t.Fatalf("second cycle claimer calls = %v, want %v", fake.calls, wantCalls)
+		}
+		for i, w := range wantCalls {
+			if fake.calls[i] != w {
+				t.Errorf("second cycle call[%d] = %v, want %v", i, fake.calls[i], w)
+			}
+		}
+	})
+}
+
+// TestResumeFromRecoveryLocked_ResetsExecutingOwnedStory keeps the selection-
+// half sub-test (it's a genuine selection regression pinning the bug root).
+// The tautological "resume_does_not_false_complete" sub-test that asserted
+// natsClient==nil bookkeeping fields is REMOVED — it proved nothing about the
+// story walk because reopenOwnedStoriesForRecoveryLocked is a no-op when
+// natsClient==nil. The honest end-to-end walk coverage is in
+// TestReopenStoriesFromPlan_ExecutingWalk above.
+//
+// This test retains the selection assertion because it exercises
+// storiesToReopenForRecovery directly and is genuinely RED against pre-fix
+// code (pre-fix excludes Executing; post-fix includes it).
+func TestResumeFromRecoveryLocked_ResetsExecutingOwnedStory(t *testing.T) {
+	t.Run("executing_owned_story_is_selected_for_reopen", func(t *testing.T) {
+		plan := &workflow.Plan{Stories: []workflow.Story{
+			{ID: "story-1", Status: workflow.StoryStatusExecuting, RequirementIDs: []string{"req-gate"}},
+		}}
+		got := storiesToReopenForRecovery(plan, "req-gate")
+		if len(got) != 1 || got[0] != "story-1" {
+			t.Errorf("storiesToReopenForRecovery: got %v, want [story-1]; "+
+				"an Executing owned story must be a reopen candidate for recovery resume", got)
+		}
+	})
 }
 
 func equalStringSlices(a, b []string) bool {

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -1218,6 +1218,18 @@ tasks:
           # cp-into-volume init container snapshots the working tree, not
           # the fixture's git index.
           git checkout -q HEAD -- "$fixture/.semspec/" 2>/dev/null || true
+          # Same restore for .gitignore. The parent-tracked .gitignore carries
+          # the #177 scratch/merge-artefact hardening (*.orig, *.rej, patch.diff,
+          # *.bak, ...), but the fixture's root commit predates it, so the
+          # `reset --hard ROOT` above reverts the on-disk file to the pre-#177
+          # version. Two consequences without this line: (1) the parent repo
+          # perpetually shows the fixture .gitignore as modified after every run;
+          # (2) — the real bug — the sandbox snapshots the reverted working tree,
+          # so #177's protection is INERT during runs and the artefacts it exists
+          # to keep off parallel branches (the 2026-06-13 assembly wedge) can be
+          # committed again. Separate checkout so a fixture with no parent-tracked
+          # .gitignore doesn't fail the .semspec/ restore above.
+          git checkout -q HEAD -- "$fixture/.gitignore" 2>/dev/null || true
         done
         echo "[OK] Fixtures reset"
 


### PR DESCRIPTION
## Summary

ADR-049 (component ownership topology — mergeable surfaces) plus the follow-on fix surfaced when validating it live in a paid `mavlink-hard` run (slug `a6819e22bb85`).

### Commits
- **`feat(ownership)` ADR-049** — architect prompt reframed to *mergeable ownership surface* (avoid both under-split and over-split); file-count overload rule retired for evidence-based stub-risk + cohesion-violation checks; declared-territory dev gate (Move-3); softened reviewer rule 6 to permit *declared* shared files.
- **`fix(requirement-executor)` dev-gate recovery** — the dev gate left the owned Story in `Executing`; on recovery resume the re-claim (`Executing→Executing`) was misread as foreign M:N contention → requirement false-completed `nodes_completed=0` → plan deadlock. Now resets owned stories on the dev-gate/iteration-exhaustion recovery path (the #167/#168 lesson, previously only on the QA path), walks `Executing→Failed→Pending→Ready` via valid edges, self-heals across cycles, and defers-on-incomplete-reopen instead of dispatching into a false-complete. Adds a claim seam + reproducing test (red pre-fix).
- **`fix(e2e)` fixture-reset .gitignore** — restore the parent-tracked `.gitignore` after `reset --hard ROOT`, so #177's scratch/merge-artefact hardening is actually active during e2e runs (it was being silently reverted) and the file stops showing as perpetually modified.

## Live validation (the paid run)
- ✅ Architect produced **one cohesive `mavsdk-driver`** (4 caps / 14 files) — the 06-14 over-split is gone.
- ✅ **Move-3 dev gate fired correctly** — caught an out-of-territory test file, fast-failed to recovery, deterministic, no `escalate_human`.
- 🔧 The recovery false-completion it then hit is fixed here (offline, with a reproducing test).

## Deferred follow-ups (TODO comments in code)
- Typed `ClaimStoryStatus` result so `dispatchCurrentStoryLocked` can distinguish foreign-contention vs own-invalid-transition vs transport failure (the real root of the misclassification).
- `ps.save` swallows KV `Put` failures (`plan-manager/plan_store.go`) → returns `Success=true` while the durable write didn't land.

## Test
`go build ./...`, `go test ./processor/requirement-executor/... ./workflow/... ./processor/plan-manager/...`, and `task lint` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)