### PR TITLE
[codex] fix scoped architecture revise artifacts

### DIFF
--- a/docs/adr/ADR-045-bmad-story-gate-operator-executed-tiers.md
+++ b/docs/adr/ADR-045-bmad-story-gate-operator-executed-tiers.md
@@ -81,10 +81,12 @@ When recovery diagnoses an *architecture-root* wedge (a missing/mis-resolved ups
 a wrong component boundary, an un-runnable integration target), the recovery-agent now picks
 `architecture_revise` instead of `escalate_human`. On accept, plan-manager captures the prior
 architecture into `PreviousArchitectureJSON` (the revision base the architect already reads),
-routes the diagnosis into `ReviewFormattedFindings`, wipes Architecture + Stories + Scenarios,
-resets all requirement executions, and drives the new back-transition `implementing →
+routes the diagnosis into `ReviewFormattedFindings`, clears Architecture, resets the affected
+requirement/story closure, and drives the new back-transition `implementing →
 requirements_generated`. The architect re-fires and *revises* the prior architecture against the
-diagnosis; the full pipeline (Sarah → Bob → execution) re-runs clean.
+diagnosis. Whole-phase decisions may regenerate the full downstream pipeline when explicitly
+justified; scoped decisions preserve unrelated Stories/Scenarios and merge only the dirty closure
+before execution resumes.
 
 Because this fires from `implementing` — a LIVE phase with in-flight executor state, unlike its
 sibling `story_reprepare` (which fires from the quiescent `stories_generated`) — three guards

--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -64,3 +64,4 @@
 - [x] 8.3 Add a legal post-QA architecture recovery transition and regression coverage for `rejected -> requirements_generated`
 - [x] 8.4 Floor recovery contract-impact policy by action kind so scope/topology-changing actions cannot self-report as preserve/refine
 - [x] 8.5 Fix UI false-green and stale observability state regressions from the PR review
+- [x] 8.6 Fix scoped `architecture_revise` so a single dirty requirement closure does not rewrite unrelated Stories/Scenarios

--- a/processor/plan-decision-handler/component.go
+++ b/processor/plan-decision-handler/component.go
@@ -300,7 +300,7 @@ func (c *Component) handleCascadeRequest(ctx context.Context, req *payloads.Plan
 	if err != nil {
 		return nil, fmt.Errorf("cascade change proposal: %w", err)
 	}
-	expandPlanningReentryClosure(result, plan.Requirements, plan.Scenarios)
+	expandPlanningReentryClosure(result, plan.Requirements, plan.Stories, plan.Scenarios)
 
 	c.logger.Info("cascade complete",
 		"proposal_id", req.ProposalID,
@@ -333,13 +333,13 @@ func (c *Component) handleCascadeRequest(ctx context.Context, req *payloads.Plan
 	return result, nil
 }
 
-func expandPlanningReentryClosure(result *cascade.Result, requirements []workflow.Requirement, scenarios []workflow.Scenario) {
+func expandPlanningReentryClosure(result *cascade.Result, requirements []workflow.Requirement, stories []workflow.Story, scenarios []workflow.Scenario) {
 	if result == nil {
 		return
 	}
 	switch result.Kind {
 	case workflow.PlanDecisionKindArchitectureRevise:
-		result.AffectedRequirementIDs = cascade.ExpandRequirementClosure(requirements, result.AffectedRequirementIDs)
+		result.AffectedRequirementIDs = cascade.ExpandRequirementStoryClosure(requirements, stories, result.AffectedRequirementIDs)
 	case workflow.PlanDecisionKindRequirementChange, workflow.PlanDecisionKindStoryReprepare:
 		result.AffectedRequirementIDs = cascade.ExpandRequirementClosure(requirements, result.AffectedRequirementIDs)
 		result.AffectedScenarioIDs = mergeScenarioIDsForRequirements(result.AffectedScenarioIDs, scenarios, result.AffectedRequirementIDs)

--- a/processor/plan-decision-handler/config.go
+++ b/processor/plan-decision-handler/config.go
@@ -46,15 +46,16 @@ type Config struct {
 	AutoAcceptRecovery bool `json:"auto_accept_recovery" schema:"type:boolean,description:Auto-accept PlanDecisions from recovery-agent (ADR-037 stage-2 apply path),category:advanced,default:false"`
 
 	// MaxAutoArchitectureRevises bounds how many architecture_revise recovery
-	// PlanDecisions the watcher will auto-accept for a single plan. Each accepted
-	// architecture_revise wipes Architecture + Stories + Scenarios and re-runs the
-	// whole pipeline from the architect — the heaviest, most expensive recovery
-	// action. Without a cap, a plan whose revised architecture still wedges would
-	// loop (implement → wedge → architecture_revise → implement → …) burning a
-	// full re-run each cycle. Once this many architecture_revise decisions are
-	// already accepted on the plan, further ones stay proposed for human review.
-	// The count is monotonic — PlanDecisions persist across the wipe. Default 1:
-	// one automatic architecture revision, then a human must decide.
+	// PlanDecisions may be auto-accepted for a single plan when policy permits
+	// architecture auto-accept. The default policy still human-gates
+	// contract-changing architecture revisions; this cap is the loop bound if a
+	// deployment relaxes that gate. Each accepted architecture_revise re-runs the
+	// architect and may cascade through Sarah/Bob for either a scoped dirty
+	// closure or an explicitly justified whole phase — the heaviest, most
+	// expensive recovery action. Without a cap, a plan whose revised architecture
+	// still wedges would loop (implement → wedge → architecture_revise → implement
+	// → …) burning a re-run each cycle. The count is monotonic because
+	// PlanDecisions are never cleared.
 	MaxAutoArchitectureRevises int `json:"max_auto_architecture_revises" schema:"type:int,description:Max architecture_revise recovery decisions auto-accepted per plan before human review,category:advanced,default:1,min:0,max:10"`
 
 	// MaxAutoStoryReprepares bounds how many story_reprepare recovery

--- a/processor/plan-decision-handler/planning_reentry_closure_test.go
+++ b/processor/plan-decision-handler/planning_reentry_closure_test.go
@@ -16,13 +16,18 @@ func TestExpandPlanningReentryClosure_ArchitectureRevise(t *testing.T) {
 	requirements := []workflow.Requirement{
 		{ID: "bootstrap"},
 		{ID: "contract", DependsOn: []string{"bootstrap"}},
+		{ID: "control"},
 		{ID: "consumer", DependsOn: []string{"contract"}},
 		{ID: "unrelated"},
 	}
+	stories := []workflow.Story{
+		{ID: "story.mapper", RequirementIDs: []string{"contract", "control"}},
+		{ID: "story.unrelated", RequirementIDs: []string{"unrelated"}},
+	}
 
-	expandPlanningReentryClosure(result, requirements, nil)
+	expandPlanningReentryClosure(result, requirements, stories, nil)
 
-	want := []string{"consumer", "contract"}
+	want := []string{"consumer", "contract", "control"}
 	if !reflect.DeepEqual(result.AffectedRequirementIDs, want) {
 		t.Fatalf("AffectedRequirementIDs = %v, want %v", result.AffectedRequirementIDs, want)
 	}
@@ -45,7 +50,7 @@ func TestExpandPlanningReentryClosure_RequirementChangeAddsDependentScenarios(t 
 		{ID: "scenario.unrelated", RequirementID: "unrelated"},
 	}
 
-	expandPlanningReentryClosure(result, requirements, scenarios)
+	expandPlanningReentryClosure(result, requirements, nil, scenarios)
 
 	wantReqs := []string{"consumer", "contract"}
 	if !reflect.DeepEqual(result.AffectedRequirementIDs, wantReqs) {

--- a/processor/plan-decision-handler/recovery_autoaccept.go
+++ b/processor/plan-decision-handler/recovery_autoaccept.go
@@ -166,7 +166,7 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 // review.
 // countAcceptedArchitectureRevises counts PlanDecisions already in accepted
 // status with Kind=architecture_revise. Used as the monotonic loop bound for
-// the architecture_revise auto-accept cap — the count survives the entity wipe
+// the architecture_revise auto-accept cap — the count survives planning re-entry
 // because PlanDecisions are never cleared, so it strictly increases each cycle.
 func countAcceptedArchitectureRevises(decisions []workflow.PlanDecision) int {
 	n := 0

--- a/processor/plan-manager/architecture_revise_test.go
+++ b/processor/plan-manager/architecture_revise_test.go
@@ -2,18 +2,19 @@ package planmanager
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
 )
 
-// TestReviseArchitectureState_HappyPath pins the pure state mutation an
-// accepted architecture_revise PlanDecision performs from the implementing
-// status: capture the prior architecture, wipe Architecture + Stories +
-// Scenarios, route the diagnosis into ReviewFormattedFindings, and drive the
-// back-transition to requirements_generated. This is the seam that the
-// EXECUTION_STATES reset (NATS I/O) wraps in applyArchitectureRevise.
+// TestReviseArchitectureState_HappyPath pins the pure whole-phase state
+// mutation an accepted architecture_revise PlanDecision performs from the
+// implementing status: capture the prior architecture, wipe Architecture +
+// Stories + Scenarios, route the diagnosis into ReviewFormattedFindings, and
+// drive the back-transition to requirements_generated. Scoped decisions use
+// reviseScopedArchitectureState via applyArchitectureRevise.
 func TestReviseArchitectureState_HappyPath(t *testing.T) {
 	plan := &workflow.Plan{
 		Slug:   "mavlink-hard",
@@ -183,11 +184,15 @@ func TestApplyArchitectureRevise_ScopedResetUsesAffectedRequirementClosure(t *te
 			{ID: "consumer", Title: "Consumer integration", DependsOn: []string{"contract"}},
 		},
 		Architecture: &workflow.ArchitectureDocument{DataFlow: "prior design"},
-		Stories:      []workflow.Story{{ID: "story.contract", RequirementIDs: []string{"contract"}}},
+		Stories: []workflow.Story{
+			{ID: "story.contract", RequirementIDs: []string{"contract"}},
+			{ID: "story.consumer", RequirementIDs: []string{"consumer"}},
+			{ID: "story.unrelated", RequirementIDs: []string{"unrelated"}},
+		},
 		Scenarios: []workflow.Scenario{
-			{ID: "scen.contract", RequirementID: "contract"},
-			{ID: "scen.consumer", RequirementID: "consumer"},
-			{ID: "scen.unrelated", RequirementID: "unrelated"},
+			{ID: "scen.contract", RequirementID: "contract", StoryID: "story.contract"},
+			{ID: "scen.consumer", RequirementID: "consumer", StoryID: "story.consumer"},
+			{ID: "scen.unrelated", RequirementID: "unrelated", StoryID: "story.unrelated"},
 		},
 	}
 	proposal := &workflow.PlanDecision{
@@ -216,6 +221,75 @@ func TestApplyArchitectureRevise_ScopedResetUsesAffectedRequirementClosure(t *te
 	if plan.Status != workflow.StatusRequirementsGenerated {
 		t.Fatalf("plan.Status = %s, want requirements_generated", plan.Status)
 	}
+	if plan.Architecture != nil {
+		t.Fatal("Architecture should be cleared so Winston revises it")
+	}
+	if plan.PendingArchitectureRevision == nil {
+		t.Fatal("PendingArchitectureRevision should record the scoped dirty closure")
+	}
+	assertStringSet(t, plan.PendingArchitectureRevision.RequirementIDs, []string{"contract", "consumer"})
+	assertStringSet(t, plan.PendingArchitectureRevision.StoryIDs, []string{"story.contract", "story.consumer"})
+	if len(plan.Stories) != 3 {
+		t.Fatalf("Stories len = %d, want 3 preserved until scoped merge", len(plan.Stories))
+	}
+	if len(plan.Scenarios) != 3 {
+		t.Fatalf("Scenarios len = %d, want 3 preserved until scoped story merge", len(plan.Scenarios))
+	}
+	if got := storyRecoveryHint(plan.Stories, "story.unrelated"); got != "" {
+		t.Fatalf("unrelated story RecoveryHint = %q, want empty", got)
+	}
+}
+
+func TestApplyArchitectureRevise_ScopedResetExpandsMNStoryCoverage(t *testing.T) {
+	c := setupTestComponent(t)
+	c.execBucket = resetKVStub{
+		keys: []string{
+			"req.demo.telemetry",
+			"req.demo.control",
+			"req.demo.async",
+			"req.demo.unrelated",
+		},
+	}
+	var reset []string
+	c.reqResetSender = func(_ context.Context, key string) error {
+		reset = append(reset, key)
+		return nil
+	}
+
+	plan := &workflow.Plan{
+		Slug:   "demo",
+		Status: workflow.StatusImplementing,
+		Requirements: []workflow.Requirement{
+			{ID: "telemetry"},
+			{ID: "control"},
+			{ID: "async"},
+			{ID: "unrelated"},
+		},
+		Architecture: &workflow.ArchitectureDocument{DataFlow: "prior design"},
+		Stories: []workflow.Story{
+			{ID: "story.mapper", RequirementIDs: []string{"telemetry", "control", "async"}},
+			{ID: "story.unrelated", RequirementIDs: []string{"unrelated"}},
+		},
+	}
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.demo.recovery.mapper",
+		Kind:           workflow.PlanDecisionKindArchitectureRevise,
+		AffectedReqIDs: []string{"telemetry"},
+		Rationale:      "Revise the shared mapper architecture.",
+	}
+
+	if err := c.applyArchitectureRevise(context.Background(), plan, proposal); err != nil {
+		t.Fatalf("applyArchitectureRevise: %v", err)
+	}
+
+	assertResetKeys(t, reset, []string{
+		"req.demo.telemetry",
+		"req.demo.control",
+		"req.demo.async",
+	})
+	assertNoResetKeys(t, reset, []string{"req.demo.unrelated"})
+	assertStringSet(t, plan.PendingArchitectureRevision.RequirementIDs, []string{"async", "control", "telemetry"})
+	assertStringSet(t, plan.PendingArchitectureRevision.StoryIDs, []string{"story.mapper"})
 }
 
 func TestPlanDecisionResetScope_UnscopedRequiresExplicitEvidence(t *testing.T) {
@@ -293,6 +367,175 @@ func TestApplyArchitectureRevise_UnscopedWithoutPhaseEvidenceLeavesPlanUntouched
 	}
 }
 
+func TestHandleStoriesMutation_ScopedArchitectureRevisionMergesDirtyStoriesOnly(t *testing.T) {
+	c := setupTestComponent(t)
+	plan := setupTestPlan(t, c, "demo")
+	plan.Status = workflow.StatusPreparingStories
+	plan.Requirements = []workflow.Requirement{
+		{ID: "bootstrap"},
+		{ID: "unrelated"},
+		{ID: "contract", DependsOn: []string{"bootstrap"}},
+		{ID: "consumer", DependsOn: []string{"contract"}},
+	}
+	plan.PendingArchitectureRevision = &workflow.ArchitectureRevisionScope{
+		ProposalID:     "plan-decision.demo.recovery.contract",
+		RequirementIDs: []string{"contract", "consumer"},
+		StoryIDs:       []string{"story.contract.old", "story.consumer.old"},
+	}
+	plan.Stories = []workflow.Story{
+		testStory("story.bootstrap.old", []string{"bootstrap"}, "src/bootstrap.go"),
+		testStory("story.unrelated.old", []string{"unrelated"}, "src/unrelated.go"),
+		testStory("story.contract.old", []string{"contract"}, "src/contract_old.go"),
+		testStory("story.consumer.old", []string{"consumer"}, "src/consumer_old.go"),
+	}
+	plan.Scenarios = []workflow.Scenario{
+		{ID: "scen.bootstrap", RequirementID: "bootstrap", StoryID: "story.bootstrap.old"},
+		{ID: "scen.unrelated", RequirementID: "unrelated", StoryID: "story.unrelated.old"},
+		{ID: "scen.contract", RequirementID: "contract", StoryID: "story.contract.old"},
+		{ID: "scen.consumer", RequirementID: "consumer", StoryID: "story.consumer.old"},
+	}
+	if err := c.plans.save(context.Background(), plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	emitted := []workflow.Story{
+		testStory("story.bootstrap.new", []string{"bootstrap"}, "src/bootstrap_new.go"),
+		testStory("story.unrelated.new", []string{"unrelated"}, "src/unrelated_new.go"),
+		testStory("story.contract.new", []string{"contract"}, "src/contract_new.go"),
+		testStory("story.consumer.new", []string{"consumer"}, "src/consumer_new.go"),
+	}
+	data, err := json.Marshal(storiesMutationRequest{Slug: "demo", Stories: emitted})
+	if err != nil {
+		t.Fatalf("marshal stories mutation: %v", err)
+	}
+
+	resp := c.handleStoriesMutation(context.Background(), data)
+	if !resp.Success {
+		t.Fatalf("handleStoriesMutation failed: %s", resp.Error)
+	}
+
+	loaded, ok := c.plans.get("demo")
+	if !ok {
+		t.Fatal("plan not found after stories mutation")
+	}
+	if loaded.Status != workflow.StatusStoriesGenerated {
+		t.Fatalf("Status = %s, want stories_generated", loaded.Status)
+	}
+	if loaded.PendingArchitectureRevision == nil {
+		t.Fatal("PendingArchitectureRevision should remain until scoped scenarios converge")
+	}
+	assertStoryPresent(t, loaded.Stories, "story.bootstrap.old")
+	assertStoryPresent(t, loaded.Stories, "story.unrelated.old")
+	assertStoryPresent(t, loaded.Stories, "story.contract.new")
+	assertStoryPresent(t, loaded.Stories, "story.consumer.new")
+	assertStoryAbsent(t, loaded.Stories, "story.bootstrap.new")
+	assertStoryAbsent(t, loaded.Stories, "story.unrelated.new")
+	assertStoryAbsent(t, loaded.Stories, "story.contract.old")
+	assertStoryAbsent(t, loaded.Stories, "story.consumer.old")
+	assertScenarioIDs(t, loaded.Scenarios, []string{"scen.bootstrap", "scen.unrelated"})
+}
+
+func TestHandleScenariosMutation_ScopedArchitectureRevisionPreservesUnrelatedScenarios(t *testing.T) {
+	c := setupTestComponent(t)
+	plan := setupTestPlan(t, c, "demo")
+	plan.Status = workflow.StatusGeneratingScenarios
+	plan.Requirements = []workflow.Requirement{
+		{ID: "bootstrap"},
+		{ID: "unrelated"},
+		{ID: "contract", DependsOn: []string{"bootstrap"}},
+		{ID: "consumer", DependsOn: []string{"contract"}},
+	}
+	plan.PendingArchitectureRevision = &workflow.ArchitectureRevisionScope{
+		ProposalID:     "plan-decision.demo.recovery.contract",
+		RequirementIDs: []string{"contract", "consumer"},
+		StoryIDs:       []string{"story.contract.new", "story.consumer.new"},
+	}
+	plan.Stories = []workflow.Story{
+		testStory("story.bootstrap.old", []string{"bootstrap"}, "src/bootstrap.go"),
+		testStory("story.unrelated.old", []string{"unrelated"}, "src/unrelated.go"),
+		testStory("story.contract.new", []string{"contract"}, "src/contract_new.go"),
+		testStory("story.consumer.new", []string{"consumer"}, "src/consumer_new.go"),
+	}
+	plan.Scenarios = []workflow.Scenario{
+		{ID: "scen.bootstrap", RequirementID: "bootstrap", StoryID: "story.bootstrap.old"},
+		{ID: "scen.unrelated", RequirementID: "unrelated", StoryID: "story.unrelated.old"},
+	}
+	if err := c.plans.save(context.Background(), plan); err != nil {
+		t.Fatalf("save plan: %v", err)
+	}
+
+	contractData, err := json.Marshal(ScenariosMutationRequest{
+		Slug:          "demo",
+		RequirementID: "contract",
+		StoryID:       "story.contract.new",
+		Scenarios: []workflow.Scenario{{
+			ID:            "scen.contract.new",
+			RequirementID: "contract",
+			StoryID:       "story.contract.new",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal contract scenarios mutation: %v", err)
+	}
+
+	resp := c.handleScenariosMutation(context.Background(), contractData)
+	if !resp.Success {
+		t.Fatalf("handleScenariosMutation contract failed: %s", resp.Error)
+	}
+
+	loaded, ok := c.plans.get("demo")
+	if !ok {
+		t.Fatal("plan not found after contract scenarios mutation")
+	}
+	if loaded.Status != workflow.StatusGeneratingScenarios {
+		t.Fatalf("Status = %s, want generating_scenarios before dirty scope converges", loaded.Status)
+	}
+	if loaded.PendingArchitectureRevision == nil {
+		t.Fatal("PendingArchitectureRevision should remain until all dirty scenarios converge")
+	}
+	assertScenarioIDs(t, loaded.Scenarios, []string{
+		"scen.bootstrap",
+		"scen.unrelated",
+		"scen.contract.new",
+	})
+
+	consumerData, err := json.Marshal(ScenariosMutationRequest{
+		Slug:          "demo",
+		RequirementID: "consumer",
+		StoryID:       "story.consumer.new",
+		Scenarios: []workflow.Scenario{{
+			ID:            "scen.consumer.new",
+			RequirementID: "consumer",
+			StoryID:       "story.consumer.new",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal consumer scenarios mutation: %v", err)
+	}
+
+	resp = c.handleScenariosMutation(context.Background(), consumerData)
+	if !resp.Success {
+		t.Fatalf("handleScenariosMutation consumer failed: %s", resp.Error)
+	}
+
+	loaded, ok = c.plans.get("demo")
+	if !ok {
+		t.Fatal("plan not found after consumer scenarios mutation")
+	}
+	if loaded.Status != workflow.StatusScenariosGenerated {
+		t.Fatalf("Status = %s, want scenarios_generated after dirty scope converges", loaded.Status)
+	}
+	if loaded.PendingArchitectureRevision != nil {
+		t.Fatalf("PendingArchitectureRevision = %+v, want cleared after scoped scenarios converge", loaded.PendingArchitectureRevision)
+	}
+	assertScenarioIDs(t, loaded.Scenarios, []string{
+		"scen.bootstrap",
+		"scen.unrelated",
+		"scen.contract.new",
+		"scen.consumer.new",
+	})
+}
+
 func TestApplyArchitectureRevise_PreservesUnrelatedCompletedExecutions(t *testing.T) {
 	c := setupTestComponent(t)
 	c.execBucket = resetKVStub{
@@ -347,6 +590,74 @@ func TestApplyArchitectureRevise_PreservesUnrelatedCompletedExecutions(t *testin
 		"req.demo.completed-unrelated",
 		"task.demo.node-completed-unrelated",
 	})
+}
+
+func testStory(id string, reqIDs []string, file string) workflow.Story {
+	return workflow.Story{
+		ID:             id,
+		ComponentName:  id + "-component",
+		RequirementIDs: reqIDs,
+		Title:          id,
+		FilesOwned:     []string{file},
+		Tasks: []workflow.Task{{
+			ID:          "task." + id,
+			StoryID:     id,
+			Description: "verify " + id,
+		}},
+	}
+}
+
+func storyRecoveryHint(stories []workflow.Story, id string) string {
+	for _, story := range stories {
+		if story.ID == id {
+			return story.RecoveryHint
+		}
+	}
+	return ""
+}
+
+func assertStringSet(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want set %v", got, want)
+	}
+	seen := make(map[string]struct{}, len(got))
+	for _, id := range got {
+		seen[id] = struct{}{}
+	}
+	for _, id := range want {
+		if _, ok := seen[id]; !ok {
+			t.Fatalf("got %v, missing %q", got, id)
+		}
+	}
+}
+
+func assertStoryPresent(t *testing.T, stories []workflow.Story, id string) {
+	t.Helper()
+	for _, story := range stories {
+		if story.ID == id {
+			return
+		}
+	}
+	t.Fatalf("stories = %+v, missing %q", stories, id)
+}
+
+func assertStoryAbsent(t *testing.T, stories []workflow.Story, id string) {
+	t.Helper()
+	for _, story := range stories {
+		if story.ID == id {
+			t.Fatalf("stories = %+v, should not include %q", stories, id)
+		}
+	}
+}
+
+func assertScenarioIDs(t *testing.T, scenarios []workflow.Scenario, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		got = append(got, scenario.ID)
+	}
+	assertStringSet(t, got, want)
 }
 
 func assertResetKeys(t *testing.T, got []string, want []string) {

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -404,7 +404,24 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 		return MutationResponse{Success: false, Error: fmt.Sprintf("invalid transition: %s → stories_generated", current)}
 	}
 
-	plan.Stories = req.Stories
+	storiesToSave := req.Stories
+	if plan.PendingArchitectureRevision != nil && len(plan.PendingArchitectureRevision.RequirementIDs) > 0 {
+		merged, removedStoryIDs, acceptedCount, err := mergeStoriesForScopedArchitectureRevision(plan, req.Stories)
+		if err != nil {
+			return MutationResponse{Success: false, Error: fmt.Sprintf("scoped architecture revision merge: %v", err)}
+		}
+		plan.Scenarios = removeScenariosForScopedArchitectureRevision(plan.Scenarios, plan.PendingArchitectureRevision, removedStoryIDs)
+		storiesToSave = merged
+		c.logger.Info("Stories merged for scoped architecture revision",
+			"slug", req.Slug,
+			"proposal_id", plan.PendingArchitectureRevision.ProposalID,
+			"accepted_count", acceptedCount,
+			"emitted_count", len(req.Stories),
+			"preserved_count", len(merged)-acceptedCount,
+			"dirty_requirements", len(plan.PendingArchitectureRevision.RequirementIDs))
+	}
+
+	plan.Stories = storiesToSave
 	plan.Status = workflow.StatusStoriesGenerated
 
 	// ADR-043 follow-up — auto-derive plan.Scope.Create from the union of
@@ -417,7 +434,7 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 	// always reflects what stories actually intend to create. Files
 	// already in scope.include are excluded — they exist already, no
 	// creation intent needed.
-	plan.Scope = ensureScopeCreateCoversStories(plan.Scope, req.Stories)
+	plan.Scope = ensureScopeCreateCoversStories(plan.Scope, plan.Stories)
 
 	if err := ps.save(ctx, plan); err != nil {
 		c.logger.Error("Failed to save stories via mutation", "slug", req.Slug, "error", err)
@@ -426,10 +443,108 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 
 	c.logger.Info("Stories saved via mutation",
 		"slug", req.Slug,
-		"count", len(req.Stories),
+		"count", len(plan.Stories),
 		"scope_create_count", len(plan.Scope.Create))
 
 	return MutationResponse{Success: true}
+}
+
+func mergeStoriesForScopedArchitectureRevision(plan *workflow.Plan, emitted []workflow.Story) ([]workflow.Story, []string, int, error) {
+	scope := plan.PendingArchitectureRevision
+	reqSet := stringSet(scope.RequirementIDs)
+	storySet := stringSet(scope.StoryIDs)
+	if len(reqSet) == 0 {
+		return nil, nil, 0, fmt.Errorf("pending architecture revision has no requirement scope")
+	}
+
+	var removedStoryIDs []string
+	kept := make([]workflow.Story, 0, len(plan.Stories))
+	for _, story := range plan.Stories {
+		if storySet[story.ID] || storyTouchesRequirements(story, reqSet) {
+			removedStoryIDs = append(removedStoryIDs, story.ID)
+			continue
+		}
+		kept = append(kept, story)
+	}
+
+	accepted := make([]workflow.Story, 0, len(emitted))
+	for _, story := range emitted {
+		if !storyTouchesRequirements(story, reqSet) {
+			continue
+		}
+		if outside := storyRequirementsOutsideScope(story, reqSet); len(outside) > 0 {
+			return nil, nil, 0, fmt.Errorf("story %q covers requirements outside accepted architecture revision scope: %v", story.ID, outside)
+		}
+		accepted = append(accepted, story)
+	}
+	if len(accepted) == 0 {
+		return nil, nil, 0, fmt.Errorf("story-preparer emitted no stories for scoped requirements %v", scope.RequirementIDs)
+	}
+
+	merged := append(kept, accepted...)
+	if err := workflow.DeriveStoryScheduling(merged, plan.Requirements); err != nil {
+		return nil, nil, 0, fmt.Errorf("derive merged story scheduling: %w", err)
+	}
+	if err := workflow.ValidateStories(merged); err != nil {
+		return nil, nil, 0, fmt.Errorf("validate merged stories: %w", err)
+	}
+	sort.Strings(removedStoryIDs)
+	return merged, removedStoryIDs, len(accepted), nil
+}
+
+func removeScenariosForScopedArchitectureRevision(scenarios []workflow.Scenario, scope *workflow.ArchitectureRevisionScope, storyIDs []string) []workflow.Scenario {
+	if scope == nil {
+		return scenarios
+	}
+	reqSet := stringSet(scope.RequirementIDs)
+	storySet := stringSet(storyIDs)
+	for _, id := range scope.StoryIDs {
+		if id != "" {
+			storySet[id] = true
+		}
+	}
+	out := make([]workflow.Scenario, 0, len(scenarios))
+	for _, scenario := range scenarios {
+		if storySet[scenario.StoryID] {
+			continue
+		}
+		if reqSet[scenario.RequirementID] {
+			continue
+		}
+		out = append(out, scenario)
+	}
+	return out
+}
+
+func stringSet(ids []string) map[string]bool {
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+func storyTouchesRequirements(story workflow.Story, reqSet map[string]bool) bool {
+	for _, id := range story.RequirementIDs {
+		if reqSet[id] {
+			return true
+		}
+	}
+	return false
+}
+
+func storyRequirementsOutsideScope(story workflow.Story, reqSet map[string]bool) []string {
+	var out []string
+	for _, id := range story.RequirementIDs {
+		if id == "" || reqSet[id] {
+			continue
+		}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // ensureScopeCreateCoversStories augments scope.Create with every
@@ -565,6 +680,7 @@ func (c *Component) handleScenariosMutation(ctx context.Context, data []byte) Mu
 		if !current.CanTransitionTo(workflow.StatusScenariosGenerated) {
 			return MutationResponse{Success: false, Error: fmt.Sprintf("invalid transition: %s → scenarios_generated", current)}
 		}
+		plan.PendingArchitectureRevision = nil
 		plan.Status = workflow.StatusScenariosGenerated
 		c.logger.Info("All requirements have scenarios — advanced to scenarios_generated",
 			"slug", req.Slug,
@@ -2026,21 +2142,24 @@ func (c *Component) resetRequirementExecutionsByID(ctx context.Context, slug str
 // architecture_revise PlanDecision (RecoveryActionArchitectureRevise). It is
 // the execution-phase counterpart of determineR2ReentryPoint's "architecture"
 // case: capture the prior architecture so the architect REVISES rather than
-// rewrites, wipe Architecture + Stories + Scenarios, reset affected requirement
-// executions so the re-run cannot reuse stale Story owner evidence via Tier-1 dedup,
-// route the recovery diagnosis into ReviewFormattedFindings (the channel the
-// architecture-generator already reads on revision rounds — component.go:301),
-// and drive the back-transition implementing → requirements_generated so the
-// architect re-fires.
+// rewrites, clear Architecture, reset the affected requirement/story closure so
+// the re-run cannot reuse stale Story owner evidence via Tier-1 dedup, route the
+// recovery diagnosis into ReviewFormattedFindings (the channel the architecture-
+// generator already reads on revision rounds — component.go:301), and drive the
+// back-transition implementing → requirements_generated so the architect
+// re-fires. Whole-phase decisions with explicit contract-impact evidence still
+// wipe Stories + Scenarios; scoped decisions preserve unrelated artifacts and
+// merge only the dirty closure after Sarah/Bob regenerate.
 //
 // Called inline from both accept paths (mutation + HTTP). It does the status
 // mutation IN PLACE rather than via setPlanStatusCached for the same reason
 // the story_reprepare block does: the trailing ps.save in the caller is the
 // sole persist point, so an inline status set avoids a double save / double
-// watcher event. The caller skips applyRecoveryHint for this kind — the
-// diagnosis reaches the architect through ReviewFormattedFindings, not through
-// per-entity RecoveryHints (which would otherwise leak stale architecture
-// context into a future developer prompt).
+// watcher event. The caller skips the generic applyRecoveryHint branch for this
+// kind — the diagnosis reaches the architect through ReviewFormattedFindings.
+// Scoped architecture revisions also copy the diagnosis onto affected Stories so
+// Sarah sees it during the scoped merge pass; those old Stories are replaced
+// before execution resumes, so the hint does not leak into unrelated dev prompts.
 //
 // The EXECUTION_STATES reset is I/O (NATS request/reply via resetRequirement-
 // Executions, scoped when the PlanDecision identifies affected requirements,
@@ -2076,7 +2195,11 @@ func (c *Component) applyArchitectureRevise(ctx context.Context, plan *workflow.
 		return fmt.Errorf("reset requirement executions for architecture_revise: %w", err)
 	}
 
-	reviseArchitectureState(plan, proposal)
+	if resetScope == "all" {
+		reviseArchitectureState(plan, proposal)
+	} else {
+		reviseScopedArchitectureState(plan, proposal, resetReqIDs)
+	}
 
 	c.logger.Info("Architecture revise applied — plan re-queued for architecture regeneration",
 		"slug", plan.Slug,
@@ -2085,7 +2208,8 @@ func (c *Component) applyArchitectureRevise(ctx context.Context, plan *workflow.
 		"reset_requirements", len(resetReqIDs),
 		"reset_count", resetCount,
 		"from_status", from,
-		"had_previous_architecture", plan.PreviousArchitectureJSON != "")
+		"had_previous_architecture", plan.PreviousArchitectureJSON != "",
+		"scoped", plan.PendingArchitectureRevision != nil)
 	return nil
 }
 
@@ -2094,10 +2218,12 @@ func (c *Component) applyArchitectureRevise(ctx context.Context, plan *workflow.
 // both stay byte-identical. Branches on proposal.Kind:
 //
 //   - architecture_revise → applyArchitectureRevise (capture prior architecture,
-//     wipe Architecture + Stories + Scenarios, reset affected requirement executions,
-//     drive implementing → requirements_generated). Routes the diagnosis through
-//     ReviewFormattedFindings, so the recovery-hint + story_reprepare branches
-//     are intentionally skipped.
+//     clear Architecture, reset affected requirement executions, drive
+//     implementing → requirements_generated). Whole-phase decisions wipe
+//     Stories/Scenarios; scoped decisions set PendingArchitectureRevision so
+//     unrelated artifacts survive. Routes the diagnosis through
+//     ReviewFormattedFindings, so the generic recovery-hint + story_reprepare
+//     branches are intentionally skipped.
 //   - any other kind → apply the recovery hint when proposed_by=recovery-agent,
 //     and for story_reprepare drive stories_generated/implementing →
 //     preparing_stories so Sarah re-runs with Story.RecoveryHint set (Train C
@@ -2278,7 +2404,7 @@ func planDecisionResetScope(plan *workflow.Plan, proposal *workflow.PlanDecision
 }
 
 func resetScopeFromRequirements(plan *workflow.Plan, affectedReqIDs []string, proposal *workflow.PlanDecision, phase string) (string, []string, error) {
-	closure := cascade.ExpandRequirementClosure(plan.Requirements, affectedReqIDs)
+	closure := cascade.ExpandRequirementStoryClosure(plan.Requirements, plan.Stories, affectedReqIDs)
 	if len(closure) == 0 {
 		if contractImpactAllowsWholePhaseReset(proposal, phase) {
 			return "all", nil, nil
@@ -2337,6 +2463,70 @@ func removeScenariosForStoryReprepare(scenarios []workflow.Scenario, proposal *w
 	return out
 }
 
+func reviseScopedArchitectureState(plan *workflow.Plan, proposal *workflow.PlanDecision, affectedReqIDs []string) (transitioned bool, from workflow.Status) {
+	from = plan.EffectiveStatus()
+	if !from.CanTransitionTo(workflow.StatusRequirementsGenerated) {
+		return false, from
+	}
+
+	prepareArchitectureRevisionBase(plan, proposal)
+
+	storyIDs := storyIDsForRequirements(plan.Stories, affectedReqIDs)
+	applyArchitectureRevisionHintToStories(plan, storyIDs, proposal.Rationale)
+	// The architecture document is regenerated as one artifact, but the scoped
+	// marker below keeps unrelated Stories/Scenarios attached to completed work.
+	plan.PendingArchitectureRevision = &workflow.ArchitectureRevisionScope{
+		ProposalID:     proposal.ID,
+		RequirementIDs: append([]string(nil), affectedReqIDs...),
+		StoryIDs:       storyIDs,
+	}
+	plan.Status = workflow.StatusRequirementsGenerated
+	return true, from
+}
+
+func prepareArchitectureRevisionBase(plan *workflow.Plan, proposal *workflow.PlanDecision) {
+	if proposal.Rationale != "" {
+		plan.ReviewFormattedFindings = proposal.Rationale
+	}
+
+	// Clear any stale carry-over first so a failed marshal leaves no leftover.
+	plan.PreviousArchitectureJSON = ""
+	if plan.Architecture != nil {
+		if b, err := json.Marshal(plan.Architecture); err == nil {
+			plan.PreviousArchitectureJSON = string(b)
+		}
+	}
+	plan.Architecture = nil
+}
+
+func storyIDsForRequirements(stories []workflow.Story, reqIDs []string) []string {
+	reqSet := stringSet(reqIDs)
+	out := make([]string, 0, len(stories))
+	for _, story := range stories {
+		if story.ID == "" || !storyTouchesRequirements(story, reqSet) {
+			continue
+		}
+		out = append(out, story.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func applyArchitectureRevisionHintToStories(plan *workflow.Plan, storyIDs []string, hint string) {
+	if hint == "" || len(storyIDs) == 0 {
+		return
+	}
+	target := stringSet(storyIDs)
+	now := time.Now()
+	for i := range plan.Stories {
+		if !target[plan.Stories[i].ID] {
+			continue
+		}
+		plan.Stories[i].RecoveryHint = hint
+		plan.Stories[i].UpdatedAt = now
+	}
+}
+
 // reviseArchitectureState performs the pure in-memory state mutation for an
 // accepted architecture_revise PlanDecision, with no I/O so it is unit-testable
 // in isolation (the seam):
@@ -2346,7 +2536,7 @@ func removeScenariosForStoryReprepare(scenarios []workflow.Scenario, proposal *w
 //   - capture the prior architecture into PreviousArchitectureJSON so the
 //     architect REVISES rather than rewrites (mirrors determineR2ReentryPoint's
 //     "architecture" case);
-//   - wipe Architecture + Stories + Scenarios;
+//   - wipe Architecture + Stories + Scenarios for a whole-phase reset;
 //   - drive the back-transition implementing → requirements_generated.
 //
 // The wipe is gated behind the same CanTransitionTo check the caller performs,
@@ -2361,20 +2551,10 @@ func reviseArchitectureState(plan *workflow.Plan, proposal *workflow.PlanDecisio
 		return false, from
 	}
 
-	if proposal.Rationale != "" {
-		plan.ReviewFormattedFindings = proposal.Rationale
-	}
-
-	// Clear any stale carry-over first so a failed marshal leaves no leftover.
-	plan.PreviousArchitectureJSON = ""
-	if plan.Architecture != nil {
-		if b, err := json.Marshal(plan.Architecture); err == nil {
-			plan.PreviousArchitectureJSON = string(b)
-		}
-	}
-	plan.Architecture = nil
+	prepareArchitectureRevisionBase(plan, proposal)
 	plan.Stories = nil
 	plan.Scenarios = nil
+	plan.PendingArchitectureRevision = nil
 
 	plan.Status = workflow.StatusRequirementsGenerated
 	return true, from

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -739,9 +739,11 @@ func (c *Component) deriveDecision(loop *agentic.LoopEntity, escalationReason st
 //     requirement_change, which silently degraded into a scenarios-only
 //     cascade that left Sarah's stories unchanged.
 //   - architecture_revise → architecture_revise. Heaviest kind: plan-manager
-//     wipes Architecture + Stories + Scenarios + all requirement executions
-//     and drives implementing → requirements_generated so the architect
-//     re-fires. Distinct from story_reprepare (which keeps the architecture).
+//     clears Architecture, resets the affected requirement/story closure, and
+//     drives implementing → requirements_generated so the architect re-fires.
+//     Whole-phase decisions may wipe Stories/Scenarios; scoped decisions
+//     preserve unrelated artifacts. Distinct from story_reprepare (which keeps
+//     the architecture).
 //   - escalate_human / mark_unrecoverable → execution_exhausted. Terminal;
 //     plan-manager auto-archives when the subject req reaches a non-failed
 //     terminal state.

--- a/processor/scenario-generator/plan_watcher.go
+++ b/processor/scenario-generator/plan_watcher.go
@@ -103,7 +103,11 @@ func (c *Component) generateScenariosFromKV(ctx context.Context, plan *workflow.
 	// plans / pre-Sarah mock fixtures) the dispatcher falls back to
 	// per-Requirement dispatch — preserves backwards compatibility with
 	// fixtures that don't author Stories.
+	targetReqs := scenarioGenerationRequirementScope(plan)
 	for _, req := range plan.Requirements {
+		if len(targetReqs) > 0 && !targetReqs[req.ID] {
+			continue
+		}
 		emissions := Classify(req, caps, plan.Architecture, catalog)
 		required := emissionsToWireTiers(emissions)
 
@@ -116,6 +120,19 @@ func (c *Component) generateScenariosFromKV(ctx context.Context, plan *workflow.
 			c.dispatchPerStory(ctx, plan, req, story, required, archContext)
 		}
 	}
+}
+
+func scenarioGenerationRequirementScope(plan *workflow.Plan) map[string]bool {
+	if plan == nil || plan.PendingArchitectureRevision == nil {
+		return nil
+	}
+	out := make(map[string]bool, len(plan.PendingArchitectureRevision.RequirementIDs))
+	for _, id := range plan.PendingArchitectureRevision.RequirementIDs {
+		if id != "" {
+			out[id] = true
+		}
+	}
+	return out
 }
 
 // dispatchPerStory issues a scenario-generator agent loop scoped to a single

--- a/processor/scenario-generator/scoped_architecture_revision_test.go
+++ b/processor/scenario-generator/scoped_architecture_revision_test.go
@@ -1,0 +1,34 @@
+package scenariogenerator
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestScenarioGenerationRequirementScope_ScopedArchitectureRevision(t *testing.T) {
+	plan := &workflow.Plan{
+		PendingArchitectureRevision: &workflow.ArchitectureRevisionScope{
+			RequirementIDs: []string{"req.demo.6", "", "req.demo.7"},
+		},
+	}
+
+	got := scenarioGenerationRequirementScope(plan)
+	if len(got) != 2 {
+		t.Fatalf("scope len = %d, want 2: %v", len(got), got)
+	}
+	for _, id := range []string{"req.demo.6", "req.demo.7"} {
+		if !got[id] {
+			t.Fatalf("scope = %v, missing %q", got, id)
+		}
+	}
+	if got["req.demo.1"] {
+		t.Fatalf("scope = %v, should not include unrelated requirement", got)
+	}
+}
+
+func TestScenarioGenerationRequirementScope_FullPlan(t *testing.T) {
+	if got := scenarioGenerationRequirementScope(&workflow.Plan{}); got != nil {
+		t.Fatalf("scope = %v, want nil for full-plan generation", got)
+	}
+}

--- a/workflow/cascade/cascade.go
+++ b/workflow/cascade/cascade.go
@@ -45,10 +45,11 @@ type Result struct {
 //   - Kind=execution_exhausted: terminal acknowledgement; cascade is a
 //     no-op (callers shouldn't invoke PlanDecision for this kind, but
 //     the function returns empty Result safely if they do).
-//   - Kind=architecture_revise: no-op for Story/Scenario dirty marks. The
-//     plan-manager accept handler wipes Architecture + Stories + Scenarios
-//     and resets execution rows for the affected requirement closure inline;
-//     the re-run regenerates from the architect down.
+//   - Kind=architecture_revise: no-op for Story/Scenario dirty marks here.
+//     The plan-manager accept handler captures the affected requirement/story
+//     closure inline. Whole-phase decisions regenerate from the architect
+//     down; scoped decisions preserve unrelated Stories/Scenarios and merge
+//     only the dirty closure after Winston/Sarah/Bob re-run.
 //
 // Pure business logic — no I/O. Caller loads the plan from KV and passes
 // stories + scenarios. Returns the IDs that were dirty-marked so
@@ -119,12 +120,10 @@ func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, sce
 		// rejected, so there is nothing to dirty-cascade.
 
 	case workflow.PlanDecisionKindArchitectureRevise:
-		// The plan-manager accept handler wipes Architecture + Stories +
-		// Scenarios and resets scoped execution rows inline, then drives
-		// implementing → requirements_generated. There is nothing left for
-		// the dirty-cascade to mark — the re-run regenerates those entities
-		// from the architect down. No-op beyond the recorded
-		// AffectedRequirementIDs (caller telemetry).
+		// The plan-manager accept handler applies the planning re-entry inline.
+		// This cascade remains telemetry-only; expandPlanningReentryClosure
+		// widens AffectedRequirementIDs before publishing the accepted event so
+		// requirement-executor abandons the same closure plan-manager reset.
 
 	default:
 		// Kind=requirement_change OR unset (back-compat with pre-Kind records).
@@ -219,5 +218,64 @@ func ExpandRequirementClosure(requirements []workflow.Requirement, seeds []strin
 		out = append(out, id)
 	}
 	sort.Strings(out)
+	return out
+}
+
+// ExpandRequirementStoryClosure returns the affected requirement IDs plus every
+// downstream requirement, while also widening through M:N Story coverage. If an
+// affected requirement is covered by a Story, every other requirement covered by
+// that Story must be considered dirty too: replacing the Story invalidates the
+// shared execution evidence for all of its requirement joins.
+func ExpandRequirementStoryClosure(requirements []workflow.Requirement, stories []workflow.Story, seeds []string) []string {
+	selected := make(map[string]struct{}, len(seeds))
+	for _, id := range seeds {
+		if id == "" {
+			continue
+		}
+		selected[id] = struct{}{}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+
+	for {
+		before := len(selected)
+		for _, id := range ExpandRequirementClosure(requirements, keys(selected)) {
+			selected[id] = struct{}{}
+		}
+		for _, story := range stories {
+			if !storyIntersectsRequirements(story, selected) {
+				continue
+			}
+			for _, id := range story.RequirementIDs {
+				if id != "" {
+					selected[id] = struct{}{}
+				}
+			}
+		}
+		if len(selected) == before {
+			break
+		}
+	}
+
+	out := keys(selected)
+	sort.Strings(out)
+	return out
+}
+
+func storyIntersectsRequirements(story workflow.Story, reqIDs map[string]struct{}) bool {
+	for _, id := range story.RequirementIDs {
+		if _, ok := reqIDs[id]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func keys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
 	return out
 }

--- a/workflow/cascade/cascade_test.go
+++ b/workflow/cascade/cascade_test.go
@@ -35,10 +35,10 @@ func TestPlanDecision_NoAffectedRequirements(t *testing.T) {
 
 // TestPlanDecision_ArchitectureRevise_NoOp verifies the architecture_revise
 // cascade is a no-op even with Stories + Scenarios present: the plan-manager
-// accept handler already wiped those entities and reset execution inline, so
-// the cascade must not dirty-mark anything (it records only the affected reqs
-// for telemetry). Without an explicit case this kind would fall through to the
-// requirement_change default and wrongly dirty-mark scenarios.
+// accept handler applies the planning re-entry inline, so the cascade must not
+// dirty-mark anything (it records only the affected reqs for telemetry). Without
+// an explicit case this kind would fall through to the requirement_change
+// default and wrongly dirty-mark scenarios.
 func TestPlanDecision_ArchitectureRevise_NoOp(t *testing.T) {
 	proposal := &workflow.PlanDecision{
 		ID:             "plan-decision.slug.recovery.abcd1234",

--- a/workflow/cascade/requirement_story_closure_test.go
+++ b/workflow/cascade/requirement_story_closure_test.go
@@ -1,0 +1,28 @@
+package cascade
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestExpandRequirementStoryClosure_WidensThroughMNStoryCoverage(t *testing.T) {
+	reqs := []workflow.Requirement{
+		{ID: "telemetry"},
+		{ID: "control"},
+		{ID: "async"},
+		{ID: "consumer", DependsOn: []string{"async"}},
+		{ID: "unrelated"},
+	}
+	stories := []workflow.Story{
+		{ID: "story.mapper", RequirementIDs: []string{"telemetry", "control", "async"}},
+		{ID: "story.unrelated", RequirementIDs: []string{"unrelated"}},
+	}
+
+	got := ExpandRequirementStoryClosure(reqs, stories, []string{"telemetry"})
+	want := []string{"async", "consumer", "control", "telemetry"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExpandRequirementStoryClosure() = %v, want %v", got, want)
+	}
+}

--- a/workflow/payloads/recovery.go
+++ b/workflow/payloads/recovery.go
@@ -71,14 +71,14 @@ const (
 	// dev prompt against a broken architecture only re-wedges.
 	//
 	// Heaviest action in the set. On accept, plan-manager captures the prior
-	// architecture into PreviousArchitectureJSON, clears Architecture +
-	// Stories + Scenarios, resets ALL requirement executions, writes the
-	// recovery diagnosis to ReviewFormattedFindings (the channel the
-	// architecture-generator already reads on revision rounds), and drives
-	// the back-transition implementing → requirements_generated so the
-	// architect re-fires and REVISES the prior architecture against the
-	// diagnosis. The full downstream pipeline (Sarah → Bob → execution)
-	// then re-runs clean.
+	// architecture into PreviousArchitectureJSON, clears Architecture, resets the
+	// affected requirement/story closure, writes the recovery diagnosis to
+	// ReviewFormattedFindings (the channel the architecture-generator already
+	// reads on revision rounds), and drives the back-transition implementing →
+	// requirements_generated so the architect re-fires and REVISES the prior
+	// architecture against the diagnosis. Whole-phase decisions may clear
+	// Stories/Scenarios; scoped decisions preserve unrelated artifacts and merge
+	// only the dirty closure before execution resumes.
 	//
 	// Distinct from story_reprepare: story_reprepare keeps Architecture and
 	// asks Sarah to re-shard; architecture_revise discards the architecture

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -321,10 +321,12 @@ func (s Status) CanTransitionTo(target Status) bool {
 		//   resets affected requirement executions, and re-runs Sarah/Bob.)
 		// implementing → requirements_generated (architecture_revise recovery:
 		//   a wedge rooted in the architecture is escalated; the recovery-agent's
-		//   architecture_revise PlanDecision wipes Architecture/Stories/Scenarios +
-		//   all requirement executions and re-runs the architect. These two
-		//   execution-phase → plan-prep back-edges are gated to their accept paths
-		//   in plan-manager.)
+		//   architecture_revise PlanDecision clears Architecture, resets the
+		//   affected requirement/story closure, and re-runs the architect.
+		//   Whole-phase decisions may wipe Stories/Scenarios when justified;
+		//   scoped decisions preserve unrelated artifacts. These two execution-
+		//   phase → plan-prep back-edges are gated to their accept paths in
+		//   plan-manager.)
 		// implementing → rejected (execution escalation)
 		return target == StatusReviewingRollup || target == StatusReviewingQA || target == StatusReadyForQA ||
 			target == StatusAwaitingReview || target == StatusComplete ||
@@ -673,6 +675,15 @@ type Plan struct {
 	// architecture. Transient — empty on the forward flow.
 	PreviousArchitectureJSON string `json:"previous_architecture_json,omitempty"`
 
+	// PendingArchitectureRevision scopes an accepted execution/post-QA
+	// architecture_revise recovery while the plan re-enters architecture,
+	// story, and scenario generation. Nil means the revision invalidated the
+	// whole planning layer. When set, downstream generators may emit a full
+	// refreshed artifact set, but plan-manager only accepts changes inside
+	// RequirementIDs/StoryIDs and preserves unrelated completed artifacts.
+	// Cleared once the scoped scenario regeneration converges.
+	PendingArchitectureRevision *ArchitectureRevisionScope `json:"pending_architecture_revision,omitempty"`
+
 	// Requirements, Scenarios, Stories, and PlanDecisions are populated when
 	// the plan is written to the PLAN_STATES KV bucket so downstream watchers
 	// have everything they need without follow-up queries.
@@ -743,6 +754,16 @@ type Plan struct {
 	// refuse with 409 in that state until an operator has cleared the
 	// underlying cause (e.g. sandbox /admin/reconcile).
 	InfraHealth string `json:"infra_health,omitempty"`
+}
+
+// ArchitectureRevisionScope records the dirty closure for a scoped
+// architecture_revise recovery. It lets the architecture phase re-run while the
+// story/scenario layers merge only the affected closure instead of rewriting
+// unrelated completed artifacts.
+type ArchitectureRevisionScope struct {
+	ProposalID     string   `json:"proposal_id,omitempty"`
+	RequirementIDs []string `json:"requirement_ids,omitempty"`
+	StoryIDs       []string `json:"story_ids,omitempty"`
 }
 
 // QARun carries the executor result persisted on the plan at reviewing_qa.
@@ -1932,15 +1953,15 @@ const (
 
 	// PlanDecisionKindArchitectureRevise marks a decision proposing that
 	// Winston re-run the architecture. Heaviest recovery kind: on accept,
-	// plan-manager captures PreviousArchitectureJSON, clears Architecture +
-	// Stories + Scenarios, resets all requirement executions, and drives the
-	// back-transition implementing → requirements_generated so the architect
+	// plan-manager captures PreviousArchitectureJSON, clears Architecture,
+	// resets the affected requirement/story closure, and drives the back-
+	// transition implementing → requirements_generated so the architect
 	// re-fires and revises the prior architecture against the recovery
 	// diagnosis (carried via ReviewFormattedFindings — the same channel the
-	// R2 architecture re-entry uses). Distinct from story_reprepare, whose
-	// cascade keeps Architecture and only re-shards Stories; this kind
-	// discards the architecture itself and the cascade is a no-op because the
-	// accept handler already performed the wipe inline. Emitted by the
+	// R2 architecture re-entry uses). Whole-phase decisions with explicit
+	// evidence may clear Stories + Scenarios; scoped decisions record
+	// PendingArchitectureRevision so unrelated Stories/Scenarios survive and
+	// only the dirty closure is merged after Sarah/Bob re-run. Emitted by the
 	// recovery-agent for the architecture_revise action.
 	PlanDecisionKindArchitectureRevise PlanDecisionKind = "architecture_revise"
 


### PR DESCRIPTION
## Summary
- add a scoped `PendingArchitectureRevision` marker so accepted `architecture_revise` decisions preserve unrelated Stories and Scenarios
- merge only the dirty requirement/story closure after story preparation, and dispatch scenario generation only for that closure
- widen scoped resets through M:N Story coverage so shared owner evidence cannot remain stale
- update recovery docs/comments and record OpenSpec task 8.6 under `contract-authoritative-planning-handoffs`

## Root cause
A single-requirement `architecture_revise` already reset EXECUTION_STATES narrowly, but the planning artifact path still cleared/regenerated the whole Story/Scenario layer. That left completed requirement execution rows pointing at rewritten plan artifacts.

## Not in this PR
This PR does not fix the separate auto-accept/deferred-terminal race observed in the same hard run, where an `architecture_revise` PlanDecision can remain `proposed` long enough for a deferred terminal timeout to reject the plan first. That needs its own follow-up because it is a decision/terminal-timer ordering bug, not the artifact invalidation bug addressed here.

## Validation
- `go test ./processor/plan-manager`
- `go test ./...`
- `openspec validate contract-authoritative-planning-handoffs --strict`