### PR TITLE
docs(sponsor): honest capability measure — mavlink-hard run #6 (vs run #4)

### DIFF
--- a/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/README.md
+++ b/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/README.md
@@ -1,0 +1,132 @@
+# Semspec — Honest Capability Measure: MAVLink/OSH driver, run #6 (2026‑06‑16)
+
+> **What this is.** A second truthful snapshot of Semspec's autonomous pipeline on the same
+> hard task (build an OpenSensorHub MAVLink/MAVSDK driver), captured one day after the first
+> honest pack (`docs/sponsor/2026-06-15-honest-measure-mavlink-osh/`). Its purpose is a
+> **direct, like‑for‑like comparison**: *did the generated code get better than the last one
+> we captured?* Every claim here is backed by quoted run evidence and was independently
+> verified — the deliverable was rebuilt from source and its tests re‑executed **by hand**,
+> outside the pipeline, before any statement was made.
+>
+> **The headline:** **yes — materially better on the dimensions the pipeline now measures.**
+> Run #6's deliverable carries the OSH module‑discovery registration the last one was missing,
+> a fuller OSH module topology, and — for the first time — the end‑to‑end integration‑QA gate
+> *actually compiled and ran the project's test suite* (osh‑core resolved from source, no 401)
+> instead of dying at dependency resolution. It then **honestly failed closed** on integration
+> tests that cannot run in‑sandbox (they need a live SITL simulator). Same MVP scope ceiling,
+> same shallow raw‑MAVLink transmit path, plus one *new* defect the new completeness gate
+> induced (a duplicated module provider). Honest red, real progress.
+
+## The one‑paragraph version
+
+On 2026‑06‑16, on `main` (all four hardening PRs from the prior session merged: sandbox
+`NATS_URL`, OSH‑source substitution, non‑fatal QA subscriber, scratch/argfile scoping),
+Semspec autonomously took a single prompt ("OSH MAVLink/MAVSDK driver") through plan →
+architecture → scenarios → a **5‑requirement** execution phase, producing **782 lines of
+main Java + 616 lines of tests across 6 main classes + 8 test classes** in an idiomatic
+OpenSensorHub `UnmannedSystem` module shape. **All 5 requirements completed with real
+per‑node evidence** (`phase=completed` + `nodes_completed` each — the 2026‑06‑14
+dedup‑false‑complete failure mode did **not** recur). A new `osh-module-provider-registration`
+completeness gate **fired 4× mid‑run** and drove the model to produce the
+`META-INF/services/...IModuleProvider` registration the previous run lacked. The end‑of‑plan
+**integration‑QA gate then compiled the whole deliverable with `osh-core` built from source**
+(`BUILD SUCCESSFUL in 53s`, no 401) and ran `./gradlew test` — **13 unit tests passed, 0
+failures** — then **correctly rejected the plan** because **6 `@integration` tests skipped**
+(they `assumeTrue(SITL_ENDPOINT)` and there is no live PX4 simulator in the sandbox). That is
+a **true negative, not a fake green**: the code builds and its unit surface is green, but the
+behavior that actually matters (connect to a vehicle, stream telemetry, execute commands) is
+**unverified**, and the pipeline declined to call it done.
+
+## Did the code get better than last time? (the core question)
+
+**Baseline = run #4** (the deliverable reviewed in the 2026‑06‑15 pack, assembled branch
+`semspec/plan-f76c9d8ba0ac`). **This = run #6** (assembled branch `semspec/plan-2b996a0aabe6`).
+
+| Dimension | Run #4 (last pack) | Run #6 (this pack) | Verdict |
+|---|---|---|---|
+| OSH module‑discovery registration (`META-INF/services/...IModuleProvider`) | **missing** (flagged weakness #3) | **present** (driven by new gate that fired 4×) | ✅ **better** |
+| OSH module topology | single `MavsdkSensor` + outputs/commands | `UnmannedSystem` + `Activator` + `Descriptor` + `Config` + `MavLinkCommNetwork` + `MavlinkDirectStream` | ✅ **fuller / closer to a real module** |
+| Did integration QA actually build + test the deliverable? | **no** — died at dependency resolution (osh‑core 401) | **yes** — `BUILD SUCCESSFUL`, osh from source, `./gradlew test` ran | ✅ **better (harness #196)** |
+| Real per‑requirement work, no dedup/false‑complete | yes (4 reqs) | yes (**5 reqs**, each `phase=completed` + `nodes_completed`) | ✅ **held** |
+| Unit‑test surface | 23 tests / 0 fail (built by hand from source) | 19 tests, **13 executed / 0 fail**, 6 skipped (built **by QA itself**) | ≈ **comparable; now verified in‑pipeline** |
+| Scope | vertical‑slice MVP (2 telemetry, 2 commands) | vertical‑slice MVP (telemetry pos+battery; cmds Arm/Takeoff/MissionUpload) | ≈ **same ceiling** |
+| Raw‑MAVLink **transmit** path | dummy‑checksum encode, unwired island | `sendMessage` echoes payload (no real frame encode/CRC), `setTransport` never wired | ≈ **same class of weakness** |
+| Committed build self‑containment | not self‑contained (401) | still declares external `org.sensorhub:sensorhub-core`; builds **only** because the harness substitutes source | ≈ **deliverable unchanged; harness improved** |
+| New defect introduced | — | **duplicate `IModuleProvider`** (`Activator` ≈ `Descriptor`, both registered → module discovered twice) | ⚠️ **new, gate‑induced** |
+| Final QA verdict | rejected — build not self‑contained (401) | rejected — mandatory integration tests skipped (no SITL) | both **honest red, deeper layer reached** |
+
+**Net:** run #6 is a genuine step forward. The pipeline now produces a deliverable that
+*compiles and unit‑tests green inside its own QA gate*, carries the module registration and
+topology a real OSH driver needs, and reaches a **deeper, more meaningful failure** (the
+behavior is untested) than run #4's (it didn't build). The residual gaps are stable (MVP
+scope, shallow transmit path) and there is one new, clearly‑characterized regression the new
+completeness gate caused.
+
+## What is proven (with evidence)
+
+| Claim | Evidence |
+|---|---|
+| Plan converged through a **5‑requirement** execution phase | assembled branch `semspec/plan-2b996a0aabe6`; reqs `.1`–`.5` each `phase=completed` |
+| All requirements completed with **real** node evidence (no dedup/false‑complete) | `requirement.2b996a0aabe6.{1..5} nodes_completed` + `phase=completed` (×5) |
+| New module‑registration completeness gate actually fired | `osh-module-provider-registration first_failure_excerpt=` ×4 during the run |
+| Module registration is now present | `src/main/resources/META-INF/services/org.sensorhub.api.module.IModuleProvider` exists |
+| Integration QA compiled the deliverable with osh **from source** | QA log: `OSH source substitution enabled (includeBuild from source)` → `BUILD SUCCESSFUL in 53s` |
+| Unit tests pass; integration tests skip (the honest‑red) | independently re‑run: **19 tests, 13 executed, 0 failures, 0 errors, 6 skipped** (the 6 `@Tag("integration")` SITL tests) |
+| QA **failed closed** (no fake green) | `QA verdict needs_changes at level integration` → `execution_exhausted action=escalate_human` → `to=rejected` |
+| The skip reason is real | verdict summary: *"rejected … due to skipped mandatory integration tests (MavsdkSmokeTest and UnmannedSystemTest). The tests skip when SITL_ENDPOINT is missing, leaving the core capabilities … entirely untested."* |
+| The build green is real, not a warm‑cache artifact | re‑verified by hand in a fresh worktree, isolated `maven.repo.local`, osh from source → `BUILD SUCCESSFUL`, **0 failures** |
+
+## What is honestly *not* done
+
+- **The behavior that matters is unverified.** The 6 integration tests that connect to a
+  vehicle, assert telemetry emission, and run takeoff/arm commands **skip without a SITL
+  simulator**. Unit tests cover framing, command‑status objects, config, and the provider
+  classes — not end‑to‑end flight behavior.
+- **Duplicate module provider (new defect).** `UnmannedActivator` and `UnmannedDescriptor`
+  are near‑identical `IModuleProvider` implementations both registering the same
+  `UnmannedSystem`/`UnmannedConfig`, and **both** are listed in `META-INF/services`. OSH's
+  `ServiceLoader` would discover the module twice. The new registration gate forced
+  *presence* but not *correctness* (an "Activator" in OSH/OSGi should be a `BundleActivator`,
+  not a second descriptor).
+- **Raw‑MAVLink transmit is shallow and unwired.** `MavLinkCommNetwork.sendMessage` just
+  echoes the stored payload bytes (no real frame encode / CRC‑16/MCRF4XX), and
+  `setTransport(...)` is never called in `UnmannedSystem`'s wiring — only the *receive* path
+  (UDP listen → v1/v2 decode → publish) is integrated. The QA reviewer additionally flagged a
+  *suspected* `NullPointerException` in the raw‑fallback publish path; because the tests that
+  exercise it skip, that is the reviewer's static assessment, not a build‑proven failure — but
+  it is consistent with the shallow/unwired transmit path found by reading the code.
+- **The committed build is still not self‑contained.** `build.gradle` declares
+  `org.sensorhub:sensorhub-core:2.0.1` from `mavenLocal()/mavenCentral()` (where OSH is not
+  published); it builds **only** because the harness now substitutes osh‑core from source. A
+  clean third‑party checkout without OSH source/credentials would still fail to resolve.
+
+Full detail: **[build-and-qa-findings.md](build-and-qa-findings.md)** and
+**[code-review.md](code-review.md)**.
+
+## Why this is the measure worth showing
+
+The first honest pack (one day earlier) established the principle: a green pipeline is not a
+verified delivery, and the win is **honesty under a fail‑closed gate**, not a greener
+checkmark. Run #6 is the follow‑through. Two new completeness gates
+(`osh-module-provider-registration`, `java-implementation-completeness`) plus the
+source‑substitution fix let the pipeline reach a strictly **deeper, more honest** verdict than
+the day before: it built the artifact, ran its tests, told the truth about what those tests do
+*not* cover, and even surfaced a defect (the duplicate provider) that the gate it satisfied
+introduced. That self‑correcting, evidence‑producing behavior — including catching the
+limits of its own new gates — is the capability worth showing.
+
+## Reproduce / audit
+
+- Run: `WITH_EPIC=1 DEBUG=1 task e2e:watch:llm -- gemini mavlink-hard` (code under test:
+  `main`, all four hardening PRs merged; slug `2b996a0aabe6`).
+- Raw run artifacts: `/tmp/semspec-watch-gemini-mavlink-hard-20260615-231127/`
+  (`semspec.log`, `poll.log`, `bundle.tar.gz`, snapshot).
+- QA artifact (the in‑pipeline build log): in‑sandbox
+  `/workspace/.semspec/qa-artifacts/2b996a0aabe6/.../integration-test.log` (`BUILD SUCCESSFUL`,
+  osh from `/tmp/semspec-osh-src`).
+- Independent code‑works proof: assembled branch `semspec/plan-2b996a0aabe6` rebuilt by hand
+  with osh from writable source + isolated `maven.repo.local` → `BUILD SUCCESSFUL`,
+  **19 tests / 13 executed / 0 failures / 6 skipped**.
+
+*Status: draft for internal review. Not published. No success claim beyond what the evidence
+above supports.*

--- a/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/build-and-qa-findings.md
+++ b/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/build-and-qa-findings.md
@@ -1,0 +1,146 @@
+# Build & QA findings — run #6 (what the hardening fixed, and the new honest‑red)
+
+These are the **execution + QA infrastructure** observations from run #6 (the generated code
+is reviewed separately in [code-review.md](code-review.md)). The theme: the four findings the
+prior pack opened are now **closed**, the integration‑QA gate reached a strictly deeper layer,
+and the honest‑red moved from *"won't build"* to *"behavior untested."*
+
+---
+
+## 1. The prior pack's blockers are closed (regression‑style confirmation)
+
+The 2026‑06‑15 pack documented four issues that prevented integration QA from honestly
+exercising the deliverable. Run #6 ran on `main` with all four fixes merged; each is confirmed
+resolved by this run:
+
+| Prior finding | Fix (PR) | Run #6 confirmation |
+|---|---|---|
+| Integration QA wedged: UI‑e2e sandbox had no `NATS_URL`, QA subscriber never started | sandbox `NATS_URL` (#195) | QA subscriber attached; QA ran to a verdict |
+| Committed build not self‑contained → osh‑core **401** at QA time | OSH source substitution (#196) | QA log: `OSH source substitution enabled (includeBuild from source)` → `BUILD SUCCESSFUL`, **no 401** |
+| Cold‑start race: QA subscriber `os.Exit(1)` when `WORKFLOW` stream absent | non‑fatal background subscriber (#197) | no cold‑start crash; subscriber came up and consumed the request |
+| ADR‑049 ownership fast‑fails on dev **scratch files** | scratch/argfile scoping (#198) | **0 scratch/argfile ownership gaps** this run |
+
+**Net:** the plumbing the prior pack characterized as broken now works end‑to‑end. Integration
+QA compiled the full deliverable (osh‑core from source) and ran the project's real test command.
+
+---
+
+## 2. The new honest‑red: build green, integration tests skip → fail closed
+
+**Symptom.** Integration QA compiled everything and ran `./gradlew test`:
+
+```
+QA cache isolation enabled: GRADLE_USER_HOME=/tmp/semspec-qa-…/gradle  MAVEN_OPTS=-Dmaven.repo.local=/tmp/semspec-qa-…/m2/repository
+OSH source substitution enabled (includeBuild from source): …osh-addons, …osh-core
+…
+> Task :test
+BUILD SUCCESSFUL in 53s
+```
+
+…and then **rejected the plan**:
+
+```
+QA verdict needs_changes at level integration
+verdict=needs_changes level=integration
+execution_exhausted action=escalate_human affected_reqs=[all 5]   → STAGE_CHANGE … to=rejected
+```
+
+**Reason (quoted verdict).**
+
+> "rejected … due to skipped mandatory integration tests (MavsdkSmokeTest and
+> UnmannedSystemTest). The tests skip when SITL_ENDPOINT is missing, leaving the core
+> capabilities (mavsdk‑bootstrap, telemetry‑mapping) entirely untested. Furthermore, the raw
+> MAVLink fallback implementation contains a defect that throws NullPointerExceptions during
+> event publishing."
+
+**Independently verified** (not trusting the pipeline's green): the assembled branch was
+rebuilt by hand in a fresh worktree, osh‑core from writable source, isolated
+`-Dmaven.repo.local`:
+
+```
+./gradlew cleanTest test  →  BUILD SUCCESSFUL
+19 tests, 13 executed, 0 failures, 0 errors, 6 skipped
+  skipped = MavsdkSmokeTest (5) + UnmannedSystemTest (1)   — all @Tag("integration"), assumeTrue(SITL_ENDPOINT)
+```
+
+This is a **true negative**: the deliverable builds and its unit surface is green, but the
+behavior that matters is gated behind a live PX4/SITL simulator that the sandbox doesn't have,
+so the pipeline declined to call it done.
+
+---
+
+## 3. The next layer: SITL‑gated tests are e2e — keep the red, fix the *messaging* (ADR‑045)
+
+**Observation.** The 6 skipped tests are genuine end‑to‑end behavior checks that require a live
+MAVLink endpoint (`SITL_ENDPOINT`). They `assumeTrue(...)` → JUnit reports them **skipped**, the
+gradle build **succeeds**, but the QA gate (correctly, by its current rule —
+`qa_subscriber.go:257`, `passed = exit0 && !timedOut && len(skippedEvidence)==0`) treats
+*skipped mandatory integration tests* as not‑passing and fails closed. The fixture
+(`osh-driver-mavsdk`) has `qa_level: integration` and `qa_test_command: ./gradlew test`.
+
+**Why this is the honest ceiling, not a bug.** Per ADR‑045, *integration* QA runs in the
+sandbox; *full/e2e* (anything needing live external systems — a flight simulator here) is
+**operator CI**, not sandbox QA. These SITL tests are e2e‑class. With them counted by the
+sandbox gate, **the run can never pass in the sandbox** regardless of code quality — the gate is
+asking for a simulator the sandbox can't provide.
+
+**Decision: keep the honest‑red; do not weaken the gate to force a green.** The `skip == fail`
+rule is the #193 no‑false‑green invariant and stays exactly as is. We deliberately do **not**
+exclude the e2e tests from the integration run to manufacture a pass — for a *driver*, a
+sandbox "green" that verified only framing/config unit tests would be a softer false‑green, and
+the red is the more truthful signal. Two changes follow, neither of which touches pass/fail:
+
+1. **Fix the verdict *messaging* (next code change).** The gate message
+   (`integration QA skipped test(s): <files>`) and the qa‑reviewer summary read like code
+   defects. They should instead say *"e2e behavior deferred: these tests require a live
+   `SITL_ENDPOINT` and must run in operator CI"* — surfacing the JUnit `<skipped message=…>`
+   reason so the verdict explains *why* it's red and *where* the behavior gets verified, not
+   that the code is broken.
+2. **Stand up operator‑CI SITL (the real path to behavior verification).** Per ADR‑045's
+   full/e2e tier, provision a PX4/SITL `SITL_ENDPOINT` in operator CI and run the live tests
+   there. That is where this fixture's behavior actually gets proven; the sandbox honestly
+   reports "built + unit‑green, behavior pending e2e."
+
+Until operator‑CI SITL exists, the sandbox red is the correct, explicit state — we make it
+*legible* (messaging) rather than *re‑discovered* each run.
+
+---
+
+## 4. The new completeness gate works — and shows its own limit
+
+**`osh-module-provider-registration` fired 4× during the run** (`osh-module-provider-registration
+first_failure_excerpt=…` ×4), rejecting dev work until a
+`META-INF/services/...IModuleProvider` registration appeared. That is the gate doing exactly
+its job — and it closed the prior pack's weakness #3 (missing registration).
+
+**But the gate enforces presence, not correctness.** The model satisfied it by producing **two**
+near‑identical `IModuleProvider`s (`UnmannedActivator` ≈ `UnmannedDescriptor`) and registering
+both, so OSH would discover the module twice (see [code-review.md](code-review.md) §1). The
+useful harness lesson: a *presence* gate needs a *shape* assertion behind it — e.g. exactly one
+provider per module class, provider points at a concrete `AbstractSensorModule`, and the
+provider is reachable/loadable — or it will be satisfied by duplication.
+
+---
+
+## 5. Secondary observability / harness items (non‑blocking)
+
+| Item | Evidence | Fix |
+|---|---|---|
+| QA `skipped` excerpt is the gradle deprecation warning tail, not the skipped test list | verdict excerpt shows `…AccessControlException … deprecated…` instead of the SITL assumption message | capture the JUnit `<skipped message=…>` reason into the QA excerpt so the verdict explains *why* tests skipped |
+| Per‑node test execution for Java still rides on `checklist.json` having a gradle‑test entry | (carried from prior pack; still Go‑only auto‑fallback in structural validator) | make per‑node test execution deterministic from project language + `qa_test_command`; warn loudly when a known‑language project lacks a test check |
+| `WEDGE_DETECT`/`active-poll` noise on terminal `stage=rejected` | poll noise after `to=rejected` | exclude terminal stages from wedge/poll alerting (carried) |
+| Build self‑containment is provided by the harness, not the deliverable | QA builds only because osh is substituted from source; committed `build.gradle` still declares external osh‑core | optional: have the dev loop emit a self‑contained composite (`settings.gradle includeBuild` + substitution) into the deliverable so it builds from a clean checkout, or vendor osh‑core |
+
+---
+
+## Net
+
+The hardening landed: integration QA now **builds the deliverable from source and runs its
+tests**, and the four prior blockers are closed. The honest‑red advanced from *"the artifact
+doesn't build"* (run #4) to *"the artifact builds and is unit‑green, but its core behavior is
+untested because the integration tests need a live simulator"* (run #6) — a deeper, more useful
+truth. The next steps keep the gate strict and are infrastructural, not gate‑weakening:
+**make the SITL‑skip verdict legible** (message it as "e2e behavior deferred to operator CI",
+not as a code defect — pass/fail unchanged), **stand up operator‑CI SITL** (ADR‑045 full/e2e
+tier) as the real path to verifying behavior, and **add a shape assertion behind the new
+registration gate** (so presence can't be satisfied by a duplicate provider).

--- a/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/code-review.md
+++ b/docs/sponsor/2026-06-16-honest-measure-mavlink-osh-run6/code-review.md
@@ -1,0 +1,139 @@
+# Code review — generated OSH MAVSDK driver (run #6) + comparison to run #4
+
+**Scope reviewed.** The full deliverable from run #6 (assembled branch
+`semspec/plan-2b996a0aabe6`): **782 LOC main + 616 LOC tests**, 6 main classes + 8 test
+classes. Reviewed by reading every main class and every test, after independently rebuilding
+it (osh‑core from writable source, isolated `maven.repo.local`) and re‑running its suite —
+**19 tests, 13 executed, 0 failures, 6 skipped**.
+
+**Overall verdict: real, idiomatic OpenSensorHub + MAVSDK code — roughly B / B+, a step up
+from run #4 on structure and pipeline‑verified buildability, with the same MVP ceiling and one
+new gate‑induced defect.** It compiles inside its own QA gate, its unit surface is green, and
+the telemetry / command / lifecycle / module‑registration paths are real. It is an
+**incomplete MVP**: a shallow, unwired raw‑MAVLink transmit path, behavior that only
+integration tests (which can't run here) would verify, and a duplicated module provider.
+
+## What's new vs run #4 (the comparison)
+
+Run #4 (last pack) was *"real but unregistered, and never built in QA."* Run #6 is *"real,
+registered, builds and unit‑tests green in QA, honest‑red on un‑runnable integration tests."*
+
+**Improved:**
+
+- **Module‑discovery registration now exists.** `src/main/resources/META-INF/services/
+  org.sensorhub.api.module.IModuleProvider` is present — the exact gap that was run #4's
+  weakness #3. It was produced because a **new `osh-module-provider-registration` completeness
+  gate fired 4× mid‑run** and rejected the dev work until a registration appeared.
+- **Fuller OSH module topology.** Run #4 was one `MavsdkSensor extends AbstractSensorModule`.
+  Run #6 is a proper module cluster: `UnmannedSystem` (the `AbstractSensorModule`),
+  `UnmannedConfig` (`SensorConfig`), `UnmannedDescriptor`/`UnmannedActivator`
+  (`IModuleProvider`), plus `MavLinkCommNetwork` (raw transport + dialect parsing) and
+  `MavlinkDirectStream` (a second output) — much closer to how a real OSH driver is laid out.
+- **It builds and runs inside QA.** Run #4's deliverable never compiled in the QA gate (osh
+  401). Run #6's QA log shows osh‑core compiled from source and `./gradlew test` executed
+  (`BUILD SUCCESSFUL in 53s`). The verdict now reflects *test execution*, not tooling failure.
+
+**Unchanged / still weak (see "Weaknesses").** MVP scope; shallow + unwired transmit path.
+
+**Regressed (new):** duplicate `IModuleProvider` (below).
+
+## Strengths — this is real, not facade
+
+- **Correct OpenSensorHub idioms.** `UnmannedSystem extends AbstractSensorModule<UnmannedConfig>`
+  with `beforeInit`/`init`/`start`/`stop`/`isConnected`; outputs extend `AbstractDataInterface`;
+  commands extend `AbstractControlInterface`; `UnmannedConfig extends SensorConfig`;
+  `UnmannedDescriptor implements IModuleProvider`. Written by something that understands the
+  framework.
+- **Real MAVSDK reactive API.** `io.mavsdk.System`, `getCore().getConnectionState().subscribe(...)`,
+  `getTelemetry().getPosition()/getBattery().subscribe(...)`, `getAction().arm()/takeoff()`
+  and `getMission().uploadMission(...)` returning RxJava `Completable`, with error callbacks.
+  Optionally spawns `mavsdk_server -p <port> <connectionString>`. Not mocked out.
+- **Idiomatic SWE Common data modeling.** `SWEHelper` records with UOMs
+  (lat/lon = deg, alt = m, battery = %), `DataBlock` population, `DataEvent` publishing.
+- **Correct command‑status lifecycle.** `submitCommand` emits `EXECUTING` (progress 50) up
+  front, then `COMPLETED` (100) / `FAILED` via `CommandStatusEvent` from the MAVSDK
+  `Completable` callbacks; unsupported commands fail cleanly (`FAILED`, progress 0). A custom
+  `SimpleCommandStatus implements ICommandStatus` models the contract correctly (`isFinal()`
+  true on COMPLETED/FAILED).
+- **Genuine MAVLink frame decode.** `MavLinkCommNetwork.parseMavlinkFrames` handles **both
+  v1 (`0xFE`, msgId at byte 5) and v2 (`0xFD`, 24‑bit little‑endian msgId at bytes 7–9)**,
+  including the **v2 incompat‑flag signature** (13 extra bytes when `incompatFlags & 0x01`),
+  and re‑syncs by advancing one byte on a bad/short frame.
+- **Security‑conscious dialect parsing.** Custom XML dialect loading disables DTDs
+  (`disallow-doctype-decl`) — XXE‑hardened, which most generated code omits.
+- **Careful resource handling.** UDP listener uses `SO_REUSEADDR`/`SO_REUSEPORT`, a 1 s socket
+  timeout, a bounded listen loop, and a join‑with‑timeout `stop()`; `MavlinkDirectStream`
+  caps its in‑memory buffer at 100 messages. Defensive `eventHandler != null` and try/catch
+  around every publish.
+- **Appropriately‑gated integration tests.** `MavsdkSmokeTest` (5 tests) and
+  `UnmannedSystemTest` (1 test) are `@Tag("integration")` and `assumeTrue(SITL_ENDPOINT)`:
+  they actually start the driver, wait for connection, submit Arm/Takeoff, assert telemetry
+  emission and a `COMPLETED` status — correct end‑to‑end test design, gated so they don't run
+  without a simulator.
+
+## Weaknesses — the honest part
+
+1. **Duplicate `IModuleProvider` (new defect, gate‑induced).** `UnmannedActivator` and
+   `UnmannedDescriptor` are byte‑for‑byte near‑identical: both `implements IModuleProvider`,
+   both return `UnmannedSystem.class` / `UnmannedConfig.class`, both named `"UnmannedSystem"`
+   (only the description string differs). **Both** are listed in `META-INF/services/
+   org.sensorhub.api.module.IModuleProvider`, so OSH's `ServiceLoader` discovers the same
+   module **twice**. Conceptually wrong, too: an OSH/OSGi *Activator* should be a
+   `BundleActivator`, not a second descriptor. This is the new `osh-module-provider-registration`
+   gate's signature failure mode — it forced *presence* of a registration but couldn't enforce
+   that the registration is singular and correct, so the model satisfied it by cloning the
+   descriptor.
+2. **Raw‑MAVLink transmit is shallow and unwired** — the most important code caveat, and the
+   same *class* as run #4's stubbed encoder.
+   - *Receive* is real: UDP listen → v1/v2 frame decode → dialect id↔name map → subscriber
+     fan‑out → `MavlinkDirectStream` publish. Wired in `UnmannedSystem.init` when
+     `rawFallbackEnabled`.
+   - *Transmit* is not: `MavLinkCommNetwork.sendMessage(msg)` calls `transport.send(msg.toByteArray())`,
+     and `MavlinkMessage.toByteArray()` just returns the **stored payload** (or `name.getBytes()`)
+     — there is no real MAVLink frame construction, sequence number, or CRC‑16/MCRF4XX +
+     `CRC_EXTRA`. Worse, `setTransport(...)` is **never called** in `UnmannedSystem`, so in the
+     assembled wiring the transmit path has no transport at all. The capability exists only
+     behind a test seam (`MavLinkCommNetworkTest` injects a mock transport and asserts the
+     bytes pass through unchanged).
+3. **Behavior is unverified by the green build.** Every executed test covers a *static* surface
+   — frame parsing via reflection, `SimpleCommandStatus` getters, config defaults, the provider
+   classes, telemetry‑interface metadata. The 6 tests that would prove the driver actually
+   connects, streams telemetry, and executes commands all **skip**. The unit green is real but
+   shallow relative to the task.
+4. **Scope is a vertical slice.** Telemetry exposes one record (lat/lon/alt/battery); commands
+   are Arm, Takeoff, and an empty‑plan MissionUpload. No land, no broad command set, no mission
+   management beyond an empty upload — comparable partial scope to run #4.
+5. **Minor nits.**
+   - `start()`'s battery handler mutates and re‑publishes the *latest* telemetry `DataBlock`
+     in place (`getLatestRecord()` then `setDoubleValue`), which races the position handler
+     writing the same block — a real (if low‑severity) data‑race on the shared record.
+   - `lastBatteryLevel` defaults to `100.0` and is stamped into the position record before any
+     battery sample arrives (telemetry reports a fake full battery until the first battery
+     event).
+   - `getRecommendedEncoding()` returns `null` on both outputs.
+   - A large design‑rationale comment is inlined in `UnmannedSystem` with the note *"README.md
+     update is strictly blocked by file‑ownership rules, so documented here"* — an artifact of
+     the ADR‑049 ownership gate pushing prose into code comments.
+   - `MissionUpload` control is created anonymously (not stored in a field) and uploads an
+     empty `MissionPlan`.
+
+## The subtle gap QA can't currently catch
+
+Weaknesses #1 and #2 are the instructive ones. The **duplicate provider** passes every test
+(both classes have trivial passing unit tests, `UnmannedActivatorTest` / `UnmannedDescriptorTest`)
+and satisfies the registration gate — yet it is a runtime defect (double‑registration) that no
+test asserts against. The **transmit path** is unit‑green through its seam but never wired and
+never frame‑encoded, so "send raw MAVLink" does not function end‑to‑end. Both are the same
+shape as the prior pack's lesson — *locally green, globally inert* — and both point at the same
+next round of QA‑completeness work: assert that declared components are **singular and reachable
+from the module**, and that encode/decode **round‑trip on the wire**, not just per‑seam.
+
+## Bottom line
+
+Run #6 produced real, careful, idiomatic OpenSensorHub code that **builds and unit‑tests green
+inside its own QA gate** and now carries the module registration and topology a deployable OSH
+driver needs — a clear step up from run #4 on the dimensions the pipeline measures. It remains
+an **incomplete MVP**: a shallow, unwired raw‑MAVLink transmit path, a duplicated module
+provider the new gate induced, and core flight behavior that only un‑runnable integration tests
+would verify. Presented honestly, that is a stronger foundation than the day before — and the
+pipeline's own QA correctly declined to call it "done."


### PR DESCRIPTION
## What

Second **honest** sponsor pack for the OSH MAVLink/MAVSDK driver task, captured as a like-for-like comparison against the 2026-06-15 pack (run #4). It answers one question: **did the generated code get better than the last one we captured?**

Docs-only. No code or unrelated changes bundled.

## Did the code get better? Yes — materially, on the dimensions the pipeline now measures.

Every claim is grounded in the real artifacts (assembled branch `semspec/plan-2b996a0aabe6`) and **independently re-built + re-tested by hand** (osh from source, isolated `maven.repo.local`, no trusting the pipeline green): `BUILD SUCCESSFUL`, **19 tests / 13 executed / 0 failures / 6 skipped** (the `@integration` SITL tests) — matches the QA log exactly.

| Dimension | Run #4 | Run #6 | |
|---|---|---|---|
| Module registration (`META-INF/services/…IModuleProvider`) | missing | present (new gate fired 4×) | ✅ |
| OSH module topology | single `MavsdkSensor` | `UnmannedSystem`+`Activator`+`Descriptor`+`Config`+`MavLinkCommNetwork`+`MavlinkDirectStream` | ✅ |
| Did QA build + test it? | no (osh-core 401) | yes — built from source, ran suite | ✅ |
| Real per-req work, no false-complete | yes (4) | yes (5) | ✅ |
| Scope / raw-MAVLink transmit | MVP; dummy-checksum stub | MVP; echo payload, `setTransport` unwired | ≈ |
| Build self-containment | not self-contained (401) | harness substitutes source; deliverable still declares external osh-core | ≈ |
| New defect | — | duplicate `IModuleProvider` (gate-induced) | ⚠️ |
| Final verdict | rejected (won't build) | rejected (integration tests skip, no SITL) | both honest red |

**Net:** run #4 was "real but unregistered, never built in QA." Run #6 is "real, registered, builds + unit-green inside its own QA gate, honest-red on un-runnable integration tests." A genuine step forward with a stable MVP ceiling and one cleanly-characterized new regression.

## Integration-classification decision (recorded in the pack)

The 6 gate-failing tests need a live PX4/SITL simulator the sandbox can't provide (e2e-class per ADR-045), so this fixture can never pass *sandbox* QA. Decision: **keep the honest-red — `skip == fail` (the #193 no-false-green invariant) stays.** We do NOT exclude the tests to manufacture a green. The follow-up (separate work) is to (1) make the verdict *messaging* read "e2e behavior deferred to operator CI" instead of as a code defect, and (2) stand up operator-CI SITL as the real path to behavior verification.

## Contents

- `README.md` — headline, comparison table, what's proven / not done, reproduce/audit
- `build-and-qa-findings.md` — prior blockers closed, the new honest-red mechanism, the classification decision, registration-gate shape gap
- `code-review.md` — full review of the generated code + explicit run #4 vs run #6 diff

## Audit

- Run: `WITH_EPIC=1 DEBUG=1 task e2e:watch:llm -- gemini mavlink-hard` (slug `2b996a0aabe6`, all four hardening PRs merged)
- Independent build proof: `semspec/plan-2b996a0aabe6` rebuilt by hand → `BUILD SUCCESSFUL`, 19 tests / 13 executed / 0 failures / 6 skipped

*Status: draft for internal review. No success claim beyond what the evidence supports.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)