### PR TITLE
feat(ui): surface execution task attempts

### DIFF
--- a/ui/src/lib/components/plan/ExecutionDetail.svelte
+++ b/ui/src/lib/components/plan/ExecutionDetail.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
 	import Icon from '$lib/components/shared/Icon.svelte';
-	import { executionBlockers, qaOutcomeState, storyTaskCounts } from '$lib/components/plan/observabilityModels';
+	import {
+		executionAttemptModel,
+		executionBlockers,
+		qaOutcomeState,
+		storyTaskCounts,
+		type ExecutionTask,
+		type ExecutionTaskAttempt,
+		type ExecutionTaskGroupStatus
+	} from '$lib/components/plan/observabilityModels';
 	import type { PlanWithStatus } from '$lib/types/plan';
 
 	interface Props {
 		plan: PlanWithStatus;
+		executionTasks?: ExecutionTask[];
 	}
 
-	let { plan }: Props = $props();
+	let { plan, executionTasks = [] }: Props = $props();
 
 	type Story = NonNullable<PlanWithStatus['stories']>[number];
 	type StoryTask = NonNullable<Story['tasks']>[number];
@@ -19,6 +28,12 @@
 	const qaRun = $derived(plan.qa_run ?? null);
 	const qaVerdict = $derived(plan.qa_verdict_summary ?? null);
 	const qaState = $derived(qaOutcomeState(plan));
+	const attemptModel = $derived(executionAttemptModel(executionTasks));
+	const skippedTests = $derived(qaRun?.skipped_tests ?? []);
+	const skipGuardTriggered = $derived(
+		skippedTests.length > 0 &&
+			((qaVerdict?.summary ?? '').includes('[skip-guard]') || qaVerdict?.verdict === 'needs_changes')
+	);
 	const terminalState = $derived(
 		summary?.phase === 'terminal' || ['complete', 'complete_with_deferrals', 'failed'].includes(plan.stage)
 	);
@@ -42,6 +57,7 @@
 				return 'active';
 			case 'blocked':
 			case 'waiting':
+			case 'recovered':
 				return 'warning';
 			default:
 				return 'neutral';
@@ -58,6 +74,69 @@
 
 	function taskTitle(task: StoryTask): string {
 		return task.description || task.id;
+	}
+
+	function groupStatusLabel(status: ExecutionTaskGroupStatus): string {
+		switch (status) {
+			case 'active':
+				return 'active';
+			case 'approved':
+				return 'approved';
+			case 'recovered':
+				return 'recovered';
+			case 'blocked':
+				return 'blocked';
+			default:
+				return 'pending';
+		}
+	}
+
+	function attemptState(attempt: ExecutionTaskAttempt): string {
+		if (attempt.stage === 'approved') return 'success';
+		if (attempt.stage === 'escalated') return 'warning';
+		if (attempt.stage === 'error' || attempt.stage === 'rejected') return 'error';
+		return 'active';
+	}
+
+	function attemptIcon(attempt: ExecutionTaskAttempt): string {
+		switch (attemptState(attempt)) {
+			case 'success':
+				return 'check-circle';
+			case 'warning':
+				return 'alert-triangle';
+			case 'error':
+				return 'x-circle';
+			default:
+				return 'loader';
+		}
+	}
+
+	function cycleLabel(attempt: ExecutionTaskAttempt): string {
+		if (typeof attempt.tddCycle !== 'number') return '';
+		const current = attempt.tddCycle + 1;
+		if (typeof attempt.maxTddCycles === 'number') return `cycle ${current}/${attempt.maxTddCycles}`;
+		return `cycle ${current}`;
+	}
+
+	function shortRequirement(id: string | undefined): string {
+		if (!id) return 'Plan';
+		const match = id.match(/(\d+)$/);
+		return match ? `Req ${match[1]}` : id;
+	}
+
+	function shortSha(sha: string | undefined): string {
+		return sha ? sha.slice(0, 8) : '';
+	}
+
+	function timeLabel(value: string | undefined): string {
+		if (!value) return '';
+		const date = new Date(value);
+		if (!Number.isFinite(date.getTime())) return '';
+		return `${date.toISOString().slice(11, 19)}Z`;
+	}
+
+	function attemptDetail(attempt: ExecutionTaskAttempt): string {
+		return attempt.errorReason || attempt.escalationReason || attempt.feedback || '';
 	}
 </script>
 
@@ -89,6 +168,16 @@
 			<span class="overview-label">Loops</span>
 			<span class="overview-value">{activeLoops.length}</span>
 		</div>
+		{#if attemptModel.totalAttempts > 0}
+			<div class="overview-item">
+				<span class="overview-label">Attempts</span>
+				<span class="overview-value">{attemptModel.totalAttempts}</span>
+			</div>
+			<div class="overview-item" data-state={attemptModel.orphanedGroups > 0 ? 'warning' : 'neutral'}>
+				<span class="overview-label">Recovered</span>
+				<span class="overview-value">{attemptModel.orphanedGroups}</span>
+			</div>
+		{/if}
 		{#if execution}
 			<div class="overview-item">
 				<span class="overview-label">Reqs Done</span>
@@ -101,7 +190,7 @@
 		{/if}
 	</div>
 
-	{#if blockers.length > 0}
+	{#if blockers.length > 0 || attemptModel.warnings.length > 0 || skipGuardTriggered}
 		<div class="blockers">
 			{#each blockers as blocker}
 				<div class="blocker" data-kind={blocker.kind}>
@@ -109,6 +198,26 @@
 					<div>
 						<div class="blocker-label">{blocker.label}</div>
 						{#if blocker.detail}<div class="blocker-detail">{blocker.detail}</div>{/if}
+					</div>
+				</div>
+			{/each}
+			{#if skipGuardTriggered}
+				<div class="blocker" data-kind="qa">
+					<Icon name="alert-triangle" size={14} />
+					<div>
+						<div class="blocker-label">Skipped tests need classification</div>
+						<div class="blocker-detail">
+							{skippedTests.length} skipped test{skippedTests.length === 1 ? '' : 's'} kept QA from treating this as all-green.
+						</div>
+					</div>
+				</div>
+			{/if}
+			{#each attemptModel.warnings as warning (warning.relatedId)}
+				<div class="blocker" data-kind="attempt">
+					<Icon name="alert-triangle" size={14} />
+					<div>
+						<div class="blocker-label">{warning.title}</div>
+						<div class="blocker-detail">{warning.detail}</div>
 					</div>
 				</div>
 			{/each}
@@ -126,6 +235,52 @@
 					<div class="loop-row" data-state={statusClass(loop.state)}>
 						<span class="loop-main">{loopLabel(loop)}</span>
 						<span class="loop-id">{loop.loop_id.slice(0, 12)}</span>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	{#if attemptModel.taskGroups.length > 0}
+		<div class="subsection">
+			<div class="subsection-title">
+				<Icon name="git-branch" size={13} />
+				<span>Execution Attempts</span>
+			</div>
+			<div class="attempt-group-list">
+				{#each attemptModel.taskGroups as group (group.key)}
+					<div class="attempt-group" data-status={group.status}>
+						<div class="attempt-group-main">
+							<span class="req-chip">{shortRequirement(group.requirementId)}</span>
+							<span class="attempt-title">{group.title}</span>
+							<span class="status-pill" data-state={statusClass(group.status)}>
+								{groupStatusLabel(group.status)}
+							</span>
+						</div>
+						<div class="attempt-list">
+							{#each group.attempts as attempt, index (attempt.taskId)}
+								<div class="attempt-row" data-state={attemptState(attempt)}>
+									<Icon name={attemptIcon(attempt)} size={13} />
+									<span>Attempt {index + 1}</span>
+									<span class="attempt-stage">{compactStatus(attempt.stage)}</span>
+									{#if cycleLabel(attempt)}
+										<span>{cycleLabel(attempt)}</span>
+									{/if}
+									{#if attempt.mergeCommit}
+										<span class="attempt-sha">
+											<Icon name="git-commit" size={12} />
+											{shortSha(attempt.mergeCommit)}
+										</span>
+									{/if}
+									{#if attempt.updatedAt}
+										<span class="attempt-time">{timeLabel(attempt.updatedAt)}</span>
+									{/if}
+								</div>
+								{#if attemptDetail(attempt)}
+									<div class="attempt-detail">{attemptDetail(attempt)}</div>
+								{/if}
+							{/each}
+						</div>
 					</div>
 				{/each}
 			</div>
@@ -202,6 +357,17 @@
 								</li>
 							{/each}
 						</ul>
+					{/if}
+					{#if skippedTests.length}
+						<div class="skip-list">
+							<div class="skip-title">
+								<Icon name="skip-forward" size={13} />
+								<span>{skippedTests.length} skipped test{skippedTests.length === 1 ? '' : 's'}</span>
+							</div>
+							{#each skippedTests.slice(0, 4) as skipped, index (skipped.name + index)}
+								<span class="skip-item">{skipped.name}</span>
+							{/each}
+						</div>
 					{/if}
 				{/if}
 				{#if qaVerdict}
@@ -305,13 +471,20 @@
 		color: var(--color-error);
 	}
 
+	.overview-item[data-state='warning'] .overview-value {
+		color: var(--color-warning);
+	}
+
 	.overview-label,
 	.story-meta,
 	.loop-id,
 	.task-status,
+	.attempt-row,
+	.attempt-detail,
 	.empty-note,
 	.qa-row span,
 	.qa-failures small,
+	.skip-item,
 	.blocker-detail {
 		font-size: var(--font-size-xs);
 		color: var(--color-text-muted);
@@ -326,6 +499,9 @@
 	.blockers,
 	.loop-list,
 	.story-list,
+	.attempt-group-list,
+	.attempt-list,
+	.skip-list,
 	.task-list,
 	.qa-failures {
 		display: flex;
@@ -346,6 +522,11 @@
 	.blocker[data-kind='qa'] {
 		background: var(--color-error-muted, rgba(239, 68, 68, 0.12));
 		color: var(--color-error);
+	}
+
+	.blocker[data-kind='attempt'] {
+		background: var(--color-warning-muted, rgba(245, 158, 11, 0.1));
+		color: var(--color-warning);
 	}
 
 	.blocker-label {
@@ -413,6 +594,87 @@
 		list-style: none;
 		margin: 0;
 		padding: 0 var(--space-3) var(--space-2);
+	}
+
+	.attempt-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-2);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-tertiary);
+	}
+
+	.attempt-group-main {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.req-chip {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-secondary);
+		white-space: nowrap;
+	}
+
+	.attempt-title {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-medium);
+		color: var(--color-text-primary);
+	}
+
+	.attempt-list {
+		gap: var(--space-1);
+		padding-left: var(--space-3);
+	}
+
+	.attempt-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		min-height: 22px;
+	}
+
+	.attempt-row[data-state='success'] {
+		color: var(--color-success);
+	}
+
+	.attempt-row[data-state='warning'] {
+		color: var(--color-warning);
+	}
+
+	.attempt-row[data-state='error'] {
+		color: var(--color-error);
+	}
+
+	.attempt-row[data-state='active'] {
+		color: var(--color-accent);
+	}
+
+	.attempt-stage,
+	.attempt-sha,
+	.attempt-time {
+		color: var(--color-text-secondary);
+	}
+
+	.attempt-sha {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		font-family: var(--font-family-mono);
+	}
+
+	.attempt-detail {
+		padding-left: calc(13px + var(--space-2));
+		line-height: var(--line-height-normal);
 	}
 
 	.task-row {
@@ -508,5 +770,37 @@
 		font-size: var(--font-size-sm);
 		line-height: var(--line-height-normal);
 		color: var(--color-text-secondary);
+	}
+
+	.skip-list {
+		gap: var(--space-1);
+	}
+
+	.skip-title {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-medium);
+		color: var(--color-warning);
+	}
+
+	.skip-item {
+		line-height: var(--line-height-normal);
+	}
+
+	@media (max-width: 720px) {
+		.attempt-group-main {
+			grid-template-columns: auto minmax(0, 1fr);
+		}
+
+		.attempt-group-main .status-pill {
+			grid-column: 1 / -1;
+			justify-self: flex-start;
+		}
+
+		.attempt-row {
+			flex-wrap: wrap;
+		}
 	}
 </style>

--- a/ui/src/lib/components/plan/LessonActivityDetail.svelte
+++ b/ui/src/lib/components/plan/LessonActivityDetail.svelte
@@ -7,7 +7,8 @@
 	} from '$lib/types/costAccounting';
 	import {
 		formatToken,
-		lessonActivityModel
+		lessonActivityModel,
+		type PersistedLessonSummary
 	} from '$lib/components/plan/observabilityModels';
 	import type { PlanWithStatus } from '$lib/types/plan';
 	import type { TrajectoryListItem } from '$lib/types/trajectory';
@@ -15,10 +16,11 @@
 	interface Props {
 		plan: PlanWithStatus;
 		trajectoryItems?: TrajectoryListItem[];
+		persistedLessons?: PersistedLessonSummary[];
 		providerRates?: ProviderRate[];
 	}
 
-	let { plan, trajectoryItems = [], providerRates = [] }: Props = $props();
+	let { plan, trajectoryItems = [], persistedLessons = [], providerRates = [] }: Props = $props();
 
 	const lessonSummary = $derived(plan.phase_summary?.lessons ?? null);
 	const model = $derived(lessonActivityModel(plan, trajectoryItems, providerRates));
@@ -32,6 +34,13 @@
 		if (ms < 1000) return `${ms}ms`;
 		if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
 		return `${(ms / 60000).toFixed(1)}m`;
+	}
+
+	function timeLabel(value: string | null | undefined): string {
+		if (!value) return '';
+		const date = new Date(value);
+		if (!Number.isFinite(date.getTime())) return '';
+		return `${date.toISOString().slice(11, 19)}Z`;
 	}
 </script>
 
@@ -82,7 +91,27 @@
 				</div>
 			{/each}
 		</div>
-	{:else}
+	{/if}
+
+	{#if persistedLessons.length > 0}
+		<div class="captured-list">
+			{#each persistedLessons.slice(0, 6) as lesson (lesson.id)}
+				<div class="captured-row" data-positive={lesson.positive}>
+					<Icon name={lesson.positive ? 'lightbulb' : 'alert-circle'} size={14} />
+					<div class="captured-copy">
+						<span>{lesson.summary}</span>
+						<small>
+							{lesson.relatedTaskTitle ?? lesson.source}
+							<span aria-hidden="true">·</span>
+							{lesson.futureRunOnly ? 'future-run only' : `injected ${timeLabel(lesson.lastInjectedAt)}`}
+						</small>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	{#if model.lessonLoops.length === 0 && persistedLessons.length === 0}
 		<div class="empty-note">
 			<Icon name="info" size={16} />
 			<span>Lesson activity has not produced measured trajectory usage for this run.</span>
@@ -105,6 +134,7 @@
 	.section-title,
 	.metric-row,
 	.role-row,
+	.captured-row,
 	.empty-note {
 		display: flex;
 		align-items: center;
@@ -184,6 +214,46 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-1);
+	}
+
+	.captured-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.captured-row {
+		align-items: flex-start;
+		gap: var(--space-2);
+		padding: var(--space-2);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-tertiary);
+		color: var(--color-warning);
+	}
+
+	.captured-row[data-positive='true'] {
+		color: var(--color-success);
+	}
+
+	.captured-copy {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.captured-copy span {
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-normal);
+		color: var(--color-text-primary);
+	}
+
+	.captured-copy small {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
 	}
 
 	.role-row {

--- a/ui/src/lib/components/plan/observabilityModels.test.ts
+++ b/ui/src/lib/components/plan/observabilityModels.test.ts
@@ -4,16 +4,21 @@ import type { PlanPhaseSummary } from '$lib/types/feed';
 import type { PlanWithStatus } from '$lib/types/plan';
 import type { TrajectoryListItem } from '$lib/types/trajectory';
 import {
+	executionAttemptModel,
 	executionBlockers,
 	inferRecoveryAutoAccept,
 	isLessonTrajectoryItem,
 	lessonActivityModel,
+	mergeExecutionTaskSSE,
+	persistedLessonSummaries,
 	phaseSummaryDetail,
 	planFreshnessIndicatorState,
 	qaOutcomeState,
 	recoveryAffectedNodes,
 	shouldShowPhaseSummaryBanner,
-	storyTaskCounts
+	storyTaskCounts,
+	type ExecutionTask,
+	type Lesson
 } from './observabilityModels';
 
 function plan(overrides: Partial<PlanWithStatus> = {}): PlanWithStatus {
@@ -61,6 +66,39 @@ function trajectory(overrides: Partial<TrajectoryListItem> = {}): TrajectoryList
 		total_tokens_out: 300,
 		...overrides
 	} as TrajectoryListItem;
+}
+
+function executionTask(overrides: Partial<ExecutionTask> = {}): ExecutionTask {
+	return {
+		slug: 'demo',
+		task_id: 'node-1',
+		requirement_id: 'requirement.demo.1',
+		stage: 'approved',
+		title: 'Implement raw fallback',
+		updated_at: '2026-06-16T12:15:00Z',
+		...overrides
+	};
+}
+
+function lesson(overrides: Partial<Lesson> = {}): Lesson {
+	return {
+		ID: 'lesson-1',
+		Source: 'decomposer',
+		ScenarioID: 'node-1',
+		Summary: 'Avoid bypassing coverage checks with placeholder code.',
+		CategoryIDs: [],
+		Role: 'developer',
+		CreatedAt: '2026-06-16T12:16:00Z',
+		Detail: 'The developer created empty classes instead of satisfying scenarios.',
+		InjectionForm: 'Document unsupported features with rationale.',
+		EvidenceSteps: [],
+		EvidenceFiles: [],
+		RootCauseRole: 'developer',
+		Positive: false,
+		RetiredAt: null,
+		LastInjectedAt: null,
+		...overrides
+	};
 }
 
 describe('phase banner observability model', () => {
@@ -181,6 +219,89 @@ describe('execution detail observability model', () => {
 				verdict: 'approved'
 			}
 		}))).toBe('success');
+	});
+
+	it('merges live task SSE over durable execution task rows', () => {
+		const taskStages = new Map([
+			[
+				'node-1',
+				{
+					entity_id: 'entity-1',
+					slug: 'demo',
+					task_id: 'node-1',
+					stage: 'reviewing',
+					title: 'Implement raw fallback',
+					iteration: 1,
+					max_iterations: 5,
+					tdd_cycle: 2,
+					max_tdd_cycles: 5,
+					updated_at: '2026-06-16T12:17:00Z'
+				}
+			],
+			[
+				'node-new',
+				{
+					entity_id: 'entity-new',
+					slug: 'demo',
+					task_id: 'node-new',
+					stage: 'developing',
+					title: 'New live task',
+					iteration: 0,
+					max_iterations: 5,
+					updated_at: '2026-06-16T12:18:00Z'
+				}
+			]
+		]);
+
+		const merged = mergeExecutionTaskSSE([executionTask()], taskStages, 'demo');
+
+		expect(merged).toHaveLength(2);
+		expect(merged.find((item) => item.task_id === 'node-1')?.stage).toBe('reviewing');
+		expect(merged.find((item) => item.task_id === 'node-1')?.tdd_cycle).toBe(2);
+		expect(merged.find((item) => item.task_id === 'node-new')?.title).toBe('New live task');
+	});
+
+	it('groups replacement attempts and flags stale terminal rows as recovered', () => {
+		const model = executionAttemptModel([
+			executionTask({
+				task_id: 'node-original',
+				stage: 'escalated',
+				verdict: 'rejected',
+				updated_at: '2026-06-16T12:10:00Z'
+			}),
+			executionTask({
+				task_id: 'node-replacement',
+				stage: 'approved',
+				verdict: 'approved',
+				merge_commit: '28e9a4df444b8eaa64b23b500f962be868ff0572',
+				updated_at: '2026-06-16T12:20:00Z'
+			})
+		]);
+
+		expect(model.taskGroups).toHaveLength(1);
+		expect(model.taskGroups[0].status).toBe('recovered');
+		expect(model.taskGroups[0].attempts.map((attempt) => attempt.taskId)).toEqual([
+			'node-original',
+			'node-replacement'
+		]);
+		expect(model.orphanedGroups).toBe(1);
+		expect(model.warnings[0].kind).toBe('orphaned-attempt');
+	});
+
+	it('matches persisted developer lessons to execution tasks and future-run state', () => {
+		const summaries = persistedLessonSummaries(
+			plan({ slug: 'demo' }),
+			[executionTask({ task_id: 'node-1', title: 'Implement raw fallback' })],
+			[trajectory({ loop_id: 'loop-1', task_id: 'node-1' })],
+			[
+				lesson({ ID: 'matched', ScenarioID: 'node-1', LastInjectedAt: null }),
+				lesson({ ID: 'unrelated', ScenarioID: 'node-other', Summary: 'Unrelated' })
+			]
+		);
+
+		expect(summaries.map((item) => item.id)).toEqual(['matched']);
+		expect(summaries[0].futureRunOnly).toBe(true);
+		expect(summaries[0].relatedTaskTitle).toBe('Implement raw fallback');
 	});
 });
 

--- a/ui/src/lib/components/plan/observabilityModels.ts
+++ b/ui/src/lib/components/plan/observabilityModels.ts
@@ -6,12 +6,116 @@ import {
 	type MeasuredTokenUsage,
 	type ProviderRate
 } from '$lib/types/costAccounting';
+import type { components } from '$lib/types/api.generated';
 import type { PlanPhaseSummary } from '$lib/types/feed';
+import type { TaskSSEPayload } from '$lib/types/feed';
 import type { PlanWithStatus } from '$lib/types/plan';
 import type { TrajectoryListItem } from '$lib/types/trajectory';
 
 type Story = NonNullable<PlanWithStatus['stories']>[number];
 type RecoveryDecision = NonNullable<PlanWithStatus['plan_decisions']>[number];
+export type Lesson = components['schemas']['Lesson'];
+
+export type ExecutionScenario = {
+	id?: string;
+	title?: string;
+	requirement_id?: string;
+	story_id?: string;
+	tags?: string[];
+};
+
+export type ExecutionTask = {
+	entity_id?: string;
+	slug: string;
+	task_id: string;
+	requirement_id?: string;
+	stage: string;
+	tdd_cycle?: number;
+	max_tdd_cycles?: number;
+	title?: string;
+	description?: string;
+	project_id?: string;
+	prompt?: string;
+	model?: string;
+	trace_id?: string;
+	loop_id?: string;
+	request_id?: string;
+	task_type?: string;
+	worktree_path?: string;
+	worktree_branch?: string;
+	scenario_branch?: string;
+	file_scope?: string[];
+	scenarios?: ExecutionScenario[];
+	files_modified?: string[];
+	tests_passed?: boolean;
+	validation_passed?: boolean;
+	merge_commit?: string;
+	developer_task_id?: string;
+	validator_task_id?: string;
+	reviewer_task_id?: string;
+	verdict?: string;
+	rejection_type?: string;
+	feedback?: string;
+	review_retry_count?: number;
+	error_reason?: string;
+	error_class?: string;
+	escalation_reason?: string;
+	created_at?: string;
+	updated_at?: string;
+};
+
+export type ExecutionTaskGroupStatus = 'active' | 'approved' | 'recovered' | 'blocked' | 'pending';
+
+export type ExecutionTaskAttempt = {
+	taskId: string;
+	stage: string;
+	verdict?: string;
+	tddCycle?: number;
+	maxTddCycles?: number;
+	updatedAt?: string;
+	mergeCommit?: string;
+	feedback?: string;
+	errorReason?: string;
+	escalationReason?: string;
+};
+
+export type ExecutionTaskGroup = {
+	key: string;
+	title: string;
+	requirementId?: string;
+	status: ExecutionTaskGroupStatus;
+	attempts: ExecutionTaskAttempt[];
+	hasOrphanedTerminalAttempt: boolean;
+	latestUpdatedAt?: string;
+};
+
+export type ExecutionAttemptWarning = {
+	kind: 'orphaned-attempt';
+	title: string;
+	detail: string;
+	relatedId: string;
+};
+
+export type ExecutionAttemptModel = {
+	taskGroups: ExecutionTaskGroup[];
+	warnings: ExecutionAttemptWarning[];
+	totalAttempts: number;
+	approvedGroups: number;
+	activeGroups: number;
+	blockedGroups: number;
+	orphanedGroups: number;
+};
+
+export type PersistedLessonSummary = {
+	id: string;
+	summary: string;
+	source: string;
+	positive: boolean;
+	createdAt: string;
+	lastInjectedAt?: string | null;
+	futureRunOnly: boolean;
+	relatedTaskTitle?: string;
+};
 
 export type ExecutionBlocker = {
 	label: string;
@@ -74,6 +178,9 @@ export type QAOutcomeState = 'success' | 'warning' | 'error' | 'neutral';
 
 const LESSON_STEPS = new Set(['decompose', 'lesson-decompose', 'lesson-decomposition']);
 const LESSON_ROLES = new Set(['lesson-decomposer', 'lesson-curator']);
+const ACTIVE_TASK_STAGES = new Set(['developing', 'validating', 'reviewing', 'testing', 'building']);
+const BLOCKED_TASK_STAGES = new Set(['escalated', 'error', 'rejected']);
+const TERMINAL_TASK_STAGES = new Set(['approved', ...BLOCKED_TASK_STAGES]);
 
 export function shouldShowPhaseSummaryBanner(summary: PlanPhaseSummary): boolean {
 	if (summary.phase === 'terminal') return false;
@@ -143,6 +250,95 @@ export function storyTaskCounts(story: Story): TaskCounts {
 		failed: tasks.filter((task) => ['failed', 'error', 'rejected'].includes(task.status ?? '')).length,
 		active: tasks.filter((task) => ['executing', 'in_progress', 'running'].includes(task.status ?? '')).length
 	};
+}
+
+export function mergeExecutionTaskSSE(
+	loadedTasks: ExecutionTask[],
+	taskStages: Map<string, TaskSSEPayload>,
+	planSlug: string
+): ExecutionTask[] {
+	if (!planSlug) return loadedTasks;
+
+	const byTask = new Map(loadedTasks.map((task) => [task.task_id, task]));
+	for (const payload of taskStages.values()) {
+		if (payload.slug !== planSlug) continue;
+		const previous = byTask.get(payload.task_id);
+		byTask.set(payload.task_id, {
+			...previous,
+			slug: payload.slug,
+			task_id: payload.task_id,
+			entity_id: payload.entity_id ?? previous?.entity_id,
+			stage: payload.stage ?? previous?.stage ?? 'developing',
+			title: payload.title ?? previous?.title,
+			loop_id: payload.loop_id ?? previous?.loop_id,
+			tests_passed: payload.tests_passed ?? previous?.tests_passed,
+			validation_passed: payload.validation_passed ?? previous?.validation_passed,
+			verdict: payload.verdict ?? previous?.verdict,
+			feedback: payload.feedback ?? previous?.feedback,
+			tdd_cycle: payload.tdd_cycle ?? previous?.tdd_cycle,
+			max_tdd_cycles: payload.max_tdd_cycles ?? previous?.max_tdd_cycles,
+			review_retry_count: payload.review_retry_count ?? previous?.review_retry_count,
+			created_at: previous?.created_at ?? payload.updated_at,
+			updated_at: payload.updated_at ?? previous?.updated_at
+		});
+	}
+
+	return Array.from(byTask.values()).sort(byExecutionTaskUpdatedAt);
+}
+
+export function executionAttemptModel(executionTasks: ExecutionTask[]): ExecutionAttemptModel {
+	const taskGroups = groupExecutionTasks(executionTasks);
+	const warnings = taskGroups
+		.filter((group) => group.hasOrphanedTerminalAttempt)
+		.map((group) => ({
+			kind: 'orphaned-attempt' as const,
+			title: 'Recovered task has old terminal attempt',
+			detail: `${group.title} has an approved replacement but an older rejected/escalated row is still present.`,
+			relatedId: group.key
+		}));
+
+	return {
+		taskGroups,
+		warnings,
+		totalAttempts: executionTasks.length,
+		approvedGroups: taskGroups.filter((group) => group.status === 'approved' || group.status === 'recovered').length,
+		activeGroups: taskGroups.filter((group) => group.status === 'active').length,
+		blockedGroups: taskGroups.filter((group) => group.status === 'blocked').length,
+		orphanedGroups: taskGroups.filter((group) => group.hasOrphanedTerminalAttempt).length
+	};
+}
+
+export function persistedLessonSummaries(
+	plan: PlanWithStatus,
+	tasks: ExecutionTask[],
+	trajectoryItems: TrajectoryListItem[],
+	lessons: Lesson[]
+): PersistedLessonSummary[] {
+	const taskIDs = new Set(tasks.map((task) => task.task_id));
+	const scenarioIDs = new Set(
+		tasks.flatMap((task) => task.scenarios?.map((scenario) => scenario.id).filter(Boolean) ?? [])
+	);
+	const loopIDs = new Set(trajectoryItems.map((item) => item.loop_id));
+	const taskTitles = new Map(tasks.map((task) => [task.task_id, executionTaskTitle(task)]));
+
+	return lessons
+		.filter((lesson) => {
+			if (taskIDs.has(lesson.ScenarioID)) return true;
+			if (scenarioIDs.has(lesson.ScenarioID)) return true;
+			if (lesson.ScenarioID?.includes(plan.slug)) return true;
+			return lesson.EvidenceSteps?.some((step) => loopIDs.has(step.loop_id)) ?? false;
+		})
+		.sort((a, b) => dateMs(b.CreatedAt) - dateMs(a.CreatedAt))
+		.map((lesson) => ({
+			id: lesson.ID,
+			summary: lesson.Summary,
+			source: lesson.Source,
+			positive: lesson.Positive,
+			createdAt: lesson.CreatedAt,
+			lastInjectedAt: lesson.LastInjectedAt,
+			futureRunOnly: !lesson.LastInjectedAt,
+			relatedTaskTitle: taskTitles.get(lesson.ScenarioID)
+		}));
 }
 
 export function recoveryAffectedNodes(decision: RecoveryDecision): AffectedNode[] {
@@ -280,4 +476,103 @@ export function formatRole(role: string | undefined): string {
 
 export function formatToken(value: string): string {
 	return value.replaceAll('_', ' ').replaceAll('-', ' ');
+}
+
+function groupExecutionTasks(tasks: ExecutionTask[]): ExecutionTaskGroup[] {
+	const groups = new Map<string, ExecutionTask[]>();
+	for (const task of tasks) {
+		const key = executionTaskGroupKey(task);
+		groups.set(key, [...(groups.get(key) ?? []), task]);
+	}
+
+	return Array.from(groups.entries())
+		.map(([key, groupTasks]) => {
+			const attempts = groupTasks.sort(byExecutionTaskUpdatedAt).map(taskAttempt);
+			const hasApproved = attempts.some((attempt) => attempt.stage === 'approved');
+			const hasActive = attempts.some((attempt) => isActiveExecutionTaskStage(attempt.stage));
+			const hasBlocked = attempts.some((attempt) => BLOCKED_TASK_STAGES.has(attempt.stage));
+			const hasOrphanedTerminalAttempt = hasApproved && hasBlocked;
+			const latest = latestExecutionTask(groupTasks);
+			return {
+				key,
+				title: executionTaskTitle(latest ?? groupTasks[0]),
+				requirementId: latest?.requirement_id ?? groupTasks[0]?.requirement_id,
+				status: executionTaskGroupStatus(hasActive, hasApproved, hasBlocked, hasOrphanedTerminalAttempt),
+				attempts,
+				hasOrphanedTerminalAttempt,
+				latestUpdatedAt: newestTimestamp(groupTasks.map((task) => task.updated_at ?? task.created_at))
+			};
+		})
+		.sort((a, b) => {
+			const req = (a.requirementId ?? '').localeCompare(b.requirementId ?? '');
+			if (req !== 0) return req;
+			return (b.latestUpdatedAt ?? '').localeCompare(a.latestUpdatedAt ?? '');
+		});
+}
+
+function executionTaskGroupStatus(
+	hasActive: boolean,
+	hasApproved: boolean,
+	hasBlocked: boolean,
+	hasOrphanedTerminalAttempt: boolean
+): ExecutionTaskGroupStatus {
+	if (hasActive) return 'active';
+	if (hasApproved && hasOrphanedTerminalAttempt) return 'recovered';
+	if (hasApproved) return 'approved';
+	if (hasBlocked) return 'blocked';
+	return 'pending';
+}
+
+function taskAttempt(task: ExecutionTask): ExecutionTaskAttempt {
+	return {
+		taskId: task.task_id,
+		stage: task.stage,
+		verdict: task.verdict,
+		tddCycle: task.tdd_cycle,
+		maxTddCycles: task.max_tdd_cycles,
+		updatedAt: task.updated_at ?? task.created_at,
+		mergeCommit: task.merge_commit,
+		feedback: task.feedback,
+		errorReason: task.error_reason,
+		escalationReason: task.escalation_reason
+	};
+}
+
+function executionTaskGroupKey(task: ExecutionTask): string {
+	return `${task.requirement_id ?? 'plan'}::${normalizeTaskTitle(executionTaskTitle(task))}`;
+}
+
+function executionTaskTitle(task: ExecutionTask | undefined): string {
+	if (!task) return 'Untitled task';
+	return task.title || task.prompt || task.description || task.task_id;
+}
+
+function normalizeTaskTitle(title: string): string {
+	return title.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function latestExecutionTask(tasks: ExecutionTask[]): ExecutionTask | undefined {
+	return [...tasks].sort((a, b) => dateMs(b.updated_at ?? b.created_at) - dateMs(a.updated_at ?? a.created_at))[0];
+}
+
+function byExecutionTaskUpdatedAt(a: ExecutionTask, b: ExecutionTask): number {
+	return dateMs(a.updated_at ?? a.created_at) - dateMs(b.updated_at ?? b.created_at);
+}
+
+function isActiveExecutionTaskStage(stage: string | undefined): boolean {
+	if (!stage) return false;
+	if (ACTIVE_TASK_STAGES.has(stage)) return true;
+	return !TERMINAL_TASK_STAGES.has(stage);
+}
+
+function newestTimestamp(values: Array<string | null | undefined>): string | undefined {
+	return values
+		.filter((value): value is string => Boolean(value))
+		.sort((a, b) => dateMs(b) - dateMs(a))[0];
+}
+
+function dateMs(value: string | null | undefined): number {
+	if (!value) return 0;
+	const ms = new Date(value).getTime();
+	return Number.isFinite(ms) ? ms : 0;
 }

--- a/ui/src/lib/stores/feed.svelte.ts
+++ b/ui/src/lib/stores/feed.svelte.ts
@@ -247,8 +247,21 @@ class FeedStore {
 		// and consumers should see them without a server round-trip.
 		this.currentPlan = payload;
 
-		// Lazily connect execution SSE when plan reaches execution
-		const execStages = ['implementing', 'executing', 'reviewing_rollup'];
+		// Lazily connect execution SSE when task/requirement KV rows can still
+		// explain what the user is seeing. QA and terminal stages need the same
+		// stream because recovered/rejected attempts often arrive before the
+		// final plan stage settles.
+		const execStages = [
+			'implementing',
+			'executing',
+			'ready_for_qa',
+			'reviewing_qa',
+			'reviewing_rollup',
+			'complete',
+			'complete_with_deferrals',
+			'failed',
+			'rejected'
+		];
 		if (execStages.includes(stage) && !this.execSSE && this.currentSlug) {
 			this.connectExecutionSSE(this.currentSlug);
 		}

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -32,7 +32,9 @@
 	import { mergeLiveTrajectoryItems } from '$lib/types/trajectoryActivityProjection';
 	import {
 		isLessonTrajectoryItem,
+		mergeExecutionTaskSSE,
 		phaseSummaryDetail,
+		persistedLessonSummaries,
 		shouldShowPhaseSummaryBanner
 	} from '$lib/components/plan/observabilityModels';
 	import { activityStore } from '$lib/stores/activity.svelte';
@@ -67,10 +69,22 @@
 	const scenariosByReq = $derived(data.scenariosByReq);
 	const hasRequirements = $derived(requirements.length > 0);
 	const hasScenarios = $derived(Object.values(scenariosByReq).some((s) => s.length > 0));
+	const liveTrajectoryItems = $derived(
+		mergeLiveTrajectoryItems(data.trajectoryItems, activityStore.recent, slug ?? '')
+	);
+	const liveExecutionTasks = $derived(
+		mergeExecutionTaskSSE(data.executionTasks ?? [], feedStore.taskStages, slug ?? '')
+	);
+	const persistedLessons = $derived(
+		plan
+			? persistedLessonSummaries(plan, liveExecutionTasks, liveTrajectoryItems, data.lessons ?? [])
+			: []
+	);
 	const showExecutionDetail = $derived(
 		plan
 			? Boolean(
 				(plan.stories?.length ?? 0) > 0 ||
+					liveExecutionTasks.length > 0 ||
 					plan.execution_summary ||
 					plan.qa_run ||
 					plan.qa_verdict_summary ||
@@ -87,13 +101,12 @@
 				)
 			: false
 	);
-	const liveTrajectoryItems = $derived(
-		mergeLiveTrajectoryItems(data.trajectoryItems, activityStore.recent, slug ?? '')
-	);
 	const showLessonActivityDetail = $derived(
 		plan
 			? Boolean(
-					plan.phase_summary?.lessons || liveTrajectoryItems.some(isLessonTrajectoryItem)
+					plan.phase_summary?.lessons ||
+						liveTrajectoryItems.some(isLessonTrajectoryItem) ||
+						persistedLessons.length > 0
 				)
 			: false
 	);
@@ -673,7 +686,7 @@
 			<PlanDetail {plan} phases={[]} requirements={requirements} onRefresh={handleRefresh} />
 
 			{#if showExecutionDetail}
-				<ExecutionDetail {plan} />
+				<ExecutionDetail {plan} executionTasks={liveExecutionTasks} />
 			{/if}
 
 			{#if showRecoveryDetail}
@@ -681,7 +694,7 @@
 			{/if}
 
 			{#if showLessonActivityDetail}
-				<LessonActivityDetail {plan} trajectoryItems={liveTrajectoryItems} />
+				<LessonActivityDetail {plan} trajectoryItems={liveTrajectoryItems} {persistedLessons} />
 			{/if}
 
 			<!-- Reviews: collapsible. R1 plan-reviewer verdict appears as soon as the

--- a/ui/src/routes/plans/[slug]/+page.ts
+++ b/ui/src/routes/plans/[slug]/+page.ts
@@ -4,14 +4,15 @@ import type { Requirement } from '$lib/types/requirement';
 import type { Scenario } from '$lib/types/scenario';
 import type { TrajectoryListItem, TrajectoryListResponse } from '$lib/types/trajectory';
 import type { SynthesisResult } from '$lib/types/review';
+import type { ExecutionTask, Lesson } from '$lib/components/plan/observabilityModels';
 
 export const load: PageLoad = async ({ params, fetch, depends }) => {
 	depends('app:plans');
 	const slug = params.slug;
 
-	// Fetch plan, requirements, trajectory summaries, and reviews in parallel
+	// Fetch plan, requirements, trajectory summaries, reviews, and execution state in parallel
 	// Backend may return JSON `null` for empty collections, so coalesce to []
-	const [plan, requirements, trajectoryItems, reviews] = await Promise.all([
+	const [plan, requirements, trajectoryItems, reviews, executionTasks, lessons] = await Promise.all([
 		fetch(`/plan-manager/plans/${slug}`)
 			.then((r) => (r.ok ? (r.json() as Promise<PlanWithStatus>) : null))
 			.catch(() => null),
@@ -27,7 +28,13 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 			.catch(() => [] as TrajectoryListItem[]),
 		fetch(`/plan-manager/plans/${slug}/reviews`)
 			.then((r) => (r.ok ? r.json().then((d: SynthesisResult | null) => d) : null))
-			.catch(() => null)
+			.catch(() => null),
+		fetch(`/execution-manager/plans/${encodeURIComponent(slug)}/tasks`)
+			.then((r) => (r.ok ? r.json().then((d: ExecutionTask[] | null) => d ?? []) : []))
+			.catch(() => [] as ExecutionTask[]),
+		fetch('/execution-manager/lessons?role=developer')
+			.then((r) => (r.ok ? r.json().then((d: Lesson[] | null) => d ?? []) : []))
+			.catch(() => [] as Lesson[])
 	]);
 
 	// Fetch scenarios for each requirement in parallel
@@ -47,5 +54,13 @@ export const load: PageLoad = async ({ params, fetch, depends }) => {
 		scenariosByReq[reqId] = scenarios;
 	}
 
-	return { plan, requirements, scenariosByReq, trajectoryItems: trajectoryItems ?? [], reviews: reviews ?? null };
+	return {
+		plan,
+		requirements,
+		scenariosByReq,
+		trajectoryItems: trajectoryItems ?? [],
+		reviews: reviews ?? null,
+		executionTasks: executionTasks ?? [],
+		lessons: lessons ?? []
+	};
 };


### PR DESCRIPTION
## Summary
- port the useful residual #205 behavior into the current plan observability UI instead of merging the stale RunVisibilityPanel branch
- fetch durable execution-manager task rows on plan detail and merge live execution SSE task updates by plan slug/task ID
- show execution attempts, recovered/orphaned terminal rows, QA skipped-test guard signal, and persisted developer lessons in the existing Execution Detail / Lesson Activity panels
- extend execution SSE subscription through QA and terminal stages so the UI keeps explaining what happened after implementation hands off

## Validation
- npm run test -- observabilityModels
- npm run check (0 errors; existing settings autofocus warnings remain)
- npm run test
- npm run build (passes; existing settings autofocus and graph unused-import warnings remain)
- go vet ./...
- revive -config revive.toml -formatter friendly ./...
- go test ./...
- gofmt -l . only reports archived docs/sponsor artifacts already excluded by CI

## PR 205 reconciliation
This is intended as the focused replacement for the non-obsolete parts of #205. Once this lands, #205 should be safe to close as superseded by current-main observability plus this extraction.