### PR TITLE
feat(qa): reason about skipped tests instead of failing closed on them

### DIFF
--- a/cmd/sandbox/qa_subscriber.go
+++ b/cmd/sandbox/qa_subscriber.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"log/slog"
 	"os"
@@ -251,10 +252,19 @@ func (h *qaHandler) runSandboxQA(
 		".semspec", "qa-artifacts", evt.Slug, runID, fmt.Sprintf("%s-test.log", evt.Mode))
 	artifacts := h.archiveLog(evt.Slug, runID, artifactRelPath, combined, fmt.Sprintf("%s test output", evt.Mode))
 
-	skippedEvidence := integrationSkippedTestEvidence(evt.Mode, workDir)
+	skippedTests := integrationSkippedTests(evt.Mode, workDir)
 
-	// Build pass/fail result.
-	passed := exitCode == 0 && !timedOut && len(skippedEvidence) == 0
+	// Build pass/fail result. A SKIP is NOT a failure: Passed reflects only that
+	// the build succeeded and every test that ACTUALLY RAN passed. Skipped tests
+	// are surfaced as evidence (SkippedTests) for qa-reviewer to reason about —
+	// the agent reads each skipped test's source to decide whether the skip is a
+	// legitimate sandbox limitation (a test gated on a live external harness this
+	// sandbox can't provide → conditionally_approved) or gaming (a disabled test
+	// dodging a failure → needs_changes). The executor stays deterministic on the
+	// unambiguous (build/test failures, timeouts) and defers the judgment call to
+	// the agent. (Until 2026-06-16 a skip here forced passed=false, which made a
+	// fixture whose behavior tests need SITL un-passable in the sandbox forever.)
+	passed := exitCode == 0 && !timedOut
 	var failures []workflow.QAFailure
 	if !passed {
 		excerpt := combined
@@ -264,8 +274,6 @@ func (h *qaHandler) runSandboxQA(
 		msg := fmt.Sprintf("test command failed (exit %d)", exitCode)
 		if timedOut {
 			msg = fmt.Sprintf("test command timed out after %s", timeout)
-		} else if len(skippedEvidence) > 0 {
-			msg = fmt.Sprintf("integration QA skipped test(s): %s", strings.Join(skippedEvidence, ", "))
 		}
 		failures = []workflow.QAFailure{
 			{
@@ -277,15 +285,16 @@ func (h *qaHandler) runSandboxQA(
 	}
 
 	return &workflow.QACompletedEvent{
-		Slug:       evt.Slug,
-		PlanID:     evt.PlanID,
-		RunID:      runID,
-		Level:      evt.Mode,
-		Passed:     passed,
-		Failures:   failures,
-		Artifacts:  artifacts,
-		DurationMs: durationMs,
-		TraceID:    evt.TraceID,
+		Slug:         evt.Slug,
+		PlanID:       evt.PlanID,
+		RunID:        runID,
+		Level:        evt.Mode,
+		Passed:       passed,
+		Failures:     failures,
+		SkippedTests: skippedTests,
+		Artifacts:    artifacts,
+		DurationMs:   durationMs,
+		TraceID:      evt.TraceID,
 	}
 }
 
@@ -369,7 +378,19 @@ func (h *qaHandler) archiveLog(slug, runID, relPath, content, purpose string) []
 	}
 }
 
-func integrationSkippedTestEvidence(mode workflow.QALevel, workDir string) []string {
+// maxSkippedTestsReported bounds how many skipped tests the executor surfaces to
+// qa-reviewer. Bounded so a suite with hundreds of (legitimately) skipped tests
+// can't bloat the verdict payload; the agent reasons over a representative set.
+const maxSkippedTestsReported = 50
+
+// integrationSkippedTests best-effort parses the JUnit-format reports a sandbox
+// test run leaves behind and returns the tests reported as SKIPPED, identified
+// by suite + name so qa-reviewer can open each one's source and judge whether
+// the skip is a legitimate sandbox limitation or gaming. The skip REASON is not
+// returned: Gradle's JUnit XML routinely emits a bare <skipped/> (no message),
+// so the reason is recovered from the test source by the reviewer, not parsed
+// here. Non-JUnit projects yield nothing; the agent still has the full test log.
+func integrationSkippedTests(mode workflow.QALevel, workDir string) []workflow.QASkippedTest {
 	if mode != workflow.QALevelIntegration || workDir == "" {
 		return nil
 	}
@@ -378,34 +399,79 @@ func integrationSkippedTestEvidence(mode workflow.QALevel, workDir string) []str
 		filepath.Join(workDir, "target", "surefire-reports"),
 		filepath.Join(workDir, "target", "failsafe-reports"),
 	}
-	var evidence []string
+	var skipped []workflow.QASkippedTest
 	for _, root := range roots {
 		if _, err := os.Stat(root); err != nil {
 			continue
 		}
 		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() || len(evidence) >= 5 {
+			if err != nil || d.IsDir() || len(skipped) >= maxSkippedTestsReported {
 				return nil
 			}
-			ext := strings.ToLower(filepath.Ext(path))
-			if ext != ".xml" {
+			if strings.ToLower(filepath.Ext(path)) != ".xml" {
 				return nil
 			}
 			data, err := os.ReadFile(path)
 			if err != nil {
 				return nil
 			}
-			if strings.Contains(strings.ToLower(string(data)), "<skipped") {
-				rel, relErr := filepath.Rel(workDir, path)
-				if relErr != nil {
-					rel = path
-				}
-				evidence = append(evidence, rel)
+			rel, relErr := filepath.Rel(workDir, path)
+			if relErr != nil {
+				rel = path
 			}
+			skipped = append(skipped, parseSkippedJUnitCases(data, rel, maxSkippedTestsReported-len(skipped))...)
 			return nil
 		})
 	}
-	return evidence
+	return skipped
+}
+
+// parseSkippedJUnitCases extracts skipped <testcase> entries from one JUnit XML
+// report. Handles both a single <testsuite> root and a <testsuites> wrapper.
+// Returns at most `limit` entries.
+func parseSkippedJUnitCases(data []byte, file string, limit int) []workflow.QASkippedTest {
+	if limit <= 0 {
+		return nil
+	}
+	type junitCase struct {
+		Name      string    `xml:"name,attr"`
+		Classname string    `xml:"classname,attr"`
+		Skipped   *struct{} `xml:"skipped"` // non-nil iff a <skipped> child is present
+	}
+	// junitSuite is recursive: aggregate reports can nest <testsuite> elements,
+	// and a skip buried in a nested suite must not be silently dropped (that
+	// would weaken the no-false-green guard).
+	type junitSuite struct {
+		Cases  []junitCase  `xml:"testcase"`
+		Suites []junitSuite `xml:"testsuite"`
+	}
+	var root struct {
+		Cases  []junitCase  `xml:"testcase"`  // when the document root is <testsuite>
+		Suites []junitSuite `xml:"testsuite"` // when the document root is <testsuites> (possibly nested)
+	}
+	if err := xml.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+	var out []workflow.QASkippedTest
+	var walk func(cases []junitCase, suites []junitSuite)
+	walk = func(cases []junitCase, suites []junitSuite) {
+		for _, tc := range cases {
+			if len(out) >= limit {
+				return
+			}
+			if tc.Skipped != nil {
+				out = append(out, workflow.QASkippedTest{Suite: tc.Classname, Name: tc.Name, File: file})
+			}
+		}
+		for _, s := range suites {
+			if len(out) >= limit {
+				return
+			}
+			walk(s.Cases, s.Suites)
+		}
+	}
+	walk(root.Cases, root.Suites)
+	return out
 }
 
 // publishCompleted wraps evt in a BaseMessage envelope and publishes it to

--- a/cmd/sandbox/qa_subscriber_test.go
+++ b/cmd/sandbox/qa_subscriber_test.go
@@ -104,14 +104,27 @@ func TestPrepareQAIsolation_ReturnsColdBuildCacheEnvAndCleanup(t *testing.T) {
 	}
 }
 
-func TestRunSandboxQAIntegrationFailsOnSkippedJUnitTests(t *testing.T) {
+// TestRunSandboxQAIntegrationReportsSkipsAsEvidenceNotFailure asserts the
+// 2026-06-16 redesign: a SKIP is no longer an automatic integration failure.
+// When the build + every executed test pass, the run is Passed=true and the
+// skipped tests are surfaced as SkippedTests evidence for qa-reviewer to reason
+// about (legit sandbox limitation vs gaming). The XML below is the real shape
+// Gradle's JUnit reporter emits for an assumeTrue-aborted test — a bare
+// <skipped/> with NO reason (captured from the mavlink-hard run #6 fixture),
+// which is exactly why the reason can't be parsed and the judgment is the
+// reviewer's, not a regex's.
+func TestRunSandboxQAIntegrationReportsSkipsAsEvidenceNotFailure(t *testing.T) {
 	dir := t.TempDir()
 	resultsDir := filepath.Join(dir, "build", "test-results", "test")
 	if err := os.MkdirAll(resultsDir, 0o755); err != nil {
 		t.Fatalf("mkdir results: %v", err)
 	}
-	xml := `<testsuite tests="1" skipped="1"><testcase classname="DriverIT" name="sitl"><skipped/></testcase></testsuite>`
-	if err := os.WriteFile(filepath.Join(resultsDir, "TEST-DriverIT.xml"), []byte(xml), 0o644); err != nil {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="org.sensorhub.impl.sensor.mavsdk.MavsdkSmokeTest" tests="2" skipped="2" failures="0" errors="0">
+  <testcase name="test_scenario_1_1_3()" classname="org.sensorhub.impl.sensor.mavsdk.MavsdkSmokeTest"><skipped/></testcase>
+  <testcase name="test_scenario_1_1_4()" classname="org.sensorhub.impl.sensor.mavsdk.MavsdkSmokeTest"><skipped/></testcase>
+</testsuite>`
+	if err := os.WriteFile(filepath.Join(resultsDir, "TEST-MavsdkSmokeTest.xml"), []byte(xml), 0o644); err != nil {
 		t.Fatalf("write junit xml: %v", err)
 	}
 
@@ -128,19 +141,98 @@ func TestRunSandboxQAIntegrationFailsOnSkippedJUnitTests(t *testing.T) {
 		Slug:        "mavlink-hard",
 		PlanID:      "plan-1",
 		Mode:        workflow.QALevelIntegration,
-		TestCommand: "true",
+		TestCommand: "true", // exit 0: build + executed tests "pass"
+	}, "run-1", time.Now())
+
+	if !got.Passed {
+		t.Fatalf("Passed = false, want true — a skip is not a failure when the run exits 0")
+	}
+	if len(got.Failures) != 0 {
+		t.Fatalf("Failures = %d, want 0 — skips must not be reported as failures", len(got.Failures))
+	}
+	if len(got.SkippedTests) != 2 {
+		t.Fatalf("SkippedTests = %d, want 2", len(got.SkippedTests))
+	}
+	for _, s := range got.SkippedTests {
+		if s.Suite != "org.sensorhub.impl.sensor.mavsdk.MavsdkSmokeTest" {
+			t.Errorf("Suite = %q, want the JUnit classname", s.Suite)
+		}
+		if s.Name == "" {
+			t.Errorf("skipped test missing name: %+v", s)
+		}
+	}
+}
+
+// TestParseSkippedJUnitCases covers the report shapes the parser must handle:
+// a single <testsuite> root, a <testsuites> wrapper, and a NESTED <testsuite>
+// (aggregate reports) — a skip in any of them must be found, never dropped.
+func TestParseSkippedJUnitCases(t *testing.T) {
+	cases := []struct {
+		name string
+		xml  string
+		want int
+	}{
+		{
+			name: "single testsuite root, bare skipped",
+			xml:  `<testsuite><testcase classname="A" name="t1"><skipped/></testcase><testcase classname="A" name="t2"/></testsuite>`,
+			want: 1,
+		},
+		{
+			name: "testsuites wrapper",
+			xml:  `<testsuites><testsuite><testcase classname="A" name="t1"><skipped/></testcase></testsuite><testsuite><testcase classname="B" name="t2"><skipped/></testcase></testsuite></testsuites>`,
+			want: 2,
+		},
+		{
+			name: "nested testsuite",
+			xml:  `<testsuites><testsuite><testsuite><testcase classname="C" name="deep"><skipped/></testcase></testsuite></testsuite></testsuites>`,
+			want: 1,
+		},
+		{
+			name: "no skips",
+			xml:  `<testsuite><testcase classname="A" name="t1"/></testsuite>`,
+			want: 0,
+		},
+		{
+			name: "malformed xml yields nothing",
+			xml:  `<testsuite><testcase`,
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseSkippedJUnitCases([]byte(tc.xml), "report.xml", maxSkippedTestsReported)
+			if len(got) != tc.want {
+				t.Errorf("parseSkippedJUnitCases found %d skipped, want %d (%+v)", len(got), tc.want, got)
+			}
+		})
+	}
+}
+
+// TestRunSandboxQAIntegrationFailsOnRealTestFailure asserts the deterministic
+// red path is unchanged: a non-zero exit (real test/build failure) still fails
+// closed regardless of any skip reasoning.
+func TestRunSandboxQAIntegrationFailsOnRealTestFailure(t *testing.T) {
+	dir := t.TempDir()
+	h := &qaHandler{
+		srv: &Server{
+			repoPath:       dir,
+			maxTimeout:     5 * time.Second,
+			maxOutputBytes: 64 * 1024,
+			worktreeRoot:   filepath.Join(dir, ".semspec", "worktrees"),
+		},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	got := h.runSandboxQA(context.Background(), workflow.QARequestedEvent{
+		Slug:        "mavlink-hard",
+		PlanID:      "plan-1",
+		Mode:        workflow.QALevelIntegration,
+		TestCommand: "false", // exit 1
 	}, "run-1", time.Now())
 
 	if got.Passed {
-		t.Fatalf("Passed = true, want false for skipped integration tests")
-	}
-	if got.Level != workflow.QALevelIntegration {
-		t.Fatalf("Level = %q, want integration", got.Level)
+		t.Fatalf("Passed = true, want false for a non-zero test command exit")
 	}
 	if len(got.Failures) != 1 {
 		t.Fatalf("Failures = %d, want 1", len(got.Failures))
-	}
-	if !strings.Contains(got.Failures[0].Message, "skipped") {
-		t.Errorf("failure message should mention skipped tests, got %q", got.Failures[0].Message)
 	}
 }

--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -944,6 +944,13 @@ func (c *Component) determinePlanStage(plan *workflow.Plan) string {
 	case workflow.StatusAwaitingReview:
 		return "awaiting_review"
 	case workflow.StatusComplete:
+		// A conditionally-approved plan is terminal-complete but NOT all-green:
+		// the sandbox verified all it could and deferred some behavior to the
+		// operator-CI e2e tier (ADR-045). Surface it as a distinct yellow stage
+		// so consumers never render it as a plain green "complete".
+		if plan.QAVerdictSummary != nil && plan.QAVerdictSummary.Verdict == workflow.QAVerdictConditionallyApproved {
+			return "complete_with_deferrals"
+		}
 		return "complete"
 	case workflow.StatusChanged:
 		return "changed"

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1303,9 +1303,9 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 		return MutationResponse{Success: false, Error: "slug required"}
 	}
 	switch req.Verdict {
-	case workflow.QAVerdictApproved, workflow.QAVerdictNeedsChanges, workflow.QAVerdictRejected:
+	case workflow.QAVerdictApproved, workflow.QAVerdictConditionallyApproved, workflow.QAVerdictNeedsChanges, workflow.QAVerdictRejected:
 	default:
-		return MutationResponse{Success: false, Error: fmt.Sprintf("verdict must be approved|needs_changes|rejected, got %q", req.Verdict)}
+		return MutationResponse{Success: false, Error: fmt.Sprintf("verdict must be approved|conditionally_approved|needs_changes|rejected, got %q", req.Verdict)}
 	}
 
 	defer c.lockSlug(req.Slug)()
@@ -1343,7 +1343,13 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 	}
 
 	switch req.Verdict {
-	case workflow.QAVerdictApproved:
+	case workflow.QAVerdictApproved, workflow.QAVerdictConditionallyApproved:
+		// conditionally_approved shares the approved terminal path (assemble the
+		// branches, mark complete) — the deliverable is as verified as the sandbox
+		// tier allows. It is NOT all-green: the conditional verdict is recorded in
+		// QAVerdictSummary (above) and surfaced as a distinct user-facing stage
+		// (complete_with_deferrals), and the deferred behavior must be verified in
+		// the operator-CI e2e tier (ADR-045).
 		target := workflow.StatusComplete
 		if c.shouldGateReview(plan) {
 			target = workflow.StatusAwaitingReview
@@ -1383,8 +1389,8 @@ func (c *Component) handleQAVerdictMutation(ctx context.Context, data []byte) Mu
 			return MutationResponse{Success: false, Error: plan.LastError}
 		}
 		plan.Status = target
-		c.logger.Info("QA verdict approved",
-			"slug", req.Slug, "level", req.Level, "target", target,
+		c.logger.Info("QA verdict accepted — plan assembled",
+			"slug", req.Slug, "verdict", req.Verdict, "level", req.Level, "target", target,
 			"plan_branch", plan.AssembledBranch, "plan_merge_commit", plan.AssembledMergeCommit)
 
 	case workflow.QAVerdictNeedsChanges, workflow.QAVerdictRejected:

--- a/processor/plan-manager/qa_verdict_test.go
+++ b/processor/plan-manager/qa_verdict_test.go
@@ -156,3 +156,55 @@ func TestHandleQAVerdictMutation_PersistsSummaryOnMergeFail(t *testing.T) {
 		t.Error("LastError should record the merge failure for operator visibility")
 	}
 }
+
+// TestDeterminePlanStage_ConditionallyApproved asserts a conditionally-approved
+// terminal plan renders as a distinct yellow stage, never plain green
+// "complete" — the user-visible half of the done-with-deferrals contract.
+func TestDeterminePlanStage_ConditionallyApproved(t *testing.T) {
+	c := setupTestComponent(t)
+
+	plain := &workflow.Plan{Slug: "s", Status: workflow.StatusComplete}
+	if got := c.determinePlanStage(plain); got != "complete" {
+		t.Errorf("plain complete stage = %q, want complete", got)
+	}
+
+	cond := &workflow.Plan{
+		Slug:             "s",
+		Status:           workflow.StatusComplete,
+		QAVerdictSummary: &workflow.QAVerdictSummary{Verdict: workflow.QAVerdictConditionallyApproved},
+	}
+	if got := c.determinePlanStage(cond); got != "complete_with_deferrals" {
+		t.Errorf("conditionally-approved complete stage = %q, want complete_with_deferrals", got)
+	}
+
+	// An ordinary approval must remain plain green.
+	appr := &workflow.Plan{
+		Slug:             "s",
+		Status:           workflow.StatusComplete,
+		QAVerdictSummary: &workflow.QAVerdictSummary{Verdict: workflow.QAVerdictApproved},
+	}
+	if got := c.determinePlanStage(appr); got != "complete" {
+		t.Errorf("approved complete stage = %q, want complete", got)
+	}
+}
+
+// TestHandleQAVerdictMutation_AcceptsConditionallyApproved asserts the new
+// verdict passes validation (it reaches the plan lookup rather than being
+// rejected as an unknown verdict).
+func TestHandleQAVerdictMutation_AcceptsConditionallyApproved(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+
+	event := workflow.QAVerdictEvent{Slug: "missing-plan", Verdict: workflow.QAVerdictConditionallyApproved}
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp := c.handleQAVerdictMutation(ctx, data)
+	if resp.Success {
+		t.Fatal("expected failure for a missing plan")
+	}
+	if resp.Error != "plan not found" {
+		t.Errorf("Error = %q, want \"plan not found\" (proves conditionally_approved passed verdict validation)", resp.Error)
+	}
+}

--- a/processor/qa-reviewer/component.go
+++ b/processor/qa-reviewer/component.go
@@ -669,7 +669,10 @@ func (c *Component) handleLoopCompletion(ctx context.Context, loop *agentic.Loop
 		"had_test_data", hadTestData)
 
 	verdict := buildQAVerdictEvent(slug, plan, result)
-	c.recordQARejectionLesson(ctx, slug, result)
+	// Record the lesson on the PUBLISHED verdict, not the raw agent output: the
+	// skip-guard can coerce approved→needs_changes, and we want the reviewer to
+	// learn from exactly that failure mode (it approved a skipped run).
+	c.recordQARejectionLesson(ctx, slug, verdict.Verdict, verdict.Summary, result)
 	c.publishQAVerdict(ctx, verdict)
 	// Clear retry state AFTER the verdict mutation is dispatched. publishQAVerdict
 	// doesn't currently surface mutation errors back here (logged + swallowed),
@@ -689,11 +692,23 @@ func buildQAVerdictEvent(slug string, plan *workflow.Plan, result *qaReviewOutpu
 	if forced := forcedExecutableQAVerdict(slug, plan, level); forced != nil {
 		return forced
 	}
+
+	// Deterministic safety net over the LLM's skip judgment: the agent is told to
+	// never return `approved` when tests were skipped (it must use
+	// conditionally_approved for legitimate deferrals or needs_changes for
+	// gaming). reconcileSkipVerdict enforces that invariant in code so a
+	// misbehaving review can't produce a false all-green.
+	var qaRun *workflow.QARun
+	if plan != nil {
+		qaRun = plan.QARun
+	}
+	finalVerdict, skipNote := reconcileSkipVerdict(result.Verdict, qaRun)
+
 	verdict := &workflow.QAVerdictEvent{
 		Slug:    slug,
 		Level:   level,
-		Verdict: workflow.QAVerdict(result.Verdict),
-		Summary: result.Summary,
+		Verdict: finalVerdict,
+		Summary: appendVerdictNote(result.Summary, skipNote),
 		Dimensions: workflow.QAVerdictDimensions{
 			RequirementFulfillment: result.Dimensions.RequirementFulfillment,
 			CapabilityEvidence:     result.Dimensions.CapabilityEvidence,
@@ -706,7 +721,7 @@ func buildQAVerdictEvent(slug string, plan *workflow.Plan, result *qaReviewOutpu
 	if plan != nil {
 		verdict.PlanID = plan.ID
 	}
-	if workflow.QAVerdict(result.Verdict) != workflow.QAVerdictNeedsChanges || len(result.PlanDecisions) == 0 {
+	if finalVerdict != workflow.QAVerdictNeedsChanges || len(result.PlanDecisions) == 0 {
 		return verdict
 	}
 	now := time.Now()
@@ -732,6 +747,48 @@ func buildQAVerdictEvent(slug string, plan *workflow.Plan, result *qaReviewOutpu
 		verdict.PlanDecisionIDs = append(verdict.PlanDecisionIDs, proposal.ID)
 	}
 	return verdict
+}
+
+// reconcileSkipVerdict is the deterministic safety net over the LLM's skip
+// judgment. By the time it runs, the executor reported Passed (build + every
+// executed test succeeded — real failures already short-circuited to red in
+// forcedExecutableQAVerdict). It enforces, in code, the invariant that a run
+// with skipped tests is never reported as a full all-green `approved`:
+//
+//   - approved + skips present          → needs_changes (fail closed: the agent
+//     approved without classifying the skips; bias to red so a retry/human
+//     resolves it — a skipped test must never silently pass as green)
+//   - conditionally_approved + no skips → approved (nothing was deferred)
+//   - everything else passes through unchanged
+//
+// Returns the reconciled verdict and an optional note appended to the summary.
+func reconcileSkipVerdict(raw string, qaRun *workflow.QARun) (workflow.QAVerdict, string) {
+	v := workflow.QAVerdict(raw)
+	hasSkips := qaRun != nil && len(qaRun.SkippedTests) > 0
+	switch {
+	case hasSkips && v == workflow.QAVerdictApproved:
+		return workflow.QAVerdictNeedsChanges, fmt.Sprintf(
+			"[skip-guard] coerced approved→needs_changes: %d test(s) were skipped but the review approved without classifying them; a run with skipped tests cannot be all-green. Classify each skip (legitimate sandbox limitation → conditionally_approved; gaming → needs_changes).",
+			len(qaRun.SkippedTests))
+	case !hasSkips && v == workflow.QAVerdictConditionallyApproved:
+		// Nothing was actually deferred — a conditional approval with no skips is
+		// just an approval.
+		return workflow.QAVerdictApproved, ""
+	default:
+		return v, ""
+	}
+}
+
+// appendVerdictNote joins a coercion note onto the reviewer's summary.
+func appendVerdictNote(summary, note string) string {
+	switch {
+	case note == "":
+		return summary
+	case summary == "":
+		return note
+	default:
+		return summary + "\n\n" + note
+	}
 }
 
 func forcedExecutableQAVerdict(slug string, plan *workflow.Plan, level workflow.QALevel) *workflow.QAVerdictEvent {
@@ -810,15 +867,15 @@ func summarizeQAFailures(level workflow.QALevel, run *workflow.QARun) string {
 // evidence); otherwise fall back to a stable citation pointing at the plan
 // artifact (`.semspec/plans/<slug>/plan.json`) so the writer's evidence
 // requirement is satisfied.
-func (c *Component) recordQARejectionLesson(ctx context.Context, slug string, result *qaReviewOutput) {
-	if workflow.QAVerdict(result.Verdict) != workflow.QAVerdictNeedsChanges || c.lessonWriter == nil {
+func (c *Component) recordQARejectionLesson(ctx context.Context, slug string, finalVerdict workflow.QAVerdict, finalSummary string, result *qaReviewOutput) {
+	if finalVerdict != workflow.QAVerdictNeedsChanges || c.lessonWriter == nil {
 		return
 	}
 	evidenceFiles := qaEvidenceFiles(slug, result)
 	lesson := workflow.Lesson{
 		Source:        "qa-review",
 		ScenarioID:    slug,
-		Summary:       fmt.Sprintf("QA rejection: %s", result.Summary),
+		Summary:       fmt.Sprintf("QA rejection: %s", finalSummary),
 		Role:          string(prompt.RolePlanQAReviewer),
 		EvidenceFiles: evidenceFiles,
 	}
@@ -1016,6 +1073,7 @@ func buildQAReviewContext(plan *workflow.Plan) *prompt.QAReviewContext {
 	if plan.QARun != nil {
 		qrc.Passed = plan.QARun.Passed
 		qrc.Failures = plan.QARun.Failures
+		qrc.SkippedTests = plan.QARun.SkippedTests
 		qrc.Artifacts = plan.QARun.Artifacts
 		qrc.RunnerError = plan.QARun.RunnerError
 	}
@@ -1220,15 +1278,16 @@ func parseQAReviewResult(result string) (*qaReviewOutput, error) {
 	}
 
 	if !isValidQAVerdict(output.Verdict) {
-		return nil, fmt.Errorf("invalid qa verdict %q: must be approved|needs_changes|rejected", output.Verdict)
+		return nil, fmt.Errorf("invalid qa verdict %q: must be approved|conditionally_approved|needs_changes|rejected", output.Verdict)
 	}
 
 	return &output, nil
 }
 
-// isValidQAVerdict returns true for the three accepted verdict strings.
+// isValidQAVerdict returns true for the accepted verdict strings.
 func isValidQAVerdict(v string) bool {
 	return v == string(workflow.QAVerdictApproved) ||
+		v == string(workflow.QAVerdictConditionallyApproved) ||
 		v == string(workflow.QAVerdictNeedsChanges) ||
 		v == string(workflow.QAVerdictRejected)
 }

--- a/processor/qa-reviewer/component_test.go
+++ b/processor/qa-reviewer/component_test.go
@@ -14,6 +14,7 @@ func TestIsValidQAVerdict(t *testing.T) {
 		want    bool
 	}{
 		{"approved", true},
+		{"conditionally_approved", true},
 		{"needs_changes", true},
 		{"rejected", true},
 		{"", false},

--- a/processor/qa-reviewer/qa_completed.go
+++ b/processor/qa-reviewer/qa_completed.go
@@ -97,14 +97,15 @@ func (c *Component) handleQACompleted(lifecycleCtx, msgCtx context.Context, msg 
 	}
 
 	qaRun := &workflow.QARun{
-		RunID:       evt.RunID,
-		Passed:      evt.Passed,
-		Failures:    evt.Failures,
-		Artifacts:   evt.Artifacts,
-		DurationMs:  evt.DurationMs,
-		RunnerError: evt.RunnerError,
-		TraceID:     evt.TraceID,
-		CompletedAt: time.Now(),
+		RunID:        evt.RunID,
+		Passed:       evt.Passed,
+		Failures:     evt.Failures,
+		SkippedTests: evt.SkippedTests,
+		Artifacts:    evt.Artifacts,
+		DurationMs:   evt.DurationMs,
+		RunnerError:  evt.RunnerError,
+		TraceID:      evt.TraceID,
+		CompletedAt:  time.Now(),
 	}
 
 	c.triggersProcessed.Add(1)

--- a/processor/qa-reviewer/skip_verdict_test.go
+++ b/processor/qa-reviewer/skip_verdict_test.go
@@ -1,0 +1,67 @@
+package qareviewer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestReconcileSkipVerdict covers the deterministic safety net that prevents a
+// run with skipped tests from ever being reported as a full all-green approval,
+// and that strips a meaningless conditional approval when nothing was skipped.
+func TestReconcileSkipVerdict(t *testing.T) {
+	withSkips := &workflow.QARun{SkippedTests: []workflow.QASkippedTest{{Suite: "DriverIT", Name: "sitl"}}}
+	noSkips := &workflow.QARun{}
+
+	tests := []struct {
+		name     string
+		raw      string
+		qaRun    *workflow.QARun
+		want     workflow.QAVerdict
+		wantNote bool
+	}{
+		{"approved+skips coerced to needs_changes", "approved", withSkips, workflow.QAVerdictNeedsChanges, true},
+		{"approved+no-skips stays approved", "approved", noSkips, workflow.QAVerdictApproved, false},
+		{"conditionally_approved+skips kept", "conditionally_approved", withSkips, workflow.QAVerdictConditionallyApproved, false},
+		{"conditionally_approved+no-skips downgraded to approved", "conditionally_approved", noSkips, workflow.QAVerdictApproved, false},
+		{"needs_changes+skips kept", "needs_changes", withSkips, workflow.QAVerdictNeedsChanges, false},
+		{"rejected+skips kept", "rejected", withSkips, workflow.QAVerdictRejected, false},
+		{"nil qaRun passes through", "approved", nil, workflow.QAVerdictApproved, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, note := reconcileSkipVerdict(tc.raw, tc.qaRun)
+			if got != tc.want {
+				t.Errorf("verdict = %q, want %q", got, tc.want)
+			}
+			if (note != "") != tc.wantNote {
+				t.Errorf("note presence = %v (%q), want %v", note != "", note, tc.wantNote)
+			}
+			if tc.wantNote && !strings.Contains(note, "skip-guard") {
+				t.Errorf("note should be a labeled skip-guard coercion, got %q", note)
+			}
+		})
+	}
+}
+
+// TestBuildQAVerdictEventSkipGuard asserts the guard fires end-to-end through
+// buildQAVerdictEvent: an agent that approves a run with skipped tests yields a
+// needs_changes verdict (fail closed), never approved.
+func TestBuildQAVerdictEventSkipGuard(t *testing.T) {
+	plan := &workflow.Plan{
+		ID:      "plan.test",
+		Slug:    "test",
+		QALevel: workflow.QALevelIntegration,
+		QARun:   &workflow.QARun{Passed: true, SkippedTests: []workflow.QASkippedTest{{Suite: "MavsdkSmokeTest", Name: "sitl"}}},
+	}
+	result := &qaReviewOutput{Verdict: string(workflow.QAVerdictApproved), Summary: "looks good"}
+
+	ev := buildQAVerdictEvent("test", plan, result)
+	if ev.Verdict != workflow.QAVerdictNeedsChanges {
+		t.Fatalf("Verdict = %q, want needs_changes (approved+skips must fail closed)", ev.Verdict)
+	}
+	if !strings.Contains(ev.Summary, "skip-guard") {
+		t.Errorf("summary should carry the skip-guard coercion note, got %q", ev.Summary)
+	}
+}

--- a/prompt/context.go
+++ b/prompt/context.go
@@ -396,6 +396,14 @@ type QAReviewContext struct {
 	// Empty for synthesis-level review or when Passed is true.
 	Failures []workflow.QAFailure
 
+	// SkippedTests lists tests the executor ran but reported as SKIPPED. These
+	// are NOT failures — the reviewer must read each skipped test's source to
+	// decide whether the skip is a legitimate sandbox limitation (the test needs
+	// a live external harness this sandbox can't provide → conditionally_approved)
+	// or gaming (a disabled test dodging a failure → needs_changes). A run with
+	// skipped tests must NEVER be approved (all-green).
+	SkippedTests []workflow.QASkippedTest
+
 	// Artifacts lists workspace-relative references to logs, screenshots, traces,
 	// and coverage reports produced by the QA run.
 	Artifacts []workflow.QAArtifactRef

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -2549,9 +2549,12 @@ The Persona system prompt above (Murat) sets your identity and style. These role
 				if qc.QALevel == workflow.QALevelSynthesis {
 					sb.WriteString("**Level: synthesis** — No test execution was performed. Your assessment is based on the implementation completeness and requirement fulfillment inferred from the plan artifacts and files modified.\n\n")
 				} else {
-					if qc.Passed {
+					switch {
+					case qc.Passed && len(qc.SkippedTests) > 0:
+						sb.WriteString("**Overall: PASSED WITH SKIPS** — The build and every test that RAN passed, but some tests were SKIPPED (listed below). A run with skipped tests is NOT all-green: you MUST classify each skip before choosing a verdict, and you may NOT return `approved`.\n\n")
+					case qc.Passed:
 						sb.WriteString("**Overall: PASSED** — The QA executor reported no test failures.\n\n")
-					} else {
+					default:
 						sb.WriteString("**Overall: FAILED** — The QA executor reported test failures.\n\n")
 					}
 
@@ -2570,6 +2573,29 @@ The Persona system prompt above (Murat) sets your identity and style. These role
 							}
 						}
 						sb.WriteString("\n")
+					}
+
+					if len(qc.SkippedTests) > 0 {
+						sb.WriteString("**Skipped tests (NOT run — you MUST reason about each):**\n")
+						for _, s := range qc.SkippedTests {
+							if s.Suite != "" {
+								sb.WriteString(fmt.Sprintf("- %s / %s", s.Suite, s.Name))
+							} else {
+								sb.WriteString(fmt.Sprintf("- %s", s.Name))
+							}
+							if s.File != "" {
+								sb.WriteString(fmt.Sprintf("  (reported in %s)", s.File))
+							}
+							sb.WriteString("\n")
+						}
+						sb.WriteString("\nThese tests were SKIPPED, not executed. The skip reason is usually ABSENT from the report — OPEN each test's source with bash and read its skip condition (e.g. `assumeTrue(...)`, `@Disabled`, an env-var guard).\n\n")
+						sb.WriteString("Classify every skip:\n")
+						sb.WriteString("- **Legitimate sandbox limitation** — the test needs an environment this sandbox cannot provide (a live simulator / SITL endpoint, real hardware, an external network service). These are deferrals to the operator-CI e2e tier (ADR-045), not defects.\n")
+						sb.WriteString("- **Gaming / unjustified** — the test was disabled to dodge a failure, or its precondition SHOULD hold in the sandbox (no external dependency). This is a defect.\n\n")
+						sb.WriteString("Then choose your verdict:\n")
+						sb.WriteString("- EVERY skip a legitimate sandbox limitation AND everything that ran passed → **`conditionally_approved`** (NOT `approved`): name the deferred behavior and state it must be verified in operator-CI e2e.\n")
+						sb.WriteString("- ANY skip gaming/unjustified, or you cannot justify a skip from its source → **`needs_changes`** with a plan_decision. When uncertain, choose `needs_changes`.\n")
+						sb.WriteString("- NEVER return `approved` when any test was skipped.\n\n")
 					}
 
 					if len(qc.Artifacts) > 0 {
@@ -2692,8 +2718,9 @@ Needs-changes example (integration/full — flaky test):
 				}
 
 				sb.WriteString("Verdict semantics:\n")
-				sb.WriteString("- `approved`: ship it — all assessed dimensions pass\n")
-				sb.WriteString("- `needs_changes`: specific fixable issues found — include plan_decisions\n")
+				sb.WriteString("- `approved`: ship it — all assessed dimensions pass AND no test was skipped\n")
+				sb.WriteString("- `conditionally_approved`: build + all executed tests pass, but some tests were SKIPPED because they need an environment this sandbox can't provide (e.g. a live SITL/hardware endpoint), and you judged every such skip a legitimate deferral. Terminal but NOT all-green — name the deferred behavior; it must be verified in operator-CI e2e. Use this INSTEAD of `approved` whenever tests were skipped for legitimate environmental reasons.\n")
+				sb.WriteString("- `needs_changes`: specific fixable issues found (including a test skipped to dodge a failure) — include plan_decisions\n")
 				sb.WriteString("- `rejected`: escalate to human — systemic failure, cannot be automatically retried\n\n")
 				sb.WriteString("Respond ONLY via the submit_work tool call. No markdown prose, no preamble, no explanation outside the tool call.")
 

--- a/ui/src/lib/types/plan.ts
+++ b/ui/src/lib/types/plan.ts
@@ -61,6 +61,7 @@ export type PlanStage =
 	| 'reviewing_qa' // QA in progress (sandbox unit tests or qa-runner act)
 	| 'reviewing_rollup' // Plan rollup review in progress
 	| 'complete' // All tasks completed successfully
+	| 'complete_with_deferrals' // Terminal-complete, but QA was conditionally_approved: some behavior deferred to operator-CI e2e (ADR-045)
 	| 'archived' // Plan archived (soft deleted)
 	| 'failed'; // Execution failed
 
@@ -178,7 +179,8 @@ export function derivePlanPipeline(plan: PlanWithStatus): PlanPipeline {
 		'implementing',
 		'executing',
 		'reviewing_rollup',
-		'complete'
+		'complete',
+		'complete_with_deferrals'
 	];
 	const reqsActiveStages: PlanStage[] = [
 		'approved',
@@ -198,7 +200,10 @@ export function derivePlanPipeline(plan: PlanWithStatus): PlanPipeline {
 
 	// Determine execute phase state
 	let executeState: PlanPhaseState = 'none';
-	if (stage === 'complete') {
+	if (stage === 'complete' || stage === 'complete_with_deferrals') {
+		// complete_with_deferrals is terminal-complete (work assembled); the
+		// "not all-green" nuance is carried by the stage label, not the pipeline
+		// phase, so the execute phase reads as done rather than stalled.
 		executeState = 'complete';
 	} else if (stage === 'failed') {
 		executeState = 'failed';
@@ -220,7 +225,7 @@ export const LOCKED_STAGES: readonly string[] = [
 	'drafting', 'reviewing_draft', 'approved',
 	'generating_requirements', 'generating_architecture', 'generating_scenarios',
 	'reviewing_scenarios', 'implementing', 'executing',
-	'reviewing_rollup', 'complete', 'failed', 'archived',
+	'reviewing_rollup', 'complete', 'complete_with_deferrals', 'failed', 'archived',
 ] as const;
 
 /**
@@ -249,6 +254,7 @@ export function getStageLabel(stage: PlanStage): string {
 		executing: 'Executing',
 		reviewing_rollup: 'Reviewing',
 		complete: 'Complete',
+		complete_with_deferrals: 'Complete — e2e deferred',
 		archived: 'Archived',
 		failed: 'Failed'
 	};

--- a/workflow/subjects.go
+++ b/workflow/subjects.go
@@ -137,6 +137,21 @@ type QAFailure struct {
 	LogExcerpt string `json:"log_excerpt,omitempty"`
 }
 
+// QASkippedTest identifies a single test the executor reported as SKIPPED (not
+// run). The executor does NOT decide whether a skip is acceptable — that is a
+// judgment call for qa-reviewer, which reads each skipped test's source to tell
+// a legitimate environment/sandbox limitation (e.g. a test gated on a live
+// SITL/hardware endpoint the sandbox can't provide) from a gamed skip (e.g. a
+// disabled test dodging a failure). The skip *reason* is deliberately absent:
+// it is frequently not present in machine-readable test output (Gradle's JUnit
+// XML emits a bare <skipped/>), so the reason is recovered by the reviewer from
+// the test source, not parsed here. See ADR — QA skip reasoning.
+type QASkippedTest struct {
+	Suite string `json:"suite,omitempty"` // test suite / class (e.g. JUnit classname)
+	Name  string `json:"name"`            // test method / case name
+	File  string `json:"file,omitempty"`  // workspace-relative report file the skip was read from
+}
+
 // QAArtifactRef is a workspace-relative reference to an artifact produced by a
 // QA run (logs, screenshots, traces, coverage reports).
 type QAArtifactRef struct {
@@ -149,16 +164,21 @@ type QAArtifactRef struct {
 // qa-reviewer consumes it and produces a QAVerdictEvent. plan-manager does
 // NOT consume this event directly.
 type QACompletedEvent struct {
-	Slug        string          `json:"slug"`
-	PlanID      string          `json:"plan_id"`
-	RunID       string          `json:"run_id"`
-	Level       QALevel         `json:"level"` // level the executor ran at
-	Passed      bool            `json:"passed"`
-	Failures    []QAFailure     `json:"failures,omitempty"`
-	Artifacts   []QAArtifactRef `json:"artifacts,omitempty"`
-	DurationMs  int64           `json:"duration_ms"`
-	RunnerError string          `json:"runner_error,omitempty"` // executor infra error, distinct from test failures
-	TraceID     string          `json:"trace_id,omitempty"`
+	Slug     string      `json:"slug"`
+	PlanID   string      `json:"plan_id"`
+	RunID    string      `json:"run_id"`
+	Level    QALevel     `json:"level"` // level the executor ran at
+	Passed   bool        `json:"passed"`
+	Failures []QAFailure `json:"failures,omitempty"`
+	// SkippedTests lists tests the executor ran but reported as SKIPPED. A skip
+	// is NOT a failure here (Passed reflects only build + executed-test success);
+	// qa-reviewer reasons about whether each skip is a legitimate sandbox
+	// limitation (→ conditionally_approved) or gaming (→ needs_changes).
+	SkippedTests []QASkippedTest `json:"skipped_tests,omitempty"`
+	Artifacts    []QAArtifactRef `json:"artifacts,omitempty"`
+	DurationMs   int64           `json:"duration_ms"`
+	RunnerError  string          `json:"runner_error,omitempty"` // executor infra error, distinct from test failures
+	TraceID      string          `json:"trace_id,omitempty"`
 }
 
 // QAVerdict describes qa-reviewer's release-readiness decision.
@@ -166,8 +186,18 @@ type QAVerdict string
 
 const (
 	// QAVerdictApproved means the plan passes qa-reviewer's judgment and can
-	// proceed to complete (or awaiting_review when gated).
+	// proceed to complete (or awaiting_review when gated). Only valid when the
+	// executor ran with NO skipped tests — a fully-green run.
 	QAVerdictApproved QAVerdict = "approved"
+	// QAVerdictConditionallyApproved means everything the sandbox could execute
+	// passed, but some tests were SKIPPED because they require an environment
+	// the sandbox cannot provide (e.g. a live SITL/hardware endpoint), and
+	// qa-reviewer judged those skips to be legitimate deferrals — not gaming.
+	// The plan reaches a terminal "complete with deferrals" state: as verified
+	// as this tier allows, but explicitly NOT all-green — the deferred behavior
+	// must be verified in the operator-CI e2e tier (ADR-045). Distinct from
+	// approved so it is never rendered as "good to go."
+	QAVerdictConditionallyApproved QAVerdict = "conditionally_approved"
 	// QAVerdictNeedsChanges means qa-reviewer found issues fixable with a
 	// retry. PlanDecisions accompany this verdict.
 	QAVerdictNeedsChanges QAVerdict = "needs_changes"

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -733,14 +733,15 @@ type Plan struct {
 // Mirrors the informative fields of QACompletedEvent minus slug/plan_id/level
 // which already live on the plan.
 type QARun struct {
-	RunID       string          `json:"run_id"`
-	Passed      bool            `json:"passed"`
-	Failures    []QAFailure     `json:"failures,omitempty"`
-	Artifacts   []QAArtifactRef `json:"artifacts,omitempty"`
-	DurationMs  int64           `json:"duration_ms"`
-	RunnerError string          `json:"runner_error,omitempty"`
-	TraceID     string          `json:"trace_id,omitempty"`
-	CompletedAt time.Time       `json:"completed_at"`
+	RunID        string          `json:"run_id"`
+	Passed       bool            `json:"passed"`
+	Failures     []QAFailure     `json:"failures,omitempty"`
+	SkippedTests []QASkippedTest `json:"skipped_tests,omitempty"`
+	Artifacts    []QAArtifactRef `json:"artifacts,omitempty"`
+	DurationMs   int64           `json:"duration_ms"`
+	RunnerError  string          `json:"runner_error,omitempty"`
+	TraceID      string          `json:"trace_id,omitempty"`
+	CompletedAt  time.Time       `json:"completed_at"`
 }
 
 // QAVerdictSummary is the persisted, human-readable form of the qa-reviewer's


### PR DESCRIPTION
## Problem

The sandbox QA executor failed an integration run if **any** test was reported SKIPPED (`passed = exit0 && !timedOut && noSkips`, the #193 no-false-green guard). That made a fixture whose behavior tests need a live external harness — e.g. SITL tests that `assumeTrue(SITL_ENDPOINT != null)` and therefore always skip in the sandbox — **permanently un-passable**: the gate demanded a simulator the sandbox can't provide, regardless of code quality.

A skip is neither inherently a failure nor a pass. Whether it's a **legitimate sandbox limitation** or **gaming** (a disabled test dodging a failure) is a judgment call — and JUnit XML can't answer it (Gradle emits a bare `<skipped/>` with no reason; not every project is JUnit). So this routes the judgment to the QA agent, with a deterministic safety net so a skip can never silently become all-green.

## Design

New verdict **`conditionally_approved`** — terminal "done with deferrals", visibly **NOT** all-green. Trichotomy:

| Outcome | Decided by | Result |
|---|---|---|
| build/test failure or timeout | deterministic (unchanged) | 🔴 red — no LLM in this path |
| build + all **run** tests pass, **no skips** | agent | 🟢 `approved` |
| build + all **run** tests pass, **skipped** | **agent classifies each skip** | 🟡 `conditionally_approved` (legit sandbox limit → deferred to operator-CI e2e, ADR-045) **or** 🔴 `needs_changes` (gamed/unjustified) |

**Invariant preserved:** the safety net `reconcileSkipVerdict` coerces `approved + skips → needs_changes` (fail-closed). A skip never silently passes as green — the rule just moved from "auto-fail" to "agent must justify; unjustified → red".

## Changes

- **workflow**: `QAVerdictConditionallyApproved`; `QASkippedTest` + `SkippedTests` on `QACompletedEvent` and `QARun`.
- **cmd/sandbox**: `passed = exit0 && !timedOut`; `integrationSkippedTests`/`parseSkippedJUnitCases` parse JUnit reports (recursive — handles `<testsuites>`/nested suites) into skip *evidence* instead of auto-failing.
- **qa-reviewer**: skip evidence + classification instructions in Murat's prompt; `reconcileSkipVerdict` safety net; `isValidQAVerdict` accepts the new verdict; lessons recorded on the **reconciled** (published) verdict so a coerced `approved→needs_changes` still teaches the reviewer.
- **plan-manager**: `conditionally_approved` shares the approved → assemble → `complete` terminal path; distinct user-facing stage `complete_with_deferrals` (Status stays `complete` — no state-machine/enum churn, e2e Status-polling unaffected).
- **ui**: `PlanStage` union, pipeline derivation, locked stages, label ("Complete — e2e deferred").

## Testing

Offline-tested at every layer. `go build ./...` + `go test ./...` green; UI `svelte-check` 0 errors.

- `TestReconcileSkipVerdict` / `TestBuildQAVerdictEventSkipGuard` — the fail-closed safety net (approved+skips → needs_changes), incl. end-to-end through `buildQAVerdictEvent`.
- `TestRunSandboxQAIntegrationReportsSkipsAsEvidenceNotFailure` — uses the **real** captured `<skipped/>` fixture (bare, no reason — why the reason can't be parsed).
- `TestRunSandboxQAIntegrationFailsOnRealTestFailure` — deterministic red unchanged.
- `TestParseSkippedJUnitCases` — single root, `<testsuites>` wrapper, nested suite, malformed.
- `TestDeterminePlanStage_ConditionallyApproved` / `TestHandleQAVerdictMutation_AcceptsConditionallyApproved`.

## Review

go-reviewer pass: fixed lessons-loop (record on reconciled verdict), frontend stage (no stalled-pipeline render), nested-suite skip drop (recursive parser). Consciously **declined** parsing `<failure>`/`<error>` from XML to harden exit-0-with-failures — it risks false-*reds* from stale report files, and the exit-code contract for failures is unchanged and well-tested.

## Behavior change to expect

The `osh-driver-mavsdk` fixture's SITL tests now drive `conditionally_approved` (terminal `complete_with_deferrals`) instead of a permanent red — the deliverable is reported as "verified all the sandbox can; flight behavior deferred to operator-CI e2e."

🤖 Generated with [Claude Code](https://claude.com/claude-code)