### PR TITLE
[codex] surface execution run visibility

### DIFF
--- a/processor/execution-manager/mutations.go
+++ b/processor/execution-manager/mutations.go
@@ -138,8 +138,20 @@ type ReqPhaseRequest struct {
 
 // ReqResetRequest deletes a requirement execution entry from EXECUTION_STATES.
 // Called by plan-manager's retry handler to clear failed/error entries before re-dispatch.
+//
+// SMELL / TRACKED (2026-06-16, not fixing now): this crosses the
+// plan-manager↔execution-manager boundary as a raw, untyped KV key string —
+// plan-manager builds the key by string concatenation, execution-manager
+// blindly deletes whatever it receives. That stringly-typed coupling is the
+// root cause of the 2026-06-16 architecture_revise re-dispatch wedge: the
+// plan-manager reset matched only the "req.<slug>." prefix and silently missed
+// the "task.<slug>.node-*" entries, which orphaned and blocked re-dispatch.
+// Two reset paths shared the blind spot (resetRequirementExecutions and
+// resetRequirementExecutionsByID). A typed descriptor — (entityKind, slug, id)
+// instead of a pre-joined key — would make a missed key family a compile error
+// rather than a silent prod wedge. Follow-up: see the tracking issue.
 type ReqResetRequest struct {
-	Key string `json:"key"` // KV key: req.<slug>.<reqID>
+	Key string `json:"key"` // KV key: req.<slug>.<reqID> | task.<slug>.node-<...>
 }
 
 // ReqResetNodeResultsRequest replaces the NodeResults slice on an

--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -1301,8 +1301,9 @@ func (c *Component) handleRetryPlan(w http.ResponseWriter, r *http.Request, slug
 	})
 }
 
-// resetRequirementExecutions scans EXECUTION_STATES for req.<slug>.* keys and
-// resets entries selected by scope. Returns the number of entries reset.
+// resetRequirementExecutions scans EXECUTION_STATES for this plan's execution
+// entries — both req.<slug>.* (requirement-level) and task.<slug>.* (per-node
+// task) keys — and resets those selected by scope. Returns the number reset.
 //
 // Scope semantics:
 //
@@ -1317,7 +1318,17 @@ func (c *Component) resetRequirementExecutions(ctx context.Context, slug, scope 
 		return 0, nil
 	}
 
-	prefix := "req." + slug + "."
+	// EXECUTION_STATES holds two entry shapes for a plan, written by two
+	// different components:
+	//   req.<slug>.<reqID>     — requirement-level execution (requirement-executor)
+	//   task.<slug>.node-<...> — per-node task execution (execution-manager)
+	// A full reset must clear BOTH. The req.-only filter used previously left
+	// escalated task-node entries stranded: after an architecture_revise
+	// recovery re-planned the plan back to ready_for_execution, the orphaned
+	// task node blocked re-dispatch and the plan wedged (2026-06-16 hybrid-gpt5
+	// mavlink-hard). See reset_execution_taskkeys_test.go.
+	reqPrefix := "req." + slug + "."
+	taskPrefix := "task." + slug + "."
 	keys, err := bucket.Keys(ctx, jetstream.MetaOnly())
 	if err != nil {
 		if errors.Is(err, jetstream.ErrNoKeysFound) {
@@ -1326,8 +1337,7 @@ func (c *Component) resetRequirementExecutions(ctx context.Context, slug, scope 
 		return 0, fmt.Errorf("list execution keys: %w", err)
 	}
 
-	// Build a quick lookup set for scope="requirements". The key format is
-	// "req.<slug>.<requirement_id>" so we match the suffix after the prefix.
+	// Build a quick lookup set for scope="requirements".
 	var idSet map[string]struct{}
 	if scope == "requirements" {
 		idSet = make(map[string]struct{}, len(requirementIDs))
@@ -1340,31 +1350,53 @@ func (c *Component) resetRequirementExecutions(ctx context.Context, slug, scope 
 
 	var resetCount int
 	for _, key := range keys {
-		if !strings.HasPrefix(key, prefix) {
+		isReq := strings.HasPrefix(key, reqPrefix)
+		isTask := strings.HasPrefix(key, taskPrefix)
+		if !isReq && !isTask {
 			continue
 		}
 
 		switch scope {
 		case "failed":
-			// Only reset entries in a failed or error stage.
+			// Only reset entries currently in a failed or error stage. Applies
+			// to both req and task entries — both carry a "stage" field.
 			entry, getErr := bucket.Get(ctx, key)
 			if getErr != nil {
 				c.logger.Debug("Failed to get execution entry during retry scan", "key", key, "error", getErr)
 				continue
 			}
-			var reqExec struct {
+			var execMeta struct {
 				Stage string `json:"stage"`
 			}
-			if jsonErr := json.Unmarshal(entry.Value(), &reqExec); jsonErr != nil {
+			if jsonErr := json.Unmarshal(entry.Value(), &execMeta); jsonErr != nil {
 				c.logger.Debug("Failed to unmarshal execution entry during retry scan", "key", key, "error", jsonErr)
 				continue
 			}
-			if reqExec.Stage != "failed" && reqExec.Stage != "error" {
+			if execMeta.Stage != "failed" && execMeta.Stage != "error" {
 				continue
 			}
 		case "requirements":
-			// Match the requirement_id portion of the key against the allow-list.
-			reqID := strings.TrimPrefix(key, prefix)
+			// Match against the allow-list. req.* keys carry the requirement id
+			// as the key suffix; task.* keys carry it in the entry body (the
+			// key suffix is the node id, not a requirement id).
+			reqID := ""
+			if isReq {
+				reqID = strings.TrimPrefix(key, reqPrefix)
+			} else {
+				entry, getErr := bucket.Get(ctx, key)
+				if getErr != nil {
+					c.logger.Debug("Failed to get task execution entry during requirements scan", "key", key, "error", getErr)
+					continue
+				}
+				var execMeta struct {
+					RequirementID string `json:"requirement_id"`
+				}
+				if jsonErr := json.Unmarshal(entry.Value(), &execMeta); jsonErr != nil {
+					c.logger.Debug("Failed to unmarshal task execution entry during requirements scan", "key", key, "error", jsonErr)
+					continue
+				}
+				reqID = execMeta.RequirementID
+			}
 			if _, ok := idSet[reqID]; !ok {
 				continue
 			}

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1806,6 +1806,14 @@ func (c *Component) handleGitHubPRMetadataMutation(ctx context.Context, data []b
 // resetRequirementExecutionsByID resets specific requirement executions by ID,
 // regardless of their current stage. Used by PR feedback to reset completed
 // requirements for re-execution.
+//
+// KNOWN GAP / TRACKED (2026-06-16, not fixing now): this only constructs and
+// resets "req.<slug>.<reqID>" keys — it cannot reach the "task.<slug>.node-*"
+// per-node executions for those requirements, so escalated task nodes orphan
+// here exactly as they did in the architecture_revise wedge that
+// resetRequirementExecutions(scope="all") was fixed for. Same raw-key smell
+// (see execution-manager ReqResetRequest). When fixed, mirror the scope=
+// "requirements" task-key handling from resetRequirementExecutions.
 func (c *Component) resetRequirementExecutionsByID(ctx context.Context, slug string, reqIDs []string) (int, error) {
 	var resetCount int
 	for _, reqID := range reqIDs {

--- a/processor/plan-manager/reset_execution_taskkeys_test.go
+++ b/processor/plan-manager/reset_execution_taskkeys_test.go
@@ -1,0 +1,71 @@
+package planmanager
+
+import (
+	"context"
+	"testing"
+)
+
+// TestResetRequirementExecutions_All_ClearsTaskNodeKeys reproduces the
+// 2026-06-16 hybrid-gpt5 mavlink-hard wedge.
+//
+// Sequence observed live (plan 94dd8f41465d):
+//  1. requirement.1 dev node hit a "restructure rejection" → markEscalatedLocked
+//     → RecoveryRequested → recovery-agent chose architecture_revise
+//     (recovery_succeeded=true).
+//  2. applyArchitectureRevise back-transitioned the plan to
+//     requirements_generated and called resetRequirementExecutions(scope="all")
+//     to "wipe ... all requirement executions", then the pipeline re-planned
+//     forward to ready_for_execution.
+//  3. The plan then WEDGED at ready_for_execution (idle, never re-dispatched).
+//
+// Root cause: EXECUTION_STATES carries per-node task executions keyed
+// "task.<slug>.node-*" (execution-manager owns them), but
+// resetRequirementExecutions only matches the "req.<slug>." prefix. The
+// scope="all" reset therefore skips the escalated task-node entries; they
+// orphan and block re-dispatch.
+//
+// This test seeds the bucket with the live key shapes (a req.* entry AND two
+// task.*.node-* entries — exactly what the EXECUTION_STATES dump showed) and
+// asserts scope="all" clears EVERY execution entry for the plan. It FAILS
+// against the current "req." prefix filter and passes once the reset also
+// covers task-node keys.
+func TestResetRequirementExecutions_All_ClearsTaskNodeKeys(t *testing.T) {
+	c := setupTestComponent(t)
+	c.execBucket = resetKVStub{keys: []string{
+		"req.demo.1",                            // requirement-level execution
+		"task.demo.node-eb2926e6097b66c7-aaaa",  // approved task node
+		"task.demo.node-0ea0bba39b5a2ac6-bbbb",  // escalated task node (the orphan)
+	}}
+	var reset []string
+	c.reqResetSender = func(_ context.Context, key string) error {
+		reset = append(reset, key)
+		return nil
+	}
+
+	n, err := c.resetRequirementExecutions(context.Background(), "demo", "all", nil)
+	if err != nil {
+		t.Fatalf("resetRequirementExecutions returned error: %v", err)
+	}
+
+	// scope="all" must clear every execution entry for the plan — the req.*
+	// entry AND both task.*.node-* entries. The current prefix filter only
+	// matches "req.demo." so n==1 and the task nodes survive.
+	if n != 3 {
+		t.Errorf("reset count = %d, want 3 (1 req + 2 task nodes); task.<slug>.node-* keys are being skipped by the req.-prefix filter", n)
+	}
+	for _, want := range []string{
+		"task.demo.node-eb2926e6097b66c7-aaaa",
+		"task.demo.node-0ea0bba39b5a2ac6-bbbb",
+	} {
+		found := false
+		for _, k := range reset {
+			if k == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("task-node execution %q was NOT reset by scope=all — architecture_revise leaves it orphaned, which blocks re-dispatch (the ready_for_execution wedge)", want)
+		}
+	}
+}

--- a/ui/src/lib/components/activity/ActivityFeed.svelte
+++ b/ui/src/lib/components/activity/ActivityFeed.svelte
@@ -29,8 +29,8 @@
 
 	let sourceFilter = $state<string>('all');
 
-	const sourceOptions = ['all', 'plan', 'execution', 'question'];
-	const sourcesForCount = ['plan', 'execution', 'question'] as const;
+	const sourceOptions = ['all', 'plan', 'execution', 'activity', 'question'];
+	const sourcesForCount = ['plan', 'execution', 'activity', 'question'] as const;
 
 	// All events before the source-filter is applied. We need the unfiltered
 	// list so per-source counts in the dropdown reflect the totals, not the
@@ -73,6 +73,8 @@
 					return 'hammer';
 				}
 				return 'layers';
+			case 'activity':
+				return 'activity';
 			case 'question':
 				if (event.type === 'question_answered') return 'check-circle';
 				if (event.type === 'question_timeout') return 'clock';
@@ -96,6 +98,8 @@
 				if (stage === 'error' || stage === 'failed' || stage === 'escalated') return 'var(--color-error)';
 				return 'var(--color-text-muted)';
 			}
+			case 'activity':
+				return 'var(--color-text-muted)';
 			case 'question':
 				if (event.type === 'question_answered') return 'var(--color-success)';
 				if (event.type === 'question_timeout') return 'var(--color-warning, var(--color-error))';
@@ -114,6 +118,7 @@
 			all: 'All events',
 			plan: 'Plan',
 			execution: 'Execution',
+			activity: 'Activity',
 			question: 'Questions'
 		};
 		return labels[source] ?? source;
@@ -546,6 +551,11 @@
 	.event-source-tag.execution {
 		background: color-mix(in srgb, var(--color-success) 15%, transparent);
 		color: var(--color-success);
+	}
+
+	.event-source-tag.activity {
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-muted);
 	}
 
 	.event-source-tag.question {

--- a/ui/src/lib/components/activity/feedRouting.test.ts
+++ b/ui/src/lib/components/activity/feedRouting.test.ts
@@ -111,7 +111,7 @@ describe('getRequirementAnchor — bug #7.9 requirement pill', () => {
 });
 
 describe('countBySource — bug #7.5 dropdown counts', () => {
-	const sources = ['plan', 'execution', 'question'] as const;
+	const sources = ['plan', 'execution', 'activity', 'question'] as const;
 
 	it('sums events per source plus an all-events total', () => {
 		const events = [
@@ -120,10 +120,11 @@ describe('countBySource — bug #7.5 dropdown counts', () => {
 			baseEvent({ id: '3', source: 'execution' }),
 			baseEvent({ id: '4', source: 'execution' }),
 			baseEvent({ id: '5', source: 'execution' }),
-			baseEvent({ id: '6', source: 'question' })
+			baseEvent({ id: '6', source: 'activity' }),
+			baseEvent({ id: '7', source: 'question' })
 		];
 		const counts = countBySource(events, sources);
-		expect(counts).toEqual({ all: 6, plan: 2, execution: 3, question: 1 });
+		expect(counts).toEqual({ all: 7, plan: 2, execution: 3, activity: 1, question: 1 });
 	});
 
 	it('reports zero for sources with no events (so dropdown can grey them)', () => {
@@ -131,12 +132,13 @@ describe('countBySource — bug #7.5 dropdown counts', () => {
 		const counts = countBySource(events, sources);
 		expect(counts.plan).toBe(1);
 		expect(counts.execution).toBe(0);
+		expect(counts.activity).toBe(0);
 		expect(counts.question).toBe(0);
 	});
 
 	it('returns zeros + 0 total for empty input', () => {
 		const counts = countBySource([], sources);
-		expect(counts).toEqual({ all: 0, plan: 0, execution: 0, question: 0 });
+		expect(counts).toEqual({ all: 0, plan: 0, execution: 0, activity: 0, question: 0 });
 	});
 
 	it('ignores events with unknown sources (defensive against wire drift)', () => {

--- a/ui/src/lib/components/activity/feedRouting.ts
+++ b/ui/src/lib/components/activity/feedRouting.ts
@@ -39,8 +39,8 @@ export function getEventLinkText(event: FeedEvent): string {
 /**
  * Count events by `source` field for the filter dropdown (bug #7.5).
  * Returns totals for "all" plus each known source, so the dropdown can show
- * "All events (42) / Plan (5) / Execution (37) / Questions (0)" and the user
- * can tell at a glance which source dominates.
+ * "All events (42) / Plan (5) / Execution (37) / Activity (2) / Questions (0)"
+ * and the user can tell at a glance which source dominates.
  *
  * `knownSources` is typed off FeedEvent['source'] so the compiler fails the
  * component build if the wire-level union grows and the component's filter

--- a/ui/src/lib/components/graph/SigmaCanvas.svelte
+++ b/ui/src/lib/components/graph/SigmaCanvas.svelte
@@ -43,6 +43,7 @@
 	let graph: MultiDirectedGraph | null = null;
 	let layout: LayoutController | null = null;
 	let lastEntityCount = 0;
+	let renderError = $state<string | null>(null);
 
 	// Initialise Sigma once the container is in the DOM — SSR safe
 	$effect(() => {
@@ -164,14 +165,21 @@
 		void relationships.length;
 		if (entities.length === 0 && graph.order === 0) return;
 
-		const prevCount = lastEntityCount;
-		syncStoreToGraph(graph, entities, relationships);
-		// Only restart layout when new data arrives (load/expand), not on filter toggle
-		if (entities.length !== prevCount) {
-			layout.start(graph);
-			lastEntityCount = entities.length;
+		try {
+			const prevCount = lastEntityCount;
+			syncStoreToGraph(graph, entities, relationships);
+			// Only restart layout when new data arrives (load/expand), not on filter toggle
+			if (entities.length !== prevCount) {
+				layout.start(graph);
+				lastEntityCount = entities.length;
+			}
+			sigma.refresh();
+			renderError = null;
+		} catch (err) {
+			layout.stop();
+			renderError = err instanceof Error ? err.message : 'Graph rendering failed';
+			console.error('Graph rendering failed', err);
 		}
-		sigma.refresh();
 	});
 
 	// Refresh renderer when selection or hover state changes
@@ -200,8 +208,15 @@
 
 	function handleRefreshLayout() {
 		if (!graph || !layout || !sigma) return;
-		layout.start(graph);
-		sigma.refresh();
+		try {
+			layout.start(graph);
+			sigma.refresh();
+			renderError = null;
+		} catch (err) {
+			layout.stop();
+			renderError = err instanceof Error ? err.message : 'Graph rendering failed';
+			console.error('Graph layout refresh failed', err);
+		}
 	}
 </script>
 
@@ -251,8 +266,16 @@
 		</div>
 	{/if}
 
+	<!-- Renderer failures stay local so the surrounding app shell remains usable. -->
+	{#if renderError}
+		<div class="empty-state" role="alert">
+			<p>Graph rendering failed.</p>
+			<p class="empty-hint">{renderError}</p>
+		</div>
+	{/if}
+
 	<!-- Empty state -->
-	{#if !loading && entities.length === 0}
+	{#if !loading && !renderError && entities.length === 0}
 		<div class="empty-state">
 			<p>No entities to display.</p>
 			<p class="empty-hint">Load initial data or adjust filters.</p>

--- a/ui/src/lib/components/plan/RunVisibilityPanel.svelte
+++ b/ui/src/lib/components/plan/RunVisibilityPanel.svelte
@@ -1,0 +1,706 @@
+<script lang="ts">
+	import Icon from '$lib/components/shared/Icon.svelte';
+	import {
+		formatDuration,
+		formatTokens,
+		summarizeRunVisibility,
+		type ExecutionTask,
+		type Lesson,
+		type RunStatusTone,
+		type TaskAttemptSummary,
+		type TaskGroupStatus
+	} from '$lib/types/runVisibility';
+	import type { PlanWithStatus } from '$lib/types/plan';
+	import type { TrajectoryListItem } from '$lib/types/trajectory';
+
+	interface Props {
+		plan: PlanWithStatus;
+		executionTasks?: ExecutionTask[];
+		trajectoryItems?: TrajectoryListItem[];
+		lessons?: Lesson[];
+	}
+
+	let {
+		plan,
+		executionTasks = [],
+		trajectoryItems = [],
+		lessons = []
+	}: Props = $props();
+
+	const visibility = $derived(
+		summarizeRunVisibility(plan, executionTasks, trajectoryItems, lessons)
+	);
+	const displayedWarnings = $derived(visibility.warnings.slice(0, 4));
+	const displayedLessons = $derived(visibility.lessons.slice(0, 6));
+
+	function statusIcon(tone: RunStatusTone): string {
+		switch (tone) {
+			case 'active':
+				return 'loader';
+			case 'success':
+				return 'check-circle';
+			case 'warning':
+				return 'alert-triangle';
+			case 'danger':
+				return 'x-circle';
+			default:
+				return 'activity';
+		}
+	}
+
+	function groupStatusLabel(status: TaskGroupStatus): string {
+		switch (status) {
+			case 'active':
+				return 'Active';
+			case 'approved':
+				return 'Approved';
+			case 'recovered':
+				return 'Recovered';
+			case 'blocked':
+				return 'Blocked';
+			default:
+				return 'Pending';
+		}
+	}
+
+	function attemptIcon(attempt: TaskAttemptSummary): string {
+		switch (attempt.stage) {
+			case 'approved':
+				return 'check-circle';
+			case 'error':
+			case 'rejected':
+				return 'x-circle';
+			case 'escalated':
+				return 'alert-triangle';
+			default:
+				return 'loader';
+		}
+	}
+
+	function attemptTone(attempt: TaskAttemptSummary): string {
+		switch (attempt.stage) {
+			case 'approved':
+				return 'success';
+			case 'error':
+			case 'rejected':
+				return 'danger';
+			case 'escalated':
+				return 'warning';
+			default:
+				return 'active';
+		}
+	}
+
+	function cycleLabel(attempt: TaskAttemptSummary): string {
+		if (typeof attempt.tddCycle !== 'number') return '';
+		const current = attempt.tddCycle + 1;
+		if (typeof attempt.maxTddCycles === 'number') return `cycle ${current}/${attempt.maxTddCycles}`;
+		return `cycle ${current}`;
+	}
+
+	function shortRequirement(id: string | undefined): string {
+		if (!id) return 'Plan';
+		const match = id.match(/(\d+)$/);
+		return match ? `Req ${match[1]}` : id;
+	}
+
+	function shortSha(sha: string | undefined): string {
+		return sha ? sha.slice(0, 8) : '';
+	}
+
+	function timeLabel(value: string | null | undefined): string {
+		if (!value) return '';
+		const date = new Date(value);
+		if (!Number.isFinite(date.getTime())) return '';
+		return `${date.toISOString().slice(11, 19)}Z`;
+	}
+
+	function clip(text: string | undefined, max = 190): string {
+		if (!text) return '';
+		const compact = text.replace(/\s+/g, ' ').trim();
+		return compact.length > max ? `${compact.slice(0, max - 1)}...` : compact;
+	}
+</script>
+
+{#if visibility.shouldRender}
+	<section class="run-visibility" data-testid="run-visibility-panel">
+		<div class="status-band" data-tone={visibility.status.tone} role="status" aria-live="polite">
+			<div class="status-icon" aria-hidden="true">
+				<Icon name={statusIcon(visibility.status.tone)} size={22} />
+			</div>
+			<div class="status-copy">
+				<span class="eyebrow">Run state</span>
+				<h2>{visibility.status.title}</h2>
+				{#if visibility.status.detail}
+					<p>{clip(visibility.status.detail, 260)}</p>
+				{/if}
+			</div>
+			<div class="status-meta">
+				<span class="stage-chip">{visibility.status.stageLabel}</span>
+				{#if visibility.status.timestamp}
+					<span class="time-chip">
+						<Icon name="clock" size={13} />
+						{timeLabel(visibility.status.timestamp)}
+					</span>
+				{/if}
+			</div>
+		</div>
+
+		<div class="metric-row" aria-label="Run metrics">
+			<div class="metric">
+				<span>Tasks</span>
+				<strong>{visibility.taskStats.approvedGroups}/{visibility.taskStats.totalGroups}</strong>
+			</div>
+			<div class="metric">
+				<span>Attempts</span>
+				<strong>{visibility.taskStats.totalAttempts}</strong>
+			</div>
+			<div class="metric" class:metric-alert={visibility.warnings.length > 0}>
+				<span>Signals</span>
+				<strong>{visibility.warnings.length}</strong>
+			</div>
+			<div class="metric">
+				<span>Tokens</span>
+				<strong>{formatTokens(visibility.usage.totalTokens)}</strong>
+			</div>
+			<div class="metric">
+				<span>Cost</span>
+				<strong>{visibility.usage.costLabel}</strong>
+			</div>
+		</div>
+
+		{#if displayedWarnings.length > 0}
+			<div class="warning-lane" aria-label="Run warnings">
+				{#each displayedWarnings as warning (warning.kind + warning.relatedId)}
+					<div class="warning-row" data-tone={warning.tone}>
+						<Icon name={warning.tone === 'danger' ? 'x-circle' : 'alert-triangle'} size={15} />
+						<div>
+							<strong>{warning.title}</strong>
+							<span>{warning.detail}</span>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		{#if visibility.qa}
+			<div class="run-section qa-section">
+				<div class="section-heading">
+					<div>
+						<span class="eyebrow">QA</span>
+						<h3>{visibility.qa.level} verdict: {visibility.qa.verdict}</h3>
+					</div>
+					<div class="section-meta">
+						<span class="pill" data-tone={visibility.qa.passed ? 'success' : 'warning'}>
+							{visibility.qa.passed ? 'tests passed' : 'tests failed'}
+						</span>
+						{#if visibility.qa.durationMs}
+							<span class="pill">{formatDuration(visibility.qa.durationMs)}</span>
+						{/if}
+					</div>
+				</div>
+				{#if visibility.qa.summary}
+					<p class="section-summary">{clip(visibility.qa.summary, 320)}</p>
+				{/if}
+				{#if visibility.qa.skippedTests.length > 0}
+					<div class="skip-list">
+						<span class="skip-title">
+							<Icon name="skip-forward" size={13} />
+							{visibility.qa.skippedTests.length} skipped live test{visibility.qa.skippedTests.length === 1 ? '' : 's'}
+						</span>
+						{#each visibility.qa.skippedTests.slice(0, 4) as skipped, index (skipped.name + index)}
+							<span class="skip-item">{skipped.name}</span>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		{#if visibility.taskGroups.length > 0}
+			<div class="run-section">
+				<div class="section-heading">
+					<div>
+						<span class="eyebrow">Execution</span>
+						<h3>{visibility.taskStats.totalGroups} task group{visibility.taskStats.totalGroups === 1 ? '' : 's'}</h3>
+					</div>
+					<div class="section-meta">
+						<span class="pill" data-tone="success">{visibility.taskStats.approvedGroups} approved</span>
+						{#if visibility.taskStats.activeGroups > 0}
+							<span class="pill" data-tone="active">{visibility.taskStats.activeGroups} active</span>
+						{/if}
+						{#if visibility.taskStats.orphanedGroups > 0}
+							<span class="pill" data-tone="warning">{visibility.taskStats.orphanedGroups} recovered</span>
+						{/if}
+					</div>
+				</div>
+
+				<div class="task-list">
+					{#each visibility.taskGroups as group (group.key)}
+						<div class="task-group" data-status={group.status}>
+							<div class="task-main">
+								<span class="req-chip">{shortRequirement(group.requirementId)}</span>
+								<span class="task-title">{group.title}</span>
+								<span class="task-status" data-status={group.status}>{groupStatusLabel(group.status)}</span>
+							</div>
+							<div class="attempt-list">
+								{#each group.attempts as attempt, index (attempt.taskId)}
+									<div class="attempt-row" data-tone={attemptTone(attempt)}>
+										<Icon name={attemptIcon(attempt)} size={13} />
+										<span>Attempt {index + 1}</span>
+										<span class="attempt-stage">{attempt.stage}</span>
+										{#if cycleLabel(attempt)}
+											<span>{cycleLabel(attempt)}</span>
+										{/if}
+										{#if attempt.mergeCommit}
+											<span class="sha">
+												<Icon name="git-commit" size={12} />
+												{shortSha(attempt.mergeCommit)}
+											</span>
+										{/if}
+										{#if attempt.updatedAt}
+											<span class="attempt-time">{timeLabel(attempt.updatedAt)}</span>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		{#if displayedLessons.length > 0}
+			<div class="run-section lessons-section">
+				<div class="section-heading">
+					<div>
+						<span class="eyebrow">Learning</span>
+						<h3>{visibility.lessons.length} lesson{visibility.lessons.length === 1 ? '' : 's'} captured</h3>
+					</div>
+					<div class="section-meta">
+						<span class="pill" data-tone="success">
+							{visibility.lessons.filter((lesson) => lesson.positive).length} reinforcing
+						</span>
+						<span class="pill" data-tone="warning">
+							{visibility.lessons.filter((lesson) => !lesson.positive).length} corrective
+						</span>
+					</div>
+				</div>
+				<div class="lesson-list">
+					{#each displayedLessons as lesson (lesson.id)}
+						<div class="lesson-row" data-positive={lesson.positive}>
+							<Icon name={lesson.positive ? 'lightbulb' : 'alert-circle'} size={14} />
+							<div class="lesson-copy">
+								<span>{lesson.summary}</span>
+								<small>
+									{lesson.relatedTaskTitle ?? lesson.source}
+									<span aria-hidden="true">·</span>
+									{lesson.futureRunOnly ? 'future-run only' : `injected ${timeLabel(lesson.lastInjectedAt)}`}
+								</small>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</section>
+{/if}
+
+<style>
+	.run-visibility {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+		margin-bottom: var(--space-4);
+	}
+
+	.status-band {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		align-items: center;
+		gap: var(--space-3);
+		padding: var(--space-3) var(--space-4);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
+		background: var(--color-bg-secondary);
+	}
+
+	.status-band[data-tone='active'] {
+		border-color: var(--color-accent);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 14%, transparent);
+	}
+
+	.status-band[data-tone='success'] {
+		border-color: var(--color-success);
+	}
+
+	.status-band[data-tone='warning'] {
+		border-color: var(--color-warning);
+	}
+
+	.status-band[data-tone='danger'] {
+		border-color: var(--color-error);
+	}
+
+	.status-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		color: var(--color-text-secondary);
+		background: var(--color-bg-tertiary);
+	}
+
+	.status-band[data-tone='active'] .status-icon {
+		color: var(--color-accent);
+	}
+
+	.status-band[data-tone='active'] .status-icon :global(svg) {
+		animation: spin 1.6s linear infinite;
+	}
+
+	.status-band[data-tone='success'] .status-icon {
+		color: var(--color-success);
+	}
+
+	.status-band[data-tone='warning'] .status-icon {
+		color: var(--color-warning);
+	}
+
+	.status-band[data-tone='danger'] .status-icon {
+		color: var(--color-error);
+	}
+
+	.status-copy {
+		min-width: 0;
+	}
+
+	.eyebrow {
+		display: block;
+		margin-bottom: var(--space-1);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+	}
+
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h2 {
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-semibold);
+		color: var(--color-text-primary);
+	}
+
+	h3 {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		color: var(--color-text-primary);
+	}
+
+	p,
+	.section-summary {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-secondary);
+		line-height: var(--line-height-normal);
+	}
+
+	.status-meta,
+	.section-meta,
+	.metric-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+
+	.status-meta {
+		justify-content: flex-end;
+	}
+
+	.stage-chip,
+	.time-chip,
+	.pill,
+	.req-chip,
+	.task-status {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		min-height: 22px;
+		padding: 0 var(--space-2);
+		border-radius: var(--radius-full);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-secondary);
+		background: var(--color-bg-tertiary);
+		white-space: nowrap;
+	}
+
+	.metric-row {
+		display: grid;
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		gap: var(--space-2);
+	}
+
+	.metric {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: var(--space-1);
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-secondary);
+	}
+
+	.metric span {
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+	}
+
+	.metric strong {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		color: var(--color-text-primary);
+		line-height: var(--line-height-tight);
+		overflow-wrap: anywhere;
+	}
+
+	.metric-alert strong {
+		color: var(--color-warning);
+	}
+
+	.warning-lane,
+	.run-section {
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-lg);
+		background: var(--color-bg-secondary);
+		overflow: hidden;
+	}
+
+	.warning-row {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		color: var(--color-text-secondary);
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.warning-row:last-child {
+		border-bottom: none;
+	}
+
+	.warning-row[data-tone='warning'] {
+		color: var(--color-warning);
+	}
+
+	.warning-row[data-tone='danger'] {
+		color: var(--color-error);
+	}
+
+	.warning-row div {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.warning-row strong {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-primary);
+	}
+
+	.warning-row span {
+		font-size: var(--font-size-xs);
+		color: var(--color-text-secondary);
+		line-height: var(--line-height-normal);
+	}
+
+	.run-section {
+		padding: var(--space-3);
+	}
+
+	.section-heading {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--space-3);
+		margin-bottom: var(--space-3);
+	}
+
+	.pill[data-tone='success'],
+	.task-status[data-status='approved'] {
+		color: var(--color-success);
+		background: color-mix(in srgb, var(--color-success) 14%, transparent);
+	}
+
+	.pill[data-tone='warning'],
+	.task-status[data-status='recovered'],
+	.task-status[data-status='blocked'] {
+		color: var(--color-warning);
+		background: color-mix(in srgb, var(--color-warning) 14%, transparent);
+	}
+
+	.pill[data-tone='active'],
+	.task-status[data-status='active'] {
+		color: var(--color-accent);
+		background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+	}
+
+	.skip-list,
+	.task-list,
+	.lesson-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.skip-title,
+	.skip-item {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--space-1);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-secondary);
+	}
+
+	.skip-title {
+		color: var(--color-warning);
+		font-weight: var(--font-weight-medium);
+	}
+
+	.task-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-2) 0;
+		border-top: 1px solid var(--color-border);
+	}
+
+	.task-group:first-child {
+		border-top: none;
+		padding-top: 0;
+	}
+
+	.task-group:last-child {
+		padding-bottom: 0;
+	}
+
+	.task-main {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.task-title {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-medium);
+		color: var(--color-text-primary);
+		line-height: var(--line-height-normal);
+		overflow-wrap: anywhere;
+	}
+
+	.attempt-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		padding-left: var(--space-4);
+	}
+
+	.attempt-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		min-height: 22px;
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+	}
+
+	.attempt-row[data-tone='success'] {
+		color: var(--color-success);
+	}
+
+	.attempt-row[data-tone='warning'] {
+		color: var(--color-warning);
+	}
+
+	.attempt-row[data-tone='danger'] {
+		color: var(--color-error);
+	}
+
+	.attempt-stage,
+	.sha,
+	.attempt-time {
+		color: var(--color-text-secondary);
+	}
+
+	.sha {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		font-family: var(--font-family-mono);
+	}
+
+	.lesson-row {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		gap: var(--space-2);
+		color: var(--color-warning);
+	}
+
+	.lesson-row[data-positive='true'] {
+		color: var(--color-success);
+	}
+
+	.lesson-copy {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.lesson-copy span {
+		font-size: var(--font-size-sm);
+		color: var(--color-text-primary);
+		line-height: var(--line-height-normal);
+	}
+
+	.lesson-copy small {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+	}
+
+	@keyframes spin {
+		from { transform: rotate(0deg); }
+		to { transform: rotate(360deg); }
+	}
+
+	@media (max-width: 720px) {
+		.status-band,
+		.task-main {
+			grid-template-columns: auto minmax(0, 1fr);
+		}
+
+		.status-meta,
+		.task-status {
+			grid-column: 1 / -1;
+			justify-content: flex-start;
+		}
+
+		.metric-row {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.section-heading {
+			flex-direction: column;
+		}
+	}
+</style>

--- a/ui/src/lib/components/trajectory/ExecutionTimeline.svelte
+++ b/ui/src/lib/components/trajectory/ExecutionTimeline.svelte
@@ -64,11 +64,33 @@
 	// planning activity. `architecture-generation` was previously missing,
 	// causing those loops to land in the Execution section (caught 2026-05-21).
 	const PLAN_STEPS = new Set([
+		'exploring',
 		'drafting',
 		'reviewing',
 		'requirement-generation',
 		'architecture-generation',
-		'scenario-generation',
+		'story-preparation',
+		'scenario-generation'
+	]);
+
+	const PLAN_ROLES = new Set([
+		'planner',
+		'plan-reviewer',
+		'requirement-generator',
+		'architect',
+		'story-preparer',
+		'scenario-generator'
+	]);
+
+	const EXECUTION_SECTION_STAGES = new Set<PlanStage>([
+		'implementing',
+		'executing',
+		'ready_for_qa',
+		'reviewing_qa',
+		'reviewing_rollup',
+		'complete',
+		'complete_with_deferrals',
+		'failed'
 	]);
 
 	// Map TrajectoryListItem fields to the shape used throughout this component.
@@ -92,14 +114,18 @@
 
 	const planLoops = $derived(
 		loopEntries
-			.filter((l) => PLAN_STEPS.has(l.workflow_step ?? '') || isPlanRole(l))
+			.filter(isPlanLoop)
 			.sort(byCreatedAt)
 	);
 
 	const executionLoops = $derived(
 		loopEntries
-			.filter((l) => !PLAN_STEPS.has(l.workflow_step ?? '') && !isPlanRole(l))
+			.filter((l) => !isPlanLoop(l))
 			.sort(byCreatedAt)
+	);
+	const executionStageReached = $derived(EXECUTION_SECTION_STAGES.has(stage));
+	const visibleExecutionLoops = $derived(
+		executionStageReached ? executionLoops : []
 	);
 
 	// ── Collapse state management ──────────────────────────────────
@@ -119,7 +145,7 @@
 
 	// Execution phase: auto-expanded when implementing/executing
 	const execPhaseActive = $derived(
-		['implementing', 'executing', 'reviewing_rollup'].includes(stage)
+		['implementing', 'executing', 'reviewing_qa', 'reviewing_rollup'].includes(stage)
 	);
 	const execPhaseExpanded = $derived(
 		userToggles.has('exec-phase')
@@ -148,7 +174,10 @@
 	// Minimal shape required by helper functions — matches loopEntries items
 	interface LoopEntry {
 		loop_id: string;
+		task_id?: string;
+		workflow_slug?: string;
 		workflow_step?: string | null;
+		role?: string;
 		state: string;
 		created_at: string;
 	}
@@ -172,14 +201,14 @@
 	}
 
 	const planStats = $derived(phaseStats(planLoops));
-	const execStats = $derived(phaseStats(executionLoops));
+	const execStats = $derived(phaseStats(visibleExecutionLoops));
 
 	// ── Trajectory fetching ────────────────────────────────────────
 	// Fetch trajectories for visible loops
 	$effect(() => {
 		const loopsToFetch = [
 			...(planPhaseExpanded ? planLoops : []),
-			...(execPhaseExpanded ? executionLoops : [])
+			...(execPhaseExpanded ? visibleExecutionLoops : [])
 		];
 		for (const loop of loopsToFetch) {
 			fetchTrajectory(loop.loop_id);
@@ -200,7 +229,7 @@
 	$effect(() => {
 		const allPlanLoopIds = new Set([
 			...planLoops.map((l) => l.loop_id),
-			...executionLoops.map((l) => l.loop_id)
+			...visibleExecutionLoops.map((l) => l.loop_id)
 		]);
 
 		const unsubscribe = activityStore.onEvent((event) => {
@@ -214,9 +243,22 @@
 	});
 
 	// ── Helpers ────────────────────────────────────────────────────
-	function isPlanRole(loop: LoopEntry): boolean {
+	function isPlanLoop(loop: LoopEntry): boolean {
+		const workflowSlug = loop.workflow_slug ?? '';
 		const step = loop.workflow_step ?? '';
-		return step.startsWith('plan') || step.includes('requirement-gen') || step.includes('scenario-gen');
+		const taskID = loop.task_id ?? '';
+		const role = loop.role ?? '';
+		return (
+			workflowSlug === 'semspec-planning' ||
+			PLAN_STEPS.has(step) ||
+			step.startsWith('plan') ||
+			step.includes('requirement-gen') ||
+			step.includes('scenario-gen') ||
+			step.includes('architecture-gen') ||
+			step.includes('story-prep') ||
+			PLAN_ROLES.has(role) ||
+			/^(analyst|plan|review|reqgen|archgen|storyprep|scengen)-/.test(taskID)
+		);
 	}
 
 	function byCreatedAt(a: LoopEntry, b: LoopEntry): number {
@@ -326,8 +368,8 @@
 		<!-- Execution Phase. Same ghost-when-empty pattern as Planning so the
 		     workflow roadmap (Planning → Execution) is visible from plan
 		     creation onward. -->
-		<div class="phase-section" class:phase-section--ghost={executionLoops.length === 0}>
-			{#if executionLoops.length === 0}
+		<div class="phase-section" class:phase-section--ghost={visibleExecutionLoops.length === 0}>
+			{#if visibleExecutionLoops.length === 0}
 				<div class="phase-header phase-header--ghost">
 					<div class="phase-left">
 						<Icon name="circle" size={14} />
@@ -342,7 +384,7 @@
 						<Icon name={execPhaseExpanded ? 'chevron-down' : 'chevron-right'} size={14} />
 						<Icon name="play" size={14} />
 						<span class="phase-title">Execution</span>
-						<span class="phase-count">{executionLoops.length} loop{executionLoops.length !== 1 ? 's' : ''}</span>
+						<span class="phase-count">{visibleExecutionLoops.length} loop{visibleExecutionLoops.length !== 1 ? 's' : ''}</span>
 					</div>
 					<div class="phase-stats">
 						{#if execStats.llmCalls > 0}
@@ -362,7 +404,7 @@
 
 				{#if execPhaseExpanded}
 					<div class="phase-content">
-						{#each executionLoops as loop (loop.loop_id)}
+						{#each visibleExecutionLoops as loop (loop.loop_id)}
 							<div class="loop-block">
 								<div class="loop-row">
 									<button class="loop-header" onclick={() => toggle(loop.loop_id)}>

--- a/ui/src/lib/components/trajectory/LoopSummary.svelte
+++ b/ui/src/lib/components/trajectory/LoopSummary.svelte
@@ -13,21 +13,24 @@
 	let { role, state, trajectory, summary }: Props = $props();
 
 	// Prefer full trajectory data; fall back to summary when available
-	const totalTokens = $derived(
-		trajectory
-			? trajectory.total_tokens_in + trajectory.total_tokens_out
-			: summary
-				? summary.total_tokens_in + summary.total_tokens_out
-				: 0
-	);
-
-	const displayDuration = $derived(
-		trajectory ? trajectory.duration : summary ? summary.duration : 0
-	);
-
-	const displayIterations = $derived(trajectory ? null : summary ? summary.iterations : null);
-
 	const isActive = $derived(state === 'executing' || state === 'pending');
+
+	const totalTokens = $derived.by(() => {
+		const trajectoryTokens = trajectory ? trajectory.total_tokens_in + trajectory.total_tokens_out : 0;
+		const summaryTokens = summary ? summary.total_tokens_in + summary.total_tokens_out : 0;
+		return isActive ? Math.max(trajectoryTokens, summaryTokens) : trajectoryTokens || summaryTokens;
+	});
+
+	const displayDuration = $derived.by(() => {
+		const trajectoryDuration = trajectory?.duration ?? 0;
+		const summaryDuration = summary?.duration ?? 0;
+		return isActive ? Math.max(trajectoryDuration, summaryDuration) : trajectoryDuration || summaryDuration;
+	});
+
+	const displayIterations = $derived(
+		isActive && summary ? summary.iterations : trajectory ? null : summary ? summary.iterations : null
+	);
+
 	const isComplete = $derived(state === 'completed');
 	const isFailed = $derived(state === 'failed' || state === 'error');
 

--- a/ui/src/lib/stores/activity.svelte.ts
+++ b/ui/src/lib/stores/activity.svelte.ts
@@ -8,6 +8,7 @@ import type { ActivityEvent } from '$lib/types';
 import { settingsStore } from '$lib/stores/settings.svelte';
 
 const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true';
+const RECONNECT_GRACE_MS = 15_000;
 
 type ActivityCallback = (event: ActivityEvent) => void;
 
@@ -27,6 +28,7 @@ class ActivityStore {
 	private mockCleanup: (() => void) | null = null;
 	private currentFilter: string | undefined;
 	private callbacks: Set<ActivityCallback> = new Set();
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 	// Cached derived — avoids untracked getter reads inside addEvent
 	private maxEvents = $derived(settingsStore.activityLimit);
@@ -56,16 +58,17 @@ class ActivityStore {
 		// events, and all loop mutations as 'event: activity' with the type
 		// (loop_created/loop_updated/loop_deleted) inside data.type.
 		this.eventSource.addEventListener('connected', () => {
-			this.connected = true;
+			this.markConnected();
 		});
 
 		this.eventSource.addEventListener('activity', (event) => {
+			this.markConnected();
 			const activity = JSON.parse((event as MessageEvent).data) as ActivityEvent;
 			this.addEvent(activity);
 		});
 
 		this.eventSource.onerror = () => {
-			this.connected = false;
+			this.handleStreamError(this.eventSource?.readyState);
 			// Native EventSource auto-reconnect handles backoff; backend sends retry: 5000.
 		};
 	}
@@ -129,11 +132,44 @@ class ActivityStore {
 			this.mockCleanup = null;
 			stopMockActivityStream();
 		}
-		this.connected = false;
+		this.markDisconnected();
 	}
 
 	clear(): void {
 		this.recent = [];
+	}
+
+	private markConnected(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+		this.connected = true;
+	}
+
+	private markDisconnected(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+		this.connected = false;
+	}
+
+	private handleStreamError(readyState: number | undefined): void {
+		const closed = typeof EventSource !== 'undefined' ? EventSource.CLOSED : 2;
+		if (readyState === closed) {
+			this.markDisconnected();
+			return;
+		}
+
+		// EventSource reports transient reconnect attempts through `error`.
+		// Keep the UI steady during the browser's normal retry window; if the
+		// stream stays down, then surface a real disconnected state.
+		if (this.reconnectTimer) return;
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			this.connected = false;
+		}, RECONNECT_GRACE_MS);
 	}
 }
 

--- a/ui/src/lib/stores/activity.test.ts
+++ b/ui/src/lib/stores/activity.test.ts
@@ -13,7 +13,7 @@
  * production API clean and forces this test to be obvious about poking
  * internals.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { activityStore } from '$lib/stores/activity.svelte';
 import type { ActivityEvent } from '$lib/types';
 
@@ -36,6 +36,11 @@ describe('ActivityStore — loopLastSeen', () => {
 		for (const id of keys) {
 			tick({ type: 'loop_deleted', loop_id: id });
 		}
+		(activityStore as unknown as { markDisconnected: () => void }).markDisconnected();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it('records a timestamp on loop_created', () => {
@@ -128,5 +133,63 @@ describe('ActivityStore — loopLastSeen', () => {
 			tick({ type: 'loop_deleted', loop_id: 'loop-i' });
 			expect(activityStore.idleMsForLoop('loop-i')).toBeNull();
 		});
+	});
+});
+
+describe('ActivityStore — connection state', () => {
+	beforeEach(() => {
+		(activityStore as unknown as { markDisconnected: () => void }).markDisconnected();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('keeps connected true during transient EventSource reconnects', () => {
+		vi.useFakeTimers();
+		const store = activityStore as unknown as {
+			connected: boolean;
+			markConnected: () => void;
+			handleStreamError: (readyState: number | undefined) => void;
+		};
+
+		store.markConnected();
+		store.handleStreamError(0);
+
+		expect(store.connected).toBe(true);
+		vi.advanceTimersByTime(14_999);
+		expect(store.connected).toBe(true);
+		vi.advanceTimersByTime(1);
+		expect(store.connected).toBe(false);
+	});
+
+	it('cancels the disconnect grace timer when the stream reconnects', () => {
+		vi.useFakeTimers();
+		const store = activityStore as unknown as {
+			connected: boolean;
+			markConnected: () => void;
+			handleStreamError: (readyState: number | undefined) => void;
+		};
+
+		store.markConnected();
+		store.handleStreamError(0);
+		vi.advanceTimersByTime(5_000);
+		store.markConnected();
+		vi.advanceTimersByTime(20_000);
+
+		expect(store.connected).toBe(true);
+	});
+
+	it('marks disconnected immediately when the EventSource is closed', () => {
+		const store = activityStore as unknown as {
+			connected: boolean;
+			markConnected: () => void;
+			handleStreamError: (readyState: number | undefined) => void;
+		};
+
+		store.markConnected();
+		store.handleStreamError(2);
+
+		expect(store.connected).toBe(false);
 	});
 });

--- a/ui/src/lib/stores/activityProjection.test.ts
+++ b/ui/src/lib/stores/activityProjection.test.ts
@@ -10,7 +10,12 @@ import {
 } from '$lib/stores/activityProjection';
 import type { ActivityEvent } from '$lib/types';
 
-function activity(overrides: Partial<ActivityEvent> & { type: string }): ActivityEvent {
+type ActivityOverride = Omit<Partial<ActivityEvent>, 'data'> & {
+	type: string;
+	data?: unknown;
+} & Record<string, unknown>;
+
+function activity(overrides: ActivityOverride): ActivityEvent {
 	return {
 		loop_id: '01234567-abcd',
 		timestamp: '2026-04-21T12:00:00Z',
@@ -21,10 +26,53 @@ function activity(overrides: Partial<ActivityEvent> & { type: string }): Activit
 describe('activityEventToFeedEvent', () => {
 	it('maps loop_created to a start summary with loop id prefix', () => {
 		const fe = activityEventToFeedEvent(activity({ type: 'loop_created' }));
-		expect(fe.source).toBe('execution');
+		expect(fe.source).toBe('activity');
 		expect(fe.type).toBe('loop_created');
 		expect(fe.summary).toMatch(/Loop started/);
 		expect(fe.summary).toContain('01234567');
+	});
+
+	it('labels semspec-planning loop data as plan activity', () => {
+		const fe = activityEventToFeedEvent(activity({
+			type: 'loop_updated',
+			data: {
+				task_id: 'scengen-4',
+				workflow_slug: 'semspec-planning',
+				workflow_step: 'scenario-generation',
+				role: 'scenario-generator'
+			}
+		}));
+		expect(fe.source).toBe('plan');
+		expect(fe.data?.workflow_slug).toBe('semspec-planning');
+		expect(fe.data?.workflow_step).toBe('scenario-generation');
+		expect(fe.data?.task_id).toBe('scengen-4');
+		expect(fe.data?.role).toBe('scenario-generator');
+	});
+
+	it('labels semspec-execution loop data as execution activity', () => {
+		const fe = activityEventToFeedEvent(activity({
+			type: 'loop_updated',
+			data: {
+				task_id: 'reqexec-2',
+				workflow_slug: 'semspec-execution',
+				workflow_step: 'executing',
+				role: 'developer'
+			}
+		}));
+		expect(fe.source).toBe('execution');
+	});
+
+	it('labels task-execution workflow loop data as execution activity', () => {
+		const fe = activityEventToFeedEvent(activity({
+			type: 'loop_updated',
+			data: {
+				task_id: 'task-run-1',
+				workflow_slug: 'semspec-task-execution',
+				workflow_step: 'develop',
+				role: 'general'
+			}
+		}));
+		expect(fe.source).toBe('execution');
 	});
 
 	it('maps loop_updated to a tick summary', () => {
@@ -67,6 +115,17 @@ describe('activityEventToFeedEvent', () => {
 		const raw = { ...activity({ type: 'loop_updated' }), requirement_id: 'R4' };
 		const fe = activityEventToFeedEvent(raw as ActivityEvent);
 		expect(fe.data?.requirement_id).toBe('R4');
+	});
+
+	it('passes requirement_id through from loop data when present', () => {
+		const fe = activityEventToFeedEvent(activity({
+			type: 'loop_updated',
+			data: {
+				workflow_slug: 'semspec-planning',
+				requirement_id: 'R8'
+			}
+		}));
+		expect(fe.data?.requirement_id).toBe('R8');
 	});
 
 	it('omits requirement_id when empty string on the raw event', () => {

--- a/ui/src/lib/stores/activityProjection.ts
+++ b/ui/src/lib/stores/activityProjection.ts
@@ -14,6 +14,53 @@
 import type { ActivityEvent } from '$lib/types';
 import type { FeedEvent } from '$lib/types/feed';
 
+type ActivityLoopData = {
+	task_id?: string;
+	workflow_slug?: string;
+	workflow_step?: string;
+	role?: string;
+	requirement_id?: string;
+};
+
+const PLANNING_STEPS = new Set([
+	'exploring',
+	'drafting',
+	'reviewing',
+	'requirement-generation',
+	'architecture-generation',
+	'story-preparation',
+	'scenario-generation'
+]);
+
+const PLANNING_ROLES = new Set([
+	'planner',
+	'plan-reviewer',
+	'requirement-generator',
+	'architect',
+	'story-preparer',
+	'scenario-generator'
+]);
+
+const EXECUTION_STEPS = new Set([
+	'decomposing',
+	'develop',
+	'executing',
+	'developing',
+	'review',
+	'validating',
+	'reviewing-code',
+	'reviewing_rollup',
+	'qa-review'
+]);
+
+const EXECUTION_ROLES = new Set([
+	'developer',
+	'reviewer',
+	'validator',
+	'qa-reviewer',
+	'recovery-agent'
+]);
+
 /** Convert one ActivityEvent to a FeedEvent. Stable `id` enables dedup when
  * the component keys the `{#each}` block on it. Carries `requirement_id`
  * through when the raw event includes it so the feed UI can render the
@@ -21,12 +68,19 @@ import type { FeedEvent } from '$lib/types/feed';
 export function activityEventToFeedEvent(event: ActivityEvent): FeedEvent {
 	const loopShort = event.loop_id?.slice(0, 8) ?? 'unknown';
 	const summary = summaryFor(event.type, loopShort);
+	const loop = eventData(event);
 
 	const data: Record<string, unknown> = { loop_id: event.loop_id };
+	if (loop?.task_id) data.task_id = loop.task_id;
+	if (loop?.workflow_slug) data.workflow_slug = loop.workflow_slug;
+	if (loop?.workflow_step) data.workflow_step = loop.workflow_step;
+	if (loop?.role) data.role = loop.role;
 	// The generated ActivityEvent doesn't declare requirement_id, but the wire
 	// payload sometimes carries it when the loop is scoped to a requirement.
 	// Narrow the intersection so we pull only the field we actually read.
-	const reqId = (event as ActivityEvent & { requirement_id?: string }).requirement_id;
+	const reqId =
+		(event as ActivityEvent & { requirement_id?: string }).requirement_id ??
+		loop?.requirement_id;
 	if (typeof reqId === 'string' && reqId.length > 0) {
 		data.requirement_id = reqId;
 	}
@@ -34,7 +88,7 @@ export function activityEventToFeedEvent(event: ActivityEvent): FeedEvent {
 	return {
 		id: `${event.type}:${event.loop_id}:${event.timestamp}`,
 		timestamp: event.timestamp,
-		source: 'execution',
+		source: sourceForLoop(loop),
 		type: event.type,
 		summary,
 		data
@@ -59,4 +113,46 @@ function summaryFor(type: string, loopShort: string): string {
 		default:
 			return `${type} · ${loopShort}`;
 	}
+}
+
+function eventData(event: ActivityEvent): ActivityLoopData | null {
+	const raw = (event as ActivityEvent & { data?: unknown }).data;
+	if (!raw || typeof raw !== 'object') return null;
+	return raw as ActivityLoopData;
+}
+
+function sourceForLoop(loop: ActivityLoopData | null): FeedEvent['source'] {
+	if (!loop) return 'activity';
+	if (isPlanningLoop(loop)) return 'plan';
+	if (isExecutionLoop(loop)) return 'execution';
+	return 'activity';
+}
+
+function isPlanningLoop(loop: ActivityLoopData): boolean {
+	const workflowSlug = loop.workflow_slug ?? '';
+	const step = loop.workflow_step ?? '';
+	const taskID = loop.task_id ?? '';
+	const role = loop.role ?? '';
+
+	return (
+		workflowSlug === 'semspec-planning' ||
+		PLANNING_STEPS.has(step) ||
+		PLANNING_ROLES.has(role) ||
+		/^(analyst|plan|review|reqgen|archgen|storyprep|scengen)-/.test(taskID)
+	);
+}
+
+function isExecutionLoop(loop: ActivityLoopData): boolean {
+	const workflowSlug = loop.workflow_slug ?? '';
+	const step = loop.workflow_step ?? '';
+	const taskID = loop.task_id ?? '';
+	const role = loop.role ?? '';
+
+	return (
+		workflowSlug === 'semspec-execution' ||
+		workflowSlug === 'semspec-task-execution' ||
+		EXECUTION_STEPS.has(step) ||
+		EXECUTION_ROLES.has(role) ||
+		/^(reqexec|exec|dev|reviewer|validator|qa-review|recovery)-/.test(taskID)
+	);
 }

--- a/ui/src/lib/stores/feed.svelte.ts
+++ b/ui/src/lib/stores/feed.svelte.ts
@@ -202,8 +202,20 @@ class FeedStore {
 		// and consumers should see them without a server round-trip.
 		this.currentPlan = payload;
 
-		// Lazily connect execution SSE when plan reaches execution
-		const execStages = ['implementing', 'executing', 'reviewing_rollup'];
+		// Lazily connect execution SSE once a plan reaches execution and keep it
+		// eligible through QA/terminal gates; users often open the detail page
+		// after implementation starts and still need task-attempt context.
+		const execStages = [
+			'implementing',
+			'executing',
+			'ready_for_qa',
+			'reviewing_qa',
+			'reviewing_rollup',
+			'complete',
+			'complete_with_deferrals',
+			'failed',
+			'rejected'
+		];
 		if (execStages.includes(stage) && !this.execSSE && this.currentSlug) {
 			this.connectExecutionSSE(this.currentSlug);
 		}

--- a/ui/src/lib/types/activePlanProgress.test.ts
+++ b/ui/src/lib/types/activePlanProgress.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { activePhaseProgress, activePlanProgress } from './activePlanProgress';
+import type { TrajectoryListItem } from './trajectory';
+
+function trajectory(overrides: Partial<TrajectoryListItem>): TrajectoryListItem {
+	return {
+		loop_id: 'loop-1',
+		workflow_slug: 'semspec-planning',
+		workflow_step: 'architecture-generation',
+		start_time: '2026-06-16T12:57:01Z',
+		...overrides
+	} as TrajectoryListItem;
+}
+
+describe('activePlanProgress', () => {
+	it('uses the active planning loop to drive the in-progress copy', () => {
+		const progress = activePlanProgress([
+			trajectory({
+				loop_id: 'scenario-done',
+				workflow_step: 'scenario-generation',
+				outcome: 'success',
+				start_time: '2026-06-16T13:00:17Z'
+			}),
+			trajectory({
+				loop_id: 'arch-active',
+				workflow_step: 'architecture-generation',
+				start_time: '2026-06-16T13:01:46Z'
+			})
+		]);
+
+		expect(progress?.title).toBe('Generating architecture...');
+		expect(progress?.detail).toContain('Architecture generator');
+		expect(progress?.startedAt).toBe('2026-06-16T13:01:46Z');
+		expect(progress?.loopId).toBe('arch-active');
+	});
+
+	it('ignores completed planning loops', () => {
+		const progress = activePlanProgress([
+			trajectory({ workflow_step: 'scenario-generation', outcome: 'success' })
+		]);
+		expect(progress).toBeNull();
+	});
+
+	it('ignores active execution loops in the planning-only helper', () => {
+		const progress = activePlanProgress([
+			trajectory({
+				workflow_slug: 'semspec-task-execution',
+				workflow_step: 'develop'
+			})
+		]);
+		expect(progress).toBeNull();
+	});
+
+	it('chooses the newest active planning loop when several are running', () => {
+		const progress = activePlanProgress([
+			trajectory({
+				loop_id: 'old',
+				workflow_step: 'architecture-generation',
+				start_time: '2026-06-16T12:55:00Z'
+			}),
+			trajectory({
+				loop_id: 'new',
+				workflow_step: 'scenario-generation',
+				start_time: '2026-06-16T13:00:00Z'
+			})
+		]);
+		expect(progress?.title).toBe('Generating scenarios...');
+		expect(progress?.loopId).toBe('new');
+	});
+});
+
+describe('activePhaseProgress', () => {
+	it('uses active execution loops when no planning loop is running', () => {
+		const progress = activePhaseProgress([
+			trajectory({
+				loop_id: 'dev-active',
+				workflow_slug: 'semspec-task-execution',
+				workflow_step: 'develop',
+				start_time: '2026-06-16T13:09:08Z'
+			})
+		]);
+
+		expect(progress?.title).toBe('Implementing...');
+		expect(progress?.detail).toContain('Developer');
+		expect(progress?.startedAt).toBe('2026-06-16T13:09:08Z');
+		expect(progress?.loopId).toBe('dev-active');
+	});
+
+	it('uses active review execution loops', () => {
+		const progress = activePhaseProgress([
+			trajectory({
+				loop_id: 'review-active',
+				workflow_slug: 'semspec-task-execution',
+				workflow_step: 'review'
+			})
+		]);
+
+		expect(progress?.title).toBe('Reviewing implementation...');
+		expect(progress?.loopId).toBe('review-active');
+	});
+
+	it('prefers active planning loops over execution loops during phase overlap', () => {
+		const progress = activePhaseProgress([
+			trajectory({
+				loop_id: 'dev-active',
+				workflow_slug: 'semspec-task-execution',
+				workflow_step: 'develop',
+				start_time: '2026-06-16T13:09:08Z'
+			}),
+			trajectory({
+				loop_id: 'arch-active',
+				workflow_slug: 'semspec-planning',
+				workflow_step: 'architecture-generation',
+				start_time: '2026-06-16T13:01:46Z'
+			})
+		]);
+
+		expect(progress?.title).toBe('Generating architecture...');
+		expect(progress?.loopId).toBe('arch-active');
+	});
+});

--- a/ui/src/lib/types/activePlanProgress.ts
+++ b/ui/src/lib/types/activePlanProgress.ts
@@ -1,0 +1,169 @@
+import type { TrajectoryListItem } from './trajectory';
+
+export type ActivePlanProgress = {
+	title: string;
+	detail: string;
+	startedAt: string | null;
+	workflowStep: string;
+	loopId: string;
+};
+
+const PLANNING_COPY = new Map<string, { title: string; detail: string }>([
+	[
+		'exploring',
+		{
+			title: 'Exploring context...',
+			detail: 'Analyst is gathering repository context for the plan...'
+		}
+	],
+	[
+		'drafting',
+		{
+			title: 'Drafting plan...',
+			detail: 'Planner is composing the plan goal, context, and scope...'
+		}
+	],
+	[
+		'reviewing',
+		{
+			title: 'Reviewing plan...',
+			detail: 'Plan reviewer is evaluating the current plan artifacts...'
+		}
+	],
+	[
+		'requirement-generation',
+		{
+			title: 'Generating requirements...',
+			detail: 'Decomposing the approved plan into testable requirements...'
+		}
+	],
+	[
+		'architecture-generation',
+		{
+			title: 'Generating architecture...',
+			detail: 'Architecture generator is selecting technology and component boundaries...'
+		}
+	],
+	[
+		'story-preparation',
+		{
+			title: 'Preparing stories...',
+			detail: 'Preparing implementation stories from requirements and architecture...'
+		}
+	],
+	[
+		'scenario-generation',
+		{
+			title: 'Generating scenarios...',
+			detail: 'Generating scenarios for each requirement...'
+		}
+	]
+]);
+
+const EXECUTION_COPY = new Map<string, { title: string; detail: string }>([
+	[
+		'develop',
+		{
+			title: 'Implementing...',
+			detail: 'Developer is applying code changes for the active task...'
+		}
+	],
+	[
+		'developing',
+		{
+			title: 'Implementing...',
+			detail: 'Developer is applying code changes for the active task...'
+		}
+	],
+	[
+		'review',
+		{
+			title: 'Reviewing implementation...',
+			detail: 'Reviewer is checking the latest task changes...'
+		}
+	],
+	[
+		'reviewing-code',
+		{
+			title: 'Reviewing implementation...',
+			detail: 'Reviewer is checking the latest task changes...'
+		}
+	],
+	[
+		'validating',
+		{
+			title: 'Validating implementation...',
+			detail: 'Validator is running checks against the active task...'
+		}
+	],
+	[
+		'executing',
+		{
+			title: 'Executing task...',
+			detail: 'Execution agent is working through the active task...'
+		}
+	]
+]);
+
+export function activePlanProgress(
+	trajectoryItems: TrajectoryListItem[]
+): ActivePlanProgress | null {
+	const loop = newestActiveLoop(trajectoryItems, 'semspec-planning', PLANNING_COPY);
+	if (!loop || !loop.workflow_step) return null;
+
+	const copy = PLANNING_COPY.get(loop.workflow_step);
+	if (!copy) return null;
+
+	return progressFromLoop(loop, copy);
+}
+
+export function activePhaseProgress(
+	trajectoryItems: TrajectoryListItem[]
+): ActivePlanProgress | null {
+	return (
+		activePlanProgress(trajectoryItems) ??
+		activeExecutionProgress(trajectoryItems)
+	);
+}
+
+function activeExecutionProgress(
+	trajectoryItems: TrajectoryListItem[]
+): ActivePlanProgress | null {
+	const loop = newestActiveLoop(trajectoryItems, 'semspec-task-execution', EXECUTION_COPY);
+	if (!loop || !loop.workflow_step) return null;
+
+	const copy = EXECUTION_COPY.get(loop.workflow_step);
+	if (!copy) return null;
+
+	return progressFromLoop(loop, copy);
+}
+
+function newestActiveLoop(
+	trajectoryItems: TrajectoryListItem[],
+	workflowSlug: string,
+	copy: Map<string, { title: string; detail: string }>
+): TrajectoryListItem | null {
+	return trajectoryItems
+		.filter((item) => {
+			if (item.workflow_slug !== workflowSlug) return false;
+			if (item.outcome) return false;
+			return copy.has(item.workflow_step ?? '');
+		})
+		.sort((a, b) => startedAtMs(b) - startedAtMs(a))[0] ?? null;
+}
+
+function progressFromLoop(
+	loop: TrajectoryListItem,
+	copy: { title: string; detail: string }
+): ActivePlanProgress {
+	return {
+		...copy,
+		startedAt: loop.start_time ?? null,
+		workflowStep: loop.workflow_step ?? 'unknown',
+		loopId: loop.loop_id
+	};
+}
+
+function startedAtMs(item: TrajectoryListItem): number {
+	return item.start_time ? new Date(item.start_time).getTime() : 0;
+}

--- a/ui/src/lib/types/feed.ts
+++ b/ui/src/lib/types/feed.ts
@@ -6,7 +6,7 @@ export type FeedEvent = {
 	/** Dedup key (source + SSE event ID or timestamp) */
 	id: string;
 	timestamp: string;
-	source: 'plan' | 'execution' | 'question';
+	source: 'plan' | 'execution' | 'activity' | 'question';
 	/** Original SSE event type (plan_updated, task_updated, question_created, etc.) */
 	type: string;
 	/** Human-readable summary */

--- a/ui/src/lib/types/planFreshness.test.ts
+++ b/ui/src/lib/types/planFreshness.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { selectFreshestPlan } from './planFreshness';
+import type { PlanStage, PlanWithStatus } from './plan';
+
+function plan(slug: string, stage: PlanStage): PlanWithStatus {
+	return {
+		id: `plan.${slug}`,
+		slug,
+		title: slug,
+		status: stage,
+		stage,
+		approved: true,
+		created_at: '2026-06-16T12:00:00Z',
+		active_loops: []
+	} as unknown as PlanWithStatus;
+}
+
+describe('selectFreshestPlan', () => {
+	it('prefers loader data when it has advanced beyond a stale stream plan', () => {
+		const streamPlan = plan('mavlink', 'generating_scenarios');
+		const loadedPlan = plan('mavlink', 'implementing');
+		expect(selectFreshestPlan(streamPlan, loadedPlan, 'mavlink')?.stage).toBe('implementing');
+	});
+
+	it('keeps stream data when it is ahead of loader data', () => {
+		const streamPlan = plan('mavlink', 'implementing');
+		const loadedPlan = plan('mavlink', 'generating_scenarios');
+		expect(selectFreshestPlan(streamPlan, loadedPlan, 'mavlink')?.stage).toBe('implementing');
+	});
+
+	it('ignores stream data for another slug', () => {
+		const streamPlan = plan('other', 'implementing');
+		const loadedPlan = plan('mavlink', 'generating_scenarios');
+		expect(selectFreshestPlan(streamPlan, loadedPlan, 'mavlink')?.slug).toBe('mavlink');
+	});
+
+	it('prefers stream data at the same stage so SSE details still win', () => {
+		const streamPlan = plan('mavlink', 'generating_scenarios');
+		const loadedPlan = { ...plan('mavlink', 'generating_scenarios'), title: 'loader' };
+		expect(selectFreshestPlan(streamPlan, loadedPlan, 'mavlink')?.title).toBe('mavlink');
+	});
+});

--- a/ui/src/lib/types/planFreshness.ts
+++ b/ui/src/lib/types/planFreshness.ts
@@ -1,0 +1,59 @@
+import type { PlanStage, PlanWithStatus } from './plan';
+
+const PLAN_STAGE_ORDER: PlanStage[] = [
+	'created',
+	'draft',
+	'drafting',
+	'drafted',
+	'reviewing_draft',
+	'reviewed',
+	'needs_changes',
+	'ready_for_approval',
+	'planning',
+	'approved',
+	'generating_requirements',
+	'requirements_generated',
+	'generating_architecture',
+	'architecture_generated',
+	'generating_scenarios',
+	'scenarios_generated',
+	'reviewing_scenarios',
+	'scenarios_reviewed',
+	'ready_for_execution',
+	'phases_generated',
+	'phases_approved',
+	'tasks_generated',
+	'tasks',
+	'tasks_approved',
+	'implementing',
+	'executing',
+	'ready_for_qa',
+	'reviewing_qa',
+	'reviewing_rollup',
+	'complete',
+	'complete_with_deferrals',
+	'failed',
+	'archived',
+	'rejected'
+];
+
+const PLAN_STAGE_RANK = new Map(PLAN_STAGE_ORDER.map((stage, index) => [stage, index]));
+
+export function planStageRank(stage: PlanStage | undefined): number {
+	return stage ? (PLAN_STAGE_RANK.get(stage) ?? -1) : -1;
+}
+
+export function selectFreshestPlan(
+	streamPlan: PlanWithStatus | null | undefined,
+	loadedPlan: PlanWithStatus | null | undefined,
+	slug: string
+): PlanWithStatus | null {
+	const scopedStreamPlan = streamPlan?.slug === slug ? streamPlan : null;
+	if (!scopedStreamPlan) return loadedPlan ?? null;
+	if (!loadedPlan) return scopedStreamPlan;
+
+	if (planStageRank(loadedPlan.stage) > planStageRank(scopedStreamPlan.stage)) {
+		return loadedPlan;
+	}
+	return scopedStreamPlan;
+}

--- a/ui/src/lib/types/runVisibility.test.ts
+++ b/ui/src/lib/types/runVisibility.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+	mergeTaskSse,
+	summarizeRunVisibility,
+	type ExecutionTask,
+	type Lesson
+} from './runVisibility';
+import type { PlanWithStatus } from './plan';
+import type { TrajectoryListItem } from './trajectory';
+
+function plan(overrides: Partial<PlanWithStatus> = {}): PlanWithStatus {
+	return {
+		id: 'plan-1',
+		slug: '57daa4134abb',
+		project_id: 'project-1',
+		status: 'rejected',
+		stage: 'rejected',
+		approved: true,
+		active_loops: [],
+		created_at: '2026-06-16T13:54:32Z',
+		...overrides
+	} as PlanWithStatus;
+}
+
+function task(overrides: Partial<ExecutionTask> = {}): ExecutionTask {
+	return {
+		slug: '57daa4134abb',
+		task_id: 'node-1',
+		requirement_id: 'requirement.57daa4134abb.2',
+		stage: 'approved',
+		title: 'Verify coverage matrix generation and SITL outputs',
+		updated_at: '2026-06-16T15:10:00Z',
+		...overrides
+	};
+}
+
+function lesson(overrides: Partial<Lesson> = {}): Lesson {
+	return {
+		ID: 'lesson-1',
+		Source: 'decomposer',
+		ScenarioID: 'node-1',
+		Summary: 'Do not create empty dummy classes to bypass coverage checks.',
+		CategoryIDs: [],
+		Role: 'developer',
+		CreatedAt: '2026-06-16T14:55:04Z',
+		Detail: 'The developer created empty classes instead of documenting unsupported features.',
+		InjectionForm: 'Document unsupported features with rationale.',
+		EvidenceSteps: [],
+		EvidenceFiles: [],
+		RootCauseRole: 'developer',
+		Positive: false,
+		RetiredAt: null,
+		LastInjectedAt: null,
+		...overrides
+	};
+}
+
+function trajectory(overrides: Partial<TrajectoryListItem> = {}): TrajectoryListItem {
+	return {
+		loop_id: 'loop-1',
+		start_time: '2026-06-16T15:00:00Z',
+		duration: 30_000,
+		iterations: 3,
+		model: 'gemini-pro',
+		role: 'developer',
+		task_id: 'node-1',
+		total_tokens_in: 10_000,
+		total_tokens_out: 500,
+		workflow_slug: 'semspec-task-execution',
+		workflow_step: 'develop',
+		...overrides
+	} as TrajectoryListItem;
+}
+
+describe('summarizeRunVisibility', () => {
+	it('surfaces human escalation ahead of generic rejected state', () => {
+		const summary = summarizeRunVisibility(
+			plan({
+				plan_decisions: [
+					{
+						id: 'plan-decision.57daa4134abb.recovery.c781429a',
+						plan_id: 'plan-1',
+						kind: 'execution_exhausted',
+						title: 'Recovery: escalate_human',
+						rationale:
+							'Recommended action: escalate_human\nOriginal wedge: QA verdict needs_changes at level integration',
+						status: 'proposed',
+						proposed_by: 'recovery-agent',
+						affected_requirement_ids: ['requirement.57daa4134abb.1'],
+						created_at: '2026-06-16T15:50:01Z'
+					}
+				],
+				qa_level: 'integration',
+				qa_run: {
+					run_id: 'qa-1',
+					passed: true,
+					duration_ms: 42_156,
+					completed_at: '2026-06-16T15:48:45Z',
+					skipped_tests: [{ name: 'scenario.57daa4134abb.1.1.3: SITL smoke' }]
+				} as NonNullable<PlanWithStatus['qa_run']>,
+				qa_verdict_summary: {
+					verdict: 'needs_changes',
+					level: 'integration',
+					summary:
+						'Executed tests passed.\n\n[skip-guard] coerced approved->needs_changes: skipped tests were not classified.',
+					recorded_at: '2026-06-16T15:49:54Z'
+				}
+			}),
+			[],
+			[],
+			[]
+		);
+
+		expect(summary.shouldRender).toBe(true);
+		expect(summary.status.title).toBe('Human review needed');
+		expect(summary.warnings.map((warning) => warning.kind)).toContain('human-review');
+		expect(summary.warnings.map((warning) => warning.kind)).toContain('qa-skip-guard');
+		expect(summary.qa?.skippedTests).toHaveLength(1);
+	});
+
+	it('groups replacement attempts and marks stale rejected rows as recovered', () => {
+		const summary = summarizeRunVisibility(
+			plan({ stage: 'implementing', status: 'implementing' }),
+			[
+				task({
+					task_id: 'node-original',
+					stage: 'escalated',
+					verdict: 'rejected',
+					updated_at: '2026-06-16T15:00:00Z'
+				}),
+				task({
+					task_id: 'node-replacement',
+					stage: 'approved',
+					verdict: 'approved',
+					merge_commit: '28e9a4df444b8eaa64b23b500f962be868ff0572',
+					updated_at: '2026-06-16T15:09:18Z'
+				})
+			],
+			[],
+			[]
+		);
+
+		expect(summary.taskGroups).toHaveLength(1);
+		expect(summary.taskGroups[0].status).toBe('recovered');
+		expect(summary.taskGroups[0].attempts.map((attempt) => attempt.taskId)).toEqual([
+			'node-original',
+			'node-replacement'
+		]);
+		expect(summary.taskStats.orphanedGroups).toBe(1);
+		expect(summary.warnings.some((warning) => warning.kind === 'orphaned-attempt')).toBe(true);
+	});
+
+	it('matches lessons to current execution tasks and marks future-run-only lessons', () => {
+		const summary = summarizeRunVisibility(
+			plan({ stage: 'implementing', status: 'implementing' }),
+			[task({ task_id: 'node-1', title: 'Implement raw fallback' })],
+			[trajectory({ loop_id: 'loop-1', task_id: 'node-1' })],
+			[
+				lesson({ ID: 'matched', ScenarioID: 'node-1', LastInjectedAt: null }),
+				lesson({
+					ID: 'other-plan',
+					ScenarioID: 'node-other',
+					Summary: 'Unrelated lesson',
+					LastInjectedAt: '2026-06-16T15:44:41Z'
+				})
+			]
+		);
+
+		expect(summary.lessons.map((item) => item.id)).toEqual(['matched']);
+		expect(summary.lessons[0].futureRunOnly).toBe(true);
+		expect(summary.lessons[0].relatedTaskTitle).toBe('Implement raw fallback');
+	});
+
+	it('reports token usage without inventing provider cost', () => {
+		const summary = summarizeRunVisibility(
+			plan({ stage: 'implementing', status: 'implementing' }),
+			[task()],
+			[
+				trajectory({ total_tokens_in: 10_000, total_tokens_out: 500, duration: 30_000 }),
+				trajectory({
+					loop_id: 'loop-2',
+					total_tokens_in: 20_000,
+					total_tokens_out: 1000,
+					duration: 60_000
+				})
+			],
+			[]
+		);
+
+		expect(summary.usage.totalTokens).toBe(31_500);
+		expect(summary.usage.durationMs).toBe(90_000);
+		expect(summary.usage.pricingAvailable).toBe(false);
+		expect(summary.usage.costLabel).toBe('Pricing not configured');
+	});
+});
+
+describe('mergeTaskSse', () => {
+	it('overlays live task payloads and appends newly observed task rows', () => {
+		const taskStages = new Map([
+			[
+				'node-1',
+				{
+					entity_id: 'entity-1',
+					slug: '57daa4134abb',
+					task_id: 'node-1',
+					stage: 'reviewing',
+					title: 'Verify coverage matrix generation and SITL outputs',
+					iteration: 1,
+					max_iterations: 5,
+					tdd_cycle: 2,
+					max_tdd_cycles: 5,
+					updated_at: '2026-06-16T15:11:00Z'
+				}
+			],
+			[
+				'node-new',
+				{
+					entity_id: 'entity-new',
+					slug: '57daa4134abb',
+					task_id: 'node-new',
+					stage: 'developing',
+					title: 'New live task',
+					iteration: 0,
+					max_iterations: 5,
+					updated_at: '2026-06-16T15:12:00Z'
+				}
+			]
+		]);
+
+		const merged = mergeTaskSse([task({ task_id: 'node-1', stage: 'approved' })], taskStages, '57daa4134abb');
+
+		expect(merged).toHaveLength(2);
+		expect(merged.find((item) => item.task_id === 'node-1')?.stage).toBe('reviewing');
+		expect(merged.find((item) => item.task_id === 'node-1')?.tdd_cycle).toBe(2);
+		expect(merged.find((item) => item.task_id === 'node-new')?.title).toBe('New live task');
+	});
+});

--- a/ui/src/lib/types/runVisibility.ts
+++ b/ui/src/lib/types/runVisibility.ts
@@ -1,0 +1,587 @@
+import type { components } from './api.generated';
+import type { TaskSSEPayload } from './feed';
+import type { PlanWithStatus } from './plan';
+import type { TrajectoryListItem } from './trajectory';
+
+export type Lesson = components['schemas']['Lesson'];
+
+export interface ExecutionScenario {
+	id?: string;
+	title?: string;
+	requirement_id?: string;
+	story_id?: string;
+	tags?: string[];
+}
+
+export interface ExecutionTask {
+	entity_id?: string;
+	slug: string;
+	task_id: string;
+	requirement_id?: string;
+	stage: string;
+	tdd_cycle?: number;
+	max_tdd_cycles?: number;
+	title?: string;
+	description?: string;
+	project_id?: string;
+	prompt?: string;
+	model?: string;
+	trace_id?: string;
+	loop_id?: string;
+	request_id?: string;
+	task_type?: string;
+	worktree_branch?: string;
+	scenario_branch?: string;
+	file_scope?: string[];
+	scenarios?: ExecutionScenario[];
+	files_modified?: string[];
+	tests_passed?: boolean;
+	validation_passed?: boolean;
+	merge_commit?: string;
+	developer_task_id?: string;
+	validator_task_id?: string;
+	reviewer_task_id?: string;
+	verdict?: string;
+	rejection_type?: string;
+	feedback?: string;
+	review_retry_count?: number;
+	error_reason?: string;
+	error_class?: string;
+	escalation_reason?: string;
+	created_at?: string;
+	updated_at?: string;
+}
+
+export type RunStatusTone = 'neutral' | 'active' | 'success' | 'warning' | 'danger';
+export type TaskGroupStatus = 'active' | 'approved' | 'recovered' | 'blocked' | 'pending';
+export type RunWarningKind = 'human-review' | 'qa-skip-guard' | 'orphaned-attempt';
+
+export interface RunStatusSummary {
+	title: string;
+	detail: string;
+	tone: RunStatusTone;
+	stageLabel: string;
+	timestamp?: string | null;
+}
+
+export interface TaskAttemptSummary {
+	taskId: string;
+	stage: string;
+	verdict?: string;
+	tddCycle?: number;
+	maxTddCycles?: number;
+	updatedAt?: string;
+	mergeCommit?: string;
+	feedback?: string;
+	errorReason?: string;
+	escalationReason?: string;
+}
+
+export interface TaskGroupSummary {
+	key: string;
+	title: string;
+	requirementId?: string;
+	status: TaskGroupStatus;
+	attempts: TaskAttemptSummary[];
+	hasOrphanedTerminalAttempt: boolean;
+	latestUpdatedAt?: string;
+}
+
+export interface QASkippedTest {
+	suite?: string;
+	name: string;
+	file?: string;
+}
+
+export interface QAVisibility {
+	verdict: string;
+	level: string;
+	passed: boolean;
+	summary?: string;
+	durationMs?: number;
+	completedAt?: string;
+	skippedTests: QASkippedTest[];
+	skipGuardTriggered: boolean;
+	artifactCount: number;
+}
+
+export interface LessonVisibility {
+	id: string;
+	summary: string;
+	source: string;
+	positive: boolean;
+	createdAt: string;
+	lastInjectedAt?: string | null;
+	futureRunOnly: boolean;
+	relatedTaskTitle?: string;
+}
+
+export interface RunWarning {
+	kind: RunWarningKind;
+	title: string;
+	detail: string;
+	tone: 'warning' | 'danger';
+	relatedId?: string;
+}
+
+export interface UsageSummary {
+	totalTokens: number;
+	inputTokens: number;
+	outputTokens: number;
+	durationMs: number;
+	loopCount: number;
+	pricingAvailable: false;
+	costLabel: string;
+}
+
+export interface RunVisibilitySummary {
+	shouldRender: boolean;
+	status: RunStatusSummary;
+	taskStats: {
+		totalGroups: number;
+		approvedGroups: number;
+		activeGroups: number;
+		blockedGroups: number;
+		orphanedGroups: number;
+		totalAttempts: number;
+	};
+	taskGroups: TaskGroupSummary[];
+	qa: QAVisibility | null;
+	warnings: RunWarning[];
+	lessons: LessonVisibility[];
+	usage: UsageSummary;
+}
+
+type FlexibleQaRun = NonNullable<PlanWithStatus['qa_run']> & {
+	skipped_tests?: QASkippedTest[];
+};
+
+type PlanDecision = NonNullable<PlanWithStatus['plan_decisions']>[number];
+
+const EXECUTION_STAGES = new Set([
+	'ready_for_execution',
+	'implementing',
+	'executing',
+	'ready_for_qa',
+	'reviewing_qa',
+	'reviewing_rollup',
+	'complete',
+	'complete_with_deferrals',
+	'failed'
+]);
+
+const ACTIVE_TASK_STAGES = new Set(['developing', 'validating', 'reviewing', 'testing', 'building']);
+const TERMINAL_TASK_STAGES = new Set(['approved', 'escalated', 'error', 'rejected']);
+
+export function mergeTaskSse(
+	loadedTasks: ExecutionTask[],
+	taskStages: Map<string, TaskSSEPayload>,
+	planSlug: string
+): ExecutionTask[] {
+	if (!planSlug) return loadedTasks;
+
+	const byTask = new Map(loadedTasks.map((task) => [task.task_id, task]));
+
+	for (const payload of taskStages.values()) {
+		if (payload.slug !== planSlug) continue;
+		const previous = byTask.get(payload.task_id);
+		byTask.set(payload.task_id, {
+			...previous,
+			slug: payload.slug,
+			task_id: payload.task_id,
+			entity_id: payload.entity_id ?? previous?.entity_id,
+			stage: payload.stage ?? previous?.stage ?? 'developing',
+			title: payload.title ?? previous?.title,
+			loop_id: payload.loop_id ?? previous?.loop_id,
+			tests_passed: payload.tests_passed ?? previous?.tests_passed,
+			validation_passed: payload.validation_passed ?? previous?.validation_passed,
+			verdict: payload.verdict ?? previous?.verdict,
+			feedback: payload.feedback ?? previous?.feedback,
+			tdd_cycle: payload.tdd_cycle ?? previous?.tdd_cycle,
+			max_tdd_cycles: payload.max_tdd_cycles ?? previous?.max_tdd_cycles,
+			review_retry_count: payload.review_retry_count ?? previous?.review_retry_count,
+			created_at: previous?.created_at ?? payload.updated_at,
+			updated_at: payload.updated_at ?? previous?.updated_at
+		});
+	}
+
+	return Array.from(byTask.values()).sort(byTaskUpdatedAt);
+}
+
+export function summarizeRunVisibility(
+	plan: PlanWithStatus,
+	executionTasks: ExecutionTask[],
+	trajectoryItems: TrajectoryListItem[],
+	lessons: Lesson[]
+): RunVisibilitySummary {
+	const taskGroups = groupTasks(executionTasks);
+	const qa = summarizeQA(plan);
+	const matchingLessons = summarizeLessons(plan, executionTasks, trajectoryItems, lessons);
+	const warnings = summarizeWarnings(plan, taskGroups, qa);
+	const usage = summarizeUsage(trajectoryItems);
+	const status = summarizeStatus(plan, executionTasks, taskGroups, qa, warnings);
+
+	return {
+		shouldRender:
+			EXECUTION_STAGES.has(plan.stage) ||
+			executionTasks.length > 0 ||
+			Boolean(qa) ||
+			warnings.length > 0 ||
+			matchingLessons.length > 0,
+		status,
+		taskStats: {
+			totalGroups: taskGroups.length,
+			approvedGroups: taskGroups.filter((g) => g.status === 'approved' || g.status === 'recovered').length,
+			activeGroups: taskGroups.filter((g) => g.status === 'active').length,
+			blockedGroups: taskGroups.filter((g) => g.status === 'blocked').length,
+			orphanedGroups: taskGroups.filter((g) => g.hasOrphanedTerminalAttempt).length,
+			totalAttempts: executionTasks.length
+		},
+		taskGroups,
+		qa,
+		warnings,
+		lessons: matchingLessons,
+		usage
+	};
+}
+
+function summarizeStatus(
+	plan: PlanWithStatus,
+	executionTasks: ExecutionTask[],
+	taskGroups: TaskGroupSummary[],
+	qa: QAVisibility | null,
+	warnings: RunWarning[]
+): RunStatusSummary {
+	const humanDecision = openHumanDecision(plan);
+	if (humanDecision) {
+		return {
+			title: 'Human review needed',
+			detail: firstLine(humanDecision.rationale) || humanDecision.title,
+			tone: 'warning',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: humanDecision.created_at
+		};
+	}
+
+	if (qa?.verdict === 'needs_changes' || qa?.verdict === 'rejected') {
+		return {
+			title: qa.skipGuardTriggered ? 'QA needs skipped-test classification' : 'QA needs changes',
+			detail: firstLine(qa.summary) || 'QA reviewer found work that needs follow-up.',
+			tone: qa.verdict === 'rejected' ? 'danger' : 'warning',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: qa.completedAt
+		};
+	}
+
+	if (qa?.verdict === 'conditionally_approved') {
+		return {
+			title: 'Execution complete with deferrals',
+			detail: firstLine(qa.summary) || 'QA passed with operator-tier work deferred.',
+			tone: 'warning',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: qa.completedAt
+		};
+	}
+
+	if (qa?.verdict === 'approved') {
+		return {
+			title: 'Execution and QA approved',
+			detail: firstLine(qa.summary) || 'All execution and QA gates are approved.',
+			tone: 'success',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: qa.completedAt
+		};
+	}
+
+	const activeTask = latestTask(executionTasks.filter((task) => isActiveTaskStage(task.stage)));
+	if (activeTask) {
+		return {
+			title: `Executing: ${taskTitle(activeTask)}`,
+			detail: `Task stage ${activeTask.stage}${cycleLabel(activeTask) ? `, ${cycleLabel(activeTask)}` : ''}.`,
+			tone: 'active',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: activeTask.updated_at
+		};
+	}
+
+	if (warnings.length > 0 && plan.stage === 'rejected') {
+		return {
+			title: 'Run rejected',
+			detail: warnings[0].detail,
+			tone: warnings[0].tone === 'danger' ? 'danger' : 'warning',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: plan.last_error_at ?? plan.created_at
+		};
+	}
+
+	const approved = taskGroups.filter((group) => group.status === 'approved' || group.status === 'recovered').length;
+	if (taskGroups.length > 0 && approved === taskGroups.length) {
+		return {
+			title: 'Execution tasks approved',
+			detail: `${approved} task group${approved === 1 ? '' : 's'} approved; waiting on final plan gate.`,
+			tone: plan.stage === 'complete' ? 'success' : 'neutral',
+			stageLabel: stageLabel(plan.stage),
+			timestamp: newestTimestamp(taskGroups.map((group) => group.latestUpdatedAt))
+		};
+	}
+
+	return {
+		title: stageLabel(plan.stage),
+		detail: plan.last_error || 'No execution task activity has been recorded yet.',
+		tone: plan.stage === 'failed' || plan.stage === 'rejected' ? 'danger' : 'neutral',
+		stageLabel: stageLabel(plan.stage),
+		timestamp: plan.last_error_at ?? plan.created_at
+	};
+}
+
+function groupTasks(tasks: ExecutionTask[]): TaskGroupSummary[] {
+	const groups = new Map<string, ExecutionTask[]>();
+
+	for (const task of tasks) {
+		const key = taskGroupKey(task);
+		groups.set(key, [...(groups.get(key) ?? []), task]);
+	}
+
+	return Array.from(groups.entries())
+		.map(([key, groupTasks]) => {
+			const attempts = groupTasks.sort(byTaskUpdatedAt).map(taskAttempt);
+			const hasApproved = attempts.some((attempt) => attempt.stage === 'approved');
+			const hasActive = attempts.some((attempt) => isActiveTaskStage(attempt.stage));
+			const hasBlocked = attempts.some((attempt) => ['escalated', 'error', 'rejected'].includes(attempt.stage));
+			const hasOrphanedTerminalAttempt = hasApproved && hasBlocked;
+			const latest = latestTask(groupTasks);
+
+			return {
+				key,
+				title: taskTitle(latest ?? groupTasks[0]),
+				requirementId: latest?.requirement_id ?? groupTasks[0]?.requirement_id,
+				status: taskGroupStatus(hasActive, hasApproved, hasBlocked, hasOrphanedTerminalAttempt),
+				attempts,
+				hasOrphanedTerminalAttempt,
+				latestUpdatedAt: newestTimestamp(groupTasks.map((task) => task.updated_at ?? task.created_at))
+			};
+		})
+		.sort((a, b) => {
+			const req = (a.requirementId ?? '').localeCompare(b.requirementId ?? '');
+			if (req !== 0) return req;
+			return (a.latestUpdatedAt ?? '').localeCompare(b.latestUpdatedAt ?? '');
+		});
+}
+
+function taskGroupStatus(
+	hasActive: boolean,
+	hasApproved: boolean,
+	hasBlocked: boolean,
+	hasOrphanedTerminalAttempt: boolean
+): TaskGroupStatus {
+	if (hasActive) return 'active';
+	if (hasApproved && hasOrphanedTerminalAttempt) return 'recovered';
+	if (hasApproved) return 'approved';
+	if (hasBlocked) return 'blocked';
+	return 'pending';
+}
+
+function taskAttempt(task: ExecutionTask): TaskAttemptSummary {
+	return {
+		taskId: task.task_id,
+		stage: task.stage,
+		verdict: task.verdict,
+		tddCycle: task.tdd_cycle,
+		maxTddCycles: task.max_tdd_cycles,
+		updatedAt: task.updated_at ?? task.created_at,
+		mergeCommit: task.merge_commit,
+		feedback: task.feedback,
+		errorReason: task.error_reason,
+		escalationReason: task.escalation_reason
+	};
+}
+
+function summarizeQA(plan: PlanWithStatus): QAVisibility | null {
+	const verdict = plan.qa_verdict_summary;
+	const run = plan.qa_run as FlexibleQaRun | null | undefined;
+	if (!verdict && !run) return null;
+
+	const skippedTests = run?.skipped_tests ?? [];
+	const summary = verdict?.summary;
+
+	return {
+		verdict: verdict?.verdict ?? (run?.passed ? 'approved' : 'failed'),
+		level: verdict?.level ?? plan.qa_level ?? 'qa',
+		passed: run?.passed ?? false,
+		summary,
+		durationMs: run?.duration_ms,
+		completedAt: run?.completed_at,
+		skippedTests,
+		skipGuardTriggered:
+			skippedTests.length > 0 &&
+			((summary ?? '').includes('[skip-guard]') || verdict?.verdict === 'needs_changes'),
+		artifactCount: run?.artifacts?.length ?? 0
+	};
+}
+
+function summarizeLessons(
+	plan: PlanWithStatus,
+	tasks: ExecutionTask[],
+	trajectoryItems: TrajectoryListItem[],
+	lessons: Lesson[]
+): LessonVisibility[] {
+	const taskIDs = new Set(tasks.map((task) => task.task_id));
+	const scenarioIDs = new Set(
+		tasks.flatMap((task) => task.scenarios?.map((scenario) => scenario.id).filter(Boolean) ?? [])
+	);
+	const loopIDs = new Set(trajectoryItems.map((item) => item.loop_id));
+	const taskTitles = new Map(tasks.map((task) => [task.task_id, taskTitle(task)]));
+
+	return lessons
+		.filter((lesson) => {
+			if (taskIDs.has(lesson.ScenarioID)) return true;
+			if (scenarioIDs.has(lesson.ScenarioID)) return true;
+			if (lesson.ScenarioID?.includes(plan.slug)) return true;
+			return lesson.EvidenceSteps?.some((step) => loopIDs.has(step.loop_id)) ?? false;
+		})
+		.sort((a, b) => dateMs(b.CreatedAt) - dateMs(a.CreatedAt))
+		.map((lesson) => ({
+			id: lesson.ID,
+			summary: lesson.Summary,
+			source: lesson.Source,
+			positive: lesson.Positive,
+			createdAt: lesson.CreatedAt,
+			lastInjectedAt: lesson.LastInjectedAt,
+			futureRunOnly: !lesson.LastInjectedAt,
+			relatedTaskTitle: taskTitles.get(lesson.ScenarioID)
+		}));
+}
+
+function summarizeWarnings(
+	plan: PlanWithStatus,
+	taskGroups: TaskGroupSummary[],
+	qa: QAVisibility | null
+): RunWarning[] {
+	const warnings: RunWarning[] = [];
+	const decision = openHumanDecision(plan);
+
+	if (decision) {
+		warnings.push({
+			kind: 'human-review',
+			title: decision.title || 'Human review needed',
+			detail: firstLine(decision.rationale) || 'Recovery produced an open human-review decision.',
+			tone: 'warning',
+			relatedId: decision.id
+		});
+	}
+
+	if (qa?.skipGuardTriggered) {
+		warnings.push({
+			kind: 'qa-skip-guard',
+			title: 'Skipped tests need classification',
+			detail: `${qa.skippedTests.length} skipped test${qa.skippedTests.length === 1 ? '' : 's'} kept QA from approving all-green.`,
+			tone: 'warning'
+		});
+	}
+
+	for (const group of taskGroups.filter((g) => g.hasOrphanedTerminalAttempt)) {
+		warnings.push({
+			kind: 'orphaned-attempt',
+			title: 'Recovered task has old terminal attempt',
+			detail: `${group.title} has an approved replacement but an older rejected/escalated row is still present.`,
+			tone: 'warning',
+			relatedId: group.key
+		});
+	}
+
+	return warnings;
+}
+
+function summarizeUsage(trajectoryItems: TrajectoryListItem[]): UsageSummary {
+	const inputTokens = trajectoryItems.reduce((sum, item) => sum + (item.total_tokens_in ?? 0), 0);
+	const outputTokens = trajectoryItems.reduce((sum, item) => sum + (item.total_tokens_out ?? 0), 0);
+	const durationMs = trajectoryItems.reduce((sum, item) => sum + (item.duration ?? 0), 0);
+	return {
+		totalTokens: inputTokens + outputTokens,
+		inputTokens,
+		outputTokens,
+		durationMs,
+		loopCount: trajectoryItems.length,
+		pricingAvailable: false,
+		costLabel: 'Pricing not configured'
+	};
+}
+
+function openHumanDecision(plan: PlanWithStatus): PlanDecision | undefined {
+	return (plan.plan_decisions ?? []).find((decision) => {
+		if (decision.status !== 'proposed' && decision.status !== 'under_review') return false;
+		return decision.kind === 'execution_exhausted' || /escalate[_ -]?human/i.test(decision.title);
+	});
+}
+
+function taskGroupKey(task: ExecutionTask): string {
+	return `${task.requirement_id ?? 'plan'}::${normalizeTaskTitle(taskTitle(task))}`;
+}
+
+function taskTitle(task: ExecutionTask | undefined): string {
+	if (!task) return 'Untitled task';
+	return task.title || task.prompt || task.description || task.task_id;
+}
+
+function normalizeTaskTitle(title: string): string {
+	return title.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function latestTask(tasks: ExecutionTask[]): ExecutionTask | undefined {
+	return [...tasks].sort((a, b) => dateMs(b.updated_at ?? b.created_at) - dateMs(a.updated_at ?? a.created_at))[0];
+}
+
+function byTaskUpdatedAt(a: ExecutionTask, b: ExecutionTask): number {
+	return dateMs(a.updated_at ?? a.created_at) - dateMs(b.updated_at ?? b.created_at);
+}
+
+function isActiveTaskStage(stage: string | undefined): boolean {
+	if (!stage) return false;
+	if (ACTIVE_TASK_STAGES.has(stage)) return true;
+	return !TERMINAL_TASK_STAGES.has(stage);
+}
+
+function newestTimestamp(values: Array<string | null | undefined>): string | undefined {
+	return values
+		.filter((value): value is string => Boolean(value))
+		.sort((a, b) => dateMs(b) - dateMs(a))[0];
+}
+
+function dateMs(value: string | null | undefined): number {
+	if (!value) return 0;
+	const ms = new Date(value).getTime();
+	return Number.isFinite(ms) ? ms : 0;
+}
+
+function firstLine(text: string | undefined): string {
+	return (text ?? '').split('\n').map((line) => line.trim()).find(Boolean) ?? '';
+}
+
+function stageLabel(stage: string): string {
+	return stage.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function cycleLabel(task: Pick<ExecutionTask, 'tdd_cycle' | 'max_tdd_cycles'>): string {
+	if (typeof task.tdd_cycle !== 'number') return '';
+	const current = task.tdd_cycle + 1;
+	if (typeof task.max_tdd_cycles === 'number') return `cycle ${current}/${task.max_tdd_cycles}`;
+	return `cycle ${current}`;
+}
+
+export function formatTokens(count: number): string {
+	if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+	if (count >= 1000) return `${(count / 1000).toFixed(1)}k`;
+	return String(count);
+}
+
+export function formatDuration(ms: number): string {
+	if (!Number.isFinite(ms) || ms <= 0) return '0s';
+	if (ms < 1000) return `${ms}ms`;
+	if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+	const minutes = Math.floor(ms / 60_000);
+	const seconds = Math.floor((ms % 60_000) / 1000);
+	if (minutes < 60) return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+	const hours = Math.floor(minutes / 60);
+	const remainingMinutes = minutes % 60;
+	return `${hours}h ${remainingMinutes.toString().padStart(2, '0')}m`;
+}

--- a/ui/src/lib/types/trajectoryActivityProjection.test.ts
+++ b/ui/src/lib/types/trajectoryActivityProjection.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mergeLiveTrajectoryItems } from './trajectoryActivityProjection';
+import type { ActivityEvent } from './index';
+import type { TrajectoryListItem } from './trajectory';
+
+type ActivityOverride = Omit<Partial<ActivityEvent>, 'data'> & {
+	data?: unknown;
+	type?: string;
+};
+
+function activity(overrides: ActivityOverride): ActivityEvent {
+	return {
+		loop_id: 'loop-live',
+		timestamp: '2026-06-16T13:10:00Z',
+		type: 'loop_updated',
+		...overrides
+	} as ActivityEvent;
+}
+
+function loaded(overrides: Partial<TrajectoryListItem> = {}): TrajectoryListItem {
+	return {
+		duration: 1000,
+		iterations: 1,
+		loop_id: 'loop-old',
+		model: 'gemini-pro',
+		role: 'general',
+		start_time: '2026-06-16T13:00:00Z',
+		task_id: 'old-task',
+		total_tokens_in: 10,
+		total_tokens_out: 2,
+		workflow_slug: 'semspec-planning',
+		workflow_step: 'drafting',
+		...overrides
+	} as TrajectoryListItem;
+}
+
+describe('mergeLiveTrajectoryItems', () => {
+	it('adds live execution loops for the current plan', () => {
+		const merged = mergeLiveTrajectoryItems([], [
+			activity({
+				data: {
+					created_at: '2026-06-16T13:09:08Z',
+					iterations: 4,
+					loop_id: 'loop-live',
+					metadata: {
+						model: 'gpt-5-5',
+						plan_slug: 'mavlink',
+						role: 'developer',
+						task_id: 'node-1'
+					},
+					task_id: 'dev-run-1',
+					workflow_slug: 'semspec-task-execution',
+					workflow_step: 'develop'
+				}
+			})
+		], 'mavlink');
+
+		expect(merged).toHaveLength(1);
+		expect(merged[0].loop_id).toBe('loop-live');
+		expect(merged[0].workflow_slug).toBe('semspec-task-execution');
+		expect(merged[0].workflow_step).toBe('develop');
+		expect(merged[0].iterations).toBe(4);
+		expect(merged[0].model).toBe('gpt-5-5');
+		expect(merged[0].role).toBe('developer');
+	});
+
+	it('ignores events for other plans', () => {
+		const merged = mergeLiveTrajectoryItems([loaded()], [
+			activity({
+				data: {
+					loop_id: 'other-loop',
+					metadata: { plan_slug: 'other' },
+					workflow_slug: 'semspec-task-execution',
+					workflow_step: 'develop'
+				}
+			})
+		], 'mavlink');
+
+		expect(merged.map((item) => item.loop_id)).toEqual(['loop-old']);
+	});
+
+	it('overlays live updates onto loader rows by loop id', () => {
+		const merged = mergeLiveTrajectoryItems([
+			loaded({
+				loop_id: 'loop-live',
+				iterations: 1,
+				total_tokens_in: 20
+			})
+		], [
+			activity({
+				loop_id: 'loop-live',
+				data: {
+					iterations: 5,
+					loop_id: 'loop-live',
+					metadata: { plan_slug: 'mavlink' },
+					workflow_slug: 'semspec-task-execution',
+					workflow_step: 'develop'
+				}
+			})
+		], 'mavlink');
+
+		expect(merged).toHaveLength(1);
+		expect(merged[0].iterations).toBe(5);
+		expect(merged[0].total_tokens_in).toBe(20);
+	});
+
+	it('marks loop_completed as success when the event has no explicit outcome', () => {
+		const merged = mergeLiveTrajectoryItems([], [
+			activity({
+				type: 'loop_completed',
+				data: {
+					completed_at: '2026-06-16T13:11:00Z',
+					created_at: '2026-06-16T13:10:00Z',
+					loop_id: 'loop-live',
+					metadata: { plan_slug: 'mavlink' },
+					workflow_slug: 'semspec-task-execution',
+					workflow_step: 'review'
+				}
+			})
+		], 'mavlink');
+
+		expect(merged[0].outcome).toBe('success');
+		expect(merged[0].duration).toBe(60_000);
+	});
+
+	it('uses current time for active-loop duration', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-06-16T13:11:00Z'));
+
+		const merged = mergeLiveTrajectoryItems([], [
+			activity({
+				data: {
+					created_at: '2026-06-16T13:10:00Z',
+					loop_id: 'loop-live',
+					metadata: { plan_slug: 'mavlink' },
+					workflow_slug: 'semspec-task-execution',
+					workflow_step: 'develop'
+				}
+			})
+		], 'mavlink');
+
+		expect(merged[0].duration).toBe(60_000);
+		vi.useRealTimers();
+	});
+});

--- a/ui/src/lib/types/trajectoryActivityProjection.ts
+++ b/ui/src/lib/types/trajectoryActivityProjection.ts
@@ -1,0 +1,103 @@
+import type { ActivityEvent } from './index';
+import type { TrajectoryListItem } from './trajectory';
+
+type LiveLoopData = {
+	completed_at?: string;
+	created_at?: string;
+	duration?: number;
+	end_time?: string | null;
+	iterations?: number;
+	loop_id?: string;
+	metadata?: Record<string, unknown>;
+	model?: string;
+	outcome?: string;
+	role?: string;
+	start_time?: string;
+	state?: string;
+	task_id?: string;
+	total_tokens_in?: number;
+	total_tokens_out?: number;
+	workflow_slug?: string;
+	workflow_step?: string;
+};
+
+export function mergeLiveTrajectoryItems(
+	loadedItems: TrajectoryListItem[],
+	activityEvents: ActivityEvent[],
+	planSlug: string
+): TrajectoryListItem[] {
+	if (!planSlug) return loadedItems;
+
+	const byLoop = new Map(loadedItems.map((item) => [item.loop_id, item]));
+
+	for (const event of activityEvents) {
+		const loop = loopData(event);
+		const loopID = loop?.loop_id ?? event.loop_id;
+		if (!loop || !loopID) continue;
+		if (loopPlanSlug(loop) !== planSlug) continue;
+		if (!isLoopMutation(event.type)) continue;
+
+		const previous = byLoop.get(loopID);
+		byLoop.set(loopID, toTrajectoryItem(event, loop, previous));
+	}
+
+	return Array.from(byLoop.values()).sort((a, b) => startMs(a) - startMs(b));
+}
+
+function loopData(event: ActivityEvent): LiveLoopData | null {
+	const raw = (event as ActivityEvent & { data?: unknown }).data;
+	if (!raw || typeof raw !== 'object') return null;
+	return raw as LiveLoopData;
+}
+
+function loopPlanSlug(loop: LiveLoopData): string | null {
+	const raw = loop.metadata?.plan_slug;
+	return typeof raw === 'string' ? raw : null;
+}
+
+function isLoopMutation(type: string): boolean {
+	return type === 'loop_created' || type === 'loop_updated' || type === 'loop_completed';
+}
+
+function toTrajectoryItem(
+	event: ActivityEvent,
+	loop: LiveLoopData,
+	previous: TrajectoryListItem | undefined
+): TrajectoryListItem {
+	const startTime = loop.start_time ?? loop.created_at ?? previous?.start_time ?? event.timestamp;
+	const endTime = loop.end_time ?? loop.completed_at ?? previous?.end_time ?? null;
+	const outcome = loop.outcome ?? previous?.outcome ?? (event.type === 'loop_completed' ? 'success' : undefined);
+
+	return {
+		duration: loop.duration ?? previous?.duration ?? durationMs(startTime, endTime),
+		end_time: endTime,
+		iterations: loop.iterations ?? previous?.iterations ?? 0,
+		loop_id: loop.loop_id ?? event.loop_id,
+		metadata: loop.metadata ?? previous?.metadata,
+		model: stringFrom(loop.model ?? loop.metadata?.model ?? previous?.model),
+		outcome,
+		role: stringFrom(loop.role ?? loop.metadata?.role ?? previous?.role) || 'general',
+		start_time: startTime,
+		task_id: stringFrom(loop.task_id ?? loop.metadata?.task_id ?? previous?.task_id),
+		total_tokens_in: loop.total_tokens_in ?? previous?.total_tokens_in ?? 0,
+		total_tokens_out: loop.total_tokens_out ?? previous?.total_tokens_out ?? 0,
+		workflow_slug: loop.workflow_slug ?? previous?.workflow_slug,
+		workflow_step: loop.workflow_step ?? previous?.workflow_step
+	};
+}
+
+function stringFrom(value: unknown): string {
+	return typeof value === 'string' ? value : '';
+}
+
+function durationMs(startTime: string, endTime: string | null | undefined): number {
+	const start = new Date(startTime).getTime();
+	if (!Number.isFinite(start)) return 0;
+	const end = endTime ? new Date(endTime).getTime() : Date.now();
+	if (!Number.isFinite(end)) return 0;
+	return Math.max(0, end - start);
+}
+
+function startMs(item: TrajectoryListItem): number {
+	return new Date(item.start_time).getTime();
+}

--- a/ui/src/routes/e2e-test/run-visibility/+page.svelte
+++ b/ui/src/routes/e2e-test/run-visibility/+page.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import RunVisibilityPanel from '$lib/components/plan/RunVisibilityPanel.svelte';
+	import type { PlanWithStatus } from '$lib/types/plan';
+	import type { ExecutionTask, Lesson } from '$lib/types/runVisibility';
+	import type { TrajectoryListItem } from '$lib/types/trajectory';
+
+	const plan = {
+		id: 'plan-1',
+		slug: '57daa4134abb',
+		title: 'Raw MAVLink Fallback Integration',
+		project_id: 'project-1',
+		status: 'rejected',
+		stage: 'rejected',
+		approved: true,
+		active_loops: [],
+		created_at: '2026-06-16T13:54:32Z',
+		plan_decisions: [
+			{
+				id: 'plan-decision.57daa4134abb.recovery.c781429a',
+				plan_id: 'plan-1',
+				kind: 'execution_exhausted',
+				title: 'Recovery: escalate_human',
+				rationale:
+					'Recommended action: escalate_human\nOriginal wedge: QA verdict needs_changes at level integration',
+				status: 'proposed',
+				proposed_by: 'recovery-agent',
+				affected_requirement_ids: ['requirement.57daa4134abb.1'],
+				created_at: '2026-06-16T15:50:01Z'
+			}
+		],
+		qa_level: 'integration',
+		qa_run: {
+			run_id: 'qa-1',
+			passed: true,
+			duration_ms: 42156,
+			completed_at: '2026-06-16T15:48:45Z',
+			skipped_tests: [
+				{ name: 'scenario.57daa4134abb.1.1.3: start connects MAVSDK to SITL' },
+				{ name: 'scenario.57daa4134abb.3.1.5: SITL takeoff command completes' }
+			]
+		},
+		qa_verdict_summary: {
+			verdict: 'needs_changes',
+			level: 'integration',
+			summary:
+				'Executed tests passed, but live SITL tests were skipped. [skip-guard] coerced approved->needs_changes until each skip is classified.',
+			recorded_at: '2026-06-16T15:49:54Z'
+		}
+	} as PlanWithStatus;
+
+	const executionTasks: ExecutionTask[] = [
+		{
+			slug: '57daa4134abb',
+			task_id: 'node-original',
+			requirement_id: 'requirement.57daa4134abb.2',
+			stage: 'escalated',
+			verdict: 'rejected',
+			title: 'Verify coverage matrix generation and SITL outputs',
+			updated_at: '2026-06-16T15:00:00Z'
+		},
+		{
+			slug: '57daa4134abb',
+			task_id: 'node-replacement',
+			requirement_id: 'requirement.57daa4134abb.2',
+			stage: 'approved',
+			verdict: 'approved',
+			title: 'Verify coverage matrix generation and SITL outputs',
+			merge_commit: '28e9a4df444b8eaa64b23b500f962be868ff0572',
+			updated_at: '2026-06-16T15:09:18Z'
+		},
+		{
+			slug: '57daa4134abb',
+			task_id: 'node-raw',
+			requirement_id: 'requirement.57daa4134abb.4',
+			stage: 'approved',
+			verdict: 'approved',
+			title: 'Verify loading of custom XML dialects without hand-rolled framing',
+			merge_commit: '8948d8009182925dd277ec2c9142e20a77f50774',
+			updated_at: '2026-06-16T15:47:31Z'
+		}
+	];
+
+	const trajectoryItems = [
+		{
+			loop_id: 'loop-1',
+			task_id: 'node-replacement',
+			role: 'developer',
+			model: 'gemini-pro',
+			workflow_slug: 'semspec-task-execution',
+			workflow_step: 'develop',
+			iterations: 12,
+			total_tokens_in: 110300,
+			total_tokens_out: 4600,
+			duration: 68000,
+			start_time: '2026-06-16T15:00:00Z',
+			outcome: 'success'
+		},
+		{
+			loop_id: 'loop-2',
+			task_id: 'node-raw',
+			role: 'developer',
+			model: 'gemini-pro',
+			workflow_slug: 'semspec-task-execution',
+			workflow_step: 'develop',
+			iterations: 4,
+			total_tokens_in: 16000,
+			total_tokens_out: 900,
+			duration: 20400,
+			start_time: '2026-06-16T15:40:00Z',
+			outcome: 'success'
+		}
+	] as TrajectoryListItem[];
+
+	const lessons: Lesson[] = [
+		{
+			ID: 'lesson-1',
+			Source: 'decomposer',
+			ScenarioID: 'node-replacement',
+			Summary: 'Do not create empty dummy classes to bypass coverage checks.',
+			CategoryIDs: [],
+			Role: 'developer',
+			CreatedAt: '2026-06-16T14:55:04Z',
+			Detail: '',
+			InjectionForm: 'Document unsupported features with rationale.',
+			EvidenceSteps: [],
+			EvidenceFiles: [],
+			RootCauseRole: 'developer',
+			Positive: false,
+			RetiredAt: null,
+			LastInjectedAt: '2026-06-16T15:42:15Z'
+		},
+		{
+			ID: 'lesson-2',
+			Source: 'decomposer',
+			ScenarioID: 'node-raw',
+			Summary: 'Use test display names to map test methods to acceptance scenario IDs.',
+			CategoryIDs: [],
+			Role: 'developer',
+			CreatedAt: '2026-06-16T15:47:46Z',
+			Detail: '',
+			InjectionForm: 'Use JUnit display names for scenario traceability.',
+			EvidenceSteps: [],
+			EvidenceFiles: [],
+			RootCauseRole: 'developer',
+			Positive: true,
+			RetiredAt: null,
+			LastInjectedAt: null
+		}
+	];
+</script>
+
+<main class="harness" data-testid="run-visibility-harness">
+	<RunVisibilityPanel {plan} {executionTasks} {trajectoryItems} {lessons} />
+</main>
+
+<style>
+	.harness {
+		max-width: 940px;
+		padding: var(--space-4);
+	}
+</style>

--- a/ui/src/routes/e2e-test/run-visibility/+page.ts
+++ b/ui/src/routes/e2e-test/run-visibility/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types';
+
+export const ssr = false;
+
+export const load: PageLoad = async () => {
+	return {};
+};

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -23,6 +23,10 @@
 	import { promotePlan, executePlan, retryFailed } from '$lib/actions/plans';
 	import RetrySelectedPicker from '$lib/components/plan/RetrySelectedPicker.svelte';
 	import { derivePlanPipeline, getStageLabel } from '$lib/types/plan';
+	import { activePhaseProgress } from '$lib/types/activePlanProgress';
+	import { selectFreshestPlan } from '$lib/types/planFreshness';
+	import { mergeLiveTrajectoryItems } from '$lib/types/trajectoryActivityProjection';
+	import { activityStore } from '$lib/stores/activity.svelte';
 	import { feedStore, syncQuestionsToFeed } from '$lib/stores/feed.svelte';
 	import { questionsStore } from '$lib/stores/questions.svelte';
 	import { graphStore } from '$lib/stores/graphStore.svelte';
@@ -42,23 +46,38 @@
 	// Prefer the SSE-fed feedStore mirror for the active slug — it carries the
 	// same PlanWithStatus shape the loader returns, and updates without a
 	// full loader re-run. Fall back to load-function data for initial render
-	// (before the first SSE event arrives) and for stale slugs.
+	// (before the first SSE event arrives) and for stale slugs. When loader
+	// data has advanced farther than the SSE mirror, prefer the loader; this
+	// prevents a stale "Generating scenarios" header from coexisting with
+	// freshly loaded execution trajectories.
 	const plan = $derived(
-		feedStore.currentPlan && feedStore.currentPlan.slug === slug
-			? feedStore.currentPlan
-			: data.plan
+		selectFreshestPlan(feedStore.currentPlan, data.plan, slug ?? '')
 	);
 	const pipeline = $derived(plan ? derivePlanPipeline(plan) : null);
 	const requirements = $derived(data.requirements);
 	const scenariosByReq = $derived(data.scenariosByReq);
 	const hasRequirements = $derived(requirements.length > 0);
 	const hasScenarios = $derived(Object.values(scenariosByReq).some((s) => s.length > 0));
+	const liveTrajectoryItems = $derived(
+		mergeLiveTrajectoryItems(data.trajectoryItems, activityStore.recent, slug ?? '')
+	);
 
 	// ---------------------------------------------------------------------------
 	// View mode — toggle between Doc, Graph, and Files
 	// ---------------------------------------------------------------------------
 	type ViewMode = 'doc' | 'artifacts' | 'graph' | 'files';
+	const FILES_VIEW_STAGES = new Set([
+		'implementing',
+		'executing',
+		'ready_for_qa',
+		'reviewing_qa',
+		'reviewing_rollup',
+		'complete',
+		'complete_with_deferrals',
+		'failed'
+	]);
 	let viewMode = $state<ViewMode>('doc');
+	const showFilesView = $derived(plan ? FILES_VIEW_STAGES.has(plan.stage) : false);
 
 	// Build a plan-scoped graph adapter that loads the plan's entity neighborhood
 	const planGraphAdapter: GraphStoreAdapter = {
@@ -66,7 +85,7 @@
 			// Load entities connected to this plan via pathSearch. Depth=3 is
 			// required to cover plan → requirement → scenario → dag-node — depth=2
 			// stopped at requirements and rendered a near-empty view (bug #7.3).
-			const planEntityId = `semspec.plan.${slug}`;
+			const planEntityId = plan?.id ?? `semspec.plan.${slug}`;
 			const result = await graphApi.pathSearch(planEntityId, 3, limit);
 			const entities = transformPathSearchResult(result);
 			return { entities };
@@ -160,9 +179,9 @@
 		}
 	}
 
-	// Reset files mode if plan becomes unapproved (e.g. via invalidate)
+	// Reset files mode if the plan is not in an execution/result stage.
 	$effect(() => {
-		if (plan && !plan.approved && viewMode === 'files') {
+		if (plan && !showFilesView && viewMode === 'files') {
 			viewMode = 'doc';
 		}
 	});
@@ -177,6 +196,24 @@
 	const planGuidance = $derived(
 		plan ? deriveGuidance(plan.approved, plan.stage, requirements.length) : null
 	);
+	const activeProgress = $derived(activePhaseProgress(liveTrajectoryItems));
+	const progressPanel = $derived.by(() => {
+		if (activeProgress) {
+			return {
+				title: activeProgress.title,
+				detail: activeProgress.detail,
+				startedAt: activeProgress.startedAt
+			};
+		}
+		if (planGuidance?.isLoading && plan) {
+			return {
+				title: stageTitle(plan.stage),
+				detail: planGuidance.message,
+				startedAt: stageStartedAt(plan)
+			};
+		}
+		return null;
+	});
 
 	// Pick the best available timestamp to drive the in-progress panel's
 	// elapsed-time ticker for the CURRENT stage. The plan API doesn't yet
@@ -408,7 +445,7 @@
 					<Icon name="git-merge" size={14} />
 					<span>Graph</span>
 				</button>
-				{#if plan.approved}
+				{#if showFilesView}
 					<button
 						class="toggle-btn"
 						class:active={viewMode === 'files'}
@@ -537,11 +574,11 @@
 			     context/scope sections haven't been populated yet. Reuses
 			     planGuidance — same predicate that gates the small chip
 			     inside PlanDetail — so the panel and chip stay in sync. -->
-			{#if planGuidance?.isLoading}
+			{#if progressPanel}
 				<InProgressPanel
-					title={stageTitle(plan.stage)}
-					detail={planGuidance.message}
-					startedAt={stageStartedAt(plan)}
+					title={progressPanel.title}
+					detail={progressPanel.detail}
+					startedAt={progressPanel.startedAt}
 				/>
 			{/if}
 
@@ -589,7 +626,7 @@
 			{/if}
 
 			<!-- Trajectory timeline: plan phase + execution loops -->
-			<ExecutionTimeline slug={plan.slug} stage={plan.stage} trajectoryItems={data.trajectoryItems} />
+			<ExecutionTimeline slug={plan.slug} stage={plan.stage} trajectoryItems={liveTrajectoryItems} />
 
 			<!-- Requirements + Scenarios are shown inline within PlanDetail above -->
 		</div>

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -11,6 +11,7 @@
 	import RequirementPanel from '$lib/components/plan/RequirementPanel.svelte';
 	import ActionBar from '$lib/components/plan/ActionBar.svelte';
 	import PhaseArtifactsView from '$lib/components/plan/PhaseArtifactsView.svelte';
+	import RunVisibilityPanel from '$lib/components/plan/RunVisibilityPanel.svelte';
 	import { AgentPipelineView } from '$lib/components/pipeline';
 	import ExecutionTimeline from '$lib/components/trajectory/ExecutionTimeline.svelte';
 	import { ReviewDashboard } from '$lib/components/review';
@@ -25,6 +26,7 @@
 	import { derivePlanPipeline, getStageLabel } from '$lib/types/plan';
 	import { activePhaseProgress } from '$lib/types/activePlanProgress';
 	import { selectFreshestPlan } from '$lib/types/planFreshness';
+	import { mergeTaskSse } from '$lib/types/runVisibility';
 	import { mergeLiveTrajectoryItems } from '$lib/types/trajectoryActivityProjection';
 	import { activityStore } from '$lib/stores/activity.svelte';
 	import { feedStore, syncQuestionsToFeed } from '$lib/stores/feed.svelte';
@@ -60,6 +62,9 @@
 	const hasScenarios = $derived(Object.values(scenariosByReq).some((s) => s.length > 0));
 	const liveTrajectoryItems = $derived(
 		mergeLiveTrajectoryItems(data.trajectoryItems, activityStore.recent, slug ?? '')
+	);
+	const liveExecutionTasks = $derived(
+		mergeTaskSse(data.executionTasks ?? [], feedStore.taskStages, slug ?? '')
 	);
 
 	// ---------------------------------------------------------------------------
@@ -581,6 +586,13 @@
 					startedAt={progressPanel.startedAt}
 				/>
 			{/if}
+
+			<RunVisibilityPanel
+				{plan}
+				executionTasks={liveExecutionTasks}
+				trajectoryItems={liveTrajectoryItems}
+				lessons={data.lessons ?? []}
+			/>
 
 			<!-- Agent pipeline during execution -->
 			{#if plan.active_loops && plan.active_loops.length > 0}

--- a/ui/src/routes/plans/[slug]/+page.ts
+++ b/ui/src/routes/plans/[slug]/+page.ts
@@ -4,14 +4,17 @@ import type { Requirement } from '$lib/types/requirement';
 import type { Scenario } from '$lib/types/scenario';
 import type { TrajectoryListItem, TrajectoryListResponse } from '$lib/types/trajectory';
 import type { SynthesisResult } from '$lib/types/review';
+import type { ExecutionTask, Lesson } from '$lib/types/runVisibility';
 
 export const load: PageLoad = async ({ params, fetch, depends }) => {
 	depends('app:plans');
 	const slug = params.slug;
 
-	// Fetch plan, requirements, trajectory summaries, and reviews in parallel
+	// Fetch plan, requirements, trajectory summaries, reviews, and execution
+	// state in parallel. Execution-manager rows are the durable task-attempt
+	// record; trajectories alone are a loop ledger and cannot explain recovery.
 	// Backend may return JSON `null` for empty collections, so coalesce to []
-	const [plan, requirements, trajectoryItems, reviews] = await Promise.all([
+	const [plan, requirements, trajectoryItems, reviews, executionTasks, lessons] = await Promise.all([
 		fetch(`/plan-manager/plans/${slug}`)
 			.then((r) => (r.ok ? (r.json() as Promise<PlanWithStatus>) : null))
 			.catch(() => null),
@@ -27,7 +30,13 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 			.catch(() => [] as TrajectoryListItem[]),
 		fetch(`/plan-manager/plans/${slug}/reviews`)
 			.then((r) => (r.ok ? r.json().then((d: SynthesisResult | null) => d) : null))
-			.catch(() => null)
+			.catch(() => null),
+		fetch(`/execution-manager/plans/${slug}/tasks`)
+			.then((r) => (r.ok ? r.json().then((d: ExecutionTask[] | null) => d ?? []) : []))
+			.catch(() => [] as ExecutionTask[]),
+		fetch('/execution-manager/lessons?role=developer')
+			.then((r) => (r.ok ? r.json().then((d: Lesson[] | null) => d ?? []) : []))
+			.catch(() => [] as Lesson[])
 	]);
 
 	// Fetch scenarios for each requirement in parallel
@@ -47,5 +56,13 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 		scenariosByReq[reqId] = scenarios;
 	}
 
-	return { plan, requirements, scenariosByReq, trajectoryItems: trajectoryItems ?? [], reviews: reviews ?? null };
+	return {
+		plan,
+		requirements,
+		scenariosByReq,
+		trajectoryItems: trajectoryItems ?? [],
+		reviews: reviews ?? null,
+		executionTasks: executionTasks ?? [],
+		lessons: lessons ?? []
+	};
 };


### PR DESCRIPTION
## Summary
- add a run visibility panel to the plan detail page that separates execution attempts, QA status, warnings, lesson capture, and token usage from the raw loop ledger
- fetch execution-manager task rows and developer lessons on the plan page, then merge live task SSE updates through terminal QA/rejected states
- add a fixture route and projection tests for human escalation, QA skip guard, recovered/orphaned task attempts, lesson visibility, and token-only cost display

## Why
The mavlink-hard run showed that the UI could look healthy while execution had entered a dark state: implementation tasks were approved, QA passed executed tests, live SITL skips forced needs_changes, recovery escalated to a human, and useful lessons were captured. The UI needs to state that directly instead of showing only generic phase labels and loop rows.

## Validation
- npm run test -- runVisibility
- npm run check (0 errors; existing autofocus warnings in settings remain)
- visual fixture check at /e2e-test/run-visibility: no horizontal overflow or clipped compact labels

## Notes
- Cost display remains token/time based and explicitly says Pricing not configured; no provider pricing metadata is available yet.
- This is frontend-only and was developed in an isolated worktree while the live Semspec stack stayed read-only.