### PR TITLE
fix(qa): resolve OpenSensorHub upstream from source in sandbox (QA + dev)

### DIFF
--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -90,6 +90,17 @@ func main() {
 	defer cancel()
 	go srv.CleanupLoop(ctx, *cleanupInterval, *cleanupAge)
 
+	// Install OSH source substitution for dev/validator builds (plain exec, no
+	// isolated GRADLE_USER_HOME), so the dev loop resolves OpenSensorHub from
+	// source (WITH_EPIC /sources) instead of an authenticated registry — not
+	// just QA. Fails closed: if /sources holds OSH but staging fails, exit so a
+	// broken environment contract is an immediate harness red, not a noisy 401
+	// in every dev loop. Absent /sources is a clean no-op.
+	if err := installOSHSourceSubstitutionForDev(logger); err != nil {
+		slog.Error("OSH source substitution setup failed — failing closed", "error", err)
+		os.Exit(1)
+	}
+
 	// Optional NATS subscriber for sandbox-executable QA requests.
 	// When -nats-url is empty and NATS_URL is unset, the sandbox runs HTTP-only
 	// — existing callers are unaffected.

--- a/cmd/sandbox/osh_source_substitution.go
+++ b/cmd/sandbox/osh_source_substitution.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// OpenSensorHub upstream is mounted read-only at /sources by the WITH_EPIC
+// overlay. A generated OSH driver build declares its platform dependency the
+// normal way (e.g. `org.sensorhub:sensorhub-core`) and expects to resolve it
+// from a package registry — but the configured registry (GitHub Packages)
+// returns 401 without credentials, so QA fails on a deliverable whose code is
+// otherwise sound (proven 2026-06-15: with osh-core built from source the
+// assembled driver builds and its tests pass).
+//
+// The WITH_EPIC design *intends* osh-core to be available as source, so the QA
+// (and dev) environment should make it resolvable from /sources — like a real
+// OSH developer who has the platform locally. The blocker is purely mechanical:
+// a Gradle composite build (`includeBuild`) must write its own build outputs,
+// and /sources is read-only, so a direct includeBuild against it silently falls
+// back to the registry → 401.
+//
+// This stages a WRITABLE copy of each OSH gradle build and drops an init script
+// into $GRADLE_USER_HOME/init.d/ that includeBuild()s each with explicit
+// dependency substitution (org.sensorhub:<sub> → the source :<sub> project).
+// Gradle auto-applies init.d/*.gradle, so any build run under the isolated QA
+// GRADLE_USER_HOME (see prepareQAIsolation) resolves OSH from source.
+//
+// No-op when /sources is absent or holds no OSH gradle build, so non-OSH and
+// non-Java projects are unaffected.
+//
+// NOTE (validation): the staging + script generation is unit-tested here, but
+// the end-to-end resolution (Gradle actually substituting from the composite)
+// must be validated in a live OSH sandbox before this is relied on. The explicit
+// substitution rules mirror the manually-verified diagnostic from 2026-06-15.
+
+const (
+	defaultOSHSourcesRoot = "/sources"
+	// Stable writable stage dir, reused across QA runs (copying osh-core is
+	// expensive). It lives OUTSIDE the per-run tmpRoot so it is not deleted by
+	// the per-run cleanup; each run only references it via its own init.d script.
+	defaultOSHStageRoot = "/tmp/semspec-osh-src"
+	oshInitScriptName   = "10-osh-source-substitution.gradle"
+	oshStageStampFile   = ".semspec-osh-src-of"
+)
+
+// oshSourceConfig is overridable for tests.
+type oshSourceConfig struct {
+	sourcesRoot string
+	stageRoot   string
+	// A directory under sourcesRoot is treated as an OSH gradle build to
+	// includeBuild when its name contains any token AND it has a settings.gradle.
+	matchTokens []string
+}
+
+func defaultOSHSourceConfig() oshSourceConfig {
+	cfg := oshSourceConfig{
+		sourcesRoot: oshEnvOr("SEMSPEC_OSH_SOURCES_ROOT", defaultOSHSourcesRoot),
+		stageRoot:   oshEnvOr("SEMSPEC_OSH_STAGE_ROOT", defaultOSHStageRoot),
+		matchTokens: []string{"osh-core", "osh-addons"},
+	}
+	if v := os.Getenv("SEMSPEC_OSH_SOURCE_DIRS"); v != "" {
+		cfg.matchTokens = oshSplitNonEmpty(v, ",")
+	}
+	return cfg
+}
+
+// defaultGradleHome resolves the Gradle home that plain (dev/validator) sandbox
+// exec uses: GRADLE_USER_HOME if exported, else $HOME/.gradle. This mirrors
+// execCommandWithEnv, which sets HOME=/home/sandbox and does not set
+// GRADLE_USER_HOME.
+func defaultGradleHome() string {
+	if v := os.Getenv("GRADLE_USER_HOME"); v != "" {
+		return v
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/home/sandbox"
+	}
+	return filepath.Join(home, ".gradle")
+}
+
+// installOSHSourceSubstitutionForDev installs the OSH source-substitution init
+// script into the default Gradle home so dev/validator builds (plain exec, no
+// isolated GRADLE_USER_HOME) resolve OSH from source too — not just QA.
+//
+// Fails closed: when OSH /sources are present but staging fails, it returns an
+// error. The caller treats that as fatal, turning a broken environment contract
+// into an immediate harness red instead of a noisy registry 401 in every dev
+// loop. Absent /sources is a clean no-op (returns nil).
+func installOSHSourceSubstitutionForDev(logger *slog.Logger) error {
+	home := defaultGradleHome()
+	summary, err := stageOSHSourceSubstitution(home, defaultOSHSourceConfig())
+	if err != nil {
+		return fmt.Errorf("install OSH source substitution into %s: %w", home, err)
+	}
+	if summary != "" {
+		logger.Info("OSH source substitution installed for dev/validator builds",
+			"gradle_home", home, "detail", summary)
+	}
+	return nil
+}
+
+// stageOSHSourceSubstitution stages writable OSH source builds and writes the
+// init.d substitution script under gradleHome. It returns a human-readable
+// summary (empty when nothing was staged). The caller treats a returned error
+// as non-fatal — QA then falls back to the deliverable's declared resolution.
+func stageOSHSourceSubstitution(gradleHome string, cfg oshSourceConfig) (summary string, err error) {
+	srcDirs, err := discoverOSHSourceDirs(cfg)
+	if err != nil || len(srcDirs) == 0 {
+		return "", err
+	}
+
+	type staged struct {
+		dir         string
+		subprojects []string
+	}
+	var builds []staged
+	for _, src := range srcDirs {
+		dst := filepath.Join(cfg.stageRoot, filepath.Base(src))
+		if err := stageWritableCopy(src, dst); err != nil {
+			return "", fmt.Errorf("stage OSH source %s: %w", src, err)
+		}
+		builds = append(builds, staged{
+			dir:         dst,
+			subprojects: parseGradleIncludes(filepath.Join(dst, "settings.gradle")),
+		})
+	}
+
+	var b strings.Builder
+	b.WriteString("// Auto-generated by semspec sandbox QA. Resolve OpenSensorHub upstream\n")
+	b.WriteString("// from source (WITH_EPIC /sources) instead of an authenticated registry.\n")
+	b.WriteString("gradle.settingsEvaluated { settings ->\n")
+	var staticParts []string
+	for _, bd := range builds {
+		staticParts = append(staticParts, filepath.Base(bd.dir))
+		if len(bd.subprojects) == 0 {
+			// Fall back to plain includeBuild (Gradle auto-substitution by the
+			// included build's published coordinates).
+			fmt.Fprintf(&b, "    settings.includeBuild(%q)\n", bd.dir)
+			continue
+		}
+		fmt.Fprintf(&b, "    settings.includeBuild(%q) { included ->\n", bd.dir)
+		b.WriteString("        included.dependencySubstitution {\n")
+		for _, sp := range bd.subprojects {
+			// Explicit, version-agnostic substitution of the published module
+			// onto the source project (mirrors the verified diagnostic).
+			fmt.Fprintf(&b,
+				"            substitute module('org.sensorhub:%s') using project(':%s')\n",
+				sp, sp)
+		}
+		b.WriteString("        }\n")
+		b.WriteString("    }\n")
+	}
+	b.WriteString("}\n")
+
+	if err := writeInitScript(gradleHome, b.String()); err != nil {
+		return "", err
+	}
+	return "OSH source substitution enabled (includeBuild from source): " +
+		strings.Join(staticParts, ", "), nil
+}
+
+// discoverOSHSourceDirs returns absolute paths of OSH gradle builds under
+// sourcesRoot (dir name contains a match token AND contains settings.gradle).
+func discoverOSHSourceDirs(cfg oshSourceConfig) ([]string, error) {
+	entries, err := os.ReadDir(cfg.sourcesRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // /sources not mounted → no-op
+		}
+		return nil, err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() || !oshMatchesAnyToken(e.Name(), cfg.matchTokens) {
+			continue
+		}
+		abs := filepath.Join(cfg.sourcesRoot, e.Name())
+		if _, statErr := os.Stat(filepath.Join(abs, "settings.gradle")); statErr != nil {
+			continue // not a gradle build root
+		}
+		dirs = append(dirs, abs)
+	}
+	sort.Strings(dirs)
+	return dirs, nil
+}
+
+// stageWritableCopy copies src→dst once (skips when already staged from the same
+// source, refreshes when the source path changed), since /sources is read-only
+// and copying osh-core is expensive.
+func stageWritableCopy(src, dst string) error {
+	stamp := filepath.Join(dst, oshStageStampFile)
+	if existing, err := os.ReadFile(stamp); err == nil && strings.TrimSpace(string(existing)) == src {
+		return nil // already staged from this source
+	}
+	if err := os.RemoveAll(dst); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	// `cp -a` preserves the gradle wrapper's executable bit and is robust for
+	// large trees. The trailing /. copies contents into dst.
+	if out, err := exec.Command("cp", "-a", src+"/.", dst).CombinedOutput(); err != nil {
+		return fmt.Errorf("cp -a %s -> %s: %v: %s", src, dst, err, strings.TrimSpace(string(out)))
+	}
+	return os.WriteFile(stamp, []byte(src), 0o644)
+}
+
+var gradleIncludeRe = regexp.MustCompile(`(?m)^\s*include\s+['"]([^'"]+)['"]`)
+
+// parseGradleIncludes returns the project names declared by `include '<name>'`
+// lines in a settings.gradle. Returns nil when the file is unreadable or has no
+// includes (the caller then falls back to plain includeBuild).
+func parseGradleIncludes(settingsPath string) []string {
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var names []string
+	for _, m := range gradleIncludeRe.FindAllStringSubmatch(string(data), -1) {
+		name := strings.TrimSpace(m[1])
+		name = strings.TrimPrefix(name, ":")
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+func writeInitScript(gradleHome, content string) error {
+	initDir := filepath.Join(gradleHome, "init.d")
+	if err := os.MkdirAll(initDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(initDir, oshInitScriptName), []byte(content), 0o644)
+}
+
+func oshMatchesAnyToken(name string, tokens []string) bool {
+	for _, t := range tokens {
+		if t != "" && strings.Contains(name, t) {
+			return true
+		}
+	}
+	return false
+}
+
+func oshSplitNonEmpty(s, sep string) []string {
+	var out []string
+	for _, p := range strings.Split(s, sep) {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func oshEnvOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/cmd/sandbox/osh_source_substitution_test.go
+++ b/cmd/sandbox/osh_source_substitution_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeOSHSource writes a minimal osh-core-shaped gradle build under root/name.
+func fakeOSHSource(t *testing.T, root, name string, includes []string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString("rootProject.name = 'osh-core'\n\n")
+	for _, inc := range includes {
+		b.WriteString("include '" + inc + "'\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.gradle"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// a file to copy so we can assert the stage actually copied content
+	if err := os.WriteFile(filepath.Join(dir, "build.gradle"), []byte("// osh-core\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestDiscoverOSHSourceDirs(t *testing.T) {
+	srcRoot := t.TempDir()
+	fakeOSHSource(t, srcRoot, "github-com-opensensorhub-osh-core", []string{"sensorhub-core"})
+	fakeOSHSource(t, srcRoot, "github-com-opensensorhub-osh-addons", []string{"sensorhub-driver-foo"})
+	// a non-OSH dir (matches no token) and an OSH-named dir without settings.gradle
+	if err := os.MkdirAll(filepath.Join(srcRoot, "github-com-other-thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(srcRoot, "osh-core-but-no-settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := oshSourceConfig{sourcesRoot: srcRoot, matchTokens: []string{"osh-core", "osh-addons"}}
+	dirs, err := discoverOSHSourceDirs(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 OSH dirs, got %d: %v", len(dirs), dirs)
+	}
+	for _, d := range dirs {
+		if !strings.Contains(d, "osh-core") && !strings.Contains(d, "osh-addons") {
+			t.Errorf("unexpected dir discovered: %s", d)
+		}
+	}
+}
+
+func TestDiscoverOSHSourceDirs_NoSourcesIsNoOp(t *testing.T) {
+	cfg := oshSourceConfig{sourcesRoot: filepath.Join(t.TempDir(), "does-not-exist"), matchTokens: []string{"osh-core"}}
+	dirs, err := discoverOSHSourceDirs(cfg)
+	if err != nil {
+		t.Fatalf("absent /sources must be a no-op, got error: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Fatalf("expected no dirs, got %v", dirs)
+	}
+}
+
+func TestParseGradleIncludes(t *testing.T) {
+	dir := t.TempDir()
+	content := `rootProject.name = 'osh-core'
+include 'swe-common-core'
+include 'sensorhub-core'
+  include "quoted-double"
+include ':leading-colon'
+include 'swe-common-core'
+project(':swe-common-core').projectDir = "$rootDir/lib-ogc/swe-common-core" as File
+`
+	p := filepath.Join(dir, "settings.gradle")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := parseGradleIncludes(p)
+	want := []string{"swe-common-core", "sensorhub-core", "quoted-double", "leading-colon"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("parseGradleIncludes = %v, want %v", got, want)
+	}
+	if parseGradleIncludes(filepath.Join(dir, "nope.gradle")) != nil {
+		t.Fatalf("missing file should return nil")
+	}
+}
+
+func TestStageWritableCopy_CopiesAndSkips(t *testing.T) {
+	src := fakeOSHSource(t, t.TempDir(), "github-com-opensensorhub-osh-core", []string{"sensorhub-core"})
+	dst := filepath.Join(t.TempDir(), "osh-core")
+
+	if err := stageWritableCopy(src, dst); err != nil {
+		t.Fatalf("first copy: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "settings.gradle")); err != nil {
+		t.Fatalf("expected settings.gradle copied: %v", err)
+	}
+	// mark dst so we can detect whether a second call re-copies (it shouldn't)
+	marker := filepath.Join(dst, "MARKER")
+	if err := os.WriteFile(marker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := stageWritableCopy(src, dst); err != nil {
+		t.Fatalf("second copy: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("second call must skip (marker should survive): %v", err)
+	}
+	// changing the source path should refresh (wipe) the stage
+	src2 := fakeOSHSource(t, t.TempDir(), "github-com-opensensorhub-osh-core", []string{"sensorhub-core"})
+	if err := stageWritableCopy(src2, dst); err != nil {
+		t.Fatalf("refresh copy: %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("source change must refresh the stage (marker should be gone)")
+	}
+}
+
+func TestStageOSHSourceSubstitution_EndToEnd(t *testing.T) {
+	srcRoot := t.TempDir()
+	fakeOSHSource(t, srcRoot, "github-com-opensensorhub-osh-core", []string{"sensorhub-core", "swe-common-core"})
+	cfg := oshSourceConfig{
+		sourcesRoot: srcRoot,
+		stageRoot:   filepath.Join(t.TempDir(), "stage"),
+		matchTokens: []string{"osh-core"},
+	}
+	gradleHome := filepath.Join(t.TempDir(), "gradle")
+
+	summary, err := stageOSHSourceSubstitution(gradleHome, cfg)
+	if err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if !strings.Contains(summary, "OSH source substitution enabled") {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+
+	script := filepath.Join(gradleHome, "init.d", oshInitScriptName)
+	data, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("init script not written: %v", err)
+	}
+	s := string(data)
+	for _, want := range []string{
+		"gradle.settingsEvaluated",
+		"settings.includeBuild(",
+		"dependencySubstitution",
+		"substitute module('org.sensorhub:sensorhub-core') using project(':sensorhub-core')",
+		"substitute module('org.sensorhub:swe-common-core') using project(':swe-common-core')",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("init script missing %q\n---\n%s", want, s)
+		}
+	}
+}
+
+func TestStageOSHSourceSubstitution_NoOpWithoutOSH(t *testing.T) {
+	cfg := oshSourceConfig{
+		sourcesRoot: filepath.Join(t.TempDir(), "absent"),
+		stageRoot:   t.TempDir(),
+		matchTokens: []string{"osh-core"},
+	}
+	gradleHome := filepath.Join(t.TempDir(), "gradle")
+	summary, err := stageOSHSourceSubstitution(gradleHome, cfg)
+	if err != nil {
+		t.Fatalf("no-op must not error: %v", err)
+	}
+	if summary != "" {
+		t.Fatalf("expected empty summary, got %q", summary)
+	}
+	if _, err := os.Stat(filepath.Join(gradleHome, "init.d", oshInitScriptName)); !os.IsNotExist(err) {
+		t.Fatalf("no init script should be written when no OSH source present")
+	}
+}
+
+func TestStageOSHSourceSubstitution_FailsClosedWhenStagingFails(t *testing.T) {
+	srcRoot := t.TempDir()
+	fakeOSHSource(t, srcRoot, "github-com-opensensorhub-osh-core", []string{"sensorhub-core"})
+	// stageRoot is a regular FILE, so MkdirAll beneath it fails → staging fails
+	// even though OSH source WAS discovered. This must surface a hard error
+	// (fail closed), not a silent no-op.
+	badStage := filepath.Join(t.TempDir(), "stage-is-a-file")
+	if err := os.WriteFile(badStage, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := oshSourceConfig{sourcesRoot: srcRoot, stageRoot: badStage, matchTokens: []string{"osh-core"}}
+	gradleHome := filepath.Join(t.TempDir(), "gradle")
+
+	if _, err := stageOSHSourceSubstitution(gradleHome, cfg); err == nil {
+		t.Fatal("expected fail-closed error when OSH discovered but staging fails")
+	}
+	if _, err := os.Stat(filepath.Join(gradleHome, "init.d", oshInitScriptName)); !os.IsNotExist(err) {
+		t.Fatal("init script must not be written when staging fails")
+	}
+}
+
+func TestDefaultGradleHome(t *testing.T) {
+	t.Setenv("GRADLE_USER_HOME", "/custom/gradle-home")
+	if got := defaultGradleHome(); got != "/custom/gradle-home" {
+		t.Fatalf("with GRADLE_USER_HOME set, got %q", got)
+	}
+	t.Setenv("GRADLE_USER_HOME", "")
+	t.Setenv("HOME", "/home/somebody")
+	if got := defaultGradleHome(); got != "/home/somebody/.gradle" {
+		t.Fatalf("falling back to HOME, got %q", got)
+	}
+}

--- a/cmd/sandbox/qa_subscriber.go
+++ b/cmd/sandbox/qa_subscriber.go
@@ -305,6 +305,22 @@ func prepareQAIsolation(slug, runID string) (env []string, cleanup func(), summa
 		"MAVEN_OPTS=-Dmaven.repo.local=" + mavenRepo,
 	}
 	summary = "QA cache isolation enabled: GRADLE_USER_HOME=" + gradleHome + " MAVEN_OPTS=-Dmaven.repo.local=" + mavenRepo
+
+	// Make OpenSensorHub upstream resolvable from source (WITH_EPIC /sources) so
+	// generated OSH driver builds don't fail on an authenticated registry 401.
+	// Fail closed: when /sources holds OSH but staging fails, surface a hard
+	// error so the caller fails the QA run with a clear harness message, rather
+	// than silently falling back to registry resolution and emitting another
+	// noisy 401. Absent /sources is a clean no-op (empty summary, nil error).
+	oshSummary, oshErr := stageOSHSourceSubstitution(gradleHome, defaultOSHSourceConfig())
+	if oshErr != nil {
+		cleanup()
+		return nil, func() {}, "", fmt.Errorf("OSH source substitution (harness setup): %w", oshErr)
+	}
+	if oshSummary != "" {
+		summary += "\n" + oshSummary
+	}
+
 	return env, cleanup, summary, nil
 }
 


### PR DESCRIPTION
## Summary
Generated OSH driver builds declare `org.sensorhub:sensorhub-core` and resolve it from GitHub Packages, which **401s without credentials** — failing builds on deliverables whose code is sound (proven 2026-06-15: with osh-core built from source the assembled driver builds and **23 tests pass, 0 failures**). The WITH_EPIC design *intends* osh-core to be available as source at `/sources`, but that mount is **read-only**, so a direct Gradle `includeBuild` silently falls back to the registry.

This stages a writable copy of each OSH gradle build under `/sources` and installs a Gradle init script (`includeBuild` + explicit `dependencySubstitution`: `org.sensorhub:<sub>` → source `:<sub>` project) into the Gradle home so OSH resolves from source.

## Addresses both review points
- **Dev + QA coverage** (not QA-only): the init script is installed into **both** the isolated per-run `GRADLE_USER_HOME` (QA, `prepareQAIsolation`) **and** the default Gradle home at sandbox startup (dev/validator plain `execCommand`, which uses `HOME/.gradle`). The dev loop no longer hits the 401/source-build wedge before QA runs.
- **Fail closed**: when `/sources` holds OSH but staging fails, QA returns a hard error (fails the run) and **startup exits** — a broken environment contract is an immediate harness red, not a noisy registry 401 every loop. Absent `/sources` is a clean no-op (non-OSH / non-Java projects unaffected).

## Validation (done before this PR, per review)
- **Unit tests**: staging, `settings.gradle` include parsing, init-script generation, fail-closed-on-staging-failure, no-op-without-OSH, default-gradle-home resolution.
- **Live Gradle check** (`ui-sandbox` image, JDK-21/Gradle-8.12): a consumer depending on `org.sensorhub:sensorhub-core:2.0.1` whose **only repo is unreachable** → **BUILD FAILED** without the init script, **BUILD SUCCESSFUL `--offline`** with it. Confirms `init.d` `settingsEvaluated { includeBuild { dependencySubstitution } }` substitutes **before** resolution, version-agnostically. This was the one unvalidated mechanism flagged in review.

## Design note
This makes the **environment provide osh-core from source** (legitimate — an OSH driver builds against the platform, it doesn't vendor it). It does **not** force the *committed* `build.gradle` to be self-contained on an empty machine; if that stricter property is wanted, it's a separate architect-prompt-side change.

## Not included / follow-up
- No paid e2e run was spent on this; the mavlink-hard re-run is the natural end-to-end validation once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)