### PR TITLE
fix(requirement-executor): raise file_scope cap for ADR-049 cohesive components

### DIFF
--- a/processor/requirement-executor/binding_context_test.go
+++ b/processor/requirement-executor/binding_context_test.go
@@ -224,6 +224,52 @@ func TestSynthesizeTaskDAGForStory_BindingBlockAppendedToPrompts(t *testing.T) {
 	}
 }
 
+// TestSynthesizeTaskDAGForStory_LargeCohesiveComponent_FileScopeWithinCap pins
+// the ADR-049 interaction with the DAG file_scope cap. A single cohesive
+// component (e.g. the OSH MAVSDK driver) legitimately owns >50 files, and every
+// synthesized node carries the full component territory as its file_scope
+// (FileScope = Story.FilesOwned). Synthesis must succeed for a realistic
+// single-component surface. Regression for the 2026-06-14 mavlink-hard run
+// (slug 2a6c27143fa9): the 52-file mavsdk-driver story decomposed into 5 Tasks
+// but synthesis hard-failed "file_scope exceeds maximum entry count (52 > 50)"
+// → AutoRejectOnExhaustion before any dev loop ran.
+func TestSynthesizeTaskDAGForStory_LargeCohesiveComponent_FileScopeWithinCap(t *testing.T) {
+	t.Parallel()
+	const nFiles = 52 // the live mavsdk-driver size (38 real OSH files + ~14 new)
+	files := make([]string, nFiles)
+	for i := range files {
+		// Unique paths via varying length; mirrors the real OSH package layout.
+		files[i] = "src/main/java/org/sensorhub/impl/sensor/mavsdk/File" + strings.Repeat("x", i) + ".java"
+	}
+	story := workflow.Story{
+		ID:             "story.mavsdk.1.1",
+		RequirementIDs: []string{"req.mavsdk.1"},
+		ComponentName:  "mavsdk-driver",
+		Title:          "MAVSDK driver",
+		FilesOwned:     files,
+		Tasks: []workflow.Task{
+			{ID: "task.mavsdk.1.1.1", StoryID: "story.mavsdk.1.1", Description: "Bootstrap mavsdk_server + lifecycle."},
+			{ID: "task.mavsdk.1.1.2", StoryID: "story.mavsdk.1.1", Description: "Telemetry datastreams."},
+			{ID: "task.mavsdk.1.1.3", StoryID: "story.mavsdk.1.1", Description: "Control commands."},
+			{ID: "task.mavsdk.1.1.4", StoryID: "story.mavsdk.1.1", Description: "Raw MAVLink fallback."},
+			{ID: "task.mavsdk.1.1.5", StoryID: "story.mavsdk.1.1", Description: "SITL smoke + coverage matrix."},
+		},
+	}
+
+	dag, err := synthesizeTaskDAGForStory(nil, story)
+	if err != nil {
+		t.Fatalf("synthesize 52-file cohesive component: %v", err)
+	}
+	if len(dag.Nodes) != len(story.Tasks) {
+		t.Fatalf("expected %d nodes (one per Task), got %d", len(story.Tasks), len(dag.Nodes))
+	}
+	for _, n := range dag.Nodes {
+		if len(n.FileScope) != nFiles {
+			t.Errorf("node %s: file_scope = %d entries, want %d (full component territory)", n.ID, len(n.FileScope), nFiles)
+		}
+	}
+}
+
 // TestBuildBindingContextBlock_AssertionCap pins the safety cap on
 // RequiredAssertions: a profile with more than maxAssertionsPerScenario
 // entries renders the first N + a truncation marker. Catalog authors

--- a/processor/requirement-executor/dag.go
+++ b/processor/requirement-executor/dag.go
@@ -23,8 +23,19 @@ type TaskNode struct {
 }
 
 const (
-	maxDAGNodes         = 100
-	maxFileScopeEntries = 50
+	maxDAGNodes = 100
+	// maxFileScopeEntries bounds a node's file_scope, which is the ownership
+	// TERRITORY (the Move-3 write-boundary / Story.FilesOwned), not a per-node
+	// worklist — work size is bounded by maxDAGNodes and the per-Task
+	// decomposition, never by this. A cohesive ADR-049 component legitimately
+	// owns many files (the live OSH MAVSDK driver is ~52: class-per-command +
+	// class-per-output), so the cap must clear a realistic single-component
+	// surface. Raised 50→100 after the 2026-06-14 mavlink-hard run auto-rejected
+	// on "file_scope exceeds maximum entry count (52 > 50)" before any dev loop
+	// ran — the work there was already decomposed into 5 Tasks; the cap was the
+	// only thing rejecting it, and it was conflating territory size with work
+	// size.
+	maxFileScopeEntries = 100
 )
 
 // Validate checks the DAG for structural correctness: non-empty, no duplicates,

--- a/processor/requirement-executor/dag_test.go
+++ b/processor/requirement-executor/dag_test.go
@@ -229,7 +229,7 @@ func TestValidate_FileScope_ValidGlobPatterns_NoError(t *testing.T) {
 
 func TestValidate_FileScope_MaxEntriesExceeded_ReturnsError(t *testing.T) {
 	t.Parallel()
-	scope := make([]string, 51)
+	scope := make([]string, maxFileScopeEntries+1)
 	for i := range scope {
 		scope[i] = "src/file" + strings.Repeat("x", i) + ".go"
 	}
@@ -245,13 +245,13 @@ func TestValidate_FileScope_MaxEntriesExceeded_ReturnsError(t *testing.T) {
 
 func TestValidate_FileScope_ExactlyMaxEntries_Valid(t *testing.T) {
 	t.Parallel()
-	scope := make([]string, 50)
+	scope := make([]string, maxFileScopeEntries)
 	for i := range scope {
 		scope[i] = "src/file" + strings.Repeat("x", i) + ".go"
 	}
 	d := dag(TaskNode{ID: "a", Prompt: "Do something", Role: "worker", FileScope: scope})
 	if err := d.Validate(); err != nil {
-		t.Errorf("Validate() = %v, want nil for exactly %d file_scope entries", err, 50)
+		t.Errorf("Validate() = %v, want nil for exactly %d file_scope entries", err, maxFileScopeEntries)
 	}
 }
 


### PR DESCRIPTION
## What
Raise \`maxFileScopeEntries\` (\`dag.go\`) from 50 to 100 so ADR-049 cohesive components (which legitimately own >50 files) pass DAG synthesis.

## Why
\`synthesize_dag.go\` sets \`TaskNode.FileScope = Story.FilesOwned\` for every node — the Move-3 ownership **territory**, not a per-node worklist. The live OSH MAVSDK driver is ~52 files (38 real OSH files + new handlers/tests/build). The 50-cap hard-failed synthesis (\`file_scope exceeds maximum entry count (52 > 50)\`) → all 4 reqs failed → \`AutoRejectOnExhaustion\`, **before any dev loop ran** (paid mavlink-hard, slug \`2a6c27143fa9\`). The 50 conflated territory size with work size; work size is already bounded by \`maxDAGNodes=100\` and the per-Task decomposition (this story had 5 tasks).

## Tests
- Boundary tests now reference the \`maxFileScopeEntries\` constant (track the cap, not a magic number).
- New \`TestSynthesizeTaskDAGForStory_LargeCohesiveComponent_FileScopeWithinCap\` reproduces the 52-file / 5-task mavsdk-driver case — RED at cap=50, GREEN at 100.
- \`go build ./...\`, requirement-executor suite, and \`task lint\` all green.

## Validation
Validated **live** in a paid mavlink-hard run (slug \`531f157277ba\`): plan reached \`implementing\`, DAG synthesis succeeded, dev loop dispatched — and the run also exercised the #188 recovery re-dispatch path (executing→failed→pending→ready→executing, no false-complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)