### PR TITLE
fix(plan-manager): isolate cached plan mutations

### DIFF
--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -76,3 +76,11 @@
 - [x] 9.6 Run the relevant mock E2E handoff scenario after unit coverage passes
 - [x] 9.7 Fix mock E2E execution-phase reporting so intermediate snapshots do not overwrite final plan status details
 - [x] 9.8 Stabilize mock E2E startup by bypassing unused graph model services and persisting the semembed model cache for real graph stacks
+
+## 10. Deterministic State Mutation Audit Follow-Ups
+
+- [x] 10.1 Audit PlanDecision accept paths for half-applied state when reset or cascade effects fail
+- [x] 10.2 Ensure plan-store reads and writes isolate cached plans from caller mutation
+- [x] 10.3 Add regression coverage for failed PlanDecision accept effects leaving persisted plan state unchanged
+- [x] 10.4 Fix any cache/KV mutation atomicity defects found by the audit
+- [x] 10.5 Run focused plan-manager tests, repo tests, lint, and relevant mock E2E coverage

--- a/processor/plan-manager/plan_store.go
+++ b/processor/plan-manager/plan_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -80,7 +81,7 @@ func (s *planStore) reconcile(ctx context.Context) {
 				}
 				var plan workflow.Plan
 				if json.Unmarshal(entry.Value(), &plan) == nil {
-					s.cache.Set(plan.Slug, &plan) //nolint:errcheck // cache set is best-effort
+					s.cache.Set(plan.Slug, clonePlan(&plan)) //nolint:errcheck // cache set is best-effort
 					recovered++
 				}
 			}
@@ -109,7 +110,7 @@ func (s *planStore) reconcile(ctx context.Context) {
 		if plan.Slug == "" {
 			continue
 		}
-		s.cache.Set(plan.Slug, plan) //nolint:errcheck // cache set is best-effort
+		s.cache.Set(plan.Slug, clonePlan(plan)) //nolint:errcheck // cache set is best-effort
 		recovered++
 	}
 
@@ -118,14 +119,13 @@ func (s *planStore) reconcile(ctx context.Context) {
 	}
 }
 
-// get returns a shallow copy of a plan by slug.
+// get returns an isolated copy of a plan by slug.
 // Cache is checked first; on miss the KV bucket is queried and the result is
 // back-filled into the cache.
 func (s *planStore) get(slug string) (*workflow.Plan, bool) {
-	// 1. Cache hit — shallow copy to prevent races.
+	// 1. Cache hit — clone to prevent failed mutations from leaking into cache.
 	if plan, ok := s.cache.Get(slug); ok {
-		p := *plan
-		return &p, true
+		return clonePlan(plan), true
 	}
 
 	// 2. KV fallback on cache miss.
@@ -134,9 +134,8 @@ func (s *planStore) get(slug string) (*workflow.Plan, bool) {
 		if err == nil {
 			var plan workflow.Plan
 			if json.Unmarshal(entry.Value(), &plan) == nil {
-				s.cache.Set(plan.Slug, &plan) //nolint:errcheck // cache set is best-effort
-				p := plan
-				return &p, true
+				s.cache.Set(plan.Slug, clonePlan(&plan)) //nolint:errcheck // cache set is best-effort
+				return clonePlan(&plan), true
 			}
 		}
 	}
@@ -149,7 +148,7 @@ func (s *planStore) list() []*workflow.Plan {
 	plans := make([]*workflow.Plan, 0)
 	for _, key := range s.cache.Keys() {
 		if plan, ok := s.cache.Get(key); ok {
-			plans = append(plans, plan)
+			plans = append(plans, clonePlan(plan))
 		}
 	}
 	sort.Slice(plans, func(i, j int) bool {
@@ -320,8 +319,8 @@ func (s *planStore) save(ctx context.Context, plan *workflow.Plan) error {
 		return err
 	}
 
-	// 1. Update cache.
-	s.cache.Set(plan.Slug, plan) //nolint:errcheck // cache set is best-effort
+	// 1. Update cache with a store-owned copy.
+	s.cache.Set(plan.Slug, clonePlan(plan)) //nolint:errcheck // cache set is best-effort
 
 	// 2. Write to KV bucket (observable — this IS the event).
 	// Requirements and Scenarios are already inline on the plan struct.
@@ -342,6 +341,78 @@ func (s *planStore) save(ctx context.Context, plan *workflow.Plan) error {
 	}
 
 	return nil
+}
+
+func clonePlan(plan *workflow.Plan) *workflow.Plan {
+	if plan == nil {
+		return nil
+	}
+	cloned := deepCloneValue(reflect.ValueOf(plan))
+	if !cloned.IsValid() || cloned.IsNil() {
+		return nil
+	}
+	return cloned.Interface().(*workflow.Plan)
+}
+
+func deepCloneValue(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
+
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.New(v.Type().Elem())
+		out.Elem().Set(deepCloneValue(v.Elem()))
+		return out
+	case reflect.Interface:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		elem := deepCloneValue(v.Elem())
+		out := reflect.New(v.Type()).Elem()
+		if elem.Type().AssignableTo(v.Type()) || elem.Type().Implements(v.Type()) {
+			out.Set(elem)
+			return out
+		}
+		out.Set(v)
+		return out
+	case reflect.Slice:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.MakeSlice(v.Type(), v.Len(), v.Len())
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(deepCloneValue(v.Index(i)))
+		}
+		return out
+	case reflect.Map:
+		if v.IsNil() {
+			return reflect.Zero(v.Type())
+		}
+		out := reflect.MakeMapWithSize(v.Type(), v.Len())
+		for _, key := range v.MapKeys() {
+			out.SetMapIndex(deepCloneValue(key), deepCloneValue(v.MapIndex(key)))
+		}
+		return out
+	case reflect.Struct:
+		if v.Type() == reflect.TypeOf(time.Time{}) {
+			return v
+		}
+		out := reflect.New(v.Type()).Elem()
+		for i := 0; i < v.NumField(); i++ {
+			dst := out.Field(i)
+			if !dst.CanSet() {
+				return v
+			}
+			dst.Set(deepCloneValue(v.Field(i)))
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // approve transitions a plan to approved status and writes through all layers.

--- a/processor/plan-manager/plan_store_isolation_test.go
+++ b/processor/plan-manager/plan_store_isolation_test.go
@@ -1,0 +1,172 @@
+package planmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestPlanStoreSaveAndGetIsolateCachedPlanFromCallerMutation(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	slug := "isolation"
+	now := time.Now()
+	plan := &workflow.Plan{
+		ID:          workflow.PlanEntityID(slug),
+		Slug:        slug,
+		Title:       slug,
+		Status:      workflow.StatusImplementing,
+		Constraints: []string{"preserve baseline"},
+		Scope: workflow.Scope{
+			Create:  []string{"src/required.go"},
+			Include: []string{"README.md"},
+		},
+		Contract: &workflow.ContractPacket{
+			ID:      workflow.PlanContractID(slug),
+			Version: 1,
+			Scope: workflow.ContractScopeSnapshot{
+				Create: []string{"src/required.go"},
+			},
+			CreatedAt: now,
+		},
+		Requirements: []workflow.Requirement{
+			{ID: "req.isolation.1", DependsOn: []string{"req.seed"}},
+		},
+		Stories: []workflow.Story{
+			{ID: "story.isolation.1", RequirementIDs: []string{"req.isolation.1"}},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scenario.isolation.1", RequirementID: "req.isolation.1", StoryID: "story.isolation.1", Then: []string{"passes"}},
+		},
+		PlanDecisions: []workflow.PlanDecision{
+			{ID: "plan-decision.isolation.1", Status: workflow.PlanDecisionStatusProposed},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	plan.PlanDecisions[0].Status = workflow.PlanDecisionStatusAccepted
+	plan.Requirements[0].DependsOn[0] = "mutated-after-save"
+	plan.Contract.Scope.Create[0] = "mutated-after-save.go"
+
+	first, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing after save")
+	}
+	if first.PlanDecisions[0].Status != workflow.PlanDecisionStatusProposed {
+		t.Fatalf("decision status after caller mutation = %s, want proposed", first.PlanDecisions[0].Status)
+	}
+	if first.Requirements[0].DependsOn[0] != "req.seed" {
+		t.Fatalf("depends_on after caller mutation = %v, want req.seed", first.Requirements[0].DependsOn)
+	}
+	if first.Contract.Scope.Create[0] != "src/required.go" {
+		t.Fatalf("contract scope after caller mutation = %v, want src/required.go", first.Contract.Scope.Create)
+	}
+
+	first.PlanDecisions[0].Status = workflow.PlanDecisionStatusAccepted
+	first.Requirements[0].DependsOn[0] = "mutated-after-get"
+	first.Contract.Scope.Create[0] = "mutated-after-get.go"
+
+	second, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing on second get")
+	}
+	if second.PlanDecisions[0].Status != workflow.PlanDecisionStatusProposed {
+		t.Fatalf("decision status after get mutation = %s, want proposed", second.PlanDecisions[0].Status)
+	}
+	if second.Requirements[0].DependsOn[0] != "req.seed" {
+		t.Fatalf("depends_on after get mutation = %v, want req.seed", second.Requirements[0].DependsOn)
+	}
+	if second.Contract.Scope.Create[0] != "src/required.go" {
+		t.Fatalf("contract scope after get mutation = %v, want src/required.go", second.Contract.Scope.Create)
+	}
+}
+
+func TestPlanDecisionAcceptMutationResetFailureLeavesPersistedPlanUnchanged(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	slug := "failed-accept"
+	decisionID := "plan-decision.failed-accept.arch"
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID(slug),
+		Slug:   slug,
+		Title:  slug,
+		Status: workflow.StatusImplementing,
+		Architecture: &workflow.ArchitectureDocument{
+			DataFlow: "existing architecture",
+		},
+		Contract: &workflow.ContractPacket{
+			ID:        workflow.PlanContractID(slug),
+			Version:   1,
+			CreatedAt: time.Now(),
+		},
+		Requirements: []workflow.Requirement{
+			{ID: "req.failed-accept.1", Title: "unaffected"},
+		},
+		Stories: []workflow.Story{
+			{ID: "story.failed-accept.1", RequirementIDs: []string{"req.failed-accept.1"}},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scenario.failed-accept.1", RequirementID: "req.failed-accept.1", StoryID: "story.failed-accept.1"},
+		},
+		PlanDecisions: []workflow.PlanDecision{
+			{
+				ID:         decisionID,
+				PlanID:     workflow.PlanEntityID(slug),
+				Kind:       workflow.PlanDecisionKindArchitectureRevise,
+				Title:      "Revise architecture",
+				Rationale:  "No scoped requirements and no whole-phase reset evidence.",
+				Status:     workflow.PlanDecisionStatusProposed,
+				ProposedBy: "recovery-agent",
+				ContractImpact: &workflow.ContractImpact{
+					Kind:    workflow.ContractImpactChange,
+					Summary: "Architecture must change, but the reset scope is invalid.",
+				},
+			},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	resp := c.handlePlanDecisionAcceptMutation(ctx, marshalJSON(t, planDecisionAcceptRequest{
+		Slug:       slug,
+		ProposalID: decisionID,
+		AcceptedBy: "auto:recovery",
+	}))
+	if resp.Success {
+		t.Fatal("handlePlanDecisionAcceptMutation succeeded; want reset-scope failure")
+	}
+
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing after failed accept")
+	}
+	if got.Status != workflow.StatusImplementing {
+		t.Fatalf("status after failed accept = %s, want implementing", got.Status)
+	}
+	if got.PlanDecisions[0].Status != workflow.PlanDecisionStatusProposed {
+		t.Fatalf("decision status after failed accept = %s, want proposed", got.PlanDecisions[0].Status)
+	}
+	if got.PlanDecisions[0].DecidedAt != nil {
+		t.Fatalf("DecidedAt after failed accept = %v, want nil", got.PlanDecisions[0].DecidedAt)
+	}
+	if got.Architecture == nil || got.Architecture.DataFlow != "existing architecture" {
+		t.Fatalf("Architecture after failed accept = %+v, want original", got.Architecture)
+	}
+	if got.Contract == nil {
+		t.Fatal("Contract missing after failed accept")
+	}
+	if len(got.Contract.Amendments) != 0 {
+		t.Fatalf("contract amendments after failed accept = %d, want 0", len(got.Contract.Amendments))
+	}
+	if len(got.Stories) != 1 || got.Stories[0].ID != "story.failed-accept.1" {
+		t.Fatalf("stories after failed accept = %+v, want original story", got.Stories)
+	}
+	if len(got.Scenarios) != 1 || got.Scenarios[0].ID != "scenario.failed-accept.1" {
+		t.Fatalf("scenarios after failed accept = %+v, want original scenario", got.Scenarios)
+	}
+}


### PR DESCRIPTION
## Summary
- deep-clone plans at the plan-store cache boundary for save, get, list, and reconcile paths
- add regressions proving caller mutation and failed PlanDecision accept effects cannot leak into persisted/cached plan state
- record the deterministic state mutation audit follow-up in OpenSpec Section 10

## Verification
- go test ./processor/plan-manager -run 'TestPlanStoreSaveAndGetIsolateCachedPlanFromCallerMutation|TestPlanDecisionAcceptMutationResetFailureLeavesPersistedPlanUnchanged'
- go test ./processor/plan-manager
- go test ./...
- task lint:default
- task e2e:mock -- execution-phase -> passed (1/1, final plan status complete)
- openspec validate contract-authoritative-planning-handoffs --strict

Note: OpenSpec validation completed successfully and then printed the known PostHog DNS telemetry warning in this sandbox.