### PR TITLE
fix(config/e2e): hybrid-gpt5 + active-poll hardening ahead of next hybrid run

### DIFF
--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -939,6 +939,7 @@
         "accepted_subject": "workflow.events.plan-decision.accepted",
         "auto_accept_recovery": true,
         "timeout_seconds": 120,
+        "max_auto_architecture_revises": 2,
         "ports": {
           "inputs": [
             {

--- a/configs/e2e-hybrid-gpt5.json
+++ b/configs/e2e-hybrid-gpt5.json
@@ -149,12 +149,12 @@
         ]
       },
       "reviewing": {
-        "description": "Code review, quality analysis — same code-specialized model as coding, so it reviews against the same mental model that produced the change.",
+        "description": "Code review, quality analysis. Deliberately NOT gpt-5.5 (the coding model): gpt-5.5 in the reviewer slot wedged ~15min with request_timeout unenforced (2026-05-31). gemini-pro reviews reliably; gpt-5-5 retained only as fallback.",
         "preferred": [
-          "gpt-5-5"
+          "gemini-pro"
         ],
         "fallback": [
-          "gemini-pro",
+          "gpt-5-5",
           "gemini-flash"
         ]
       },
@@ -250,7 +250,7 @@
         "fallback": [
           "seminstruct-summary"
         ],
-        "timeout": "60s"
+        "timeout": "300s"
       },
       "question_answering": {
         "description": "Answerer-agent backend for ask_question routes — bigger reasoning model than workflow default.",

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -769,6 +769,20 @@ tasks:
             mavlink-decode)     echo '100m' ;;  # PW cap 80m + 20m
             *)                  echo '40m' ;;   # easy/medium PW cap 20m + 20m
           esac
+      # Per-tier active-poll implementing wedge threshold. #182 made the
+      # implementing wedge clock node-aware: this is the max time with NO node
+      # progress before a stall warns, not total time in implementing. On hard
+      # tiers a single node (cold gradle build + slow gpt-5.5 coding/reviewing
+      # calls, 900s request_timeout each) legitimately runs past the 1800s
+      # script default and tripped false WEDGE_DETECTs. Raise headroom for hard;
+      # keep easy/medium tight so genuine stalls still surface.
+      WEDGE_IMPLEMENTING_SECONDS:
+        sh: |
+          case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
+            hard|mavlink-hard)  echo '5400' ;;  # 90min — slowest legit single node on hard/hybrid
+            mavlink-decode)     echo '3600' ;;  # 60min
+            *)                  echo '1800' ;;  # easy/medium (script default)
+          esac
     # Export E2E_FIXTURE to docker-compose env so semspec's /workspace mount
     # ($E2E_FIXTURE:-go-project in ui/docker-compose.e2e.yml) matches what the
     # epic overlay hardcodes for sandbox + workspace semsource. Without this
@@ -790,6 +804,8 @@ tasks:
       SEMSPEC_EXECUTION_MANAGER_TIMEOUT_SECONDS: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}"
       SEMSPEC_SCENARIO_ORCH_TIMEOUT: "{{.REQ_EXECUTOR_TIMEOUT_SECONDS}}s"
       SEMSPEC_MAX_REQUIREMENT_RETRIES: "{{.MAX_REQUIREMENT_RETRIES}}"
+      # Per-tier active-poll implementing wedge threshold (consumed by active-poll.sh).
+      WEDGE_THRESHOLD_IMPLEMENTING: "{{.WEDGE_IMPLEMENTING_SECONDS}}"
     cmds:
       - |
         if [ ! -f "configs/{{.E2E_CONFIG}}" ]; then


### PR DESCRIPTION
Config + monitoring hardening for the next **gemini/OpenAI hybrid** mavlink-hard run, from a 2026-06-16 audit of the hybrid model registry/configs vs gemini. The next run uses `configs/e2e-hybrid-gpt5.json` (invoked `task e2e:watch:llm -- hybrid-gpt5 …`) — note `hybrid` (no suffix) is gemini/**Anthropic**, not OpenAI.

## Commits

### 1. `reviewer off gpt-5.5` + community_summary timeout (`e2e-hybrid-gpt5.json`)
- **`reviewing`: preferred `gpt-5-5` → `gemini-pro`** (gpt-5-5 demoted to fallback). `CapabilityReviewing` feeds BOTH reviewer slots on the hard path — the dev-loop code reviewer (`execution-manager/component.go:2084`) and qa-reviewer (`qa-reviewer/component.go:462,1308`). gpt-5.5 in the reviewer slot wedged ~15min with `request_timeout` unenforced (2026-05-31 lesson). `coding` stays `gpt-5-5` (the hybrid's intent; not implicated in the hang).
- **`community_summary` timeout `60s` → `300s`** to match `e2e-gemini.json`. The identical description notes the `seminstruct-summary` CPU fallback runs >180s, so 60s would time it out.

### 2. `max_auto_architecture_revises` 1 → 2 (`e2e-hybrid-gpt5.json`)
Was unset → resolved to the code default of 1 (`plan-decision-handler/component.go:82`). `e2e-gemini.json` sets 2 for the hard tier (more autonomous `architecture_revise` recovery before human review). Hard-run **parity** fix — not the 0-is-broken footgun (the component defaults unset→1).

### 3. Per-tier active-poll implementing wedge threshold (`taskfiles/e2e.yml`)
`active-poll.sh` defaults `WEDGE_THRESHOLD_IMPLEMENTING` to 1800s. #182 made the implementing wedge clock node-aware (resets on node progress) → the threshold is "max time with NO node progress before a stall warns." On hard/hybrid a single node (cold gradle build + slow gpt-5.5 calls, 900s request_timeout each) exceeds 30min and tripped **false** `WEDGE_DETECT`s. Add a per-tier overlay (matching the existing REQ_EXECUTOR_TIMEOUT / WATCH_MAX_DURATION pattern): hard/mavlink-hard → 5400s (90min), mavlink-decode → 3600s, else 1800s.

## Not included (filed separately)
The `agentic-tools-…-tool-execute-all` consumer redelivery (#140 class — ack_wait too short for long gradle bash tools) is **not** a semspec config knob; the component is the semstreams library's. Filed as a semstreams ask.

## Validation
`task --list` parses clean; both edited configs validate structurally (after env-expansion neutralization); model tags verified current (gemini-3.x, gpt-5.5, sonnet-4-6) — the staleness was routing, not tags.

Audit notes also produced tracking issue #201 (no per-step retry metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)