### PR TITLE
fix(qa): fail closed on executable evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,9 @@ Cycle in derived DAG = invalid coverage partition; Sarah retries with remediatio
 scenario-orchestrator's `filterByM2NStoryReservations` ensures ONLY the deterministic owner
 (lexicographically smallest req ID in `Story.RequirementIDs`) dispatches the dev loop. Non-owners
 are gated behind `Story.Status == complete`. On owner completion, plan-manager re-fires the
-orchestrator; non-owners dispatch and hit the executor's Tier-1 dedup which fast-completes them
-without re-running the dev loop. Cost: 1 dev loop per Story instead of N.
+orchestrator; non-owners dispatch and the executor copies the owner's completed node evidence
+before marking the requirement complete. Missing owner evidence is a failure, not a zero-node
+completion. Cost: 1 dev loop per Story instead of N.
 
 **workflow/ package**: Shared domain contracts only (types, entity IDs, subjects, payloads). NOT a
 state management layer. Components own their entity lifecycle.
@@ -97,7 +98,7 @@ state management layer. Components own their entity lifecycle.
 | `project-manager` | `processor/project-manager/` | Project config (stack, standards, checklist) |
 | `structural-validator` | `processor/structural-validator/` | Deterministic checklist validation |
 | `execution-manager` | `processor/execution-manager/` | TDD pipeline: developer → validator → reviewer |
-| `qa-reviewer` | `processor/qa-reviewer/` | Release-readiness verdict (Murat); scoped by project `qa_level` (synthesis/unit). Heavier tiers run in the operator's CI (ADR-045) |
+| `qa-reviewer` | `processor/qa-reviewer/` | Release-readiness verdict (Murat); scoped by project `qa_level` (synthesis/unit/integration/full). Unit/integration require sandbox QA evidence; full/e2e remains operator CI (ADR-045) |
 | `requirement-executor` | `processor/requirement-executor/` | DAG decomposition and serial node execution |
 | `scenario-orchestrator` | `processor/scenario-orchestrator/` | Dispatches pending requirements for execution |
 | `change-proposal-handler` | `processor/change-proposal-handler/` | ChangeProposal lifecycle: review, accept/reject, cascade |

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ the full changeset and returns per-scenario verdicts: `approved`, `needs_changes
 into a final release-readiness verdict. The plan transitions through `reviewing_qa` (or directly
 to `complete` when `qa_level=none`) before reaching `complete`. The gate counts completed
 requirements, not scenarios. Inputs vary by `qa_level`: `synthesis` reads plan+impl only;
-`unit` first routes through `ready_for_qa` so the sandbox can run project tests, then feeds
-results into the reviewer. Heavier tiers (`integration`/`full`) run in the operator's CI via
-the emitted `qa.yml` — semspec designs and gates, the operator's CI executes.
+`unit` and `integration` first route through `ready_for_qa` so the sandbox can run the
+configured project test command, then feed results into the reviewer. `full`/e2e proof remains
+operator-owned via the emitted `qa.yml`.
 
 > Older plans may show a `reviewing_rollup` status. That stage is kept for in-flight plans on
 > upgrade but no new code emits it.

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -67,7 +67,8 @@ Tier 2 — Pipeline Tests (mock LLM):
   plan-stall-retry             - Execution stall: failed requirement → retry → re-execution succeeds
   plan-stall-complete          - Execution stall: failed requirement → force-complete
   plan-stall-reject            - Execution stall: failed requirement → reject → retry from rejected
-  qa-cycle                     - QA phase: sandbox runs go test, qa-reviewer approves, plan → complete
+  qa-cycle                     - QA phase at qa_level=unit: sandbox runs go test, qa-reviewer approves, plan → complete
+  qa-cycle-integration         - QA phase at qa_level=integration: same pipeline with integration mode
 
 Real-LLM scenarios (health-check, rest-api, todo-app, epic-meshtastic) have moved
 to Playwright E2E — see docs/e2e-scenario-archive.md for details.
@@ -158,7 +159,8 @@ func listCmd() *cobra.Command {
 			fmt.Println("  plan-stall-retry             Execution stall: failed req → retry → re-execute")
 			fmt.Println("  plan-stall-complete          Execution stall: failed req → force-complete")
 			fmt.Println("  plan-stall-reject            Execution stall: failed req → reject → retry")
-			fmt.Println("  qa-cycle                     QA phase: sandbox go test + qa-reviewer verdict pipeline")
+			fmt.Println("  qa-cycle                     QA phase at qa_level=unit: sandbox go test + qa-reviewer verdict pipeline")
+			fmt.Println("  qa-cycle-integration         QA phase at qa_level=integration: sandbox go test + qa-reviewer verdict pipeline")
 			fmt.Println()
 			fmt.Println("  Real-LLM scenarios (health-check, rest-api, todo-app, epic-meshtastic)")
 			fmt.Println("  have moved to Playwright E2E — see docs/e2e-scenario-archive.md")
@@ -210,8 +212,9 @@ func run(scenarioName string, cfg *config.Config, outputJSON bool, globalTimeout
 		scenarios.NewPlanStallRecoveryScenario(cfg, scenarios.StallRecoveryRetry),
 		scenarios.NewPlanStallRecoveryScenario(cfg, scenarios.StallRecoveryComplete),
 		scenarios.NewPlanStallRecoveryScenario(cfg, scenarios.StallRecoveryReject),
-		// Tier 2: QA phase — sandbox unit-test executor + qa-reviewer verdict pipeline
+		// Tier 2: QA phase — sandbox executable QA + qa-reviewer verdict pipeline
 		scenarios.NewQACycleScenario(cfg),
+		scenarios.NewQAIntegrationCycleScenario(cfg),
 	}
 
 	scenarioMap := make(map[string]scenarios.Scenario)

--- a/cmd/mock-llm/main.go
+++ b/cmd/mock-llm/main.go
@@ -45,6 +45,10 @@ import (
 	"github.com/google/uuid"
 )
 
+var fixtureScenarioAliases = map[string]string{
+	"qa-cycle-integration": "qa-cycle",
+}
+
 // --- OpenAI-compatible types ---
 
 type chatRequest struct {
@@ -157,6 +161,22 @@ func newServer(fixtures map[string][]string, fixtureDir string) *server {
 	}
 }
 
+func resolveFixtureDir(dir string) string {
+	if _, err := os.Stat(dir); err == nil {
+		return dir
+	}
+	alias, ok := fixtureScenarioAliases[filepath.Base(dir)]
+	if !ok {
+		return dir
+	}
+	aliasedDir := filepath.Join(filepath.Dir(dir), alias)
+	if _, err := os.Stat(aliasedDir); err != nil {
+		return dir
+	}
+	log.Printf("Fixture scenario %q aliased to %q", filepath.Base(dir), alias)
+	return aliasedDir
+}
+
 // captureRequest stores a request for later retrieval via /requests endpoint.
 func (s *server) captureRequest(model string, req chatRequest, callIndex int) {
 	s.modelRequestsMu.Lock()
@@ -195,6 +215,7 @@ func main() {
 		*fixtureDir = "/fixtures"
 	}
 
+	*fixtureDir = resolveFixtureDir(*fixtureDir)
 	fixtures, err := loadFixtures(*fixtureDir)
 	if err != nil {
 		log.Fatalf("Failed to load fixtures from %s: %v", *fixtureDir, err)
@@ -391,7 +412,7 @@ func (s *server) handleReset(w http.ResponseWriter, r *http.Request) {
 	// The original fixtureDir already includes the scenario subdirectory
 	// (e.g., /fixtures/hello-world), so we go up one level.
 	baseDir := filepath.Dir(s.fixtureDir)
-	newDir := filepath.Join(baseDir, scenario)
+	newDir := resolveFixtureDir(filepath.Join(baseDir, scenario))
 
 	fixtures, err := loadFixtures(newDir)
 	if err != nil {
@@ -402,6 +423,7 @@ func (s *server) handleReset(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.Lock()
 	s.fixtures = fixtures
+	s.fixtureDir = newDir
 	s.mu.Unlock()
 
 	// Reset all counters and fault injection.

--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -90,7 +90,7 @@ func main() {
 	defer cancel()
 	go srv.CleanupLoop(ctx, *cleanupInterval, *cleanupAge)
 
-	// Optional NATS subscriber for unit-level QA requests.
+	// Optional NATS subscriber for sandbox-executable QA requests.
 	// When -nats-url is empty and NATS_URL is unset, the sandbox runs HTTP-only
 	// — existing callers are unaffected.
 	connectNATSQA(ctx, srv, *natsURL, logger)
@@ -114,7 +114,7 @@ func main() {
 	}
 }
 
-// connectNATSQA connects to NATS and starts the QA unit-mode subscriber.
+// connectNATSQA connects to NATS and starts the sandbox QA subscriber.
 // When url is empty, logs a notice and returns — sandbox operates HTTP-only.
 // On any connection error, logs and exits so the process doesn't start
 // partially configured.

--- a/cmd/sandbox/qa_subscriber.go
+++ b/cmd/sandbox/qa_subscriber.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/c360studio/semspec/workflow"
@@ -36,7 +37,8 @@ const (
 )
 
 // startQASubscriber sets up the durable JetStream consumer for QARequestedEvent
-// and begins dispatching unit-mode requests to the server's exec infrastructure.
+// and begins dispatching sandbox-executable QA requests to the server's exec
+// infrastructure.
 // The consumer context must be cancelled on shutdown to stop delivery.
 func startQASubscriber(ctx context.Context, srv *Server, natsClient *natsclient.Client, logger *slog.Logger) error {
 	// Wait for the WORKFLOW stream to exist. plan-manager creates it at its
@@ -103,11 +105,11 @@ func (h *qaHandler) handleMessage(ctx context.Context, msg jetstream.Msg) {
 		return
 	}
 
-	// Only unit mode is sandbox-executed. Heavier tiers run in the operator's
-	// CI (the qa-runner act executor was removed); plan-manager no longer
-	// publishes any non-unit QARequestedEvent, so this is a defensive guard.
-	if evt.Mode != workflow.QALevelUnit {
-		h.logger.Debug("Skipping non-unit QARequestedEvent",
+	// Only sandbox-executable modes run here. Full/e2e orchestration remains in
+	// operator CI, so stale/invalid modes are acknowledged rather than
+	// redelivered forever.
+	if !evt.Mode.UsesSandboxTests() {
+		h.logger.Debug("Skipping non-sandbox QARequestedEvent",
 			"slug", evt.Slug, "mode", evt.Mode)
 		_ = msg.Ack()
 		return
@@ -123,14 +125,15 @@ func (h *qaHandler) handleMessage(ctx context.Context, msg jetstream.Msg) {
 	runID := uuid.New().String()
 	start := time.Now()
 
-	h.logger.Info("Running unit QA",
+	h.logger.Info("Running sandbox QA",
 		"slug", evt.Slug, "plan_id", evt.PlanID,
+		"mode", evt.Mode,
 		"run_id", runID, "test_command", evt.TestCommand,
 		"trace_id", evt.TraceID)
 
-	completed := h.runUnitQA(ctx, evt, runID, start)
+	completed := h.runSandboxQA(ctx, evt, runID, start)
 	if completed == nil {
-		// runUnitQA already nak'd — nothing further to do.
+		// runSandboxQA already nak'd — nothing further to do.
 		return
 	}
 
@@ -144,12 +147,13 @@ func (h *qaHandler) handleMessage(ctx context.Context, msg jetstream.Msg) {
 	}
 
 	_ = msg.Ack()
-	h.logger.Info("Unit QA complete",
+	h.logger.Info("Sandbox QA complete",
 		"slug", evt.Slug, "run_id", runID,
+		"mode", evt.Mode,
 		"passed", completed.Passed, "duration_ms", completed.DurationMs)
 }
 
-// selectQAWorkDir resolves the directory the unit test command runs in: the
+// selectQAWorkDir resolves the directory the QA command runs in: the
 // dedicated QA worktree when plan-manager created one and it resolves, else the
 // repo root. resolve mirrors Server.worktreeFor — it returns "" when the
 // worktree is absent. fellBack is true only when a workspace was requested but
@@ -165,8 +169,8 @@ func selectQAWorkDir(repoPath, workspace string, resolve func(string) string) (d
 	return repoPath, true
 }
 
-// runUnitQA executes the test command and assembles the QACompletedEvent.
-func (h *qaHandler) runUnitQA(
+// runSandboxQA executes the test command and assembles the QACompletedEvent.
+func (h *qaHandler) runSandboxQA(
 	ctx context.Context,
 	evt workflow.QARequestedEvent,
 	runID string,
@@ -175,16 +179,16 @@ func (h *qaHandler) runUnitQA(
 	if evt.TestCommand == "" {
 		// plan-manager's EffectiveTestCommand() should have resolved this before
 		// publishing; an empty command means project config is incomplete.
-		h.logger.Error("QARequestedEvent has no test_command — cannot run unit QA",
-			"slug", evt.Slug)
+		h.logger.Error("QARequestedEvent has no test_command — cannot run sandbox QA",
+			"slug", evt.Slug, "mode", evt.Mode)
 		return &workflow.QACompletedEvent{
 			Slug:        evt.Slug,
 			PlanID:      evt.PlanID,
 			RunID:       runID,
-			Level:       workflow.QALevelUnit,
+			Level:       evt.Mode,
 			Passed:      false,
 			DurationMs:  time.Since(start).Milliseconds(),
-			RunnerError: "no test_command configured at qa.level=unit",
+			RunnerError: fmt.Sprintf("no test_command configured at qa.level=%s", evt.Mode),
 			TraceID:     evt.TraceID,
 		}
 	}
@@ -204,7 +208,7 @@ func (h *qaHandler) runUnitQA(
 	// runs against the pre-implementation main HEAD and is meaningless.
 	workDir, fellBack := selectQAWorkDir(h.srv.repoPath, evt.Workspace, h.srv.worktreeFor)
 	if fellBack {
-		h.logger.Warn("QA worktree not found — running unit tests against repo root (may be the unmerged baseline)",
+		h.logger.Warn("QA worktree not found — running QA command against repo root (may be the unmerged baseline)",
 			"slug", evt.Slug, "workspace", evt.Workspace)
 	}
 	stdout, stderr, exitCode, timedOut := execCommand(
@@ -222,11 +226,13 @@ func (h *qaHandler) runUnitQA(
 
 	// Archive the full output.
 	artifactRelPath := filepath.Join(
-		".semspec", "qa-artifacts", evt.Slug, runID, "unit-test.log")
-	artifacts := h.archiveLog(evt.Slug, runID, artifactRelPath, combined)
+		".semspec", "qa-artifacts", evt.Slug, runID, fmt.Sprintf("%s-test.log", evt.Mode))
+	artifacts := h.archiveLog(evt.Slug, runID, artifactRelPath, combined, fmt.Sprintf("%s test output", evt.Mode))
+
+	skippedEvidence := integrationSkippedTestEvidence(evt.Mode, workDir)
 
 	// Build pass/fail result.
-	passed := exitCode == 0 && !timedOut
+	passed := exitCode == 0 && !timedOut && len(skippedEvidence) == 0
 	var failures []workflow.QAFailure
 	if !passed {
 		excerpt := combined
@@ -236,10 +242,12 @@ func (h *qaHandler) runUnitQA(
 		msg := fmt.Sprintf("test command failed (exit %d)", exitCode)
 		if timedOut {
 			msg = fmt.Sprintf("test command timed out after %s", timeout)
+		} else if len(skippedEvidence) > 0 {
+			msg = fmt.Sprintf("integration QA skipped test(s): %s", strings.Join(skippedEvidence, ", "))
 		}
 		failures = []workflow.QAFailure{
 			{
-				JobName:    "unit",
+				JobName:    string(evt.Mode),
 				Message:    msg,
 				LogExcerpt: excerpt,
 			},
@@ -250,7 +258,7 @@ func (h *qaHandler) runUnitQA(
 		Slug:       evt.Slug,
 		PlanID:     evt.PlanID,
 		RunID:      runID,
-		Level:      workflow.QALevelUnit,
+		Level:      evt.Mode,
 		Passed:     passed,
 		Failures:   failures,
 		Artifacts:  artifacts,
@@ -263,7 +271,7 @@ func (h *qaHandler) runUnitQA(
 // and returns a populated QAArtifactRef slice on success. On write failure the
 // error is logged and an empty slice is returned — the caller still publishes
 // QACompletedEvent without the artifact reference.
-func (h *qaHandler) archiveLog(slug, runID, relPath, content string) []workflow.QAArtifactRef {
+func (h *qaHandler) archiveLog(slug, runID, relPath, content, purpose string) []workflow.QAArtifactRef {
 	absPath := filepath.Join(h.srv.repoPath, relPath)
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		h.logger.Warn("Failed to create qa-artifact directory — artifact will not be archived",
@@ -279,9 +287,48 @@ func (h *qaHandler) archiveLog(slug, runID, relPath, content string) []workflow.
 		{
 			Path:    relPath, // workspace-relative — consumers resolve against their own root
 			Type:    "log",
-			Purpose: "unit test output",
+			Purpose: purpose,
 		},
 	}
+}
+
+func integrationSkippedTestEvidence(mode workflow.QALevel, workDir string) []string {
+	if mode != workflow.QALevelIntegration || workDir == "" {
+		return nil
+	}
+	roots := []string{
+		filepath.Join(workDir, "build", "test-results"),
+		filepath.Join(workDir, "target", "surefire-reports"),
+		filepath.Join(workDir, "target", "failsafe-reports"),
+	}
+	var evidence []string
+	for _, root := range roots {
+		if _, err := os.Stat(root); err != nil {
+			continue
+		}
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || len(evidence) >= 5 {
+				return nil
+			}
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".xml" {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			if strings.Contains(strings.ToLower(string(data)), "<skipped") {
+				rel, relErr := filepath.Rel(workDir, path)
+				if relErr != nil {
+					rel = path
+				}
+				evidence = append(evidence, rel)
+			}
+			return nil
+		})
+	}
+	return evidence
 }
 
 // publishCompleted wraps evt in a BaseMessage envelope and publishes it to

--- a/cmd/sandbox/qa_subscriber_test.go
+++ b/cmd/sandbox/qa_subscriber_test.go
@@ -1,6 +1,17 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+)
 
 func TestSelectQAWorkDir(t *testing.T) {
 	const repoPath = "/repo"
@@ -50,5 +61,46 @@ func TestSelectQAWorkDir(t *testing.T) {
 				t.Errorf("fellBack = %v, want %v", fellBack, tt.wantFellBack)
 			}
 		})
+	}
+}
+
+func TestRunSandboxQAIntegrationFailsOnSkippedJUnitTests(t *testing.T) {
+	dir := t.TempDir()
+	resultsDir := filepath.Join(dir, "build", "test-results", "test")
+	if err := os.MkdirAll(resultsDir, 0o755); err != nil {
+		t.Fatalf("mkdir results: %v", err)
+	}
+	xml := `<testsuite tests="1" skipped="1"><testcase classname="DriverIT" name="sitl"><skipped/></testcase></testsuite>`
+	if err := os.WriteFile(filepath.Join(resultsDir, "TEST-DriverIT.xml"), []byte(xml), 0o644); err != nil {
+		t.Fatalf("write junit xml: %v", err)
+	}
+
+	h := &qaHandler{
+		srv: &Server{
+			repoPath:       dir,
+			maxTimeout:     5 * time.Second,
+			maxOutputBytes: 64 * 1024,
+			worktreeRoot:   filepath.Join(dir, ".semspec", "worktrees"),
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	got := h.runSandboxQA(context.Background(), workflow.QARequestedEvent{
+		Slug:        "mavlink-hard",
+		PlanID:      "plan-1",
+		Mode:        workflow.QALevelIntegration,
+		TestCommand: "true",
+	}, "run-1", time.Now())
+
+	if got.Passed {
+		t.Fatalf("Passed = true, want false for skipped integration tests")
+	}
+	if got.Level != workflow.QALevelIntegration {
+		t.Fatalf("Level = %q, want integration", got.Level)
+	}
+	if len(got.Failures) != 1 {
+		t.Fatalf("Failures = %d, want 1", len(got.Failures))
+	}
+	if !strings.Contains(got.Failures[0].Message, "skipped") {
+		t.Errorf("failure message should mention skipped tests, got %q", got.Failures[0].Message)
 	}
 }

--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -108,7 +108,8 @@ services:
       - "8190:8090"
     command: ["--addr", ":8090", "--repo", "/workspace"]
     environment:
-      # Enables the qa-unit subscriber during E2E runs that exercise qa_level=unit.
+      # Enables the sandbox QA subscriber during E2E runs that exercise
+      # qa_level=unit or qa_level=integration.
       - NATS_URL=nats://nats:4222
       # GitHub auth for agent upstream-resolution (curl/git). sandbox-entrypoint.sh
       # configures ~/.netrc + ~/.curlrc when set, so the architect's GitHub REST
@@ -135,9 +136,9 @@ services:
     depends_on:
       nats:
         condition: service_healthy
-      # sandbox's qa-unit subscriber exits with code 1 if the WORKFLOW stream
-      # isn't ready within ~60s of NATS connect. Gate on semspec health so
-      # the stream exists by then.
+      # sandbox's QA subscriber exits with code 1 if the WORKFLOW stream isn't
+      # ready within ~60s of NATS connect. Gate on semspec health so the stream
+      # exists by then.
       semspec:
         condition: service_healthy
     deploy:

--- a/docs/api.md
+++ b/docs/api.md
@@ -235,7 +235,7 @@ created → drafting → drafted → reviewing_draft → reviewed → approved
        → generating_scenarios → scenarios_generated
        → reviewing_scenarios → scenarios_reviewed → ready_for_execution
        → implementing
-       → ready_for_qa (qa_level=unit/integration/full only)
+       → ready_for_qa (qa_level=unit/integration only)
        → reviewing_qa
        → complete
 ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -326,9 +326,10 @@ Semspec registers 22 components at startup alongside the full semstreams compone
 │  execution-manager      TDD pipeline per DAG node:                  │
 │                          developer → validator → reviewer            │
 │  qa-reviewer            Release-readiness verdict (Murat persona);   │
-│                          scoped by qa_level (synthesis/unit).         │
-│                          Heavier tiers run in the operator's CI       │
-│                          against the emitted qa.yml (ADR-045)         │
+│                          scoped by qa_level                           │
+│                          (synthesis/unit/integration/full)            │
+│                          unit/integration use sandbox QA; full/e2e    │
+│                          remains operator CI via emitted qa.yml        │
 │  plan-decision-handler  PlanDecision OODA loop and cascade           │
 │  recovery-agent         Wedge recovery — manager-role agents that    │
 │                          unstick stuck loops via trajectory analysis │

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -137,12 +137,12 @@ plan at creation so policy changes don't retroactively affect in-flight work.
 | `none` | — | No QA gate; plan goes straight to `complete` | Doc-only hotfixes |
 | `synthesis` | qa-reviewer only | LLM verdict on plan artifacts, no test execution | Default; fast, content-based check |
 | `unit` | sandbox | `go test ./...` (or language default) against the merged worktree | Most projects |
-| `integration` | operator's CI | `.github/workflows/qa.yml` job `integration` — tagged integration tests against real service dependencies. Per ADR-039 the catalog `services`-class profiles render as qa.yml `services:` blocks; the operator's CI brings the stack up. `testcontainers` and `pure-fixture` profiles are started by the test code itself. Semspec emits the qa.yml; it does not execute it (ADR-045). Values of `integration` in `qa_level` are coerced to `synthesis` at runtime. | Projects with integration suites (operator-CI-only) |
-| `full` | operator's CI | Both `integration` + `e2e` jobs — adds Playwright browser flows. Semspec emits the qa.yml; the operator's CI executes it (ADR-045). Values of `full` in `qa_level` are coerced to `synthesis` at runtime. | Projects with UI + browser tests (operator-CI-only) |
+| `integration` | sandbox + operator CI contract | Semspec runs the configured integration command in the sandbox and requires a passing QA executor result before qa-reviewer can approve. Catalog `services` profiles still render into `.github/workflows/qa.yml` for operator CI because the sandbox cannot stand up every live dependency; `testcontainers` and `pure-fixture` profiles are owned by project test code. | Projects with runnable integration suites |
+| `full` | operator's CI | Both `integration` + `e2e` jobs — adds Playwright browser flows. Semspec emits the qa.yml; the operator's CI executes it (ADR-045). Stale `full` values are treated as `synthesis` by semspec's local gate. | Projects with UI + browser tests (operator-CI-only) |
 
-**MVP scope:** use `synthesis` for hard-scenario demos unless the project already owns a reliable integration command.
-Scenario tags and harness profile IDs remain planning/review metadata, but semspec-managed harness routing and full/e2e
-orchestration are post-MVP.
+**MVP scope:** use `integration` when the project owns a reliable sandbox-runnable command.
+Scenario tags and harness profile IDs remain planning/review metadata for service orchestration; full/e2e
+orchestration stays in operator CI.
 
 Configure via `.semspec/project.json`:
 

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -1947,7 +1947,7 @@ func ownershipPlanningGap(results []payloads.CheckResult) (string, bool) {
 // runStructuralValidation publishes a ValidationRequest to the structural-validator
 // component and waits for the result. Same pattern as ask_question — fire and wait.
 func (c *Component) runStructuralValidation(ctx context.Context, exec *taskExecution) (payloads.ValidationResult, error) {
-	timeout := 30 * time.Second
+	timeout := 15 * time.Minute
 
 	req := &payloads.ValidationRequest{
 		ExecutionID:     uuid.New().String(),

--- a/processor/execution-manager/mutations.go
+++ b/processor/execution-manager/mutations.go
@@ -130,8 +130,9 @@ type ReqPhaseRequest struct {
 	DAGRaw        json.RawMessage `json:"dag,omitempty"`
 	SortedNodeIDs []string        `json:"sorted_node_ids,omitempty"`
 	// Story sequencing (ADR-043 PR 4h)
-	SortedStoryIDs  []string `json:"sorted_story_ids,omitempty"`
-	CurrentStoryIdx *int     `json:"current_story_idx,omitempty"`
+	SortedStoryIDs  []string              `json:"sorted_story_ids,omitempty"`
+	CurrentStoryIdx *int                  `json:"current_story_idx,omitempty"`
+	NodeResults     []workflow.NodeResult `json:"node_results,omitempty"`
 }
 
 // ReqResetRequest deletes a requirement execution entry from EXECUTION_STATES.
@@ -494,6 +495,9 @@ func (c *Component) handleReqPhaseMutation(ctx context.Context, data []byte) Exe
 	}
 	if req.CurrentStoryIdx != nil {
 		exec.CurrentStoryIdx = *req.CurrentStoryIdx
+	}
+	if len(req.NodeResults) > 0 {
+		exec.NodeResults = req.NodeResults
 	}
 
 	if err := c.store.saveReq(ctx, req.Key, exec); err != nil {

--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -482,10 +482,10 @@ func (c *Component) failPlanOnAssemblyConflict(ctx context.Context, plan *workfl
 }
 
 // publishQARequestIfNeeded fires when a plan is routed to ready_for_qa. For
-// unit-level QA it publishes a QARequestedEvent so the sandbox runs the
-// project's test suite before qa-reviewer interprets. synthesis/none don't
-// dispatch (synthesis is claimed directly by qa-reviewer; none skips QA).
-// Heavier tiers run in the operator's CI, not via a semspec executor.
+// sandbox-executed QA levels it publishes a QARequestedEvent so the sandbox
+// runs the project's configured QA command before qa-reviewer interprets.
+// synthesis/none don't dispatch (synthesis is claimed directly by qa-reviewer;
+// none skips QA). Full/e2e orchestration remains operator CI for MVP.
 // No-op when plan.Status != ready_for_qa or natsClient is nil (tests).
 func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow.Plan) {
 	if plan == nil || plan.Status != workflow.StatusReadyForQA || c.natsClient == nil {
@@ -552,15 +552,14 @@ func (c *Component) publishQARequestIfNeeded(ctx context.Context, plan *workflow
 //
 // level=none      → StatusComplete (or StatusAwaitingReview when gated)
 // level=synthesis → StatusReadyForQA (qa-reviewer claims it directly, no tests run)
-// level=unit      → StatusReadyForQA (the sandbox runs project tests first via
+// level=unit/integration → StatusReadyForQA (the sandbox runs project QA first via
 //
 //	a QARequestedEvent, then qa-reviewer interprets the result)
 //
-// Heavier tiers (testcontainers integration, services-class live SITL, e2e)
-// are NOT executed by semspec — they run in the operator's CI against the
-// emitted qa.yml. qa-reviewer owns the ready_for_qa → reviewing_qa transition
-// via plan.mutation.qa.start; for unit, publishQARequestIfNeeded additionally
-// fires a QARequestedEvent so the sandbox runs before qa-reviewer claims it.
+// Full/e2e orchestration is NOT executed by semspec — it runs in the operator's
+// CI against the emitted qa.yml. qa-reviewer owns the ready_for_qa →
+// reviewing_qa transition via plan.mutation.qa.start; executable levels also
+// fire a QARequestedEvent so the sandbox runs before qa-reviewer claims it.
 func (c *Component) targetForQALevel(level workflow.QALevel, plan *workflow.Plan, _ string) workflow.Status {
 	switch level {
 	case workflow.QALevelNone:

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1819,7 +1819,7 @@ func (c *Component) resetRequirementExecutionsByID(ctx context.Context, slug str
 // the execution-phase counterpart of determineR2ReentryPoint's "architecture"
 // case: capture the prior architecture so the architect REVISES rather than
 // rewrites, wipe Architecture + Stories + Scenarios, reset every requirement
-// execution so the re-run can't fast-complete via the executor's Tier-1 dedup,
+// execution so the re-run cannot reuse stale Story owner evidence via Tier-1 dedup,
 // route the recovery diagnosis into ReviewFormattedFindings (the channel the
 // architecture-generator already reads on revision rounds — component.go:301),
 // and drive the back-transition implementing → requirements_generated so the

--- a/processor/plan-manager/plan_merge.go
+++ b/processor/plan-manager/plan_merge.go
@@ -250,10 +250,12 @@ func (c *Component) pruneBranch(ctx context.Context, slug, branch string) bool {
 //
 // Nodes (M:N, product call P2): the DeterministicStoryOwner of each Story plus
 // every requirement covered by no Story (legacy/mock plans). Non-owner covered
-// requirements are skipped — they fast-complete with no commits, so their
-// branches are empty and the owner branch already carries the whole Story's
-// work. With no Stories every requirement is its own node, reducing to the
-// pre-M:N behavior (and keeping existing assembly tests green).
+// requirements are skipped for branch assembly because their branches are empty
+// and the owner branch already carries the whole Story's work. Their
+// requirement-execution records still inherit the owner Story's node evidence;
+// this branch filter is about git assembly, not QA proof. With no Stories every
+// requirement is its own node, reducing to the pre-M:N behavior (and keeping
+// existing assembly tests green).
 //
 // Order: a node's prerequisites are ResolveRequirementBranchPrereqs (the SAME
 // resolved union that drove branch derivation — design §3), restricted to the
@@ -283,8 +285,8 @@ func assemblyBranchOrder(reqs []workflow.Requirement, stories []workflow.Story) 
 // assemblyNodes returns the requirement IDs whose branches assembly merges, in
 // requirement-slice order (stable tie-break position): each Story's owner plus
 // every requirement covered by no Story. Non-owner covered requirements are
-// excluded (empty fast-complete branches). With no Stories every requirement is
-// its own node.
+// excluded because their branches are empty and the owner branch carries the
+// shared Story's work. With no Stories every requirement is its own node.
 func assemblyNodes(reqs []workflow.Requirement, stories []workflow.Story) (order []string, set map[string]struct{}) {
 	storyOwners := make(map[string]struct{}, len(stories))
 	for _, s := range stories {

--- a/processor/project-manager/http.go
+++ b/processor/project-manager/http.go
@@ -835,7 +835,7 @@ func (c *Component) handleConfig(w http.ResponseWriter, r *http.Request) {
 	// Validate qa_level before touching state. Empty string is accepted
 	// (clears to synthesis default via EffectiveQALevel).
 	if req.QALevel != nil && *req.QALevel != "" && !workflow.QALevel(*req.QALevel).IsValid() {
-		http.Error(w, fmt.Sprintf("qa_level %q is not one of: none, synthesis, unit", *req.QALevel), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("qa_level %q is not one of: none, synthesis, unit, integration", *req.QALevel), http.StatusBadRequest)
 		return
 	}
 

--- a/processor/project-manager/http_config_test.go
+++ b/processor/project-manager/http_config_test.go
@@ -41,12 +41,12 @@ func TestHandleConfig_NoopPatchPreservesTimestamp(t *testing.T) {
 		Version:       "1.0.0",
 		InitializedAt: originalTS,
 		UpdatedAt:     originalTS,
-		QALevel:       workflow.QALevelUnit,
+		QALevel:       workflow.QALevelIntegration,
 		QATestCommand: "./gradlew test",
 	})
 
 	// PATCH with the SAME qa_level and qa_test_command — should be a no-op.
-	qaLevel := string(workflow.QALevelUnit)
+	qaLevel := string(workflow.QALevelIntegration)
 	qaCmd := "./gradlew test"
 	body, err := json.Marshal(map[string]*string{
 		"qa_level":        &qaLevel,
@@ -200,7 +200,7 @@ func TestHandleConfig_RealChangePatchUpdatesTimestamp(t *testing.T) {
 		QALevel:       workflow.QALevelSynthesis,
 	})
 
-	qaLevel := string(workflow.QALevelUnit)
+	qaLevel := string(workflow.QALevelIntegration)
 	body, err := json.Marshal(map[string]*string{"qa_level": &qaLevel})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -222,7 +222,7 @@ func TestHandleConfig_RealChangePatchUpdatesTimestamp(t *testing.T) {
 
 	var afterFile workflow.ProjectConfig
 	readJSONFile(t, filepath.Join(repoRoot, ".semspec", workflow.ProjectConfigFile), &afterFile)
-	if afterFile.QALevel != workflow.QALevelUnit {
+	if afterFile.QALevel != workflow.QALevelIntegration {
 		t.Errorf("QALevel = %q, want integration", afterFile.QALevel)
 	}
 	if !afterFile.UpdatedAt.After(originalTS) {

--- a/processor/project-manager/http_types.go
+++ b/processor/project-manager/http_types.go
@@ -45,13 +45,14 @@ type ConfigUpdateRequest struct {
 	Org         *string `json:"org,omitempty"`
 	Platform    *string `json:"platform,omitempty"`
 	// QALevel updates the project-wide QA policy. Values: "none",
-	// "synthesis", "unit". Empty string clears to default (synthesis).
+	// "synthesis", "unit", "integration". Empty string clears to default
+	// (synthesis).
 	// In-flight plans are unaffected — QA level is snapshotted onto each plan
 	// at creation time.
 	QALevel *string `json:"qa_level,omitempty"`
 
-	// QATestCommand overrides the inferred test command the sandbox runs at
-	// qa.level=unit. Empty string clears the override, reverting to
+	// QATestCommand overrides the inferred test command the sandbox runs for
+	// executable QA levels. Empty string clears the override, reverting to
 	// language-based inference.
 	QATestCommand *string `json:"qa_test_command,omitempty"`
 }

--- a/processor/qa-reviewer/component.go
+++ b/processor/qa-reviewer/component.go
@@ -5,7 +5,7 @@
 // mutation to plan-manager.
 //
 // Phase 6 wires real LLM review and populates verdict dimensions scoped by the
-// plan's qa.level (synthesis/unit/integration/full). Projects that want to
+// plan's qa.level (synthesis/unit/integration). Projects that want to
 // bypass qa-reviewer entirely set qa.level=none on their project config —
 // plan-manager then routes plans straight to complete without entering
 // reviewing_qa at all. Plan-manager is the single writer — this component
@@ -195,7 +195,7 @@ func (c *Component) Start(ctx context.Context) error {
 	go c.watchPlanStates(subCtx, js)
 	go c.watchLoopCompletions(subCtx)
 	if err := c.startQACompletedConsumer(subCtx); err != nil {
-		c.logger.Warn("Failed to start QACompleted consumer — unit/integration/full plans will stall",
+		c.logger.Warn("Failed to start QACompleted consumer — unit/integration plans will stall",
 			"error", err)
 	}
 
@@ -686,6 +686,9 @@ func buildQAVerdictEvent(slug string, plan *workflow.Plan, result *qaReviewOutpu
 	if plan != nil {
 		level = plan.EffectiveQALevel()
 	}
+	if forced := forcedExecutableQAVerdict(slug, plan, level); forced != nil {
+		return forced
+	}
 	verdict := &workflow.QAVerdictEvent{
 		Slug:    slug,
 		Level:   level,
@@ -729,6 +732,72 @@ func buildQAVerdictEvent(slug string, plan *workflow.Plan, result *qaReviewOutpu
 		verdict.PlanDecisionIDs = append(verdict.PlanDecisionIDs, proposal.ID)
 	}
 	return verdict
+}
+
+func forcedExecutableQAVerdict(slug string, plan *workflow.Plan, level workflow.QALevel) *workflow.QAVerdictEvent {
+	if plan == nil || !level.UsesSandboxTests() {
+		return nil
+	}
+	base := &workflow.QAVerdictEvent{
+		Slug:   slug,
+		PlanID: plan.ID,
+		Level:  level,
+		Dimensions: workflow.QAVerdictDimensions{
+			Coverage:          "not satisfied",
+			AssertionQuality:  "not satisfied",
+			RegressionSurface: "not satisfied",
+		},
+	}
+	if plan.QARun == nil {
+		base.Verdict = workflow.QAVerdictRejected
+		base.Summary = fmt.Sprintf("QA level %s requires an executor result, but no QARun was attached. Refusing to approve without executed test evidence.", level)
+		base.ReviewerError = "missing qa executor result"
+		return base
+	}
+	if plan.QARun.RunnerError != "" {
+		base.Verdict = workflow.QAVerdictRejected
+		base.Summary = fmt.Sprintf("QA executor failed at level %s: %s", level, plan.QARun.RunnerError)
+		base.ReviewerError = plan.QARun.RunnerError
+		return base
+	}
+	if !plan.QARun.Passed {
+		base.Verdict = workflow.QAVerdictNeedsChanges
+		base.Summary = summarizeQAFailures(level, plan.QARun)
+		return base
+	}
+	return nil
+}
+
+func summarizeQAFailures(level workflow.QALevel, run *workflow.QARun) string {
+	if run == nil {
+		return fmt.Sprintf("QA level %s did not produce a run result.", level)
+	}
+	if len(run.Failures) == 0 {
+		return fmt.Sprintf("QA level %s failed: executor reported passed=false with no structured failures.", level)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "QA level %s failed with %d failure(s).", level, len(run.Failures))
+	for i, failure := range run.Failures {
+		if i >= 3 {
+			fmt.Fprintf(&b, " %d additional failure(s) omitted.", len(run.Failures)-i)
+			break
+		}
+		fmt.Fprintf(&b, " [%s]", failure.JobName)
+		if failure.TestName != "" {
+			fmt.Fprintf(&b, " %s", failure.TestName)
+		}
+		if failure.Message != "" {
+			fmt.Fprintf(&b, ": %s", failure.Message)
+		}
+		excerpt := strings.TrimSpace(failure.LogExcerpt)
+		if excerpt != "" {
+			if len(excerpt) > 240 {
+				excerpt = excerpt[:240] + "..."
+			}
+			fmt.Fprintf(&b, " Excerpt: %s", excerpt)
+		}
+	}
+	return b.String()
 }
 
 // recordQARejectionLesson persists a role-scoped lesson when the verdict

--- a/processor/qa-reviewer/component_test.go
+++ b/processor/qa-reviewer/component_test.go
@@ -226,6 +226,58 @@ func TestBuildQAReviewContext(t *testing.T) {
 	})
 }
 
+func TestBuildQAVerdictEvent_ExecutableQAFailClosed(t *testing.T) {
+	result := &qaReviewOutput{Verdict: string(workflow.QAVerdictApproved), Summary: "looks fine"}
+
+	t.Run("missing QARun rejects integration", func(t *testing.T) {
+		plan := &workflow.Plan{Slug: "mavlink-hard", ID: "plan-1", QALevel: workflow.QALevelIntegration}
+		got := buildQAVerdictEvent(plan.Slug, plan, result)
+		if got.Verdict != workflow.QAVerdictRejected {
+			t.Fatalf("Verdict = %q, want rejected", got.Verdict)
+		}
+		if !strings.Contains(got.Summary, "no QARun") {
+			t.Errorf("Summary should explain missing QARun, got %q", got.Summary)
+		}
+	})
+
+	t.Run("failing QARun cannot be approved", func(t *testing.T) {
+		plan := &workflow.Plan{
+			Slug:    "mavlink-hard",
+			ID:      "plan-1",
+			QALevel: workflow.QALevelIntegration,
+			QARun: &workflow.QARun{
+				Passed: false,
+				Failures: []workflow.QAFailure{
+					{JobName: "integration", Message: "gradle test failed"},
+				},
+			},
+		}
+		got := buildQAVerdictEvent(plan.Slug, plan, result)
+		if got.Verdict != workflow.QAVerdictNeedsChanges {
+			t.Fatalf("Verdict = %q, want needs_changes", got.Verdict)
+		}
+		if !strings.Contains(got.Summary, "gradle test failed") {
+			t.Errorf("Summary should include failure evidence, got %q", got.Summary)
+		}
+	})
+
+	t.Run("passing QARun allows reviewer verdict", func(t *testing.T) {
+		plan := &workflow.Plan{
+			Slug:    "mavlink-hard",
+			ID:      "plan-1",
+			QALevel: workflow.QALevelIntegration,
+			QARun:   &workflow.QARun{Passed: true},
+		}
+		got := buildQAVerdictEvent(plan.Slug, plan, result)
+		if got.Verdict != workflow.QAVerdictApproved {
+			t.Fatalf("Verdict = %q, want approved", got.Verdict)
+		}
+		if got.Summary != "looks fine" {
+			t.Errorf("Summary = %q, want model summary", got.Summary)
+		}
+	})
+}
+
 // TestBuildQAReviewContext_ADR044CapabilityEvidence pins the ADR-044
 // release-readiness contract shift: QAReviewContext.Capabilities surfaces
 // per-Capability covering Story join + shipped count. A Capability with

--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -169,10 +169,10 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 // ready state (Complete, Executing, Failed, Pending) is walked back to Ready.
 // This mirrors the lesson learned on the QA-recovery path: without the reopen,
 // dispatchCurrentStoryLocked's ClaimStoryStatus(→Executing) is rejected for
-// a story not at Ready (invalid transition), the executor misreads the rejection
-// as "M:N reservation held by another executor", skips, and false-completes the
-// requirement with nodes_completed=0. The dev-gate fast-fail (ADR-049 Move-3)
-// is the primary producer of Executing-stranded stories.
+// a story not at Ready (invalid transition), the executor treats the reservation
+// as unavailable and now fails closed unless completed owner evidence exists.
+// The dev-gate fast-fail (ADR-049 Move-3) is the primary producer of
+// Executing-stranded stories.
 //
 // If the reopen was attempted (natsClient present) but not all owned stories
 // reached Ready (transient NATS error, partial walk), this function re-arms
@@ -193,10 +193,10 @@ func (c *Component) resumeFromRecoveryLocked(ctx context.Context, exec *requirem
 
 	// C1: if the walk was attempted but did not fully land, do NOT proceed to
 	// dispatchSynthesizerLocked — dispatching now would produce the same
-	// false-complete this function exists to prevent (story still non-Ready,
-	// ClaimStoryStatus(→Executing) rejected, executor skips, req marks complete
-	// with nodes_completed=0). Instead, re-arm awaiting-recovery WITHOUT burning
-	// a recoveryRestarts slot so the next cycle retries the walk from the story's
+	// false-green pressure this function exists to prevent (story still non-Ready,
+	// ClaimStoryStatus(→Executing) rejected, executor cannot attach completed
+	// owner evidence). Instead, re-arm awaiting-recovery WITHOUT burning a
+	// recoveryRestarts slot so the next cycle retries the walk from the story's
 	// current status (self-healing). The outer recovery timer still fires if no
 	// progress is made, so this path cannot loop forever within a single exec.
 	//

--- a/processor/requirement-executor/binding_context.go
+++ b/processor/requirement-executor/binding_context.go
@@ -54,8 +54,9 @@ func buildBindingContextBlock(scenarios []workflow.Scenario) string {
 	b.WriteString("For MVP, this block is authoring and review context: write tests so they can ")
 	b.WriteString("participate in the project's own integration-test protocol, usually by ")
 	b.WriteString("declaring the tier, reading environment-provided endpoints, and asserting ")
-	b.WriteString("the catalog's required behavior. Murat records whether runtime proof is ")
-	b.WriteString("present, missing, or deferred; full semspec-managed harness routing is post-MVP.\n\n")
+	b.WriteString("the catalog's required behavior. qa_level=integration runs the configured ")
+	b.WriteString("project QA command as the runtime evidence gate; full/e2e orchestration remains ")
+	b.WriteString("operator CI for MVP.\n\n")
 
 	for _, sc := range relevant {
 		b.WriteString(formatScenarioBinding(sc))

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -1065,23 +1065,25 @@ func (c *Component) dispatchSynthesizerLocked(ctx context.Context, exec *require
 // Two-tier guard:
 //
 //  1. Post-completion skip (cheap, in-process): if the freshly-loaded plan
-//     KV shows Status==Complete, another executor already shipped — advance
-//     cursor and re-enter. Catches the late-arriving case.
+//     KV shows Status==Complete, another executor already shipped — copy
+//     the deterministic owner's node evidence, advance cursor, and re-enter.
+//     Catches the late-arriving case without producing zero-node completions.
 //
 //  2. Compare-and-swap reservation (load-bearing, NATS round-trip):
 //     attempt ready→executing via workflow.ClaimStoryStatus. Plan-manager
 //     enforces Story.Status.CanTransitionTo. First executor wins; others
 //     observe the rejection and treat it as "another executor owns this
-//     Story" — skip with the same cursor-advance logic. Closes the
-//     race-load window where N executors all see Status as not-yet-set
-//     and would otherwise all dispatch.
+//     Story" only if completed-owner execution evidence exists. Closes
+//     the race-load window where N executors all see Status as not-yet-set
+//     and would otherwise all dispatch, while still failing closed when no
+//     owner proof exists.
 //
 // Failed / Pending stories fall through to dispatch so requirement-level
 // recovery still works. When the claim NATS call has no client wired
 // (test components), the reservation is silently skipped — back-compat
 // with unit tests that drive dispatchCurrentStoryLocked directly without
-// a NATS substrate. Failed claim against a real client is treated as
-// "someone else owns it" and the executor skips dispatch.
+// a NATS substrate. Failed claim against a real client requires completed
+// owner evidence before the executor skips dispatch.
 //
 // Caller must hold exec.mu.
 func (c *Component) dispatchCurrentStoryLocked(ctx context.Context, exec *requirementExecution, plan *workflow.Plan) {
@@ -1103,6 +1105,10 @@ func (c *Component) dispatchCurrentStoryLocked(ctx context.Context, exec *requir
 			"requirement_id", exec.RequirementID,
 			"story_id", currentStoryID,
 			"covered_requirements", story.RequirementIDs)
+		if !c.applyCompletedStoryEvidenceLocked(ctx, exec, story) {
+			c.markFailedLocked(ctx, exec, fmt.Sprintf("completed Story %s has no completed owner execution evidence for requirement %s", currentStoryID, exec.RequirementID))
+			return
+		}
 		c.advancePastSkippedStoryLocked(ctx, exec, plan)
 		return
 	}
@@ -1115,6 +1121,10 @@ func (c *Component) dispatchCurrentStoryLocked(ctx context.Context, exec *requir
 				"entity_id", exec.EntityID,
 				"requirement_id", exec.RequirementID,
 				"story_id", currentStoryID)
+			if !c.applyCompletedStoryEvidenceLocked(ctx, exec, story) {
+				c.markFailedLocked(ctx, exec, fmt.Sprintf("Story %s reservation was unavailable and no completed owner execution evidence exists for requirement %s", currentStoryID, exec.RequirementID))
+				return
+			}
 			c.advancePastSkippedStoryLocked(ctx, exec, plan)
 			return
 		}
@@ -1147,10 +1157,146 @@ func (c *Component) dispatchCurrentStoryLocked(ctx context.Context, exec *requir
 func (c *Component) advancePastSkippedStoryLocked(ctx context.Context, exec *requirementExecution, plan *workflow.Plan) {
 	if exec.CurrentStoryIdx+1 < len(exec.SortedStoryIDs) {
 		exec.CurrentStoryIdx++
+		resetPerStoryExecutionState(exec)
 		c.dispatchCurrentStoryLocked(ctx, exec, plan)
 		return
 	}
 	c.markCompletedLocked(ctx, exec)
+}
+
+// applyCompletedStoryEvidenceLocked attaches the owner requirement's real
+// node results before a non-owner requirement advances past a completed
+// shared Story. That keeps ADR-044's M:N dedup from producing zero-node
+// terminal completions: the non-owner still does not re-run the dev loop,
+// but its completion record carries the owner Story's execution evidence.
+//
+// Unit-test components without a NATS substrate keep the historical skip
+// behavior; production paths require KV evidence from the deterministic
+// Story owner and fail closed when it is missing.
+//
+// Caller must hold exec.mu.
+func (c *Component) applyCompletedStoryEvidenceLocked(ctx context.Context, exec *requirementExecution, story workflow.Story) bool {
+	if c.natsClient == nil {
+		return true
+	}
+
+	ownerID := workflow.DeterministicStoryOwner(story)
+	if ownerID == "" {
+		c.logger.Warn("Completed Story has no deterministic owner; refusing evidence-free skip",
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"story_id", story.ID)
+		return false
+	}
+
+	if ownerID == exec.RequirementID {
+		if executionHasStoryEvidence(exec, story) {
+			return true
+		}
+		c.logger.Warn("Owned Story is already complete but current requirement has no node evidence",
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"story_id", story.ID)
+		return false
+	}
+
+	ownerExec, err := c.loadCompletedReqExecFromKV(ctx, exec.Slug, ownerID)
+	if err != nil {
+		c.logger.Warn("Failed to load completed Story owner execution evidence",
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"owner_requirement_id", ownerID,
+			"story_id", story.ID,
+			"error", err)
+		return false
+	}
+	if ownerExec == nil {
+		c.logger.Warn("Completed Story owner execution evidence missing",
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"owner_requirement_id", ownerID,
+			"story_id", story.ID)
+		return false
+	}
+	if !copyStoryEvidence(exec, story, ownerExec) {
+		c.logger.Warn("Completed Story owner has no matching node evidence",
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"owner_requirement_id", ownerID,
+			"story_id", story.ID)
+		return false
+	}
+
+	c.logger.Info("Copied completed Story owner evidence for M:N non-owner requirement",
+		"slug", exec.Slug,
+		"requirement_id", exec.RequirementID,
+		"owner_requirement_id", ownerID,
+		"story_id", story.ID,
+		"node_results", len(exec.NodeResults))
+	return true
+}
+
+func executionHasStoryEvidence(exec *requirementExecution, story workflow.Story) bool {
+	taskIDs := storyTaskIDSet(story)
+	if len(taskIDs) == 0 {
+		return len(exec.NodeResults) > 0
+	}
+	for _, nr := range exec.NodeResults {
+		if taskIDs[nr.NodeID] {
+			return true
+		}
+	}
+	return false
+}
+
+func copyStoryEvidence(exec *requirementExecution, story workflow.Story, owner *requirementExecution) bool {
+	if owner == nil || len(owner.NodeResults) == 0 {
+		return false
+	}
+
+	taskIDs := storyTaskIDSet(story)
+	seen := make(map[string]bool, len(exec.NodeResults))
+	for _, nr := range exec.NodeResults {
+		seen[nodeEvidenceKey(nr)] = true
+	}
+	if exec.VisitedNodes == nil {
+		exec.VisitedNodes = make(map[string]bool)
+	}
+
+	copied := 0
+	for _, nr := range owner.NodeResults {
+		if len(taskIDs) > 0 && !taskIDs[nr.NodeID] {
+			continue
+		}
+		key := nodeEvidenceKey(nr)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		exec.NodeResults = append(exec.NodeResults, NodeResult{
+			NodeID:        nr.NodeID,
+			FilesModified: append([]string(nil), nr.FilesModified...),
+			Summary:       nr.Summary,
+			CommitSHA:     nr.CommitSHA,
+		})
+		exec.VisitedNodes[nr.NodeID] = true
+		copied++
+	}
+	return copied > 0 || executionHasStoryEvidence(exec, story)
+}
+
+func storyTaskIDSet(story workflow.Story) map[string]bool {
+	out := make(map[string]bool, len(story.Tasks))
+	for _, task := range story.Tasks {
+		if task.ID != "" {
+			out[task.ID] = true
+		}
+	}
+	return out
+}
+
+func nodeEvidenceKey(nr NodeResult) string {
+	return nr.NodeID + "\x00" + nr.CommitSHA
 }
 
 // findStoryByID returns the Story with the given ID from plan.Stories.
@@ -1230,10 +1376,10 @@ func (c *Component) loadPlanFromKV(ctx context.Context, slug string) (*workflow.
 // Scenarios are partitioned by tier tag (@unit / @integration / @smoke /
 // @e2e). Each tier group carries instructions that tell the reviewer
 // WHAT to look for at that tier — crucially, @integration scenarios do
-// NOT need to pass at dev-completion (the harness isn't running in the
-// dev sandbox); they need to be authored correctly. Murat records runtime
-// proof readiness at QA, and full semspec-managed harness execution is
-// post-MVP unless the project test command already owns it.
+// NOT need to pass at dev-completion (the harness may not be running in the
+// dev sandbox); they need to be authored correctly. Runtime proof is enforced
+// by qa_level=integration when the project selects that level. Full/e2e
+// orchestration remains an operator CI concern for MVP.
 //
 // Legacy scenarios without tier tags (PR 1's tags field absent) fall into
 // an "untagged" group with the legacy "verify all aspects" instruction —
@@ -1265,7 +1411,7 @@ func (c *Component) buildReviewPrompt(exec *requirementExecution, scenarios []wo
 		groups := groupScenariosByTier(scenarios)
 
 		sb.WriteString("\n## Scenarios to verify (grouped by test pyramid tier)\n")
-		sb.WriteString("\nApply tier-appropriate verification per ADR-041. The harness is NOT running in the dev sandbox — @integration scenarios are verified for AUTHORING CORRECTNESS, not runtime behavior. For MVP, Murat records whether runtime proof is present, missing, or deferred; full harness orchestration is post-MVP unless the project test command already owns it.\n")
+		sb.WriteString("\nApply tier-appropriate verification per ADR-041. The harness is not guaranteed to run in the dev sandbox — @integration scenarios are verified for AUTHORING CORRECTNESS here, not runtime behavior. Runtime proof is enforced later by qa_level=integration when the project selects that level; full/e2e orchestration remains operator CI for MVP.\n")
 
 		if len(groups.unit) > 0 {
 			sb.WriteString("\n### @unit scenarios\n")
@@ -1275,7 +1421,7 @@ func (c *Component) buildReviewPrompt(exec *requirementExecution, scenarios []wo
 
 		if len(groups.integration) > 0 {
 			sb.WriteString("\n### @integration scenarios\n")
-			sb.WriteString("Verify each has an integration test or documented integration-test plan that (a) declares the tier using the project's test framework idiom, (b) binds to the scenario's harness_profile_ids where project tooling consumes such bindings, (c) reads harness endpoints from environment variables declared by the bound catalog profile (NOT a hardcoded host/port), and (d) asserts on each required_assertion of every bound profile. The test does NOT need to PASS here — the harness isn't up in the dev sandbox. Approve when AUTHORING is correct; Murat records runtime proof readiness at QA, and full harness orchestration remains post-MVP unless the project test command already owns it.\n\n")
+			sb.WriteString("Verify each has an integration test or documented integration-test plan that (a) declares the tier using the project's test framework idiom, (b) binds to the scenario's harness_profile_ids where project tooling consumes such bindings, (c) reads harness endpoints from environment variables declared by the bound catalog profile (NOT a hardcoded host/port), and (d) asserts on each required_assertion of every bound profile. The test does NOT need to PASS here — the harness may not be up in the dev sandbox. Approve when AUTHORING is correct; qa_level=integration is the runtime evidence gate when the project selects it, while full/e2e orchestration remains operator CI for MVP.\n\n")
 			writeScenarioList(&sb, groups.integration)
 		}
 
@@ -2082,18 +2228,7 @@ func (c *Component) advanceToNextStoryLocked(ctx context.Context, exec *requirem
 	// Per-Story state reset. NodeResults intentionally NOT reset — they
 	// feed the requirement-level claim/observation cross-check at
 	// markCompletedLocked.
-	exec.DAG = nil
-	exec.SortedNodeIDs = nil
-	exec.NodeIndex = nil
-	exec.CurrentNodeIdx = -1
-	exec.CurrentNodeTaskID = ""
-	exec.VisitedNodes = make(map[string]bool)
-	exec.ReviewVerdict = ""
-	exec.ReviewFeedback = ""
-	exec.ReviewRetryCount = 0
-	exec.RetryCount = 0
-	exec.DirtyNodeIDs = nil
-	exec.ScenarioVerdicts = nil
+	resetPerStoryExecutionState(exec)
 
 	nextStoryID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
 	c.logger.Info("Advancing to next Story",
@@ -2114,6 +2249,21 @@ func (c *Component) advanceToNextStoryLocked(ctx context.Context, exec *requirem
 	}
 
 	c.dispatchCurrentStoryLocked(ctx, exec, plan)
+}
+
+func resetPerStoryExecutionState(exec *requirementExecution) {
+	exec.DAG = nil
+	exec.SortedNodeIDs = nil
+	exec.NodeIndex = nil
+	exec.CurrentNodeIdx = -1
+	exec.CurrentNodeTaskID = ""
+	exec.VisitedNodes = make(map[string]bool)
+	exec.ReviewVerdict = ""
+	exec.ReviewFeedback = ""
+	exec.ReviewRetryCount = 0
+	exec.RetryCount = 0
+	exec.DirtyNodeIDs = nil
+	exec.ScenarioVerdicts = nil
 }
 
 // filterScenariosByIDs returns the subset of scenarios whose IDs match the
@@ -2233,6 +2383,22 @@ func (c *Component) buildNodeSummaries(exec *requirementExecution) []prompt.Node
 	return summaries
 }
 
+func workflowNodeResults(results []NodeResult) []workflow.NodeResult {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]workflow.NodeResult, 0, len(results))
+	for _, nr := range results {
+		out = append(out, workflow.NodeResult{
+			NodeID:        nr.NodeID,
+			FilesModified: append([]string(nil), nr.FilesModified...),
+			Summary:       nr.Summary,
+			CommitSHA:     nr.CommitSHA,
+		})
+	}
+	return out
+}
+
 // ---------------------------------------------------------------------------
 // Terminal state handlers
 // ---------------------------------------------------------------------------
@@ -2245,7 +2411,18 @@ func (c *Component) markCompletedLocked(ctx context.Context, exec *requirementEx
 	}
 	exec.terminated = true
 
-	if err := c.sendReqPhase(ctx, exec.storeKey, phaseCompleted, nil); err != nil {
+	nodeCount := len(exec.NodeResults)
+	if nodeCount == 0 {
+		nodeCount = len(exec.VisitedNodes)
+	}
+	fields := map[string]any{
+		"node_count": nodeCount,
+	}
+	if nodeResults := workflowNodeResults(exec.NodeResults); len(nodeResults) > 0 {
+		fields["node_results"] = nodeResults
+	}
+
+	if err := c.sendReqPhase(ctx, exec.storeKey, phaseCompleted, fields); err != nil {
 		c.logger.Warn("Failed to send req.phase mutation", "stage", phaseCompleted, "error", err)
 	}
 
@@ -2255,7 +2432,7 @@ func (c *Component) markCompletedLocked(ctx context.Context, exec *requirementEx
 		"entity_id", exec.EntityID,
 		"slug", exec.Slug,
 		"requirement_id", exec.RequirementID,
-		"nodes_completed", len(exec.VisitedNodes),
+		"nodes_completed", nodeCount,
 	)
 
 	c.publishRequirementCompleteEvent(ctx, exec, "completed")
@@ -2451,6 +2628,10 @@ func (c *Component) publishRequirementCompleteEvent(ctx context.Context, exec *r
 
 	// Build summary from aggregate node summaries.
 	summary := c.aggregateNodeSummaries(exec)
+	nodeCount := len(exec.NodeResults)
+	if nodeCount == 0 {
+		nodeCount = len(exec.VisitedNodes)
+	}
 
 	event := workflow.RequirementExecutionCompleteEvent{
 		Slug:            exec.Slug,
@@ -2460,7 +2641,7 @@ func (c *Component) publishRequirementCompleteEvent(ctx context.Context, exec *r
 		ProjectID:       exec.ProjectID,
 		TraceID:         exec.TraceID,
 		Outcome:         outcome,
-		NodeCount:       len(exec.VisitedNodes),
+		NodeCount:       nodeCount,
 		FilesModified:   allFiles,
 		Summary:         summary,
 		ScenariosTotal:  len(exec.Scenarios),

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -2486,3 +2486,65 @@ func TestDispatchCurrentStoryLocked_SkipsAlreadyCompleteStory(t *testing.T) {
 		t.Error("exec.DAG should be nil (no dispatch on already-complete Story)")
 	}
 }
+
+func TestCopyStoryEvidence_CopiesOwnerNodeResultsForSharedStory(t *testing.T) {
+	story := workflow.Story{
+		ID:             "story.demo.shared",
+		RequirementIDs: []string{"req.demo.1", "req.demo.2"},
+		Tasks: []workflow.Task{
+			{ID: "task.demo.shared.1", StoryID: "story.demo.shared"},
+			{ID: "task.demo.shared.2", StoryID: "story.demo.shared"},
+		},
+	}
+	owner := &requirementExecution{
+		RequirementID: "req.demo.1",
+		NodeResults: []NodeResult{
+			{NodeID: "task.demo.shared.1", FilesModified: []string{"src/shared.go"}, CommitSHA: "abc123"},
+			{NodeID: "task.demo.other.1", FilesModified: []string{"src/other.go"}, CommitSHA: "def456"},
+		},
+	}
+	nonOwner := &requirementExecution{
+		RequirementID: "req.demo.2",
+		VisitedNodes:  make(map[string]bool),
+	}
+
+	if !copyStoryEvidence(nonOwner, story, owner) {
+		t.Fatal("copyStoryEvidence returned false, want true for matching owner node evidence")
+	}
+	if len(nonOwner.NodeResults) != 1 {
+		t.Fatalf("copied NodeResults = %d, want 1 matching the shared story tasks", len(nonOwner.NodeResults))
+	}
+	if got := nonOwner.NodeResults[0].NodeID; got != "task.demo.shared.1" {
+		t.Errorf("copied NodeID = %q, want task.demo.shared.1", got)
+	}
+	if !nonOwner.VisitedNodes["task.demo.shared.1"] {
+		t.Error("VisitedNodes should include copied story evidence for completion accounting")
+	}
+
+	if !copyStoryEvidence(nonOwner, story, owner) {
+		t.Fatal("second copyStoryEvidence returned false; existing evidence should still satisfy the story")
+	}
+	if len(nonOwner.NodeResults) != 1 {
+		t.Fatalf("second copy duplicated evidence: NodeResults = %d, want 1", len(nonOwner.NodeResults))
+	}
+}
+
+func TestCopyStoryEvidence_FailsWithoutMatchingOwnerNodes(t *testing.T) {
+	story := workflow.Story{
+		ID:             "story.demo.shared",
+		RequirementIDs: []string{"req.demo.1", "req.demo.2"},
+		Tasks:          []workflow.Task{{ID: "task.demo.shared.1", StoryID: "story.demo.shared"}},
+	}
+	owner := &requirementExecution{
+		RequirementID: "req.demo.1",
+		NodeResults:   []NodeResult{{NodeID: "task.demo.other.1", CommitSHA: "abc123"}},
+	}
+	nonOwner := &requirementExecution{RequirementID: "req.demo.2"}
+
+	if copyStoryEvidence(nonOwner, story, owner) {
+		t.Fatal("copyStoryEvidence returned true, want false when owner has no node result for this Story")
+	}
+	if len(nonOwner.NodeResults) != 0 {
+		t.Fatalf("NodeResults = %d, want 0 when no matching story evidence exists", len(nonOwner.NodeResults))
+	}
+}

--- a/processor/requirement-executor/recover_completed.go
+++ b/processor/requirement-executor/recover_completed.go
@@ -67,6 +67,43 @@ func (c *Component) loadTerminalReqExecFromKV(ctx context.Context, slug, require
 	return c.rebuildExecFromKV(key, &reqExec), nil
 }
 
+// loadCompletedReqExecFromKV fetches a completed requirement execution
+// from EXECUTION_STATES. ADR-044 M:N dedup uses this as the evidence
+// source when a non-owner requirement advances past a Story already
+// completed by its deterministic owner. Failed/error/in-flight entries
+// are not valid proof of shipped work.
+func (c *Component) loadCompletedReqExecFromKV(ctx context.Context, slug, requirementID string) (*requirementExecution, error) {
+	if c.natsClient == nil {
+		return nil, nil
+	}
+
+	bucket, err := c.natsClient.GetKeyValueBucket(ctx, "EXECUTION_STATES")
+	if err != nil {
+		return nil, fmt.Errorf("get EXECUTION_STATES bucket: %w", err)
+	}
+	kvStore := c.natsClient.NewKVStore(bucket)
+
+	key := workflow.RequirementExecutionKey(slug, requirementID)
+	entry, err := kvStore.Get(ctx, key)
+	if err != nil {
+		if isKVNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+
+	var reqExec workflow.RequirementExecution
+	if err := json.Unmarshal(entry.Value, &reqExec); err != nil {
+		c.logger.Debug("Skipping corrupt EXECUTION_STATES entry during completed-owner evidence load",
+			"key", key, "error", err)
+		return nil, nil
+	}
+	if reqExec.Stage != phaseCompleted {
+		return nil, nil
+	}
+	return c.rebuildExecFromKV(key, &reqExec), nil
+}
+
 // countAcceptedRecoveryCyclesForReq returns how many recovery-agent
 // PlanDecisions have already been accepted for this requirement on this
 // plan. Used as a defense-in-depth budget gate for the QA-recovery path —

--- a/processor/requirement-executor/recover_completed_test.go
+++ b/processor/requirement-executor/recover_completed_test.go
@@ -209,8 +209,8 @@ func TestResumeTerminalForRecoveryLocked_RecordsReasonBeforeResume(t *testing.T)
 // dev-gate fast-fail (ADR-049 Move-3) transitions the requirement to
 // awaiting-recovery — the ADR-049 / #167/#168 fix extends the original
 // QA-recovery logic (complete-only) to the iteration-exhaustion path. Reopening
-// a non-owned Story would invert the M:N reservation; a non-owner re-skips and
-// fast-completes via Tier-1 dedup once the owner re-ships.
+// a non-owned Story would invert the M:N reservation; a non-owner re-skips with
+// inherited owner evidence via Tier-1 dedup once the owner re-ships.
 func TestStoriesToReopenForRecovery(t *testing.T) {
 	plan := &workflow.Plan{Stories: []workflow.Story{
 		// owner = r1 (smallest), complete → reopen candidate for r1

--- a/processor/requirement-executor/review_prompt_test.go
+++ b/processor/requirement-executor/review_prompt_test.go
@@ -60,7 +60,7 @@ func TestFirstTierTag_HonorsFirstMatch(t *testing.T) {
 // The req-reviewer prompt MUST communicate three contracts to the LLM:
 //   - @unit scenarios need running tests
 //   - @integration scenarios need correctly-AUTHORED tests but NOT passing
-//     ones (the harness isn't running in dev sandbox)
+//     ones at dev-completion (runtime proof is the QA integration gate)
 //   - @smoke / @e2e MUST NOT block dev approval
 //
 // Without these contracts the legacy "verify all scenarios" prompt
@@ -100,10 +100,10 @@ func TestBuildReviewPrompt_TierAwareContract(t *testing.T) {
 		// The crucial sentence: @integration tests don't need to PASS at
 		// dev-completion. This is the structural fix for #37.
 		"does NOT need to PASS",
-		// MVP scope: Murat records integration runtime proof readiness; full
-		// semspec-managed harness routing is post-MVP unless the project owns it.
-		"Murat records",
-		"post-MVP",
+		// MVP scope: integration runtime proof is restored as a QA gate, while
+		// full/e2e orchestration stays with operator CI.
+		"qa_level=integration",
+		"operator CI",
 		// Env-var contract.
 		"environment variables",
 		// Required-assertion contract.

--- a/processor/scenario-orchestrator/dag.go
+++ b/processor/scenario-orchestrator/dag.go
@@ -81,9 +81,10 @@ func filterReadyRequirements(
 //  2. A non-owner requirement may dispatch ONLY when every covering
 //     Story it does NOT own has reached Story.Status == complete. The
 //     post-completion executor's Tier-1 dedup at component.go:dispatchCurrentStoryLocked
-//     immediately fires markCompletedLocked without re-running the dev
-//     loop — correct, because the work has actually shipped under the
-//     owner's executor.
+//     advances without re-running the dev loop, but only after copying
+//     the deterministic owner's node evidence into the non-owner
+//     requirement execution. That preserves the one-dev-loop property
+//     without producing zero-node completions.
 //
 // Without this gate, the post-claim-rejection path in requirement-executor
 // would call markCompletedLocked for a non-owner requirement BEFORE the
@@ -117,7 +118,7 @@ func filterByM2NStoryReservations(ready []workflow.Requirement, stories []workfl
 				continue // we own this Story — dispatch normally
 			}
 			if s.Status == workflow.StoryStatusComplete {
-				continue // owner already shipped this Story — we can dispatch and Tier-1 fast-completes
+				continue // owner already shipped this Story — executor will inherit owner evidence
 			}
 			// Non-owner Story not yet complete — defer until owner ships.
 			gated = true

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -81,10 +82,12 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		return nil, err
 	}
 
+	filesModified := e.effectiveFilesModified(ctx, trigger.FilesModified, workDir, runner)
+
 	// When FilesModified is empty, run all checks (full scan mode).
 	// This is the default for workflow-triggered validation where the
 	// developer agent doesn't report specific files modified.
-	runAll := len(trigger.FilesModified) == 0
+	runAll := len(filesModified) == 0
 
 	var results []payloads.CheckResult
 	for _, check := range checklist.Checks {
@@ -95,7 +98,7 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		// fixture authors expect. Caught PR #8 (issue #6 ring 2):
 		// hello-world-py pip-install had trigger:[] and was silently
 		// skipped on every dispatch, so pytest ran against an empty venv.
-		if !runAll && len(check.Trigger) > 0 && !matchesAny(check.Trigger, trigger.FilesModified) {
+		if !runAll && len(check.Trigger) > 0 && !matchesAny(check.Trigger, filesModified) {
 			continue
 		}
 
@@ -110,8 +113,8 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// Only fires in Go projects (go.mod exists) to avoid spurious failures.
 	if !hasCheckNamed(results, "go-test") && !hasCheckNamed(results, "go-test-modified") &&
 		!checklistHasName(checklist, "go-test") && !checklistHasName(checklist, "go-test-modified") {
-		if hasGoFiles(trigger.FilesModified) && e.isGoProjectIn(workDir) {
-			goTestResult := e.runGoTestOnModifiedIn(ctx, trigger.FilesModified, workDir, runner)
+		if hasGoFiles(filesModified) && e.isGoProjectIn(workDir) {
+			goTestResult := e.runGoTestOnModifiedIn(ctx, filesModified, workDir, runner)
 			results = append(results, goTestResult)
 		}
 	}
@@ -125,8 +128,8 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// the code-reviewer approved because `go test ./...` reported "passes
 	// all tests" — the auth/ package's pre-existing tests passed and the
 	// reviewer didn't notice main.go's package showed `?  [no test files]`.
-	if hasGoFiles(trigger.FilesModified) && e.isGoProjectIn(workDir) {
-		results = append(results, e.runGoTestsExistOnModifiedIn(ctx, trigger.FilesModified, workDir, runner))
+	if hasGoFiles(filesModified) && e.isGoProjectIn(workDir) {
+		results = append(results, e.runGoTestsExistOnModifiedIn(ctx, filesModified, workDir, runner))
 	}
 
 	// Always-on gate: a story may only MODIFY files it owns, and must not commit
@@ -140,8 +143,8 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		e.runFileOwnershipContainment(ctx, workflow.NormalizeFilePaths(trigger.FilesOwned), workDir, runner)...)
 
 	// Advisory anti-mock governance check — only when test files are present.
-	if hasTestFiles(trigger.FilesModified) {
-		antiMockResult := CheckAntiMock(workDir, trigger.FilesModified)
+	if hasTestFiles(filesModified) {
+		antiMockResult := CheckAntiMock(workDir, filesModified)
 		results = append(results, antiMockResult)
 	}
 
@@ -151,13 +154,12 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// dispatch is in flight). Post-issue #113 (2026-06-03) the check
 	// verifies only that the architect's harness_profile_selections
 	// resolve in the catalog. Binding correctness (the test actually
-	// exercises the bound harness) is enforced by the LLM reviewer +
-	// operator's CI runtime — see ADR-041 Move 5 amendment for why the
-	// literal-substring sub-checks were retired (qa-runner enforcement
-	// removed ADR-045).
+	// exercises the bound harness) is enforced by the LLM reviewer plus the
+	// executable QA runtime — see ADR-041 Move 5 amendment for why the
+	// literal-substring sub-checks were retired.
 	// Loads selections from .semspec/plans/<slug>/plan.json on disk;
 	// greenfield projects (no architecture) trivially pass.
-	if len(filterTestFiles(trigger.FilesModified)) > 0 {
+	if len(filterTestFiles(filesModified)) > 0 {
 		selections := loadHarnessProfiles(e.repoPath, trigger.Slug)
 		catalog, err := harnesscatalog.Load(e.repoPath)
 		if err != nil {
@@ -173,10 +175,14 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 			// workDir/filesModified/scenarios. The literal-substring sub-
 			// checks were retired (goodhart-able); the simplified check
 			// just verifies the architect's selections resolve in the
-			// catalog. Binding correctness is enforced by LLM reviewer +
-			// operator's CI runtime (ADR-045).
+			// catalog. Binding correctness is enforced by LLM reviewer plus
+			// executable QA runtime.
 			results = append(results, CheckHarnessProfileDiscipline(selections, catalog))
 		}
+	}
+
+	if shouldCheckGradleWrapper(filesModified, workDir) {
+		results = append(results, checkGradleWrapperCompleteness(workDir))
 	}
 
 	// Deterministic stub-artifact detector — runs whenever .jar files
@@ -184,8 +190,8 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// reject (Required: true) on stubs because fabrication is a
 	// ship-stopper that neither reviewer prose nor Testcontainers
 	// discipline catches reliably. Take-19 deferred item (c).
-	if hasJarFiles(trigger.FilesModified) {
-		stubResult := CheckStubArtifacts(workDir, trigger.FilesModified)
+	if hasJarFiles(filesModified) {
+		stubResult := CheckStubArtifacts(workDir, filesModified)
 		results = append(results, stubResult)
 	}
 
@@ -197,6 +203,38 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 		ChecksRun:    len(results),
 		CheckResults: results,
 	}, nil
+}
+
+func (e *Executor) effectiveFilesModified(ctx context.Context, reported []string, workDir string, runner CommandRunner) []string {
+	seen := make(map[string]struct{}, len(reported))
+	for _, f := range workflow.NormalizeFilePaths(reported) {
+		if f != "" {
+			seen[f] = struct{}{}
+		}
+	}
+
+	stdout, _, exitCode, err := runner.Run(ctx, "git status --porcelain=v1 --untracked-files=all", workDir, 15*time.Second)
+	if err != nil || exitCode != 0 {
+		return sortedKeys(seen)
+	}
+	for _, entry := range parsePorcelain(stdout) {
+		if entry.Path != "" {
+			seen[workflow.NormalizeFilePath(entry.Path)] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // runnerForTrigger returns a sandbox runner when the sandbox is configured and

--- a/processor/structural-validator/executor_test.go
+++ b/processor/structural-validator/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	osexec "os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -517,6 +518,88 @@ func TestRunAllChecks_WithFilesModified(t *testing.T) {
 	}
 	if !result.Passed {
 		t.Error("expected Passed=true — only the passing go check ran")
+	}
+}
+
+func TestExecute_UsesGitStatusForChecklistTriggers(t *testing.T) {
+	if _, err := osexec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-q")
+	writeChecklist(t, dir, workflow.Checklist{
+		Version: "1",
+		Checks: []workflow.Check{
+			{
+				Name:     "java-build",
+				Command:  trueCmd(),
+				Trigger:  []string{"*.java"},
+				Category: workflow.CheckCategoryCompile,
+				Required: true,
+				Timeout:  "5s",
+			},
+		},
+	})
+	javaPath := filepath.Join(dir, "src", "main", "java", "Driver.java")
+	if err := os.MkdirAll(filepath.Dir(javaPath), 0o755); err != nil {
+		t.Fatalf("mkdir java dir: %v", err)
+	}
+	if err := os.WriteFile(javaPath, []byte("class Driver {}\n"), 0o644); err != nil {
+		t.Fatalf("write java file: %v", err)
+	}
+
+	exec := newTestExecutor(dir)
+	result, err := exec.Execute(context.Background(), &payloads.ValidationRequest{
+		Slug:          "git-status-triggers",
+		FilesModified: []string{"README.md"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !hasCheckNamed(result.CheckResults, "java-build") {
+		t.Fatalf("java-build check did not run from git status changes; results=%+v", result.CheckResults)
+	}
+}
+
+func TestExecute_FailsIncompleteGradleWrapper(t *testing.T) {
+	dir := t.TempDir()
+	writeChecklist(t, dir, workflow.Checklist{Version: "1"})
+	if err := os.WriteFile(filepath.Join(dir, "gradlew"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write gradlew: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "gradle", "wrapper"), 0o755); err != nil {
+		t.Fatalf("mkdir wrapper: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "gradle", "wrapper", "gradle-wrapper.properties"), []byte("distributionUrl=https://services.gradle.org/distributions/gradle.zip\n"), 0o644); err != nil {
+		t.Fatalf("write wrapper properties: %v", err)
+	}
+
+	exec := newTestExecutor(dir)
+	result, err := exec.Execute(context.Background(), &payloads.ValidationRequest{
+		Slug:          "gradle-wrapper",
+		FilesModified: []string{"build.gradle"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Passed {
+		t.Fatalf("Passed = true, want false for incomplete Gradle wrapper")
+	}
+	found := false
+	for _, check := range result.CheckResults {
+		if check.Name == "gradle-wrapper-completeness" {
+			found = true
+			if check.Passed {
+				t.Fatalf("gradle-wrapper-completeness passed unexpectedly: %+v", check)
+			}
+			if !strings.Contains(check.Stderr, "gradle-wrapper.jar") {
+				t.Fatalf("failure should name missing jar, got %q", check.Stderr)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("gradle-wrapper-completeness check did not run; results=%+v", result.CheckResults)
 	}
 }
 

--- a/processor/structural-validator/gradle_wrapper_check.go
+++ b/processor/structural-validator/gradle_wrapper_check.go
@@ -1,0 +1,69 @@
+package structuralvalidator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+func checkGradleWrapperCompleteness(workDir string) payloads.CheckResult {
+	gradlew := filepath.Join(workDir, "gradlew")
+	if _, err := os.Stat(gradlew); err != nil {
+		return payloads.CheckResult{
+			Name:     "gradle-wrapper-completeness",
+			Passed:   true,
+			Required: true,
+			Command:  "gradle-wrapper-completeness (internal)",
+			Stdout:   "gradlew not present — wrapper completeness check skipped",
+		}
+	}
+
+	required := []string{
+		filepath.Join("gradle", "wrapper", "gradle-wrapper.properties"),
+		filepath.Join("gradle", "wrapper", "gradle-wrapper.jar"),
+	}
+	var missing []string
+	for _, rel := range required {
+		if _, err := os.Stat(filepath.Join(workDir, rel)); err != nil {
+			missing = append(missing, rel)
+		}
+	}
+	if len(missing) == 0 {
+		return payloads.CheckResult{
+			Name:     "gradle-wrapper-completeness",
+			Passed:   true,
+			Required: true,
+			Command:  "gradle-wrapper-completeness (internal)",
+			Stdout:   "gradle wrapper files are complete",
+		}
+	}
+	return payloads.CheckResult{
+		Name:     "gradle-wrapper-completeness",
+		Passed:   false,
+		Required: true,
+		Command:  "gradle-wrapper-completeness (internal)",
+		ExitCode: 1,
+		Stderr: fmt.Sprintf(
+			"gradlew is present but required wrapper file(s) are missing: %s. The project cannot run ./gradlew test without these files.",
+			strings.Join(missing, ", ")),
+	}
+}
+
+func shouldCheckGradleWrapper(files []string, workDir string) bool {
+	if _, err := os.Stat(filepath.Join(workDir, "gradlew")); err == nil {
+		return true
+	}
+	for _, f := range files {
+		clean := filepath.ToSlash(f)
+		if clean == "gradlew" ||
+			clean == "build.gradle" ||
+			clean == "build.gradle.kts" ||
+			strings.HasPrefix(clean, "gradle/wrapper/") {
+			return true
+		}
+	}
+	return false
+}

--- a/processor/structural-validator/stub_artifact_detector.go
+++ b/processor/structural-validator/stub_artifact_detector.go
@@ -42,9 +42,9 @@ const stubJarSizeThreshold = 2048
 //
 // Closes deferred item (c) from take-19 forensics. Item d-equivalent
 // (test-body mismatch / faked implementations) is now owned by the
-// LLM reviewer + operator's CI runtime after issue #113 retired the
+// LLM reviewer + executable QA runtime after issue #113 retired the
 // literal-substring harness-discipline checks; see ADR-041 Move 5
-// amendment (qa-runner integration-tier enforcement removed ADR-045).
+// amendment.
 func CheckStubArtifacts(workDir string, filesModified []string) payloads.CheckResult {
 	jars := filterJarFiles(filesModified)
 	if len(jars) == 0 {

--- a/processor/structural-validator/testcontainers_discipline.go
+++ b/processor/structural-validator/testcontainers_discipline.go
@@ -26,10 +26,10 @@ import (
 //   - **LLM reviewer** — judges whether the test actually exercises the
 //     bound harness (catches "UDP probe facade is not real mavsdk_server
 //     lifecycle" — the smoke-9 reviewer's call).
-//   - **Operator's CI runtime** — actually starts the bound service stack
-//     and runs the @integration test against it. A test that just
-//     references the literal but doesn't open the service fails here.
-//     (qa-runner integration-tier enforcement removed — ADR-045)
+//   - **Executable QA runtime** — qa_level=integration runs the configured
+//     project QA command in the sandbox; full/e2e orchestration remains in
+//     operator CI for MVP. A test that just references the literal but doesn't
+//     open the service fails at that runtime gate.
 //
 // This check now does one thing: verify that the architect didn't name
 // a profile that doesn't exist in the catalog. That's a plan-time
@@ -38,8 +38,8 @@ import (
 //
 // Future direction: see issue #113 for the path to AST-aware or
 // behavioral evidence (Option B / Option C). This commit ships
-// Option A — delete the literal checks; rely on LLM reviewer +
-// operator's CI runtime (ADR-045).
+// Option A — delete the literal checks; rely on LLM reviewer plus executable
+// QA runtime.
 func CheckHarnessProfileDiscipline(selections []workflow.HarnessProfileSelection, catalog *harnesscatalog.Catalog) payloads.CheckResult {
 	if len(selections) == 0 {
 		return passHarnessResult("no test environment profiles selected — nothing to enforce")
@@ -49,7 +49,7 @@ func CheckHarnessProfileDiscipline(selections []workflow.HarnessProfileSelection
 		return failHarnessResult(err.Error())
 	}
 	return passHarnessResult(fmt.Sprintf(
-		"required test environment profiles resolve in catalog: %d (binding correctness enforced by LLM reviewer + operator's CI runtime, not literal-grep — see issue #113; qa-runner integration-tier enforcement removed ADR-045)",
+		"required test environment profiles resolve in catalog: %d (binding correctness enforced by LLM reviewer + executable QA runtime, not literal-grep — see issue #113)",
 		len(required)))
 }
 

--- a/processor/structural-validator/testcontainers_discipline_test.go
+++ b/processor/structural-validator/testcontainers_discipline_test.go
@@ -15,8 +15,9 @@ import (
 // retired (evidence-anchor presence, @integration binding string,
 // env-key consumption). What remains is "do the architect's
 // selections resolve in the catalog?" — a plan-time validity check.
-// Binding correctness is enforced by LLM reviewer + operator's CI
-// runtime (qa-runner integration-tier enforcement removed ADR-045).
+// Binding correctness is enforced by the LLM reviewer plus executable
+// qa_level=integration runtime when the project selects it; full/e2e
+// orchestration remains in operator CI.
 
 func TestCheckHarnessProfileDiscipline_NoSelections(t *testing.T) {
 	catalog := mustCatalog(t)

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -23,10 +23,10 @@ tasks:
 
   build-image:
     internal: true
-    desc: Build semspec Docker image for E2E tests
+    desc: Build semspec and sandbox Docker images for E2E tests
     cmds:
-      - echo "[BUILD-IMAGE] Building semspec Docker image..."
-      - docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec
+      - echo "[BUILD-IMAGE] Building semspec and sandbox Docker images..."
+      - docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec sandbox
       - echo "[OK] Docker image built"
 
   check-ports:
@@ -403,8 +403,14 @@ tasks:
       - |
         echo "[E2E:MOCK] Scenario: {{.SCENARIO}}"
 
-        # Validate mock fixtures exist for this scenario.
-        FIXTURE_DIR="test/e2e/fixtures/mock-responses/{{.SCENARIO}}"
+        # Validate mock fixtures exist for this scenario. Some scenario
+        # variants intentionally share deterministic LLM fixtures while
+        # exercising different runtime routing.
+        FIXTURE_SCENARIO="{{.SCENARIO}}"
+        case "$FIXTURE_SCENARIO" in
+          qa-cycle-integration) FIXTURE_SCENARIO="qa-cycle" ;;
+        esac
+        FIXTURE_DIR="test/e2e/fixtures/mock-responses/$FIXTURE_SCENARIO"
         if [ ! -d "$FIXTURE_DIR" ]; then
           echo "[ERROR] No mock LLM fixtures found at: $FIXTURE_DIR"
           echo ""
@@ -418,7 +424,7 @@ tasks:
         fi
 
         echo "[E2E:MOCK] Starting infrastructure with mock LLM..."
-        MOCK_SCENARIO={{.SCENARIO}} docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml up -d --wait
+        MOCK_SCENARIO="$FIXTURE_SCENARIO" docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml up -d --wait
       - |
         echo "[E2E:MOCK] Running {{.SCENARIO}} with mock LLM..."
         E2E_PROVIDER_NAME=mock ./bin/e2e --json --fast-timeouts --mock-llm http://localhost:11535 --workspace $(pwd)/test/e2e/workspace {{.SCENARIO}}

--- a/test/e2e/fixtures/osh-driver-mavsdk/.semspec/project.json
+++ b/test/e2e/fixtures/osh-driver-mavsdk/.semspec/project.json
@@ -13,6 +13,6 @@
   ],
   "tooling": {},
   "repository": {},
-  "qa_level": "synthesis",
+  "qa_level": "integration",
   "qa_test_command": "./gradlew test"
 }

--- a/test/e2e/scenarios/qa_cycle.go
+++ b/test/e2e/scenarios/qa_cycle.go
@@ -16,7 +16,8 @@ import (
 	"github.com/c360studio/semspec/test/e2e/config"
 )
 
-// QACycleScenario validates the end-to-end QA phase for qa_level=unit.
+// QACycleScenario validates the end-to-end QA phase for sandbox-executable
+// qa_level values.
 //
 // This is the Tier 2 runtime validation of Phases 2.5a / 2.5b / 3 / 4 / 5 / 5.1 / 6:
 //
@@ -37,12 +38,8 @@ type QACycleScenario struct {
 	nats    *client.NATSClient
 	mockLLM *client.MockLLMClient
 
-	// qaLevel is always "unit" — the only sandbox-executed QA level.
-	// Heavier tiers (integration, full) run in the operator's CI via the
-	// emitted qa.yml and have no in-process e2e scenario (ADR-045).
 	qaLevel string
-	// name is the scenario name; also the mock-llm fixture subdirectory.
-	name string
+	name    string
 }
 
 // NewQACycleScenario creates a new QA cycle scenario at qa_level=unit.
@@ -51,17 +48,21 @@ func NewQACycleScenario(cfg *config.Config) *QACycleScenario {
 	return &QACycleScenario{config: cfg, qaLevel: "unit", name: "qa-cycle"}
 }
 
-// NOTE: the qa-cycle-integration and qa-cycle-services scenarios were removed
-// with the qa-runner executor (BMAD realignment / ADR-045). Integration/services
-// tiers now run in the operator's CI, not via a semspec executor, so there is
-// no in-process path for an e2e scenario to exercise them.
+// NewQAIntegrationCycleScenario creates a QA cycle scenario at
+// qa_level=integration. It intentionally reuses the qa-cycle mock LLM fixtures:
+// the plan/dev story is identical, but plan-manager must route through
+// QARequestedEvent(mode=integration), sandbox QA execution, and qa-reviewer
+// fail-closed verdict handling.
+func NewQAIntegrationCycleScenario(cfg *config.Config) *QACycleScenario {
+	return &QACycleScenario{config: cfg, qaLevel: "integration", name: "qa-cycle-integration"}
+}
 
 // Name implements Scenario.
 func (s *QACycleScenario) Name() string { return s.name }
 
 // Description implements Scenario.
 func (s *QACycleScenario) Description() string {
-	return "QA phase end-to-end at qa_level=unit: sandbox runs go test, qa-reviewer approves, plan → complete"
+	return fmt.Sprintf("QA phase end-to-end at qa_level=%s: sandbox runs go test, qa-reviewer approves, plan → complete", s.qaLevel)
 }
 
 // Setup prepares the scenario environment.
@@ -106,11 +107,10 @@ func (s *QACycleScenario) Execute(ctx context.Context) (*Result, error) {
 		return time.Duration(normalSec) * time.Second
 	}
 
-	// qaBudget is the per-stage timeout for stages that wait on the QA executor
-	// (reviewing_qa / qa.completed assertions / complete). Only unit is executed
-	// in-process via the sandbox; heavier tiers run in the operator's CI.
-	qaBudget := func(unitNormal, unitFast int) time.Duration {
-		return t(unitNormal, unitFast)
+	// qaBudget is the per-stage timeout for stages that wait on the sandbox QA
+	// executor (reviewing_qa / qa.completed assertions / complete).
+	qaBudget := func(normalSec, fastSec int) time.Duration {
+		return t(normalSec, fastSec)
 	}
 
 	stages := []struct {
@@ -165,7 +165,7 @@ func (s *QACycleScenario) Execute(ctx context.Context) (*Result, error) {
 // and initialises a git repository.
 //
 // The workspace must contain a passing Go test suite so the sandbox can run
-// `go test ./...` at qa_level=unit and get a green result.
+// `go test ./...` at the configured sandbox QA level and get a green result.
 func (s *QACycleScenario) stageSetupWorkspace(_ context.Context, result *Result) error {
 	// (REACTIVE_STATE purge removed — the bucket was deleted with the rules
 	// engine; PLAN_STATES/EXECUTION_STATES are reset by docker compose down -v
@@ -174,7 +174,7 @@ func (s *QACycleScenario) stageSetupWorkspace(_ context.Context, result *Result)
 	// Go module and source files — `go test ./...` passes on this workspace.
 	files := map[string]string{
 		"go.mod":    "module example.com/qa-cycle-project\n\ngo 1.21\n",
-		"README.md": "# QA Cycle Project\n\nA minimal Go project used for qa_level=unit E2E validation.\n",
+		"README.md": fmt.Sprintf("# QA Cycle Project\n\nA minimal Go project used for qa_level=%s E2E validation.\n", s.qaLevel),
 		// Package with a trivial passing test that confirms go test works.
 		"pkg/math/math.go":      "// Package math provides simple math utilities.\npackage math\n\n// Add returns the sum of a and b.\nfunc Add(a, b int) int { return a + b }\n",
 		"pkg/math/math_test.go": "package math\n\nimport \"testing\"\n\nfunc TestAdd(t *testing.T) {\n\tif got := Add(1, 2); got != 3 {\n\t\tt.Errorf(\"Add(1, 2) = %d; want 3\", got)\n\t}\n}\n",
@@ -231,7 +231,7 @@ func (s *QACycleScenario) stageInitProject(ctx context.Context, result *Result) 
 	initReq := &client.ProjectInitRequest{
 		Project: client.ProjectInitInput{
 			Name:        "QA Cycle Project",
-			Description: "Minimal Go project for qa_level=unit E2E validation",
+			Description: fmt.Sprintf("Minimal Go project for qa_level=%s E2E validation", s.qaLevel),
 			Languages:   languages,
 		},
 		Checklist: detection.ProposedChecklist,
@@ -258,7 +258,7 @@ func (s *QACycleScenario) stageInitProject(ctx context.Context, result *Result) 
 // Stage: set-qa-level
 // ---------------------------------------------------------------------------
 
-// stageSetQALevel patches the project config to set qa_level=unit.
+// stageSetQALevel patches the project config to the scenario's qa_level.
 // Plans created after this point snapshot the level and trigger the sandbox
 // executor at implementing convergence.
 func (s *QACycleScenario) stageSetQALevel(ctx context.Context, result *Result) error {
@@ -326,7 +326,7 @@ func (s *QACycleScenario) stageVerifyQALevel(_ context.Context, result *Result) 
 // Stage: create-plan
 // ---------------------------------------------------------------------------
 
-// stageCreatePlan posts a new plan. The plan will snapshot qa_level=unit from
+// stageCreatePlan posts a new plan. The plan snapshots qa_level from
 // project.json, ensuring the QA executor path fires at implementing convergence.
 func (s *QACycleScenario) stageCreatePlan(ctx context.Context, result *Result) error {
 	resp, err := s.http.CreatePlan(ctx, "add a math utility package with Add and Subtract functions and full test coverage")
@@ -630,7 +630,8 @@ func (s *QACycleScenario) stageWaitForReviewingQA(ctx context.Context, result *R
 // ---------------------------------------------------------------------------
 
 // stageAssertQACompleted fetches message-logger entries and confirms that
-// workflow.events.qa.completed was published with Level=unit and Passed=true.
+// workflow.events.qa.completed was published with Level matching the scenario
+// and Passed=true.
 func (s *QACycleScenario) stageAssertQACompleted(ctx context.Context, result *Result) error {
 	slug, _ := result.GetDetailString("plan_slug")
 

--- a/workflow/payloads/qa.go
+++ b/workflow/payloads/qa.go
@@ -10,9 +10,10 @@ import (
 )
 
 // QA phase payloads — target-project test execution gate before complete. The
-// sandbox consumes QARequestedPayload (unit mode) and publishes
-// QACompletedPayload; qa-reviewer consumes QACompletedPayload (failure path) to
-// emit PlanDecisions. Heavier tiers run in the operator's CI, not a semspec executor.
+// sandbox consumes QARequestedPayload for executable QA modes and publishes
+// QACompletedPayload; qa-reviewer consumes QACompletedPayload to emit the
+// release verdict. Full/e2e orchestration remains an operator CI concern for
+// MVP.
 
 // QARequestedType is the message type for QA execution requests.
 var QARequestedType = message.Type{
@@ -37,11 +38,11 @@ func (p *QARequestedPayload) Validate() error {
 	if err := workflow.ValidateSlug(p.Slug); err != nil {
 		return fmt.Errorf("slug: %w", err)
 	}
-	// Mode must be the sandbox-executed unit level. none and synthesis don't
-	// publish QARequestedEvent (they skip QA or go straight to reviewing_qa);
-	// heavier tiers run in the operator's CI, not via a semspec executor.
-	if p.Mode != workflow.QALevelUnit {
-		return fmt.Errorf("mode must be unit, got %q", p.Mode)
+	// Mode must be one of the sandbox-executed QA levels. none and synthesis do
+	// not publish QARequestedEvent; stale/removed levels such as "full" are not
+	// executable in-process.
+	if !p.Mode.UsesSandboxTests() {
+		return fmt.Errorf("mode must be a sandbox-executed QA level (unit or integration), got %q", p.Mode)
 	}
 	// Workspace, when present, is the QA worktree's sandbox task_id. Reject
 	// path-traversal-shaped values so a malformed event cannot escape the

--- a/workflow/payloads/qa_test.go
+++ b/workflow/payloads/qa_test.go
@@ -25,8 +25,9 @@ func TestQARequestedPayloadValidate(t *testing.T) {
 	}{
 		{"valid_no_workspace", func(*QARequestedPayload) {}, false, ""},
 		{"valid_with_workspace", func(p *QARequestedPayload) { p.Workspace = workflow.QAWorktreeID("auth") }, false, ""},
+		{"valid_integration_mode", func(p *QARequestedPayload) { p.Mode = workflow.QALevelIntegration }, false, ""},
 		{"empty_slug", func(p *QARequestedPayload) { p.Slug = "" }, true, "slug"},
-		{"non_unit_mode", func(p *QARequestedPayload) { p.Mode = workflow.QALevelSynthesis }, true, "mode must be unit"},
+		{"non_executable_mode", func(p *QARequestedPayload) { p.Mode = workflow.QALevelSynthesis }, true, "sandbox-executed QA level"},
 		{"workspace_path_traversal_dots", func(p *QARequestedPayload) { p.Workspace = "../escape" }, true, "path separators"},
 		{"workspace_slash", func(p *QARequestedPayload) { p.Workspace = "qa/auth" }, true, "path separators"},
 		{"workspace_backslash", func(p *QARequestedPayload) { p.Workspace = "qa\\auth" }, true, "path separators"},

--- a/workflow/payloads/registry.go
+++ b/workflow/payloads/registry.go
@@ -72,8 +72,8 @@ func registerRequestPayloads(reg *payloadregistry.Registry) error {
 		{GitHubPRCreatedEventType, "GitHub PR created event", func() any { return &GitHubPRCreatedEvent{} }},
 		{GitHubPRFeedbackRequestType, "GitHub PR feedback request from review", func() any { return &GitHubPRFeedbackRequest{} }},
 		// QA phase payloads
-		{QARequestedType, "QA execution request dispatched to sandbox (unit); integration/full run in the operator's CI via the emitted qa.yml", func() any { return &QARequestedPayload{} }},
-		{QACompletedType, "QA execution result event published by the sandbox (unit) or operator's CI (integration/full)", func() any { return &QACompletedPayload{} }},
+		{QARequestedType, "QA execution request dispatched to sandbox (unit/integration); full/e2e run in the operator's CI via the emitted qa.yml", func() any { return &QARequestedPayload{} }},
+		{QACompletedType, "QA execution result event published by the sandbox (unit/integration) or operator CI for external tiers", func() any { return &QACompletedPayload{} }},
 		// Lesson decomposition (ADR-033 Phase 2+)
 		{LessonDecomposeRequestedType, "Reviewer rejection signalled to lesson-decomposer for evidence-cited lesson production", func() any { return &LessonDecomposeRequested{} }},
 		// Wedge recovery (ADR-037 stage 1)

--- a/workflow/payloads/types.go
+++ b/workflow/payloads/types.go
@@ -802,8 +802,9 @@ type ScenarioOrchestrationTrigger struct {
 	// by the owning requirement (deterministic = lexicographically
 	// smallest req ID in Story.RequirementIDs). Non-owners wait for the
 	// Story to reach Complete before their executors are spawned, at
-	// which point the executor's Tier-1 dedup completes them immediately
-	// without re-dispatching the dev loop.
+	// which point the executor's Tier-1 dedup advances them only after
+	// copying the completed owner's node evidence, without re-dispatching
+	// the dev loop.
 	Stories    []workflow.Story `json:"stories,omitempty"`
 	TraceID    string           `json:"trace_id,omitempty"`
 	PlanBranch string           `json:"plan_branch,omitempty"` // GitHub plan-level branch (ADR-031)

--- a/workflow/project_config.go
+++ b/workflow/project_config.go
@@ -54,9 +54,9 @@ type ProjectConfig struct {
 
 	// QALevel is the project-wide QA policy applied at plan completion.
 	// Values: "none" (escape hatch), "synthesis" (default, LLM verdict only,
-	// no test execution), "unit" (sandbox runs project tests). Heavier tiers
-	// (testcontainers integration, services-class live SITL, e2e) run in the
-	// operator's CI against the emitted qa.yml, not via a semspec executor.
+	// no test execution), "unit" (sandbox runs project tests), "integration"
+	// (sandbox runs the configured integration-capable QA command). Full/e2e
+	// orchestration stays in operator CI for MVP.
 	// Plans snapshot this value at creation — changing qa_level does not affect
 	// in-flight plans. Empty string is treated as "synthesis".
 	QALevel QALevel `json:"qa_level,omitempty"`
@@ -75,7 +75,7 @@ type ProjectConfig struct {
 }
 
 // EffectiveQALevel returns the project's QA level, defaulting to synthesis
-// when unset or no longer a defined level (coerces a stale "integration"/"full"
+// when unset or no longer a defined level (for example, a stale "full"
 // snapshot). Matches Plan.EffectiveQALevel so both config surfaces agree.
 func (pc *ProjectConfig) EffectiveQALevel() QALevel {
 	if pc == nil || !pc.QALevel.IsValid() {
@@ -84,7 +84,8 @@ func (pc *ProjectConfig) EffectiveQALevel() QALevel {
 	return pc.QALevel
 }
 
-// EffectiveTestCommand returns the test command sandbox runs at level=unit.
+// EffectiveTestCommand returns the test command sandbox runs for executable QA
+// levels (unit and integration).
 // When unset, infers from the primary language — Go projects run
 // `go test ./...`, Node `npm test`, Python `pytest`, Rust `cargo test`,
 // Java `./gradlew test`. Falls through to an empty string when the

--- a/workflow/qa_level_test.go
+++ b/workflow/qa_level_test.go
@@ -1,0 +1,22 @@
+package workflow
+
+import "testing"
+
+func TestQALevelIntegrationIsExecutable(t *testing.T) {
+	if !QALevelIntegration.IsValid() {
+		t.Fatal("integration should be a valid QA level")
+	}
+	if !QALevelIntegration.UsesSandboxTests() {
+		t.Fatal("integration should run the configured QA command in the sandbox")
+	}
+	if QALevel("full").IsValid() {
+		t.Fatal("full remains outside MVP sandbox execution and should not be a valid snapshotted level")
+	}
+}
+
+func TestPlanEffectiveQALevelPreservesIntegration(t *testing.T) {
+	plan := &Plan{QALevel: QALevelIntegration}
+	if got := plan.EffectiveQALevel(); got != QALevelIntegration {
+		t.Fatalf("EffectiveQALevel() = %q, want integration", got)
+	}
+}

--- a/workflow/resolve_branch_prereqs.go
+++ b/workflow/resolve_branch_prereqs.go
@@ -6,8 +6,9 @@ import "sort"
 // for the story covering reqID — the DeterministicStoryOwner of that story.
 //
 // Under ADR-044 M:N, only a Story's owner runs the dev loop; non-owner
-// requirements fast-complete with no commits on their own branch. So a dependent
-// must derive from the OWNER's branch, never a non-owner's (which is empty).
+// requirements inherit the owner's node evidence but have no commits on their
+// own branch. So a dependent must derive from the OWNER's branch, never a
+// non-owner's (which is empty).
 // When no Story covers reqID (legacy/mock plans without Stories), reqID owns its
 // own work.
 func ownerRequirementFor(reqID string, stories []Story) string {

--- a/workflow/resolve_branch_prereqs_test.go
+++ b/workflow/resolve_branch_prereqs_test.go
@@ -44,7 +44,7 @@ func TestResolveRequirementBranchPrereqs(t *testing.T) {
 		{
 			// A requirement-level dep that points at a NON-owner req (a2) must
 			// resolve to that req's covering-story owner (a1), since a2's branch
-			// is an empty fast-complete.
+			// is empty even though its execution record inherits owner evidence.
 			name: "requirement dep on non-owner -> owner branch",
 			req:  Requirement{ID: "c1", DependsOn: []string{"a2"}},
 			stories: []Story{

--- a/workflow/subjects.go
+++ b/workflow/subjects.go
@@ -104,20 +104,18 @@ type UserSignalErrorEvent struct {
 }
 
 // QA phase events — target-project test execution gate between implementing
-// and complete. The sandbox executes unit-level tests; heavier tiers
-// (integration, full) run in the operator's CI via the emitted qa.yml
-// (ADR-045). qa-reviewer is always the verdict gate, consuming
-// QACompletedEvent and emitting QAVerdictEvent.
+// and complete. The sandbox executes unit/integration QA commands; full/e2e
+// orchestration runs in the operator's CI for MVP. qa-reviewer is always the
+// verdict gate, consuming QACompletedEvent and emitting QAVerdictEvent.
 
-// QARequestedEvent is published by plan-manager when a unit-level plan enters
-// ready_for_qa, so the sandbox runs the project's test suite before
-// qa-reviewer interprets. Level=synthesis skips this event (the plan goes
-// straight to reviewing_qa) and level=none skips QA entirely. Heavier tiers
-// run in the operator's CI, not via a semspec executor.
+// QARequestedEvent is published by plan-manager when an executable QA-level
+// plan enters ready_for_qa, so the sandbox runs the project's configured QA
+// command before qa-reviewer interprets. Level=synthesis skips this event and
+// level=none skips QA entirely.
 type QARequestedEvent struct {
 	Slug   string  `json:"slug"`
 	PlanID string  `json:"plan_id"`
-	Mode   QALevel `json:"mode"` // unit (the only sandbox-executed level)
+	Mode   QALevel `json:"mode"` // sandbox-executed level: unit or integration
 	// Workspace is the sandbox task_id of the per-plan QA worktree (see
 	// QAWorktreeID) — a checkout of the assembled plan branch that holds the
 	// merged per-requirement implementation. The sandbox runs the test command
@@ -147,10 +145,9 @@ type QAArtifactRef struct {
 	Purpose string `json:"purpose,omitempty"` // e.g., "playwright flow X failure"
 }
 
-// QACompletedEvent is published by the QA executor (sandbox for unit mode;
-// integration/full run in the operator's CI via the emitted qa.yml) after
-// test execution. qa-reviewer consumes it and produces a QAVerdictEvent.
-// plan-manager does NOT consume this event directly.
+// QACompletedEvent is published by the QA executor after test execution.
+// qa-reviewer consumes it and produces a QAVerdictEvent. plan-manager does
+// NOT consume this event directly.
 type QACompletedEvent struct {
 	Slug        string          `json:"slug"`
 	PlanID      string          `json:"plan_id"`
@@ -236,10 +233,11 @@ var (
 	UserSignalError = natsclient.NewSubject[UserSignalErrorEvent](
 		"user.signal.error")
 
-	// QA phase events — the sandbox (unit) or operator's CI (integration/full)
-	// publishes QACompletedEvent; qa-reviewer delivers its verdict via
-	// request/reply mutation plan.mutation.qa.verdict (see
-	// processor/plan-manager/mutations.go) rather than a fire-and-forget event.
+	// QA phase events — the sandbox publishes unit/integration
+	// QACompletedEvent; operator full/e2e CI remains outside SemSpec.
+	// qa-reviewer delivers its verdict via request/reply mutation
+	// plan.mutation.qa.verdict (see processor/plan-manager/mutations.go)
+	// rather than a fire-and-forget event.
 	QARequested = natsclient.NewSubject[QARequestedEvent](
 		"workflow.events.qa.requested")
 	QACompleted = natsclient.NewSubject[QACompletedEvent](

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -49,10 +49,10 @@ const (
 	// and the plan is awaiting partial requirement regeneration.
 	StatusChanged Status = "changed"
 	// StatusReadyForQA indicates the plan is waiting for the sandbox to run
-	// project tests at level=unit. Entered at implementing convergence when
-	// qa.level=unit; skipped for level=synthesis (which goes straight to
-	// reviewing_qa) and level=none. Integration/full tiers run in the
-	// operator's CI via the emitted qa.yml and do not use this status.
+	// project tests at an executable QA level. Entered at implementing
+	// convergence when qa.level=unit or integration; skipped for level=synthesis
+	// (which goes straight to reviewing_qa) and level=none. Full/e2e proof stays
+	// in the operator's CI via the emitted qa.yml and does not use this status.
 	StatusReadyForQA Status = "ready_for_qa"
 	// StatusReviewingQA indicates qa-reviewer is producing the release-readiness
 	// verdict. Entered for all non-"none" levels. Inputs vary by level:
@@ -119,11 +119,10 @@ func (s Status) String() string {
 // QALevel describes the project-level quality-assurance depth applied at
 // plan completion.
 //
-// semspec executes only what the sandbox can run (unit). Heavier tiers
-// (integration via testcontainers, services-class live SITL, e2e) run in the
-// OPERATOR's CI against the emitted qa.yml — semspec designs + gates, it does
-// not stand up those environments (the integration/full levels and the
-// act-based qa-runner that ran them were removed in the BMAD realignment).
+// semspec executes the project's configured QA command for unit and integration
+// levels in the sandbox. Full/e2e orchestration remains an operator CI concern
+// for MVP; plans with stale "full" snapshots coerce to synthesis rather than
+// entering an unclaimed ready_for_qa state.
 type QALevel string
 
 const (
@@ -136,6 +135,11 @@ const (
 	// QALevelUnit runs the project's existing test suite in the sandbox at
 	// plan-completion time, then qa-reviewer interprets.
 	QALevelUnit QALevel = "unit"
+	// QALevelIntegration runs the project's configured integration-capable QA
+	// command in the sandbox at plan-completion time. External e2e/browser
+	// orchestration still belongs to operator CI; this tier is the executed
+	// evidence gate for integration claims that the project command owns.
+	QALevelIntegration QALevel = "integration"
 )
 
 // String returns the string representation of the QA level.
@@ -146,17 +150,17 @@ func (l QALevel) String() string {
 // IsValid returns true if the level is one of the defined values.
 func (l QALevel) IsValid() bool {
 	switch l {
-	case QALevelNone, QALevelSynthesis, QALevelUnit:
+	case QALevelNone, QALevelSynthesis, QALevelUnit, QALevelIntegration:
 		return true
 	default:
 		return false
 	}
 }
 
-// UsesSandboxTests returns true if this level runs the project's test suite
-// in the sandbox at plan-completion time.
+// UsesSandboxTests returns true if this level runs the project's configured QA
+// command in the sandbox at plan-completion time.
 func (l QALevel) UsesSandboxTests() bool {
-	return l == QALevelUnit
+	return l == QALevelUnit || l == QALevelIntegration
 }
 
 // IsValid returns true if the status is a valid workflow status.
@@ -307,7 +311,7 @@ func (s Status) CanTransitionTo(target Status) bool {
 	case StatusImplementing:
 		// implementing → reviewing_rollup (legacy alias for reviewing_qa; still emitted today until Phase 2f branch-point move)
 		// implementing → reviewing_qa (level=synthesis after Phase 2f)
-		// implementing → ready_for_qa (level=unit|integration|full after Phase 2f; executor runs tests before review)
+		// implementing → ready_for_qa (level=unit|integration; executor runs tests before review)
 		// implementing → awaiting_review (no QA, auto_approve_review=false or GitHub)
 		// implementing → complete (level=none; direct terminal with no review)
 		// implementing → changed (change proposal deprecated requirements)
@@ -330,7 +334,7 @@ func (s Status) CanTransitionTo(target Status) bool {
 		return target == StatusAwaitingReview ||
 			target == StatusComplete || target == StatusRejected
 	case StatusReadyForQA:
-		// ready_for_qa → reviewing_qa (sandbox completes unit tests)
+		// ready_for_qa → reviewing_qa (sandbox completes unit/integration tests)
 		// ready_for_qa → rejected (sandbox cannot execute — infrastructure error)
 		return target == StatusReviewingQA || target == StatusRejected
 	case StatusReviewingQA:
@@ -751,11 +755,10 @@ type QAVerdictSummary struct {
 
 // EffectiveQALevel returns the plan's QA level, defaulting to synthesis when
 // unset OR when the snapshotted value is no longer a defined level. The latter
-// guards plans/configs created before the integration/full levels were removed:
-// a stale "integration"/"full" must coerce to synthesis rather than fall
-// through routing into a silent wedge (routed to ready_for_qa but never
-// dispatched and never claimed). Centralized so the branch point and verdict
-// handlers agree on the interpretation.
+// guards plans/configs created with removed levels such as "full": stale values
+// must coerce to synthesis rather than fall through routing into a silent wedge.
+// Centralized so the branch point and verdict handlers agree on the
+// interpretation.
 func (p *Plan) EffectiveQALevel() QALevel {
 	if !p.QALevel.IsValid() {
 		return QALevelSynthesis


### PR DESCRIPTION
## Summary
- fail closed when executable QA evidence is missing, failed, or errored before qa-reviewer can approve
- restore sandbox-executable integration QA while keeping full/e2e proof operator-owned through emitted qa.yml
- require M:N dedup non-owners to copy real owner node evidence instead of completing with zero nodes
- harden structural validation against under-reported file changes and incomplete Gradle wrappers
- add qa-cycle-integration E2E coverage and rebuild the sandbox image in mock E2E runs

## Rebase note
- rebased onto current origin/main after PR #192 removed the bad sponsor-pack artifacts

## Verification
- go test ./...
- go build ./...
- task e2e:mock -- qa-cycle-integration

## Not included
- untracked sponsor draft docs remain local and are intentionally left out of this PR