### PR TITLE
fix(recovery): unblock scope incomplete retries

### DIFF
--- a/docker/compose/e2e-mock.yml
+++ b/docker/compose/e2e-mock.yml
@@ -9,6 +9,45 @@
 # which routes all LLM calls to http://mock-llm:11434/v1.
 
 services:
+  # Mock configs use BM25 graph embedding and do not call the local graph
+  # model services. Keep these dependency placeholders healthy so the base
+  # e2e stack can boot without pulling/loading Snowflake or Qwen images.
+  semembed:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-fast:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-answer:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-summary:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
   mock-llm:
     build:
       context: ../..

--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -154,6 +154,18 @@ services:
       retries: 5
       start_period: 10s
 
+  # Shared fastembed model cache. The semembed image runs as uid/gid 1000,
+  # while fresh Docker volumes are root-owned, so initialize ownership before
+  # the service starts. The semembed-cache volume is external so the normal
+  # e2e `down -v` cleanup can reset NATS/workspace state without forcing a
+  # Hugging Face re-download on the next run.
+  semembed-cache-init:
+    image: alpine:3.19
+    command: ["sh", "-c", "mkdir -p /cache && chown -R 1000:1000 /cache"]
+    volumes:
+      - semembed-cache:/cache
+    restart: "no"
+
   # semembed serves graph-embedding's HTTP embedder (replacing BM25).
   # Background batch — embeds entity text on every ENTITY_STATES write.
   semembed:
@@ -161,6 +173,11 @@ services:
     environment:
       - SEMEMBED_MODEL=Snowflake/snowflake-arctic-embed-s
       - RUST_LOG=info
+    volumes:
+      - semembed-cache:/home/semembed/.cache/fastembed
+    depends_on:
+      semembed-cache-init:
+        condition: service_completed_successfully
     # Probe the real embeddings endpoint, not /health.
     # Caught 2026-05-02: /health returns 200 ~939ms before the Rust HTTP
     # listener actually accepts POSTs, so service_healthy fired early
@@ -274,6 +291,8 @@ services:
 
 volumes:
   nats-data:
+  semembed-cache:
+    external: true
 
 networks:
   default:

--- a/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
@@ -55,3 +55,28 @@ within configured autonomous policy.
 #### Scenario: Policy-safe recovery auto-accepts with trace
 - **WHEN** recovery proposes a targeted change within autonomous policy
 - **THEN** the system may auto-accept it and records the policy rule, affected closure, and contract impact
+
+### Requirement: Recoverable PlanDecision kinds are owned end to end
+The system MUST define validation, auto-accept policy, accept effects, cascade semantics, prompt propagation,
+timeout behavior, and UI phase summary behavior for every PlanDecision kind that can leave a plan in a
+recoverable state.
+
+#### Scenario: Scope incomplete is not a half-wired decision
+- **WHEN** the Level-0 completeness gate records a `scope_incomplete` PlanDecision
+- **THEN** the decision is valid, policy-checkable, accepted or human-gated deterministically, and has explicit
+  cascade behavior rather than falling through another kind's default path
+
+#### Scenario: Scope recovery carries missing deliverables into execution
+- **WHEN** a `scope_incomplete` decision is accepted
+- **THEN** the retry state includes the missing declared files and the reason they are still required in the next
+  developer-facing recovery guidance
+
+#### Scenario: Recoverable accepted decisions do not leave a rejected active plan
+- **WHEN** an accepted recovery decision starts a retry or planning re-entry
+- **THEN** the plan status and phase summary move to the active recovery or execution state instead of remaining
+  terminal/rejected while backend work is running
+
+#### Scenario: Human-gated recovery cannot self-timeout invisibly
+- **WHEN** full-auto mode reaches a recovery decision that policy refuses to auto-accept
+- **THEN** timeout handling and UI state keep the plan waiting on that explicit decision instead of silently
+  terminal-failing the requirement before the operator can act

--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -65,3 +65,14 @@
 - [x] 8.4 Floor recovery contract-impact policy by action kind so scope/topology-changing actions cannot self-report as preserve/refine
 - [x] 8.5 Fix UI false-green and stale observability state regressions from the PR review
 - [x] 8.6 Fix scoped `architecture_revise` so a single dirty requirement closure does not rewrite unrelated Stories/Scenarios
+
+## 9. Recovery State Machine Audit Follow-Ups
+
+- [x] 9.1 Make `scope_incomplete` a first-class PlanDecision kind across validation, cascade, and auto-accept policy
+- [x] 9.2 Apply `scope_incomplete` accept effects that write recovery guidance and move rejected plans into active retry state
+- [x] 9.3 Prevent requirement-executor from treating `scope_incomplete` as generic completed-QA recovery
+- [x] 9.4 Add deterministic tests for scope-incomplete validation, auto-accept, accept effects, cascade, prompt guidance, and executor handling
+- [x] 9.5 Add or update tests for architecture-revise full-auto timeout policy so human-gated decisions cannot self-fail invisibly
+- [x] 9.6 Run the relevant mock E2E handoff scenario after unit coverage passes
+- [x] 9.7 Fix mock E2E execution-phase reporting so intermediate snapshots do not overwrite final plan status details
+- [x] 9.8 Stabilize mock E2E startup by bypassing unused graph model services and persisting the semembed model cache for real graph stacks

--- a/processor/plan-decision-handler/component.go
+++ b/processor/plan-decision-handler/component.go
@@ -85,6 +85,9 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	if config.MaxAutoStoryReprepares == 0 {
 		config.MaxAutoStoryReprepares = defaults.MaxAutoStoryReprepares
 	}
+	if config.MaxAutoScopeIncompleteRecoveries == 0 {
+		config.MaxAutoScopeIncompleteRecoveries = defaults.MaxAutoScopeIncompleteRecoveries
+	}
 	if config.Ports == nil {
 		config.Ports = defaults.Ports
 	}

--- a/processor/plan-decision-handler/component_test.go
+++ b/processor/plan-decision-handler/component_test.go
@@ -133,6 +133,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.MaxAutoStoryReprepares != 1 {
 		t.Errorf("DefaultConfig().MaxAutoStoryReprepares = %d, want 1", cfg.MaxAutoStoryReprepares)
 	}
+	if cfg.MaxAutoScopeIncompleteRecoveries != 1 {
+		t.Errorf("DefaultConfig().MaxAutoScopeIncompleteRecoveries = %d, want 1", cfg.MaxAutoScopeIncompleteRecoveries)
+	}
 	if cfg.Ports == nil {
 		t.Error("DefaultConfig().Ports must not be nil")
 	}
@@ -156,6 +159,9 @@ func TestNewComponent_AppliesAutoAcceptCapDefaults(t *testing.T) {
 	}
 	if c.config.MaxAutoStoryReprepares != 1 {
 		t.Errorf("MaxAutoStoryReprepares = %d, want default 1", c.config.MaxAutoStoryReprepares)
+	}
+	if c.config.MaxAutoScopeIncompleteRecoveries != 1 {
+		t.Errorf("MaxAutoScopeIncompleteRecoveries = %d, want default 1", c.config.MaxAutoScopeIncompleteRecoveries)
 	}
 }
 

--- a/processor/plan-decision-handler/config.go
+++ b/processor/plan-decision-handler/config.go
@@ -66,6 +66,14 @@ type Config struct {
 	// reprepare, then a human must decide.
 	MaxAutoStoryReprepares int `json:"max_auto_story_reprepares" schema:"type:int,description:Max story_reprepare recovery decisions auto-accepted per plan before human review,category:advanced,default:1,min:0,max:10"`
 
+	// MaxAutoScopeIncompleteRecoveries bounds how many scope_incomplete
+	// PlanDecisions may be auto-accepted for a single plan. The completeness
+	// gate is deterministic and non-contract-changing when the declared scope
+	// remains required, so one automatic retry is safe. Repeating the same gate
+	// failure after that usually means over-declared scope or poor Story
+	// coverage, which needs planning recovery or human triage.
+	MaxAutoScopeIncompleteRecoveries int `json:"max_auto_scope_incomplete_recoveries" schema:"type:int,description:Max scope_incomplete recovery decisions auto-accepted per plan before human review,category:advanced,default:1,min:0,max:10"`
+
 	// Ports contains input/output port definitions.
 	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Input/output port definitions,category:basic"`
 }
@@ -73,13 +81,14 @@ type Config struct {
 // DefaultConfig returns sensible default configuration.
 func DefaultConfig() Config {
 	return Config{
-		StreamName:                 "WORKFLOW",
-		ConsumerName:               "plan-decision-handler",
-		TriggerSubject:             "workflow.trigger.plan-decision-cascade",
-		AcceptedSubject:            "workflow.events.plan-decision.accepted",
-		TimeoutSeconds:             120,
-		MaxAutoArchitectureRevises: 1,
-		MaxAutoStoryReprepares:     1,
+		StreamName:                       "WORKFLOW",
+		ConsumerName:                     "plan-decision-handler",
+		TriggerSubject:                   "workflow.trigger.plan-decision-cascade",
+		AcceptedSubject:                  "workflow.events.plan-decision.accepted",
+		TimeoutSeconds:                   120,
+		MaxAutoArchitectureRevises:       1,
+		MaxAutoStoryReprepares:           1,
+		MaxAutoScopeIncompleteRecoveries: 1,
 		Ports: &component.PortConfig{
 			Inputs: []component.PortDefinition{
 				{

--- a/processor/plan-decision-handler/recovery_autoaccept.go
+++ b/processor/plan-decision-handler/recovery_autoaccept.go
@@ -75,7 +75,7 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 
 	c.logger.Info("Recovery auto-accept watcher started",
 		"bucket", "PLAN_STATES",
-		"filter", "proposed_by=recovery-agent + status=proposed + kind=requirement_change")
+		"filter", "recoverable proposed PlanDecisions within autonomous policy")
 
 	// Dedup: decision-ID → time-accepted. Drop entries older than the
 	// TTL on each pass to keep memory bounded.
@@ -135,6 +135,13 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 					"max_auto_story_reprepares", c.config.MaxAutoStoryReprepares)
 				continue
 			}
+			if dec.Kind == workflow.PlanDecisionKindScopeIncomplete &&
+				countAcceptedScopeIncompleteRecoveries(planView.PlanDecisions) >= c.config.MaxAutoScopeIncompleteRecoveries {
+				c.logger.Warn("scope_incomplete auto-accept budget exhausted; leaving for human review",
+					"slug", planView.Slug, "proposal_id", dec.ID,
+					"max_auto_scope_incomplete_recoveries", c.config.MaxAutoScopeIncompleteRecoveries)
+				continue
+			}
 			acceptedIDs[dec.ID] = now
 			c.invokeAccept(ctx, planView.Slug, dec.ID)
 		}
@@ -192,11 +199,22 @@ func countAcceptedStoryReprepares(decisions []workflow.PlanDecision) int {
 	return n
 }
 
+// countAcceptedScopeIncompleteRecoveries bounds automatic retries after the
+// deterministic Level-0 completeness gate. Repeated accepted misses usually
+// mean the plan over-declared scope or Stories do not own the missing files.
+func countAcceptedScopeIncompleteRecoveries(decisions []workflow.PlanDecision) int {
+	n := 0
+	for i := range decisions {
+		if decisions[i].Kind == workflow.PlanDecisionKindScopeIncomplete &&
+			decisions[i].Status == workflow.PlanDecisionStatusAccepted {
+			n++
+		}
+	}
+	return n
+}
+
 func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	if dec == nil {
-		return false
-	}
-	if dec.ProposedBy != "recovery-agent" {
 		return false
 	}
 	if dec.Status != workflow.PlanDecisionStatusProposed {
@@ -206,7 +224,13 @@ func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	case workflow.PlanDecisionKindRequirementChange,
 		workflow.PlanDecisionKindStoryReprepare,
 		workflow.PlanDecisionKindArchitectureRevise:
-		// auto-acceptable
+		if dec.ProposedBy != "recovery-agent" {
+			return false
+		}
+	case workflow.PlanDecisionKindScopeIncomplete:
+		if dec.ProposedBy != "plan-manager" {
+			return false
+		}
 	default:
 		return false
 	}

--- a/processor/plan-decision-handler/should_auto_accept_test.go
+++ b/processor/plan-decision-handler/should_auto_accept_test.go
@@ -22,6 +22,42 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 		comment string
 	}{
 		{
+			name: "scope_incomplete from plan-manager is auto-acceptable",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "plan-manager",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindScopeIncomplete,
+				AffectedReqIDs: []string{"req.demo.1"},
+				ContractImpact: recoveryImpact(workflow.ContractImpactPreserve),
+			},
+			wantOK:  true,
+			comment: "Level-0 completeness recovery preserves declared scope and may retry automatically",
+		},
+		{
+			name: "scope_incomplete from recovery-agent is human-gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindScopeIncomplete,
+				AffectedReqIDs: []string{"req.demo.1"},
+				ContractImpact: recoveryImpact(workflow.ContractImpactPreserve),
+			},
+			wantOK:  false,
+			comment: "scope_incomplete is owned by the deterministic plan-manager gate",
+		},
+		{
+			name: "scope_incomplete contract change is human-gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "plan-manager",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindScopeIncomplete,
+				AffectedReqIDs: []string{"req.demo.1"},
+				ContractImpact: recoveryImpact(workflow.ContractImpactChange),
+			},
+			wantOK:  false,
+			comment: "changing declared scope needs review",
+		},
+		{
 			name: "story_reprepare is auto-acceptable",
 			dec: &workflow.PlanDecision{
 				ProposedBy:     "recovery-agent",
@@ -155,5 +191,18 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 				t.Errorf("shouldAutoAcceptRecovery = %v, want %v (%s)", got, tc.wantOK, tc.comment)
 			}
 		})
+	}
+}
+
+func TestCountAcceptedScopeIncompleteRecoveries(t *testing.T) {
+	decisions := []workflow.PlanDecision{
+		{ID: "a", Kind: workflow.PlanDecisionKindScopeIncomplete, Status: workflow.PlanDecisionStatusAccepted},
+		{ID: "b", Kind: workflow.PlanDecisionKindScopeIncomplete, Status: workflow.PlanDecisionStatusProposed},
+		{ID: "c", Kind: workflow.PlanDecisionKindRequirementChange, Status: workflow.PlanDecisionStatusAccepted},
+		{ID: "d", Kind: workflow.PlanDecisionKindScopeIncomplete, Status: workflow.PlanDecisionStatusRejected},
+		{ID: "e", Kind: workflow.PlanDecisionKindScopeIncomplete, Status: workflow.PlanDecisionStatusAccepted},
+	}
+	if got := countAcceptedScopeIncompleteRecoveries(decisions); got != 2 {
+		t.Fatalf("countAcceptedScopeIncompleteRecoveries = %d, want 2", got)
 	}
 }

--- a/processor/plan-manager/completeness_gate.go
+++ b/processor/plan-manager/completeness_gate.go
@@ -138,9 +138,14 @@ func (c *Component) failPlanOnIncompleteScope(ctx context.Context, plan *workflo
 		Title:          "Declared scope.create files not delivered",
 		Rationale:      plan.LastError,
 		AffectedReqIDs: affected,
-		Status:         workflow.PlanDecisionStatusProposed,
-		ProposedBy:     "plan-manager",
-		CreatedAt:      now,
+		ContractImpact: &workflow.ContractImpact{
+			Kind:        workflow.ContractImpactPreserve,
+			Summary:     "Declared scope.create files remain required; retry execution must deliver the missing files or propose an explicit scope amendment.",
+			AffectedIDs: scopeCompletenessAffectedIDs(missing),
+		},
+		Status:     workflow.PlanDecisionStatusProposed,
+		ProposedBy: "plan-manager",
+		CreatedAt:  now,
 	})
 
 	c.logger.Warn("Level-0 completeness gate FAILED — failing plan closed (recoverable) instead of advancing to QA",
@@ -159,4 +164,16 @@ func (c *Component) failPlanOnIncompleteScope(ctx context.Context, plan *workflo
 				"slug", plan.Slug, "error", saveErr)
 		}
 	}
+}
+
+func scopeCompletenessAffectedIDs(missing []string) []string {
+	out := make([]string, 0, len(missing))
+	for _, file := range missing {
+		file = strings.TrimSpace(file)
+		if file == "" {
+			continue
+		}
+		out = append(out, "contract.scope.create:"+file)
+	}
+	return out
 }

--- a/processor/plan-manager/completeness_gate_test.go
+++ b/processor/plan-manager/completeness_gate_test.go
@@ -1,8 +1,11 @@
 package planmanager
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"github.com/c360studio/semspec/workflow"
 )
 
 func TestUndeliveredScopeFiles(t *testing.T) {
@@ -88,5 +91,56 @@ func TestUndeliveredScopeFiles_RunShape(t *testing.T) {
 	// The first undelivered file is File08 (0-7 delivered).
 	if missing[0] != "src/main/java/org/sensorhub/impl/sensor/mavsdk/File08.java" {
 		t.Errorf("missing[0] = %q, want File08", missing[0])
+	}
+}
+
+func TestFailPlanOnIncompleteScopeCreatesRecoverableDecisionWithContractImpact(t *testing.T) {
+	c := setupTestComponent(t)
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID("scope-gap"),
+		Slug:   "scope-gap",
+		Title:  "scope-gap",
+		Status: workflow.StatusImplementing,
+		Scope:  workflow.Scope{Create: []string{"src/required.go", "src/missing.go"}},
+		Requirements: []workflow.Requirement{
+			{ID: "req.scope-gap.1"},
+			{ID: "req.scope-gap.2"},
+		},
+	}
+	if err := c.plans.save(context.Background(), plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	c.failPlanOnIncompleteScope(context.Background(), plan, []string{"src/missing.go"})
+
+	got, ok := c.plans.get(plan.Slug)
+	if !ok {
+		t.Fatal("plan missing after completeness gate")
+	}
+	if got.EffectiveStatus() != workflow.StatusRejected {
+		t.Fatalf("status = %s, want rejected", got.EffectiveStatus())
+	}
+	if len(got.PlanDecisions) != 1 {
+		t.Fatalf("PlanDecisions len = %d, want 1", len(got.PlanDecisions))
+	}
+	decision := got.PlanDecisions[0]
+	if decision.Kind != workflow.PlanDecisionKindScopeIncomplete {
+		t.Fatalf("decision.Kind = %s, want scope_incomplete", decision.Kind)
+	}
+	if decision.ProposedBy != "plan-manager" {
+		t.Fatalf("decision.ProposedBy = %q, want plan-manager", decision.ProposedBy)
+	}
+	if decision.ContractImpact == nil {
+		t.Fatal("decision.ContractImpact is nil")
+	}
+	if decision.ContractImpact.Kind != workflow.ContractImpactPreserve {
+		t.Fatalf("ContractImpact.Kind = %s, want preserve", decision.ContractImpact.Kind)
+	}
+	if len(decision.ContractImpact.AffectedIDs) != 1 ||
+		decision.ContractImpact.AffectedIDs[0] != "contract.scope.create:src/missing.go" {
+		t.Fatalf("ContractImpact.AffectedIDs = %v, want missing file contract id", decision.ContractImpact.AffectedIDs)
+	}
+	if len(decision.AffectedReqIDs) != 2 {
+		t.Fatalf("AffectedReqIDs = %v, want all requirements", decision.AffectedReqIDs)
 	}
 }

--- a/processor/plan-manager/http_plan_decision.go
+++ b/processor/plan-manager/http_plan_decision.go
@@ -512,6 +512,12 @@ func (c *Component) handleAcceptPlanDecision(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "Failed to accept change proposal", http.StatusInternalServerError)
 		return
 	}
+	if err := c.startAcceptedPlanDecisionRetry(r.Context(), plan, proposal); err != nil {
+		c.logger.Error("Failed to start accepted plan decision retry",
+			"slug", slug, "proposal_id", proposalID, "kind", proposal.Kind, "error", err)
+		http.Error(w, "Failed to start accepted plan decision retry", http.StatusInternalServerError)
+		return
+	}
 
 	c.logger.Info("Change proposal accepted via REST API", "slug", slug, "proposal_id", proposalID)
 

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -2229,6 +2229,10 @@ func (c *Component) applyArchitectureRevise(ctx context.Context, plan *workflow.
 //     preparing_stories so Sarah re-runs with Story.RecoveryHint set (Train C
 //     step 4). The implementing path also resets affected requirement executions
 //     so stale dev loops do not resume against the old story shape.
+//   - scope_incomplete → apply the Level-0 missing-deliverable rationale as
+//     requirement recovery guidance, reset affected execution rows and Stories,
+//     and move rejected/terminal plans back to ready_for_execution. The caller
+//     auto-starts execution after the accepted decision is saved.
 //
 // The status mutations are done IN PLACE (NOT setPlanStatusCached): the caller's
 // trailing save is the sole persist point, avoiding a double save / double
@@ -2244,6 +2248,10 @@ func (c *Component) applyPlanDecisionAcceptEffects(ctx context.Context, plan *wo
 		return c.applyArchitectureRevise(ctx, plan, proposal)
 	}
 
+	if proposal.Kind == workflow.PlanDecisionKindScopeIncomplete {
+		return c.applyScopeIncompleteRecovery(ctx, plan, proposal, slug)
+	}
+
 	if proposal.ProposedBy == "recovery-agent" && proposal.Rationale != "" {
 		applyRecoveryHint(plan, proposal)
 	}
@@ -2251,6 +2259,97 @@ func (c *Component) applyPlanDecisionAcceptEffects(ctx context.Context, plan *wo
 	if proposal.Kind == workflow.PlanDecisionKindStoryReprepare {
 		if err := c.applyStoryReprepare(ctx, plan, proposal, slug); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (c *Component) applyScopeIncompleteRecovery(ctx context.Context, plan *workflow.Plan, proposal *workflow.PlanDecision, slug string) error {
+	reqIDs := affectedRequirementIDsForScopeIncomplete(plan, proposal)
+	if len(reqIDs) == 0 {
+		return fmt.Errorf("scope_incomplete recovery requires affected requirements")
+	}
+
+	current := plan.EffectiveStatus()
+	if current != workflow.StatusImplementing && !current.CanTransitionTo(workflow.StatusReadyForExecution) {
+		return fmt.Errorf("cannot retry scope_incomplete from status %s", current)
+	}
+
+	resetCount, err := c.resetRequirementExecutions(context.WithoutCancel(ctx), slug, "requirements", reqIDs)
+	if err != nil {
+		return fmt.Errorf("reset requirement executions for scope_incomplete: %w", err)
+	}
+	storyResetCount := resetStoriesForRetry(plan, reqIDs)
+
+	if proposal.Rationale != "" {
+		guidance := *proposal
+		guidance.Rationale = scopeIncompleteRecoveryGuidance(proposal)
+		applyRecoveryHint(plan, &guidance)
+	}
+
+	switch {
+	case current == workflow.StatusImplementing:
+		// Already active; the post-save hook will re-trigger the orchestrator.
+	case current.CanTransitionTo(workflow.StatusReadyForExecution):
+		plan.Status = workflow.StatusReadyForExecution
+	}
+
+	c.logger.Info("Scope incomplete recovery applied — plan re-queued for execution",
+		"slug", slug,
+		"proposal_id", proposal.ID,
+		"from_status", current,
+		"affected_reqs", len(reqIDs),
+		"reset_count", resetCount,
+		"story_reset_count", storyResetCount)
+	return nil
+}
+
+func affectedRequirementIDsForScopeIncomplete(plan *workflow.Plan, proposal *workflow.PlanDecision) []string {
+	if proposal != nil && len(proposal.AffectedReqIDs) > 0 {
+		return append([]string(nil), proposal.AffectedReqIDs...)
+	}
+	if plan == nil {
+		return nil
+	}
+	out := make([]string, 0, len(plan.Requirements))
+	for _, req := range plan.Requirements {
+		if req.ID != "" {
+			out = append(out, req.ID)
+		}
+	}
+	return out
+}
+
+func scopeIncompleteRecoveryGuidance(proposal *workflow.PlanDecision) string {
+	if proposal == nil {
+		return ""
+	}
+	rationale := strings.TrimSpace(proposal.Rationale)
+	if rationale == "" {
+		return ""
+	}
+	return "Scope completeness recovery:\n" + rationale +
+		"\n\nThe declared scope.create files above remain required deliverables. Deliver the missing files in the existing project topology, or propose an explicit scope/architecture recovery if the declared scope is wrong. Do not silently omit them."
+}
+
+func (c *Component) startAcceptedPlanDecisionRetry(ctx context.Context, plan *workflow.Plan, proposal *workflow.PlanDecision) error {
+	if plan == nil || proposal == nil || proposal.Kind != workflow.PlanDecisionKindScopeIncomplete {
+		return nil
+	}
+	if !c.shouldAutoStartExecution() {
+		return nil
+	}
+
+	switch plan.EffectiveStatus() {
+	case workflow.StatusReadyForExecution:
+		if err := c.startExecutionFromReady(ctx, plan); err != nil {
+			return fmt.Errorf("start scope_incomplete retry: %w", err)
+		}
+	case workflow.StatusImplementing:
+		pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		if err := c.publishScenarioOrchestrator(pubCtx, plan); err != nil {
+			return fmt.Errorf("trigger scope_incomplete retry: %w", err)
 		}
 	}
 	return nil
@@ -2833,6 +2932,11 @@ func (c *Component) handlePlanDecisionAcceptMutation(ctx context.Context, data [
 		c.logger.Error("Failed to save plan after auto-accepting plan_decision",
 			"slug", req.Slug, "proposal_id", req.ProposalID, "error", err)
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
+	}
+	if err := c.startAcceptedPlanDecisionRetry(ctx, plan, proposal); err != nil {
+		c.logger.Error("Failed to start accepted plan decision retry",
+			"slug", req.Slug, "proposal_id", req.ProposalID, "kind", proposal.Kind, "error", err)
+		return MutationResponse{Success: false, Error: err.Error()}
 	}
 
 	c.logger.Info("Plan decision accepted via mutation",

--- a/processor/plan-manager/scope_incomplete_recovery_test.go
+++ b/processor/plan-manager/scope_incomplete_recovery_test.go
@@ -1,0 +1,106 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestScopeIncompleteAcceptEffectsWritesGuidanceAndAutoStartsRetry(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID("scope-retry"),
+		Slug:   "scope-retry",
+		Title:  "scope-retry",
+		Status: workflow.StatusRejected,
+		Requirements: []workflow.Requirement{
+			{ID: "req.scope-retry.1", Title: "first"},
+			{ID: "req.scope-retry.2", Title: "second"},
+		},
+		Stories: []workflow.Story{
+			{ID: "story.scope-retry.1.1", RequirementIDs: []string{"req.scope-retry.1"}, Status: workflow.StoryStatusComplete},
+			{ID: "story.scope-retry.2.1", RequirementIDs: []string{"req.scope-retry.2"}, Status: workflow.StoryStatusComplete},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.scope-retry.1", RequirementID: "req.scope-retry.1", StoryID: "story.scope-retry.1.1"},
+		},
+		PlanDecisions: []workflow.PlanDecision{
+			{
+				ID:             "plan-decision.scope-retry.1",
+				PlanID:         workflow.PlanEntityID("scope-retry"),
+				Kind:           workflow.PlanDecisionKindScopeIncomplete,
+				Title:          "Declared scope.create files not delivered",
+				Rationale:      "Level-0 completeness gate: missing src/required.go",
+				AffectedReqIDs: []string{"req.scope-retry.1"},
+				Status:         workflow.PlanDecisionStatusProposed,
+				ProposedBy:     "plan-manager",
+				ContractImpact: &workflow.ContractImpact{
+					Kind:    workflow.ContractImpactPreserve,
+					Summary: "Declared scope remains required.",
+				},
+			},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *workflow.Plan) error {
+		published = true
+		if got.Slug != plan.Slug {
+			t.Fatalf("published slug = %q, want %q", got.Slug, plan.Slug)
+		}
+		if got.EffectiveStatus() != workflow.StatusImplementing {
+			t.Fatalf("published status = %s, want implementing", got.EffectiveStatus())
+		}
+		return nil
+	}
+
+	body, err := json.Marshal(planDecisionAcceptRequest{
+		Slug:       plan.Slug,
+		ProposalID: "plan-decision.scope-retry.1",
+		AcceptedBy: "auto:recovery",
+	})
+	if err != nil {
+		t.Fatalf("marshal accept request: %v", err)
+	}
+	resp := c.handlePlanDecisionAcceptMutation(ctx, body)
+	if !resp.Success {
+		t.Fatalf("handlePlanDecisionAcceptMutation failed: %s", resp.Error)
+	}
+	if !published {
+		t.Fatal("expected accepted scope_incomplete retry to publish orchestrator trigger")
+	}
+
+	got, ok := c.plans.get(plan.Slug)
+	if !ok {
+		t.Fatal("plan missing after accept")
+	}
+	if got.EffectiveStatus() != workflow.StatusImplementing {
+		t.Fatalf("status = %s, want implementing", got.EffectiveStatus())
+	}
+	if got.PlanDecisions[0].Status != workflow.PlanDecisionStatusAccepted {
+		t.Fatalf("decision status = %s, want accepted", got.PlanDecisions[0].Status)
+	}
+	if got.Stories[0].Status != workflow.StoryStatusReady {
+		t.Fatalf("affected story status = %s, want ready", got.Stories[0].Status)
+	}
+	if got.Stories[1].Status != workflow.StoryStatusComplete {
+		t.Fatalf("unaffected story status = %s, want complete", got.Stories[1].Status)
+	}
+	hint := got.Requirements[0].RecoveryHint
+	if !strings.Contains(hint, "missing src/required.go") {
+		t.Fatalf("RecoveryHint = %q, want missing file rationale", hint)
+	}
+	if !strings.Contains(hint, "declared scope.create files above remain required") {
+		t.Fatalf("RecoveryHint = %q, want explicit scope guidance", hint)
+	}
+	if got.Requirements[1].RecoveryHint != "" {
+		t.Fatalf("unaffected RecoveryHint = %q, want empty", got.Requirements[1].RecoveryHint)
+	}
+}

--- a/processor/requirement-executor/abandon_execs_test.go
+++ b/processor/requirement-executor/abandon_execs_test.go
@@ -146,3 +146,40 @@ func TestHandlePlanDecisionAccepted_StoryReprepareAbandonsInsteadOfResuming(t *t
 		t.Fatal("abandoned exec should be marked terminated")
 	}
 }
+
+func TestHandlePlanDecisionAccepted_ScopeIncompleteAbandonsInsteadOfQAResume(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+
+	exec := newAwaitingExec("mavlink-hard", "req-1")
+	exec.EntityID = "entity-mavlink-scope-req-1"
+	exec.awaitingRecovery = true
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	evt := payloads.PlanDecisionAcceptedEvent{
+		ProposalID:             "plan-decision.mavlink-hard.scope-incomplete",
+		Slug:                   "mavlink-hard",
+		Kind:                   workflow.PlanDecisionKindScopeIncomplete,
+		AffectedRequirementIDs: []string{"req-1"},
+	}
+	payload, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	envelope, err := json.Marshal(map[string]json.RawMessage{"payload": payload})
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	msg := &mockMsg{data: envelope}
+
+	c.handlePlanDecisionAccepted(context.Background(), context.Background(), msg)
+
+	if !msg.acked {
+		t.Fatal("accepted event should be acked")
+	}
+	if _, ok := c.activeExecs.Get(exec.EntityID); ok {
+		t.Fatal("scope_incomplete should abandon stale active exec because plan-manager owns the retry")
+	}
+	if !exec.terminated {
+		t.Fatal("abandoned exec should be marked terminated")
+	}
+}

--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -132,6 +132,22 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 	if !exec.awaitingRecovery {
 		return
 	}
+	if c.hasPendingRecoveryDecision(context.Background(), exec.Slug, exec.RequirementID) {
+		nextTimeout := c.recoveryTimeout()
+		timer := time.AfterFunc(nextTimeout, func() {
+			c.handleRecoveryTimeout(exec, nextTimeout)
+		})
+		exec.recoveryTimer = &timeoutHandle{stop: func() { timer.Stop() }}
+		c.logger.Warn("Recovery deadline expired but a PlanDecision is still pending; extending awaiting-recovery instead of terminal-failing",
+			"entity_id", exec.EntityID,
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"reason", exec.recoveryReason,
+			"expired_timeout", timeout,
+			"next_timeout", nextTimeout,
+		)
+		return
+	}
 	c.logger.Warn("Recovery deadline expired; terminal-failing",
 		"entity_id", exec.EntityID,
 		"slug", exec.Slug,
@@ -142,6 +158,72 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 	exec.awaitingRecovery = false
 	exec.recoveryTimer = nil
 	c.markFailedLocked(context.Background(), exec, exec.recoveryReason)
+}
+
+func (c *Component) hasPendingRecoveryDecision(ctx context.Context, slug, requirementID string) bool {
+	if c.pendingRecoveryDecisionChecker != nil {
+		return c.pendingRecoveryDecisionChecker(ctx, slug, requirementID)
+	}
+	if c.natsClient == nil {
+		return false
+	}
+	js, err := c.natsClient.JetStream()
+	if err != nil {
+		c.logger.Debug("Recovery timeout: JetStream unavailable while checking pending PlanDecisions",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return false
+	}
+	bucket, err := js.KeyValue(ctx, "PLAN_STATES")
+	if err != nil {
+		c.logger.Debug("Recovery timeout: PLAN_STATES unavailable while checking pending PlanDecisions",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return false
+	}
+	entry, err := bucket.Get(ctx, slug)
+	if err != nil {
+		c.logger.Debug("Recovery timeout: plan unavailable while checking pending PlanDecisions",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return false
+	}
+	var plan struct {
+		PlanDecisions []workflow.PlanDecision `json:"plan_decisions"`
+	}
+	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
+		c.logger.Debug("Recovery timeout: plan JSON unmarshal failed while checking pending PlanDecisions",
+			"slug", slug, "requirement_id", requirementID, "error", err)
+		return false
+	}
+	for _, dec := range plan.PlanDecisions {
+		if isPendingRecoveryDecisionForRequirement(dec, requirementID) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPendingRecoveryDecisionForRequirement(dec workflow.PlanDecision, requirementID string) bool {
+	if dec.Status != workflow.PlanDecisionStatusProposed &&
+		dec.Status != workflow.PlanDecisionStatusUnderReview {
+		return false
+	}
+	switch dec.Kind {
+	case workflow.PlanDecisionKindRequirementChange,
+		workflow.PlanDecisionKindStoryReprepare,
+		workflow.PlanDecisionKindArchitectureRevise,
+		workflow.PlanDecisionKindScopeIncomplete:
+		// recoverable or waiting decisions
+	default:
+		return false
+	}
+	if len(dec.AffectedReqIDs) == 0 {
+		return true
+	}
+	for _, affected := range dec.AffectedReqIDs {
+		if affected == requirementID {
+			return true
+		}
+	}
+	return false
 }
 
 // resumeFromRecoveryLocked re-runs a wedged execution after a recovery
@@ -497,18 +579,18 @@ func (c *Component) handlePlanDecisionAccepted(lifecycleCtx, msgCtx context.Cont
 	}
 
 	// architecture_revise and story_reprepare restart the plan from a planning
-	// phase: plan-manager has already reset the relevant EXECUTION_STATES rows
-	// and moved the plan out of implementing. The wedged exec(s) must NOT be
-	// resumed — resuming would re-decompose against the stale DAG and race the
-	// regenerated execution. Abandon the event's scoped affected requirements
-	// (expanded by plan-decision-handler to include downstream dependents); fall
-	// back to every active exec for the slug only when older/unscoped events
-	// do not carry affected requirement IDs. The re-run creates clean execs once
-	// it reaches execution again.
+	// phase; scope_incomplete restarts execution from plan-manager's retry path.
+	// In all three cases plan-manager has already reset/requeued the relevant
+	// work. The wedged exec(s) must NOT be resumed here — resuming would
+	// re-decompose against stale context and race the regenerated execution.
+	// Abandon the event's scoped affected requirements (expanded by
+	// plan-decision-handler where needed); fall back to every active exec for the
+	// slug only when older/unscoped events do not carry affected requirement IDs.
 	if evt.Kind == workflow.PlanDecisionKindArchitectureRevise ||
-		evt.Kind == workflow.PlanDecisionKindStoryReprepare {
+		evt.Kind == workflow.PlanDecisionKindStoryReprepare ||
+		evt.Kind == workflow.PlanDecisionKindScopeIncomplete {
 		abandoned := c.abandonExecsForRequirements(evt.Slug, evt.AffectedRequirementIDs)
-		c.logger.Info("Abandoned in-flight execs on planning re-entry accept",
+		c.logger.Info("Abandoned in-flight execs on plan-manager-owned recovery accept",
 			"slug", evt.Slug, "proposal_id", evt.ProposalID, "kind", evt.Kind,
 			"affected_requirements", len(evt.AffectedRequirementIDs), "abandoned", abandoned)
 		_ = msg.Ack()

--- a/processor/requirement-executor/awaiting_recovery_test.go
+++ b/processor/requirement-executor/awaiting_recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/component"
 	sscache "github.com/c360studio/semstreams/pkg/cache"
@@ -156,6 +157,103 @@ func TestRecoveryTimeout_TerminalFailsWithCapturedReason(t *testing.T) {
 	}
 	if c.requirementsFailed.Load() != 1 {
 		t.Errorf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
+	}
+}
+
+func TestRecoveryTimeout_ExtendsWhenPlanDecisionStillPending(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-pending", "req-pending")
+	exec.awaitingRecovery = true
+	exec.recoveryReason = "architecture recovery proposed"
+	c.activeExecs.Set(exec.EntityID, exec)
+	c.pendingRecoveryDecisionChecker = func(_ context.Context, slug, requirementID string) bool {
+		return slug == "plan-pending" && requirementID == "req-pending"
+	}
+
+	c.handleRecoveryTimeout(exec, 50*time.Millisecond)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if exec.terminated {
+		t.Fatal("exec should not terminal-fail while a PlanDecision is pending")
+	}
+	if !exec.awaitingRecovery {
+		t.Fatal("exec should remain awaiting recovery while the PlanDecision waits")
+	}
+	if exec.recoveryTimer == nil {
+		t.Fatal("recovery timer should be re-armed")
+	}
+	exec.recoveryTimer.stop()
+	exec.recoveryTimer = nil
+	if c.requirementsFailed.Load() != 0 {
+		t.Fatalf("requirementsFailed = %d, want 0", c.requirementsFailed.Load())
+	}
+}
+
+func TestIsPendingRecoveryDecisionForRequirement(t *testing.T) {
+	tests := []struct {
+		name string
+		dec  workflow.PlanDecision
+		req  string
+		want bool
+	}{
+		{
+			name: "architecture revise proposed for req",
+			dec: workflow.PlanDecision{
+				Kind:           workflow.PlanDecisionKindArchitectureRevise,
+				Status:         workflow.PlanDecisionStatusProposed,
+				AffectedReqIDs: []string{"req-1"},
+			},
+			req:  "req-1",
+			want: true,
+		},
+		{
+			name: "scope incomplete under review for req",
+			dec: workflow.PlanDecision{
+				Kind:           workflow.PlanDecisionKindScopeIncomplete,
+				Status:         workflow.PlanDecisionStatusUnderReview,
+				AffectedReqIDs: []string{"req-1"},
+			},
+			req:  "req-1",
+			want: true,
+		},
+		{
+			name: "accepted is not pending",
+			dec: workflow.PlanDecision{
+				Kind:           workflow.PlanDecisionKindArchitectureRevise,
+				Status:         workflow.PlanDecisionStatusAccepted,
+				AffectedReqIDs: []string{"req-1"},
+			},
+			req:  "req-1",
+			want: false,
+		},
+		{
+			name: "assembly conflict is terminal not recovery wait",
+			dec: workflow.PlanDecision{
+				Kind:           workflow.PlanDecisionKindAssemblyConflict,
+				Status:         workflow.PlanDecisionStatusProposed,
+				AffectedReqIDs: []string{"req-1"},
+			},
+			req:  "req-1",
+			want: false,
+		},
+		{
+			name: "different requirement",
+			dec: workflow.PlanDecision{
+				Kind:           workflow.PlanDecisionKindStoryReprepare,
+				Status:         workflow.PlanDecisionStatusProposed,
+				AffectedReqIDs: []string{"req-2"},
+			},
+			req:  "req-1",
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPendingRecoveryDecisionForRequirement(tc.dec, tc.req); got != tc.want {
+				t.Fatalf("isPendingRecoveryDecisionForRequirement = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -190,6 +190,10 @@ type Component struct {
 	errors           atomic.Int64
 	lastActivityMu   sync.RWMutex
 	lastActivity     time.Time
+
+	// pendingRecoveryDecisionChecker is a test seam for the awaiting-recovery
+	// timeout path. Production uses PLAN_STATES via hasPendingRecoveryDecision.
+	pendingRecoveryDecisionChecker func(ctx context.Context, slug, requirementID string) bool
 }
 
 // NewComponent creates a new requirement-executor from raw JSON config.

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -29,6 +29,12 @@ tasks:
       - docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec sandbox
       - echo "[OK] Docker image built"
 
+  ensure-model-caches:
+    internal: true
+    desc: Ensure external Docker model cache volumes exist
+    cmds:
+      - docker volume create semembed-cache >/dev/null
+
   check-ports:
     internal: true
     desc: Check if required backend E2E ports are available (auto-cleans stale containers)
@@ -106,6 +112,13 @@ tasks:
       - docker network ls -q --filter name=semspec-e2e | xargs -r docker network rm 2>/dev/null || true
       - echo "[OK] Docker environment cleaned"
 
+  clean-model-caches:
+    desc: Remove shared model cache volumes used by E2E graph services
+    cmds:
+      - echo "[CLEAN-MODEL-CACHES] Removing shared model cache volumes..."
+      - docker volume rm semembed-cache 2>/dev/null || true
+      - echo "[OK] Model caches removed"
+
   clean-workspace:
     internal: true
     desc: Clean E2E workspace
@@ -171,7 +184,7 @@ tasks:
 
   up:
     desc: Start e2e infrastructure (NATS + semspec)
-    deps: [build-image]
+    deps: [ensure-model-caches, build-image]
     cmds:
       - echo "[E2E UP] Starting infrastructure..."
       - docker compose -p semspec-e2e -f docker/compose/e2e.yml up -d --wait
@@ -219,7 +232,7 @@ tasks:
 
   default:
     desc: Run all e2e tests (full lifecycle)
-    deps: [clean, clean-workspace, check-ports, build, build-image]
+    deps: [clean, clean-workspace, check-ports, ensure-model-caches, build, build-image]
     cmds:
       - echo "[E2E] Starting infrastructure..."
       - docker compose -p semspec-e2e -f docker/compose/e2e.yml up -d --wait
@@ -252,7 +265,7 @@ tasks:
 
   debug:
     desc: Start infrastructure for interactive debugging
-    deps: [clean, clean-workspace, check-ports, build, build-image]
+    deps: [clean, clean-workspace, check-ports, ensure-model-caches, build, build-image]
     cmds:
       - echo "[DEBUG] Starting infrastructure for debugging..."
       - docker compose -p semspec-e2e -f docker/compose/e2e.yml up -d --wait
@@ -270,7 +283,7 @@ tasks:
   # Mock infrastructure management (for debugging)
   up:mock:
     desc: "Start mock infrastructure - usage: task e2e:up:mock -- <scenario>"
-    deps: [clean, clean-workspace, check-ports, build, build-image, build-mock-image]
+    deps: [clean, clean-workspace, check-ports, ensure-model-caches, build, build-image, build-mock-image]
     vars:
       SCENARIO:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'plan-smoke'
@@ -326,7 +339,7 @@ tasks:
 
   debug:mock:
     desc: "Start mock infrastructure and tail logs - usage: task e2e:debug:mock -- <scenario>"
-    deps: [clean, clean-workspace, check-ports, build, build-image, build-mock-image]
+    deps: [clean, clean-workspace, check-ports, ensure-model-caches, build, build-image, build-mock-image]
     vars:
       SCENARIO:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'plan-smoke'
@@ -395,7 +408,7 @@ tasks:
 
   mock:
     desc: "Run mock LLM scenario - usage: task e2e:mock -- <scenario>"
-    deps: [clean, clean-workspace, check-ports, build, build-image, build-mock-image]
+    deps: [clean, clean-workspace, check-ports, ensure-model-caches, build, build-image, build-mock-image]
     vars:
       SCENARIO:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'plan-smoke'
@@ -468,7 +481,7 @@ tasks:
 
   ui:test:mock:
     desc: "Full lifecycle: build + start mock stack + run all @mock tests + cleanup"
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     env:
       E2E_FIXTURE: hello-world-py
     cmds:
@@ -491,7 +504,7 @@ tasks:
 
   ui:test:llm:
     desc: "Full lifecycle: build + start real LLM stack + run tests + cleanup — usage: task e2e:ui:test:llm -- <provider> [tier]"
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     vars:
       PROVIDER:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'local'
@@ -683,7 +696,7 @@ tasks:
 
   watch:llm:
     desc: "Real-LLM run with semspec watch sidecar (live alerts + final bundle) — usage: task e2e:watch:llm -- <provider> [tier]"
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     vars:
       PROVIDER:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'gemini'
@@ -1064,7 +1077,7 @@ tasks:
 
   ui:llm:up:
     desc: "Start UI E2E stack with real LLM (for interactive debugging) — usage: task e2e:ui:llm:up -- <provider>"
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     vars:
       PROVIDER:
         sh: echo '{{.CLI_ARGS}}' | awk '{print $1}' | grep . || echo 'local'
@@ -1095,7 +1108,7 @@ tasks:
 
   ui:mock:up:
     desc: Start UI E2E Docker stack with mock LLM (for interactive debugging)
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     env:
       E2E_FIXTURE: hello-world-py
     cmds:
@@ -1117,7 +1130,7 @@ tasks:
 
   ui:up:
     desc: Start UI E2E Docker stack (real LLM — requires running Ollama or API key)
-    deps: [check-ports:ui]
+    deps: [check-ports:ui, ensure-model-caches]
     cmds:
       - echo "[UI:UP] Cleaning stale state..."
       - cmd: docker compose -f ui/docker-compose.e2e.yml down -v --timeout 10 2>/dev/null

--- a/test/e2e/scenarios/execution_phase.go
+++ b/test/e2e/scenarios/execution_phase.go
@@ -265,8 +265,8 @@ func (s *ExecutionPhaseScenario) stageWaitForApproval(ctx context.Context, resul
 			}
 			if plan.Approved {
 				result.SetDetail("plan_approved", true)
-				result.SetDetail("plan_status", plan.Status)
-				result.SetDetail("plan_stage", plan.Stage)
+				result.SetDetail("plan_status_at_approval", plan.Status)
+				result.SetDetail("plan_stage_at_approval", plan.Stage)
 				return nil
 			}
 		}
@@ -285,6 +285,8 @@ func (s *ExecutionPhaseScenario) stageTriggerExecution(ctx context.Context, resu
 		}
 		if executionAlreadyStarted(plan.Status, plan.Stage) {
 			result.SetDetail("execution_already_started", true)
+			result.SetDetail("plan_status_at_execution_start", plan.Status)
+			result.SetDetail("plan_stage_at_execution_start", plan.Stage)
 			result.SetDetail("execution_stage", plan.Stage)
 			return nil
 		}
@@ -323,7 +325,10 @@ func (s *ExecutionPhaseScenario) stageWaitForExecutionComplete(ctx context.Conte
 		}
 		return err
 	}
+	result.SetDetail("plan_status", plan.Status)
+	result.SetDetail("plan_stage", plan.Stage)
 	result.SetDetail("plan_final_status", plan.Status)
+	result.SetDetail("plan_final_stage", plan.Stage)
 	return nil
 }
 

--- a/ui/docker-compose.e2e-mock.yml
+++ b/ui/docker-compose.e2e-mock.yml
@@ -14,6 +14,45 @@
 #                   and plan-reject.
 
 services:
+  # Mock configs use BM25 graph embedding and do not call the local graph
+  # model services. Keep these dependency placeholders healthy so the base
+  # e2e stack can boot without pulling/loading Snowflake or Qwen images.
+  semembed:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-fast:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-answer:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
+  seminstruct-summary:
+    image: alpine:3.19
+    command: ["sh", "-c", "tail -f /dev/null"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 1
+
   mock-llm:
     build:
       context: ..

--- a/ui/docker-compose.e2e.yml
+++ b/ui/docker-compose.e2e.yml
@@ -139,6 +139,18 @@ services:
       retries: 5
       start_period: 5s
 
+  # Shared fastembed model cache. The semembed image runs as uid/gid 1000,
+  # while fresh Docker volumes are root-owned, so initialize ownership before
+  # the service starts. The semembed-cache volume is external so the normal
+  # e2e `down -v` cleanup can reset NATS/workspace state without forcing a
+  # Hugging Face re-download on the next run.
+  semembed-cache-init:
+    image: alpine:3.19
+    command: ["sh", "-c", "mkdir -p /cache && chown -R 1000:1000 /cache"]
+    volumes:
+      - semembed-cache:/cache
+    restart: "no"
+
   # semembed serves graph-embedding's HTTP embedder (replacing BM25).
   # Background batch — embeds entity text on every ENTITY_STATES write.
   # Default model produces 384-dim vectors via fastembed-rs.
@@ -147,6 +159,11 @@ services:
     environment:
       - SEMEMBED_MODEL=Snowflake/snowflake-arctic-embed-s
       - RUST_LOG=info
+    volumes:
+      - semembed-cache:/home/semembed/.cache/fastembed
+    depends_on:
+      semembed-cache-init:
+        condition: service_completed_successfully
     # Probe the real embeddings endpoint, not /health.
     # Caught 2026-05-02: /health returns 200 ~939ms before the Rust HTTP
     # listener actually accepts POSTs, so service_healthy fired early
@@ -271,6 +288,8 @@ services:
 
 volumes:
   ui-nats-data:
+  semembed-cache:
+    external: true
 
 networks:
   default:

--- a/workflow/cascade/cascade.go
+++ b/workflow/cascade/cascade.go
@@ -50,6 +50,9 @@ type Result struct {
 //     closure inline. Whole-phase decisions regenerate from the architect
 //     down; scoped decisions preserve unrelated Stories/Scenarios and merge
 //     only the dirty closure after Winston/Sarah/Bob re-run.
+//   - Kind=scope_incomplete: no-op for Story/Scenario dirty marks here.
+//     The plan-manager accept handler owns the execution retry and writes
+//     missing-deliverable guidance before re-triggering execution.
 //
 // Pure business logic — no I/O. Caller loads the plan from KV and passes
 // stories + scenarios. Returns the IDs that were dirty-marked so
@@ -119,11 +122,13 @@ func PlanDecision(proposal *workflow.PlanDecision, stories []workflow.Story, sce
 		// (issue #176) is informational: the plan is already failed to
 		// rejected, so there is nothing to dirty-cascade.
 
-	case workflow.PlanDecisionKindArchitectureRevise:
-		// The plan-manager accept handler applies the planning re-entry inline.
-		// This cascade remains telemetry-only; expandPlanningReentryClosure
-		// widens AffectedRequirementIDs before publishing the accepted event so
-		// requirement-executor abandons the same closure plan-manager reset.
+	case workflow.PlanDecisionKindArchitectureRevise,
+		workflow.PlanDecisionKindScopeIncomplete:
+		// The plan-manager accept handler owns the state mutation for both
+		// kinds: architecture_revise applies planning re-entry, while
+		// scope_incomplete applies execution retry with missing-file guidance.
+		// This cascade remains telemetry-only so requirement-executor abandons
+		// stale active execs instead of resuming generic QA recovery.
 
 	default:
 		// Kind=requirement_change OR unset (back-compat with pre-Kind records).

--- a/workflow/cascade/cascade_test.go
+++ b/workflow/cascade/cascade_test.go
@@ -69,6 +69,36 @@ func TestPlanDecision_ArchitectureRevise_NoOp(t *testing.T) {
 	}
 }
 
+// TestPlanDecision_ScopeIncomplete_NoOp verifies the Level-0 completeness
+// recovery kind does not fall through to requirement_change's scenarios-only
+// cascade. Plan-manager owns the retry reset and missing-file guidance.
+func TestPlanDecision_ScopeIncomplete_NoOp(t *testing.T) {
+	proposal := &workflow.PlanDecision{
+		ID:             "plan-decision.slug.scope-incomplete.1",
+		Kind:           workflow.PlanDecisionKindScopeIncomplete,
+		AffectedReqIDs: []string{"req-0"},
+	}
+	stories := []workflow.Story{{ID: "story-1", RequirementIDs: []string{"req-0"}}}
+	scenarios := []workflow.Scenario{{ID: "scenario-1", RequirementID: "req-0", StoryID: "story-1"}}
+
+	result, err := PlanDecision(proposal, stories, scenarios)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.AffectedScenarioIDs) != 0 {
+		t.Errorf("AffectedScenarioIDs = %d, want 0 (plan-manager owns scope_incomplete retry)", len(result.AffectedScenarioIDs))
+	}
+	if len(result.AffectedStoryIDs) != 0 {
+		t.Errorf("AffectedStoryIDs = %d, want 0", len(result.AffectedStoryIDs))
+	}
+	if len(result.AffectedRequirementIDs) != 1 {
+		t.Errorf("AffectedRequirementIDs = %d, want 1 (telemetry only)", len(result.AffectedRequirementIDs))
+	}
+	if result.Kind != workflow.PlanDecisionKindScopeIncomplete {
+		t.Errorf("Result.Kind = %q, want scope_incomplete", result.Kind)
+	}
+}
+
 func TestExpandRequirementClosure_DownstreamOnly(t *testing.T) {
 	requirements := []workflow.Requirement{
 		{ID: "req.bootstrap"},

--- a/workflow/plan_decision_kind_test.go
+++ b/workflow/plan_decision_kind_test.go
@@ -13,6 +13,8 @@ func TestPlanDecisionKind_IsValid(t *testing.T) {
 		PlanDecisionKindExecutionExhausted: true,
 		PlanDecisionKindStoryReprepare:     true,
 		PlanDecisionKindArchitectureRevise: true,
+		PlanDecisionKindAssemblyConflict:   true,
+		PlanDecisionKindScopeIncomplete:    true,
 		"":                                 false,
 		"not-a-kind":                       false,
 		"requirement-change":               false, // hyphen not underscore

--- a/workflow/types.go
+++ b/workflow/types.go
@@ -2004,7 +2004,8 @@ func (k PlanDecisionKind) IsValid() bool {
 		PlanDecisionKindExecutionExhausted,
 		PlanDecisionKindStoryReprepare,
 		PlanDecisionKindArchitectureRevise,
-		PlanDecisionKindAssemblyConflict:
+		PlanDecisionKindAssemblyConflict,
+		PlanDecisionKindScopeIncomplete:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- make `scope_incomplete` a first-class recoverable PlanDecision kind with validation, cascade handling, auto-accept limits, and contract-impact metadata
- apply accepted scope-incomplete recovery by writing missing-file guidance, resetting only affected execution/story state, and restarting the plan retry path
- keep requirement-executor from treating scope-incomplete as generic completed-QA recovery, and extend timeout handling while recovery decisions are pending
- fix mock execution-phase reporting so intermediate snapshots no longer overwrite final plan status fields
- stabilize E2E graph model startup: persist the semembed fastembed cache and bypass unused semembed/seminstruct services in mock stacks

## Verification
- go test ./...
- task lint:default
- openspec validate contract-authoritative-planning-handoffs --strict
- task e2e:mock -- execution-phase

## Notes
- OpenSpec validation passed; PostHog telemetry flush emitted DNS noise for `edge.openspec.dev`, same as prior local runs.
- Filed upstream semembed follow-up for a baked default Snowflake model: https://github.com/C360Studio/semembed/issues/2
