### PR TITLE
fix(sandbox): attach QA subscriber non-fatally in background

### DIFF
--- a/cmd/sandbox/main.go
+++ b/cmd/sandbox/main.go
@@ -155,10 +155,29 @@ func connectNATSQA(ctx context.Context, srv *Server, url string, logger *slog.Lo
 		slog.Error("NATS connection timed out", "url", url, "error", err)
 		os.Exit(1)
 	}
-	slog.Info("NATS connected — QA subscriber enabled", "url", url)
+	slog.Info("NATS connected — attaching QA subscriber in background", "url", url)
 
-	if err := startQASubscriber(ctx, srv, nc, logger); err != nil {
-		slog.Error("failed to start QA subscriber", "error", err)
-		os.Exit(1)
-	}
+	// Attach the QA subscriber in the background, retrying until the WORKFLOW
+	// stream exists. On a cold start the sandbox can come up before semspec
+	// creates that stream (semspec is gated behind semembed/seminstruct, which
+	// are slow under WITH_EPIC). Exiting here would make the sandbox unhealthy
+	// and fail `up --wait` (and block the whole run) for a transient ordering
+	// race. The HTTP server (dev/validator exec + healthcheck) does not need the
+	// subscriber, so keep serving and attach once the stream appears.
+	go func() {
+		for {
+			if err := startQASubscriber(ctx, srv, nc, logger); err != nil {
+				slog.Warn("QA subscriber not ready yet (WORKFLOW stream missing?) — retrying",
+					"error", err)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(10 * time.Second):
+					continue
+				}
+			}
+			slog.Info("QA subscriber attached")
+			return
+		}
+	}()
 }


### PR DESCRIPTION
## Summary
On a cold start the NATS-wired sandbox (NATS_URL added in #195) can come up **before** semspec creates the `WORKFLOW` stream — semspec is gated behind `semembed`/`seminstruct`, which are slow under WITH_EPIC (and slower still when images build fresh). `startQASubscriber`'s `WaitForStream(WORKFLOW)` then exhausted its ~30-attempt budget and the sandbox called `os.Exit(1)`, going **unhealthy and failing `up --wait` for the whole run**.

This escaped CI because the mock stack's semspec starts fast (no epic), so the race never surfaced there — only on a real `WITH_EPIC` run.

## Fix
Attach the QA subscriber in a **background goroutine that retries** until the stream exists, instead of exiting. The sandbox HTTP server (dev/validator exec + healthcheck) doesn't need the subscriber, so the sandbox stays healthy and attaches QA once semspec is up.

## Validated (live)
On a real `WITH_EPIC=1 gemini mavlink-hard` start with this change:
```
"NATS connected — attaching QA subscriber in background"
"QA subscriber started … stream=WORKFLOW"
"QA subscriber attached"
```
sandbox + semspec both `healthy`, `up --wait` succeeded, the run proceeded into the plan phase (the first attempt died at sandbox startup). `go build` / `go vet` / `go test ./cmd/sandbox/...` green.

## Context
Third in the chain that makes integration QA actually run end-to-end on `watch:llm`: #195 (NATS-wire the sandbox) → #196 (resolve OSH from source) → this (don't let the NATS-wired sandbox die on the cold-start WORKFLOW race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)