### PR TITLE
fix(execution): gate missing deliverables before completion

### DIFF
--- a/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
@@ -77,6 +77,12 @@ recoverable state.
 - **THEN** the retry state includes the missing declared files and the reason they are still required in the next
   developer-facing recovery guidance
 
+#### Scenario: Scope recovery redispatches reopened requirements
+- **WHEN** an accepted `scope_incomplete` decision re-queues affected requirements for execution
+- **THEN** the orchestration retry identifies those affected requirements as force redispatches, and execution state
+  either recreates them as fresh pending executions or fails the recovery instead of treating stale rows as benign
+  idempotent dispatches
+
 #### Scenario: Recoverable accepted decisions do not leave a rejected active plan
 - **WHEN** an accepted recovery decision starts a retry or planning re-entry
 - **THEN** the plan status and phase summary move to the active recovery or execution state instead of remaining

--- a/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/specs/scope-change-governance/spec.md
@@ -36,6 +36,12 @@ accepted recovery or scope-change decision.
 The system MUST compare delivered artifacts against the current accepted scope and the root contract obligations, not
 only against the latest mutable scope list.
 
+#### Scenario: Missing deliverables are caught before final assembly
+- **WHEN** a Story or requirement has approved scenario evidence but has not delivered every accepted
+  `scope.create` path assigned to its `files_owned` closure
+- **THEN** execution rejects or retries that Story or requirement before it can be marked complete or advance to
+  final branch assembly
+
 #### Scenario: Delivered files are fewer than accepted obligations
 - **WHEN** execution converges with missing files, modules, or artifacts that remain required by the accepted contract
 - **THEN** the plan fails closed before QA and records a recoverable completeness decision

--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -84,3 +84,11 @@
 - [x] 10.3 Add regression coverage for failed PlanDecision accept effects leaving persisted plan state unchanged
 - [x] 10.4 Fix any cache/KV mutation atomicity defects found by the audit
 - [x] 10.5 Run focused plan-manager tests, repo tests, lint, and relevant mock E2E coverage
+
+## 11. Progressive Deliverable Closure Gates
+
+- [x] 11.1 Add deterministic Story/Requirement gates that compare accepted `scope.create` obligations against delivered files before marking execution complete
+- [x] 11.2 Retry the current Story with missing-file feedback when a reviewer approves scenarios but declared deliverables are absent
+- [x] 11.3 Fail closed with actionable recovery evidence when deliverable closure cannot be inspected or retries are exhausted
+- [x] 11.4 Add unit coverage for path normalization, Story-scoped missing deliverables, clean approvals, and retry/exhaustion behavior
+- [x] 11.5 Run focused requirement-executor tests plus the relevant mock E2E handoff coverage

--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -100,3 +100,4 @@
 - [x] 12.3 Return reset/delete failures from execution-manager instead of reporting successful recovery with durable execution state still present
 - [x] 12.4 Add focused unit coverage for trigger force IDs, req.create force recreation, and ordinary duplicate-dispatch rejection
 - [x] 12.5 Run focused plan-manager, scenario-orchestrator, execution-manager, and mock execution-phase coverage
+- [x] 12.6 Add regression coverage for sequential dependent redispatch after upfront scope-incomplete reset

--- a/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
+++ b/openspec/changes/contract-authoritative-planning-handoffs/tasks.md
@@ -92,3 +92,11 @@
 - [x] 11.3 Fail closed with actionable recovery evidence when deliverable closure cannot be inspected or retries are exhausted
 - [x] 11.4 Add unit coverage for path normalization, Story-scoped missing deliverables, clean approvals, and retry/exhaustion behavior
 - [x] 11.5 Run focused requirement-executor tests plus the relevant mock E2E handoff coverage
+
+## 12. Scope-Incomplete Redispatch Recovery
+
+- [x] 12.1 Carry affected requirement IDs from accepted `scope_incomplete` decisions into the scenario-orchestrator retry trigger
+- [x] 12.2 Force-recreate only those affected requirement execution rows during redispatch so stale `req.*` rows cannot wedge the retry
+- [x] 12.3 Return reset/delete failures from execution-manager instead of reporting successful recovery with durable execution state still present
+- [x] 12.4 Add focused unit coverage for trigger force IDs, req.create force recreation, and ordinary duplicate-dispatch rejection
+- [x] 12.5 Run focused plan-manager, scenario-orchestrator, execution-manager, and mock execution-phase coverage

--- a/processor/execution-manager/execution_store.go
+++ b/processor/execution-manager/execution_store.go
@@ -3,6 +3,7 @@ package executionmanager
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -264,19 +265,22 @@ func (s *executionStore) saveReq(ctx context.Context, key string, exec *workflow
 // live in-process (the 2026-06-16 re-dispatch wedge the #203 reset targets). We
 // delete from BOTH caches: a key only ever lives in one, so the other Delete is
 // a harmless no-op.
-// Cache delete errors are non-fatal (cache may already be cleared via TTL).
-// KV delete errors are logged at INFO — a silent failure here can leave the
-// KV entry stranded and break post-/retry recovery (the orchestrator's
-// subsequent re-create would fail with "req execution already exists").
-func (s *executionStore) deleteReq(ctx context.Context, key string) {
+// Cache delete errors are non-fatal (cache may already be cleared via TTL), but
+// KV delete errors are returned. Recovery accepts depend on durable reset; if
+// EXECUTION_STATES keeps the row, the orchestrator's subsequent req.create can
+// reload it and wedge with "req execution already exists" (#226).
+func (s *executionStore) deleteReq(ctx context.Context, key string) error {
 	s.reqCache.Delete(key)  //nolint:errcheck
 	s.taskCache.Delete(key) //nolint:errcheck
 	if s.kvStore != nil {
 		if err := s.kvStore.Delete(ctx, key); err != nil {
-			s.logger.Info("deleteReq: KV delete failed (cache cleared, KV may have stranded entry)",
-				"key", key, "error", err)
+			if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+				return nil
+			}
+			return fmt.Errorf("delete execution KV %s: %w", key, err)
 		}
 	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/processor/execution-manager/mutations.go
+++ b/processor/execution-manager/mutations.go
@@ -109,6 +109,9 @@ type ReqCreateRequest struct {
 	// requirement execution so the executor forks the requirement branch from
 	// its prerequisites' work rather than the plan base.
 	BaseBranch string `json:"base_branch,omitempty"`
+	// Force replaces an existing req execution. Used only by plan-manager-owned
+	// recovery redispatch after the affected execution closure has been reopened.
+	Force bool `json:"force,omitempty"`
 }
 
 // ReqPhaseRequest transitions a requirement execution to a new phase.
@@ -419,7 +422,12 @@ func (c *Component) handleReqCreateMutation(ctx context.Context, data []byte) Ex
 	key := workflow.RequirementExecutionKey(req.Slug, req.RequirementID)
 
 	if _, ok := c.store.getReq(key); ok {
-		return ExecMutationResponse{Success: false, Error: fmt.Sprintf("req execution already exists: %s", key)}
+		if !req.Force {
+			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("req execution already exists: %s", key)}
+		}
+		if err := c.store.deleteReq(ctx, key); err != nil {
+			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("force reset existing req execution %s: %v", key, err)}
+		}
 	}
 
 	now := time.Now()
@@ -565,7 +573,9 @@ func (c *Component) handleReqResetMutation(ctx context.Context, data []byte) Exe
 		return ExecMutationResponse{Success: false, Error: "key required"}
 	}
 
-	c.store.deleteReq(ctx, req.Key)
+	if err := c.store.deleteReq(ctx, req.Key); err != nil {
+		return ExecMutationResponse{Success: false, Error: fmt.Sprintf("delete: %v", err)}
+	}
 
 	c.logger.Info("Requirement execution reset via mutation", "key", req.Key)
 	return ExecMutationResponse{Success: true}

--- a/processor/execution-manager/req_create_force_test.go
+++ b/processor/execution-manager/req_create_force_test.go
@@ -1,0 +1,76 @@
+package executionmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestHandleReqCreateMutation_ExistingWithoutForceRejected(t *testing.T) {
+	c := newTestComponent(t)
+	key := workflow.RequirementExecutionKey("plan", "req-1")
+	c.store.reqCache.Set(key, &workflow.RequirementExecution{
+		Slug:          "plan",
+		RequirementID: "req-1",
+		Stage:         "active",
+		Title:         "old",
+	}) //nolint:errcheck
+
+	data, err := json.Marshal(ReqCreateRequest{
+		Slug:          "plan",
+		RequirementID: "req-1",
+		Title:         "new",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := c.handleReqCreateMutation(context.Background(), data)
+	if resp.Success {
+		t.Fatalf("handleReqCreateMutation succeeded, want duplicate rejection")
+	}
+}
+
+func TestHandleReqCreateMutation_ForceReplacesExistingReq(t *testing.T) {
+	c := newTestComponent(t)
+	key := workflow.RequirementExecutionKey("plan", "req-1")
+	c.store.reqCache.Set(key, &workflow.RequirementExecution{
+		Slug:          "plan",
+		RequirementID: "req-1",
+		Stage:         "active",
+		Title:         "old",
+		TraceID:       "trace-old",
+	}) //nolint:errcheck
+
+	data, err := json.Marshal(ReqCreateRequest{
+		Slug:          "plan",
+		RequirementID: "req-1",
+		Title:         "new",
+		TraceID:       "trace-new",
+		Force:         true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp := c.handleReqCreateMutation(context.Background(), data)
+	if !resp.Success {
+		t.Fatalf("handleReqCreateMutation failed: %s", resp.Error)
+	}
+
+	got, ok := c.store.getReq(key)
+	if !ok {
+		t.Fatalf("getReq(%q) missing after force create", key)
+	}
+	if got.Stage != "pending" {
+		t.Fatalf("Stage = %q, want pending", got.Stage)
+	}
+	if got.Title != "new" {
+		t.Fatalf("Title = %q, want new", got.Title)
+	}
+	if got.TraceID != "trace-new" {
+		t.Fatalf("TraceID = %q, want trace-new", got.TraceID)
+	}
+}

--- a/processor/execution-manager/req_create_force_test.go
+++ b/processor/execution-manager/req_create_force_test.go
@@ -74,3 +74,64 @@ func TestHandleReqCreateMutation_ForceReplacesExistingReq(t *testing.T) {
 		t.Fatalf("TraceID = %q, want trace-new", got.TraceID)
 	}
 }
+
+func TestReqResetThenSequentialRedispatchAllowsDependentWithoutForce(t *testing.T) {
+	c := newTestComponent(t)
+	ctx := context.Background()
+	req1Key := workflow.RequirementExecutionKey("plan", "req-1")
+	req2Key := workflow.RequirementExecutionKey("plan", "req-2")
+	for key, id := range map[string]string{req1Key: "req-1", req2Key: "req-2"} {
+		c.store.reqCache.Set(key, &workflow.RequirementExecution{
+			Slug:          "plan",
+			RequirementID: id,
+			Stage:         "active",
+			Title:         "old " + id,
+		}) //nolint:errcheck
+	}
+
+	for _, key := range []string{req1Key, req2Key} {
+		data, err := json.Marshal(ReqResetRequest{Key: key})
+		if err != nil {
+			t.Fatalf("marshal reset: %v", err)
+		}
+		if resp := c.handleReqResetMutation(ctx, data); !resp.Success {
+			t.Fatalf("reset %s failed: %s", key, resp.Error)
+		}
+	}
+
+	req1Create := marshalReqCreate(t, ReqCreateRequest{
+		Slug:          "plan",
+		RequirementID: "req-1",
+		Title:         "new req-1",
+		Force:         true,
+	})
+	if resp := c.handleReqCreateMutation(ctx, req1Create); !resp.Success {
+		t.Fatalf("force create req-1 failed: %s", resp.Error)
+	}
+
+	req2Create := marshalReqCreate(t, ReqCreateRequest{
+		Slug:          "plan",
+		RequirementID: "req-2",
+		Title:         "new req-2",
+	})
+	if resp := c.handleReqCreateMutation(ctx, req2Create); !resp.Success {
+		t.Fatalf("normal dependent create req-2 failed after upfront reset: %s", resp.Error)
+	}
+
+	got, ok := c.store.getReq(req2Key)
+	if !ok {
+		t.Fatalf("getReq(%q) missing after dependent create", req2Key)
+	}
+	if got.Stage != "pending" || got.Title != "new req-2" {
+		t.Fatalf("dependent req after create = stage %q title %q, want pending/new req-2", got.Stage, got.Title)
+	}
+}
+
+func marshalReqCreate(t *testing.T, req ReqCreateRequest) []byte {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal req.create: %v", err)
+	}
+	return data
+}

--- a/processor/plan-manager/component.go
+++ b/processor/plan-manager/component.go
@@ -72,8 +72,8 @@ type Component struct {
 	// orchestratorTriggerPublisher is the seam tests use to assert automatic
 	// execution start without requiring a live JetStream connection. Nil means
 	// "publish through triggerScenarioOrchestrator." Production code never sets
-	// this; tests can install a stub that captures the plan and returns an error.
-	orchestratorTriggerPublisher func(ctx context.Context, plan *workflow.Plan) error
+	// this; tests can install a stub that captures the trigger and returns an error.
+	orchestratorTriggerPublisher func(ctx context.Context, trigger *payloads.ScenarioOrchestrationTrigger) error
 
 	// slugMutexes serializes mutation handlers per plan slug. NATS dispatches
 	// each subscription's handler in its own goroutine, so two mutations for

--- a/processor/plan-manager/execution_events.go
+++ b/processor/plan-manager/execution_events.go
@@ -140,7 +140,7 @@ func (c *Component) handleRequirementStateChange(ctx context.Context, bucket jet
 		c.mu.RUnlock()
 		if ps != nil {
 			if plan, ok := ps.get(slug); ok && plan.EffectiveStatus() == workflow.StatusImplementing {
-				if err := c.triggerScenarioOrchestrator(ctx, plan); err != nil {
+				if err := c.publishScenarioOrchestrator(ctx, plan); err != nil {
 					c.logger.Warn("Failed to re-fire scenario orchestrator after requirement completion",
 						"slug", slug, "requirement_id", reqExec.RequirementID, "error", err)
 				}

--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -1353,7 +1353,7 @@ func (c *Component) handleRetryPlan(w http.ResponseWriter, r *http.Request, slug
 			}
 		}
 		// Already implementing — re-trigger orchestrator without a status change.
-		if err := c.triggerScenarioOrchestrator(pubCtx, plan); err != nil {
+		if err := c.publishScenarioOrchestrator(pubCtx, plan); err != nil {
 			c.logger.Error("Failed to re-trigger orchestrator", "slug", slug, "error", err)
 			writeJSONError(w, "Failed to re-trigger orchestrator: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1620,21 +1620,8 @@ func isFailedRetryStage(stage string) bool {
 
 // triggerScenarioOrchestrator publishes a scenario orchestration trigger for the plan.
 // Used by retry when the plan is already in implementing status.
-func (c *Component) triggerScenarioOrchestrator(ctx context.Context, plan *workflow.Plan) error {
-	subject := fmt.Sprintf("scenario.orchestrate.%s", plan.Slug)
-	tc := natsclient.NewTraceContext()
-
-	trigger := &payloads.ScenarioOrchestrationTrigger{
-		PlanSlug:     plan.Slug,
-		TraceID:      tc.TraceID,
-		Requirements: plan.Requirements,
-		Scenarios:    plan.Scenarios,
-		Stories:      plan.Stories,
-	}
-	if plan.GitHub != nil {
-		trigger.PlanBranch = plan.GitHub.PlanBranch
-	}
-
+func (c *Component) triggerScenarioOrchestrator(ctx context.Context, trigger *payloads.ScenarioOrchestrationTrigger) error {
+	subject := fmt.Sprintf("scenario.orchestrate.%s", trigger.PlanSlug)
 	baseMsg := message.NewBaseMessage(trigger.Schema(), trigger, "plan-manager")
 	data, err := json.Marshal(baseMsg)
 	if err != nil {

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -18,6 +18,7 @@ import (
 	"github.com/c360studio/semspec/workflow/cascade"
 	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -1146,7 +1147,7 @@ func (c *Component) handleStoryStatusMutation(ctx context.Context, data []byte) 
 	// race with terminal-state transitions.
 	if req.Target == workflow.StoryStatusComplete || req.Target == workflow.StoryStatusFailed {
 		if plan.EffectiveStatus() == workflow.StatusImplementing {
-			if err := c.triggerScenarioOrchestrator(ctx, plan); err != nil {
+			if err := c.publishScenarioOrchestrator(ctx, plan); err != nil {
 				c.logger.Warn("Failed to re-fire scenario orchestrator after story status change",
 					"slug", req.Slug, "story_id", req.StoryID, "target", req.Target, "error", err)
 			}
@@ -1280,7 +1281,7 @@ func (c *Component) shouldAutoStartExecution() bool {
 	return c.natsClient != nil || c.orchestratorTriggerPublisher != nil
 }
 
-func (c *Component) startExecutionFromReady(ctx context.Context, plan *workflow.Plan) error {
+func (c *Component) startExecutionFromReady(ctx context.Context, plan *workflow.Plan, forceRequirementIDs ...[]string) error {
 	if len(plan.Requirements) == 0 {
 		return fmt.Errorf("plan has no requirements")
 	}
@@ -1294,7 +1295,7 @@ func (c *Component) startExecutionFromReady(ctx context.Context, plan *workflow.
 	if err := c.setPlanStatusCached(pubCtx, plan, workflow.StatusImplementing); err != nil {
 		return fmt.Errorf("set implementing: %w", err)
 	}
-	if err := c.publishScenarioOrchestrator(pubCtx, plan); err != nil {
+	if err := c.publishScenarioOrchestrator(pubCtx, plan, forceRequirementIDs...); err != nil {
 		c.logger.Error("Failed to auto-trigger execution, rolling back status", "slug", plan.Slug, "error", err)
 		_ = c.setPlanStatusCached(pubCtx, plan, workflow.StatusReadyForExecution)
 		return fmt.Errorf("trigger scenario orchestrator: %w", err)
@@ -1303,11 +1304,34 @@ func (c *Component) startExecutionFromReady(ctx context.Context, plan *workflow.
 	return nil
 }
 
-func (c *Component) publishScenarioOrchestrator(ctx context.Context, plan *workflow.Plan) error {
+func (c *Component) publishScenarioOrchestrator(ctx context.Context, plan *workflow.Plan, forceRequirementIDs ...[]string) error {
+	trigger := scenarioOrchestrationTriggerForPlan(plan, natsclient.NewTraceContext().TraceID, firstForceRequirementIDs(forceRequirementIDs))
 	if c.orchestratorTriggerPublisher != nil {
-		return c.orchestratorTriggerPublisher(ctx, plan)
+		return c.orchestratorTriggerPublisher(ctx, trigger)
 	}
-	return c.triggerScenarioOrchestrator(ctx, plan)
+	return c.triggerScenarioOrchestrator(ctx, trigger)
+}
+
+func scenarioOrchestrationTriggerForPlan(plan *workflow.Plan, traceID string, forceRequirementIDs []string) *payloads.ScenarioOrchestrationTrigger {
+	trigger := &payloads.ScenarioOrchestrationTrigger{
+		PlanSlug:            plan.Slug,
+		TraceID:             traceID,
+		Requirements:        plan.Requirements,
+		Scenarios:           plan.Scenarios,
+		Stories:             plan.Stories,
+		ForceRequirementIDs: uniqueSortedStrings(forceRequirementIDs),
+	}
+	if plan.GitHub != nil {
+		trigger.PlanBranch = plan.GitHub.PlanBranch
+	}
+	return trigger
+}
+
+func firstForceRequirementIDs(forceRequirementIDs [][]string) []string {
+	if len(forceRequirementIDs) == 0 {
+		return nil
+	}
+	return forceRequirementIDs[0]
 }
 
 // escalateRevision transitions the plan to StatusRejected when the review iteration
@@ -2342,13 +2366,13 @@ func (c *Component) startAcceptedPlanDecisionRetry(ctx context.Context, plan *wo
 
 	switch plan.EffectiveStatus() {
 	case workflow.StatusReadyForExecution:
-		if err := c.startExecutionFromReady(ctx, plan); err != nil {
+		if err := c.startExecutionFromReady(ctx, plan, proposal.AffectedReqIDs); err != nil {
 			return fmt.Errorf("start scope_incomplete retry: %w", err)
 		}
 	case workflow.StatusImplementing:
 		pubCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
-		if err := c.publishScenarioOrchestrator(pubCtx, plan); err != nil {
+		if err := c.publishScenarioOrchestrator(pubCtx, plan, proposal.AffectedReqIDs); err != nil {
 			return fmt.Errorf("trigger scope_incomplete retry: %w", err)
 		}
 	}

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -2303,6 +2303,10 @@ func (c *Component) applyScopeIncompleteRecovery(ctx context.Context, plan *work
 	if err != nil {
 		return fmt.Errorf("reset requirement executions for scope_incomplete: %w", err)
 	}
+	if resetCount == 0 {
+		c.logger.Warn("scope_incomplete recovery affected requirements but reset no execution rows",
+			"slug", slug, "proposal_id", proposal.ID, "affected_reqs", len(reqIDs))
+	}
 	storyResetCount := resetStoriesForRetry(plan, reqIDs)
 
 	if proposal.Rationale != "" {

--- a/processor/plan-manager/mutations_test.go
+++ b/processor/plan-manager/mutations_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 // setupRevisionComponent creates a Component with MaxReviewIterations set.
@@ -50,13 +51,16 @@ func TestHandleReadyForExecutionMutation_AutoStartsExecution(t *testing.T) {
 	}
 
 	published := false
-	c.orchestratorTriggerPublisher = func(_ context.Context, got *workflow.Plan) error {
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
 		published = true
-		if got.Slug != plan.Slug {
-			t.Fatalf("published plan slug = %q, want %q", got.Slug, plan.Slug)
+		if got.PlanSlug != plan.Slug {
+			t.Fatalf("published plan slug = %q, want %q", got.PlanSlug, plan.Slug)
 		}
-		if got.EffectiveStatus() != workflow.StatusImplementing {
-			t.Fatalf("published plan status = %s, want implementing", got.EffectiveStatus())
+		if len(got.Requirements) != 1 || got.Requirements[0].ID != "contract" {
+			t.Fatalf("published requirements = %v, want contract", got.Requirements)
+		}
+		if len(got.ForceRequirementIDs) != 0 {
+			t.Fatalf("ForceRequirementIDs = %v, want none for normal auto-start", got.ForceRequirementIDs)
 		}
 		return nil
 	}

--- a/processor/plan-manager/scope_incomplete_recovery_test.go
+++ b/processor/plan-manager/scope_incomplete_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 func TestScopeIncompleteAcceptEffectsWritesGuidanceAndAutoStartsRetry(t *testing.T) {
@@ -50,13 +51,13 @@ func TestScopeIncompleteAcceptEffectsWritesGuidanceAndAutoStartsRetry(t *testing
 	}
 
 	published := false
-	c.orchestratorTriggerPublisher = func(_ context.Context, got *workflow.Plan) error {
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
 		published = true
-		if got.Slug != plan.Slug {
-			t.Fatalf("published slug = %q, want %q", got.Slug, plan.Slug)
+		if got.PlanSlug != plan.Slug {
+			t.Fatalf("published slug = %q, want %q", got.PlanSlug, plan.Slug)
 		}
-		if got.EffectiveStatus() != workflow.StatusImplementing {
-			t.Fatalf("published status = %s, want implementing", got.EffectiveStatus())
+		if len(got.ForceRequirementIDs) != 1 || got.ForceRequirementIDs[0] != "req.scope-retry.1" {
+			t.Fatalf("ForceRequirementIDs = %v, want affected req", got.ForceRequirementIDs)
 		}
 		return nil
 	}

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -86,6 +86,7 @@ type sandboxClient interface {
 	DeleteWorktree(ctx context.Context, taskID string) error
 	CreateBranch(ctx context.Context, branch, baseRef string) error
 	DeleteBranch(ctx context.Context, branch string) error
+	Exec(ctx context.Context, taskID, command string, timeoutMs int) (*sandbox.ExecResult, error)
 }
 
 type requirementReviewResult struct {
@@ -1164,6 +1165,9 @@ func (c *Component) advancePastSkippedStoryLocked(ctx context.Context, exec *req
 		exec.CurrentStoryIdx++
 		resetPerStoryExecutionState(exec)
 		c.dispatchCurrentStoryLocked(ctx, exec, plan)
+		return
+	}
+	if c.handleRequirementDeliverableGapForPlanLocked(ctx, exec, plan) {
 		return
 	}
 	c.markCompletedLocked(ctx, exec)
@@ -2400,6 +2404,9 @@ func (c *Component) handleApprovedVerdictLocked(ctx context.Context, exec *requi
 	if c.handleApprovedClaimMismatchLocked(ctx, exec) {
 		return
 	}
+	if c.handleApprovedDeliverableGapLocked(ctx, exec) {
+		return
+	}
 	// ADR-044: record the per-Story terminal Status. Best-effort — claim
 	// rejection here is non-fatal because the requirement-level advancement
 	// is what gates downstream processing. Skipped when natsClient is nil
@@ -2411,6 +2418,9 @@ func (c *Component) handleApprovedVerdictLocked(ctx context.Context, exec *requi
 	// complete.
 	if exec.CurrentStoryIdx+1 < len(exec.SortedStoryIDs) {
 		c.advanceToNextStoryLocked(ctx, exec)
+		return
+	}
+	if c.handleRequirementDeliverableGapLocked(ctx, exec) {
 		return
 	}
 	c.markCompletedLocked(ctx, exec)

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -36,6 +36,8 @@ type stubSandbox struct {
 	// requirement branch forks from the resolved DependsOn base, not plan/HEAD.
 	createdBranchBases []string
 	deleteWorktreeErr  error
+	execByTaskID       map[string]*sandbox.ExecResult
+	execErr            error
 	createBranchErr    error
 	// createBranchErrOnce, when set, is returned on the FIRST CreateBranch
 	// call and then cleared — subsequent calls return nil. Used to simulate
@@ -76,6 +78,20 @@ func (s *stubSandbox) DeleteBranch(_ context.Context, branch string) error {
 	defer s.mu.Unlock()
 	s.deletedBranchNames = append(s.deletedBranchNames, branch)
 	return nil
+}
+
+func (s *stubSandbox) Exec(_ context.Context, taskID, _ string, _ int) (*sandbox.ExecResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.execErr != nil {
+		return nil, s.execErr
+	}
+	if s.execByTaskID != nil {
+		if res, ok := s.execByTaskID[taskID]; ok {
+			return res, nil
+		}
+	}
+	return &sandbox.ExecResult{ExitCode: 0}, nil
 }
 
 func (s *stubSandbox) deletedSnapshot() []string {

--- a/processor/requirement-executor/deliverable_gate.go
+++ b/processor/requirement-executor/deliverable_gate.go
@@ -1,0 +1,259 @@
+package requirementexecutor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+const deliverableFilesTimeoutMs = 15000
+
+// handleApprovedDeliverableGapLocked prevents a scenario-approved Story from
+// becoming terminal evidence while its accepted scope.create obligations are
+// still absent from the requirement branch.
+//
+// Caller must hold exec.mu.
+func (c *Component) handleApprovedDeliverableGapLocked(ctx context.Context, exec *requirementExecution) bool {
+	if c.sandbox == nil || c.natsClient == nil || len(exec.SortedStoryIDs) == 0 {
+		return false
+	}
+	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
+	if err != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("deliverable closure gate could not load plan: %v", err))
+		return true
+	}
+	if plan == nil {
+		c.markFailedLocked(ctx, exec, "deliverable closure gate could not load plan from PLAN_STATES")
+		return true
+	}
+	return c.handleApprovedDeliverableGapForPlanLocked(ctx, exec, plan)
+}
+
+// handleApprovedDeliverableGapForPlanLocked is the deterministic core of the
+// approval gate. Tests call it directly with an in-memory Plan; production uses
+// handleApprovedDeliverableGapLocked to load the authoritative PLAN_STATES copy.
+//
+// Caller must hold exec.mu.
+func (c *Component) handleApprovedDeliverableGapForPlanLocked(ctx context.Context, exec *requirementExecution, plan *workflow.Plan) bool {
+	if c.sandbox == nil || plan == nil || len(exec.SortedStoryIDs) == 0 {
+		return false
+	}
+	if exec.CurrentStoryIdx < 0 || exec.CurrentStoryIdx >= len(exec.SortedStoryIDs) {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("deliverable closure gate could not resolve CurrentStoryIdx %d in %d stories", exec.CurrentStoryIdx, len(exec.SortedStoryIDs)))
+		return true
+	}
+
+	storyID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
+	story, ok := findStoryByID(plan, storyID)
+	if !ok {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("deliverable closure gate could not find Story %s on plan", storyID))
+		return true
+	}
+
+	expected := storyScopeCreateObligations(plan, story)
+	if len(expected) == 0 {
+		return false
+	}
+	delivered, err := c.deliveredFilesForReviewerWorktree(ctx, exec)
+	if err != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("deliverable closure gate could not inspect requirement branch: %v", err))
+		return true
+	}
+	missing := missingDeliverableFiles(expected, delivered)
+	if len(missing) == 0 {
+		return false
+	}
+
+	feedback := fmt.Sprintf(
+		"Reviewer approved scenarios, but Story %s has not delivered %d accepted scope.create file(s): %s. "+
+			"These paths remain required by the plan contract. Implement the missing files inside the declared Story file scope and resubmit.",
+		story.ID, len(missing), strings.Join(missing, ", "),
+	)
+	if exec.RetryCount < exec.MaxRetries && exec.MaxRetries > 0 {
+		c.startFixableRetryLocked(ctx, exec, feedback)
+		return true
+	}
+
+	c.emitExhaustionDecision(ctx, exec, "scope_incomplete", feedback)
+	if c.deferToAwaitingRecoveryLocked(ctx, exec, fmt.Sprintf("deliverable closure gate retries exhausted: %s", feedback)) {
+		return true
+	}
+	c.markFailedLocked(ctx, exec, fmt.Sprintf("deliverable closure gate retries exhausted: %s", feedback))
+	return true
+}
+
+// handleRequirementDeliverableGapLocked is a final local backstop before a
+// requirement enters completed. Story approval owns fixable retries; this gate
+// prevents terminal completion when the requirement branch is inspectable and
+// accepted create obligations remain absent.
+//
+// Caller must hold exec.mu.
+func (c *Component) handleRequirementDeliverableGapLocked(ctx context.Context, exec *requirementExecution) bool {
+	if c.sandbox == nil || c.natsClient == nil || len(exec.SortedStoryIDs) == 0 || exec.ReviewerTaskID == "" {
+		return false
+	}
+	plan, err := c.loadPlanFromKV(ctx, exec.Slug)
+	if err != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("requirement deliverable closure gate could not load plan: %v", err))
+		return true
+	}
+	if plan == nil {
+		c.markFailedLocked(ctx, exec, "requirement deliverable closure gate could not load plan from PLAN_STATES")
+		return true
+	}
+	return c.handleRequirementDeliverableGapForPlanLocked(ctx, exec, plan)
+}
+
+func (c *Component) handleRequirementDeliverableGapForPlanLocked(ctx context.Context, exec *requirementExecution, plan *workflow.Plan) bool {
+	if c.sandbox == nil || plan == nil || len(exec.SortedStoryIDs) == 0 || exec.ReviewerTaskID == "" {
+		return false
+	}
+	expected := requirementScopeCreateObligations(plan, exec.SortedStoryIDs)
+	if len(expected) == 0 {
+		return false
+	}
+	delivered, err := c.deliveredFilesForReviewerWorktree(ctx, exec)
+	if err != nil {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf("requirement deliverable closure gate could not inspect requirement branch: %v", err))
+		return true
+	}
+	missing := missingDeliverableFiles(expected, delivered)
+	if len(missing) == 0 {
+		return false
+	}
+
+	feedback := fmt.Sprintf(
+		"Requirement %s cannot complete because %d accepted scope.create file(s) assigned to its Stories are still missing from the requirement branch: %s.",
+		exec.RequirementID, len(missing), strings.Join(missing, ", "),
+	)
+	c.emitExhaustionDecision(ctx, exec, "scope_incomplete", feedback)
+	if c.deferToAwaitingRecoveryLocked(ctx, exec, fmt.Sprintf("requirement deliverable closure gate failed: %s", feedback)) {
+		return true
+	}
+	c.markFailedLocked(ctx, exec, fmt.Sprintf("requirement deliverable closure gate failed: %s", feedback))
+	return true
+}
+
+func storyScopeCreateObligations(plan *workflow.Plan, story workflow.Story) []string {
+	if plan == nil || len(plan.Scope.Create) == 0 || len(story.FilesOwned) == 0 {
+		return nil
+	}
+	owned := make(map[string]struct{}, len(story.FilesOwned))
+	for _, raw := range story.FilesOwned {
+		if p := workflow.NormalizeFilePath(raw); p != "" {
+			owned[p] = struct{}{}
+		}
+	}
+	if len(owned) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(plan.Scope.Create))
+	out := make([]string, 0, len(plan.Scope.Create))
+	for _, raw := range plan.Scope.Create {
+		p := workflow.NormalizeFilePath(raw)
+		if p == "" {
+			continue
+		}
+		if _, ok := owned[p]; !ok {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func requirementScopeCreateObligations(plan *workflow.Plan, storyIDs []string) []string {
+	if plan == nil || len(plan.Scope.Create) == 0 || len(storyIDs) == 0 {
+		return nil
+	}
+	wantedStories := make(map[string]struct{}, len(storyIDs))
+	for _, id := range storyIDs {
+		if id != "" {
+			wantedStories[id] = struct{}{}
+		}
+	}
+	owned := make(map[string]struct{})
+	for _, story := range plan.Stories {
+		if _, ok := wantedStories[story.ID]; !ok {
+			continue
+		}
+		for _, raw := range story.FilesOwned {
+			if p := workflow.NormalizeFilePath(raw); p != "" {
+				owned[p] = struct{}{}
+			}
+		}
+	}
+	if len(owned) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(plan.Scope.Create))
+	out := make([]string, 0, len(plan.Scope.Create))
+	for _, raw := range plan.Scope.Create {
+		p := workflow.NormalizeFilePath(raw)
+		if p == "" {
+			continue
+		}
+		if _, ok := owned[p]; !ok {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+func (c *Component) deliveredFilesForReviewerWorktree(ctx context.Context, exec *requirementExecution) ([]string, error) {
+	if exec.ReviewerTaskID == "" {
+		return nil, fmt.Errorf("reviewer worktree id is empty")
+	}
+	res, err := c.sandbox.Exec(ctx, exec.ReviewerTaskID, "git -c core.quotePath=false ls-files -z", deliverableFilesTimeoutMs)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil || res.ExitCode != 0 {
+		code := -1
+		if res != nil {
+			code = res.ExitCode
+		}
+		return nil, fmt.Errorf("git ls-files in reviewer worktree %q exited %d", exec.ReviewerTaskID, code)
+	}
+	raw := strings.Trim(res.Stdout, "\x00")
+	if raw == "" {
+		return nil, nil
+	}
+	return strings.Split(raw, "\x00"), nil
+}
+
+func missingDeliverableFiles(expected, delivered []string) []string {
+	have := make(map[string]struct{}, len(delivered))
+	for _, raw := range delivered {
+		if p := workflow.NormalizeFilePath(raw); p != "" {
+			have[p] = struct{}{}
+		}
+	}
+	var missing []string
+	seen := make(map[string]struct{}, len(expected))
+	for _, raw := range expected {
+		p := workflow.NormalizeFilePath(raw)
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		if _, ok := have[p]; !ok {
+			missing = append(missing, p)
+		}
+	}
+	return missing
+}

--- a/processor/requirement-executor/deliverable_gate_test.go
+++ b/processor/requirement-executor/deliverable_gate_test.go
@@ -1,0 +1,198 @@
+package requirementexecutor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/sandbox"
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestStoryScopeCreateObligations_IntersectsPlanCreateWithStoryFilesOwned(t *testing.T) {
+	plan := &workflow.Plan{
+		Scope: workflow.Scope{Create: []string{
+			"./src/present.go",
+			"src/missing.go",
+			"src/other.go",
+			"src/missing.go",
+			"../escape.go",
+		}},
+	}
+	story := workflow.Story{
+		ID:         "story.demo.1",
+		FilesOwned: []string{"src/present.go", "./src/missing.go", "docs/readme.md"},
+	}
+
+	got := storyScopeCreateObligations(plan, story)
+	want := []string{"src/present.go", "src/missing.go"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("storyScopeCreateObligations() = %v, want %v", got, want)
+	}
+}
+
+func TestRequirementScopeCreateObligations_UsesAllRequirementStories(t *testing.T) {
+	plan := &workflow.Plan{
+		Scope: workflow.Scope{Create: []string{"src/a.go", "src/b.go", "src/c.go"}},
+		Stories: []workflow.Story{
+			{ID: "story.demo.1", FilesOwned: []string{"src/a.go"}},
+			{ID: "story.demo.2", FilesOwned: []string{"src/b.go"}},
+			{ID: "story.demo.other", FilesOwned: []string{"src/c.go"}},
+		},
+	}
+
+	got := requirementScopeCreateObligations(plan, []string{"story.demo.1", "story.demo.2"})
+	want := []string{"src/a.go", "src/b.go"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("requirementScopeCreateObligations() = %v, want %v", got, want)
+	}
+}
+
+func TestMissingDeliverableFiles_NormalizesAndDedupes(t *testing.T) {
+	got := missingDeliverableFiles(
+		[]string{"./src/a.go", "src/b.go", "src/b.go", "../escape.go"},
+		[]string{"src/a.go", "src/c.go"},
+	)
+	want := []string{"src/b.go"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("missingDeliverableFiles() = %v, want %v", got, want)
+	}
+}
+
+func TestRequirementDeliverableGate_FailsBeforeTerminalCompleteWhenMissing(t *testing.T) {
+	c := newTestComponent(t)
+	c.sandbox = &stubSandbox{
+		execByTaskID: map[string]*sandbox.ExecResult{
+			"reviewer-1": {Stdout: "src/present.go\x00", ExitCode: 0},
+		},
+	}
+	exec := deliverableGateExec("reviewer-1")
+	plan := deliverableGatePlan()
+
+	exec.mu.Lock()
+	handled := c.handleRequirementDeliverableGapForPlanLocked(context.Background(), exec, plan)
+	exec.mu.Unlock()
+
+	if !handled {
+		t.Fatal("requirement deliverable gap was not handled")
+	}
+	if !exec.terminated {
+		t.Fatal("exec.terminated = false, want failed terminal state")
+	}
+	if c.requirementsCompleted.Load() != 0 {
+		t.Fatalf("requirementsCompleted = %d, want 0", c.requirementsCompleted.Load())
+	}
+	if c.requirementsFailed.Load() != 1 {
+		t.Fatalf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
+	}
+}
+
+func TestApprovedDeliverableGate_RetriesCurrentStoryWhenScopeCreateMissing(t *testing.T) {
+	c := newTestComponent(t)
+	c.sandbox = &stubSandbox{
+		execByTaskID: map[string]*sandbox.ExecResult{
+			"reviewer-1": {Stdout: "src/present.go\x00", ExitCode: 0},
+		},
+	}
+	exec := deliverableGateExec("reviewer-1")
+	plan := deliverableGatePlan()
+
+	exec.mu.Lock()
+	handled := c.handleApprovedDeliverableGapForPlanLocked(context.Background(), exec, plan)
+	exec.mu.Unlock()
+
+	if !handled {
+		t.Fatal("deliverable gap was not handled")
+	}
+	if exec.RetryCount != 1 {
+		t.Fatalf("RetryCount = %d, want 1", exec.RetryCount)
+	}
+	if !strings.Contains(exec.LastReviewFeedback, "src/missing.go") {
+		t.Fatalf("LastReviewFeedback = %q, want missing path", exec.LastReviewFeedback)
+	}
+	if len(exec.VisitedNodes) != 0 {
+		t.Fatalf("VisitedNodes = %v, want reset for Story retry", exec.VisitedNodes)
+	}
+	if len(exec.NodeResults) != 0 {
+		t.Fatalf("NodeResults = %v, want current Story evidence trimmed before retry", exec.NodeResults)
+	}
+	if c.requirementsCompleted.Load() != 0 {
+		t.Fatalf("requirementsCompleted = %d, want 0", c.requirementsCompleted.Load())
+	}
+}
+
+func TestApprovedDeliverableGate_AllowsCleanStory(t *testing.T) {
+	c := newTestComponent(t)
+	c.sandbox = &stubSandbox{
+		execByTaskID: map[string]*sandbox.ExecResult{
+			"reviewer-1": {Stdout: "src/present.go\x00src/missing.go\x00", ExitCode: 0},
+		},
+	}
+	exec := deliverableGateExec("reviewer-1")
+	plan := deliverableGatePlan()
+
+	exec.mu.Lock()
+	handled := c.handleApprovedDeliverableGapForPlanLocked(context.Background(), exec, plan)
+	exec.mu.Unlock()
+
+	if handled {
+		t.Fatal("clean deliverable set should not intercept approval")
+	}
+	if exec.RetryCount != 0 {
+		t.Fatalf("RetryCount = %d, want 0", exec.RetryCount)
+	}
+}
+
+func TestApprovedDeliverableGate_FailsClosedWhenBranchCannotBeInspected(t *testing.T) {
+	c := newTestComponent(t)
+	c.sandbox = &stubSandbox{execErr: fmt.Errorf("sandbox unavailable")}
+	exec := deliverableGateExec("reviewer-1")
+	plan := deliverableGatePlan()
+
+	exec.mu.Lock()
+	handled := c.handleApprovedDeliverableGapForPlanLocked(context.Background(), exec, plan)
+	exec.mu.Unlock()
+
+	if !handled {
+		t.Fatal("inspection failure was not handled")
+	}
+	if !exec.terminated {
+		t.Fatal("exec.terminated = false, want failed terminal state")
+	}
+	if c.requirementsFailed.Load() != 1 {
+		t.Fatalf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
+	}
+}
+
+func deliverableGateExec(reviewerTaskID string) *requirementExecution {
+	return &requirementExecution{
+		EntityID:        "semspec.local.exec.req.run.demo-req-1",
+		Slug:            "demo",
+		RequirementID:   "req.demo.1",
+		ReviewerTaskID:  reviewerTaskID,
+		SortedStoryIDs:  []string{"story.demo.1"},
+		CurrentStoryIdx: 0,
+		SortedNodeIDs:   []string{"task.demo.1"},
+		VisitedNodes:    map[string]bool{"task.demo.1": true},
+		NodeResults: []NodeResult{
+			{NodeID: "task.demo.1", FilesModified: []string{"src/present.go"}, CommitSHA: "abc123"},
+		},
+		CurrentNodeIdx: 0,
+		MaxRetries:     2,
+	}
+}
+
+func deliverableGatePlan() *workflow.Plan {
+	return &workflow.Plan{
+		Slug:  "demo",
+		Scope: workflow.Scope{Create: []string{"src/present.go", "src/missing.go", "src/other.go"}},
+		Stories: []workflow.Story{
+			{
+				ID:             "story.demo.1",
+				RequirementIDs: []string{"req.demo.1"},
+				FilesOwned:     []string{"src/present.go", "src/missing.go"},
+			},
+		},
+	}
+}

--- a/processor/scenario-orchestrator/component.go
+++ b/processor/scenario-orchestrator/component.go
@@ -327,12 +327,8 @@ func (c *Component) dispatchRequirements(ctx context.Context, trigger *Orchestra
 	// scan so it always reflects the latest committed state.
 	c.reconcileCompletedRequirements(ctx)
 
-	completedReqIDs := make(map[string]bool, len(requirements))
-	for _, r := range requirements {
-		if _, ok := c.completedReqs.Get(r.ID); ok {
-			completedReqIDs[r.ID] = true
-		}
-	}
+	forceReqs := forceRequirementSet(trigger.ForceRequirementIDs)
+	completedReqIDs := c.completedRequirementIDs(requirements, forceReqs)
 	toDispatch := filterReadyRequirements(requirements, completedReqIDs)
 	preStoryGateCount := len(toDispatch)
 	toDispatch = filterByM2NStoryReservations(toDispatch, trigger.Stories)
@@ -374,7 +370,8 @@ func (c *Component) dispatchRequirements(ctx context.Context, trigger *Orchestra
 		prereqs := c.buildPrereqContext(req, requirements)
 
 		wg.Add(1)
-		go func(r workflow.Requirement, sc []workflow.Scenario, deps []payloads.PrereqContext) {
+		force := forceReqs[req.ID]
+		go func(r workflow.Requirement, sc []workflow.Scenario, deps []payloads.PrereqContext, force bool) {
 			defer wg.Done()
 
 			select {
@@ -384,12 +381,12 @@ func (c *Component) dispatchRequirements(ctx context.Context, trigger *Orchestra
 				return
 			}
 
-			if err := c.dispatchRequirement(ctx, trigger, r, sc, deps); err != nil {
+			if err := c.dispatchRequirement(ctx, trigger, r, sc, deps, force); err != nil {
 				errs <- err
 			} else {
 				c.requirementsTriggered.Add(1)
 			}
-		}(req, scenarios, prereqs)
+		}(req, scenarios, prereqs, force)
 	}
 
 	wg.Wait()
@@ -461,6 +458,7 @@ func (c *Component) dispatchRequirement(
 	req workflow.Requirement,
 	scenarios []workflow.Scenario,
 	prereqs []payloads.PrereqContext,
+	force bool,
 ) error {
 	base, err := c.resolveRequirementBase(ctx, req, trigger.Stories, trigger.PlanBranch)
 	if err != nil {
@@ -468,7 +466,7 @@ func (c *Component) dispatchRequirement(
 			"requirement_id", req.ID, "error", err)
 		return err
 	}
-	if err := c.triggerRequirementExecution(ctx, trigger.PlanSlug, trigger.TraceID, trigger.PlanBranch, base, req, scenarios, prereqs); err != nil {
+	if err := c.triggerRequirementExecution(ctx, trigger.PlanSlug, trigger.TraceID, trigger.PlanBranch, base, req, scenarios, prereqs, force); err != nil {
 		// A "req execution already exists" rejection is a benign idempotency
 		// outcome, not a failure (issue #180): when plan-manager re-fires the
 		// orchestrator on a completion AND the DAG gate independently re-dispatches
@@ -544,19 +542,9 @@ func (c *Component) triggerRequirementExecution(
 	req workflow.Requirement,
 	scenarios []workflow.Scenario,
 	prereqs []payloads.PrereqContext,
+	force bool,
 ) error {
-	mutReq := map[string]any{
-		"slug":           planSlug,
-		"requirement_id": req.ID,
-		"title":          req.Title,
-		"description":    req.Description,
-		"scenarios":      scenarios,
-		"depends_on":     prereqs,
-		"trace_id":       traceID,
-		"plan_branch":    planBranch,
-		"base_branch":    baseBranch,
-	}
-
+	mutReq := reqCreateMutationPayload(planSlug, traceID, planBranch, baseBranch, req, scenarios, prereqs, force)
 	data, err := json.Marshal(mutReq)
 	if err != nil {
 		return fmt.Errorf("marshal req.create mutation: %w", err)
@@ -585,6 +573,57 @@ func (c *Component) triggerRequirementExecution(
 		"prereq_count", len(prereqs),
 	)
 	return nil
+}
+
+func reqCreateMutationPayload(
+	planSlug, traceID, planBranch, baseBranch string,
+	req workflow.Requirement,
+	scenarios []workflow.Scenario,
+	prereqs []payloads.PrereqContext,
+	force bool,
+) map[string]any {
+	mutReq := map[string]any{
+		"slug":           planSlug,
+		"requirement_id": req.ID,
+		"title":          req.Title,
+		"description":    req.Description,
+		"scenarios":      scenarios,
+		"depends_on":     prereqs,
+		"trace_id":       traceID,
+		"plan_branch":    planBranch,
+		"base_branch":    baseBranch,
+	}
+	if force {
+		mutReq["force"] = true
+	}
+	return mutReq
+}
+
+func forceRequirementSet(ids []string) map[string]bool {
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			out[id] = true
+		}
+	}
+	return out
+}
+
+func (c *Component) completedRequirementIDs(requirements []workflow.Requirement, forceReqs map[string]bool) map[string]bool {
+	completedReqIDs := make(map[string]bool, len(requirements))
+	for _, r := range requirements {
+		if _, ok := c.completedReqs.Get(r.ID); ok {
+			completedReqIDs[r.ID] = true
+		}
+	}
+	removeForceRedispatchCompletions(completedReqIDs, forceReqs)
+	return completedReqIDs
+}
+
+func removeForceRedispatchCompletions(completedReqIDs, forceReqs map[string]bool) {
+	for id := range forceReqs {
+		delete(completedReqIDs, id)
+	}
 }
 
 // reconcileCompletedRequirements backfills completedReqs from EXECUTION_STATES on

--- a/processor/scenario-orchestrator/force_redispatch_test.go
+++ b/processor/scenario-orchestrator/force_redispatch_test.go
@@ -1,0 +1,46 @@
+package scenarioorchestrator
+
+import (
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+func TestReqCreateMutationPayloadIncludesForceOnlyWhenRequested(t *testing.T) {
+	req := workflow.Requirement{ID: "req.force.1", Title: "Force me"}
+
+	forced := reqCreateMutationPayload("plan", "trace", "plan-branch", "base-branch", req, nil, nil, true)
+	if forced["force"] != true {
+		t.Fatalf("force payload = %v, want true", forced["force"])
+	}
+
+	normal := reqCreateMutationPayload("plan", "trace", "plan-branch", "base-branch", req, nil, nil, false)
+	if _, ok := normal["force"]; ok {
+		t.Fatalf("normal payload unexpectedly included force: %v", normal)
+	}
+}
+
+func TestForceRequirementSetIgnoresBlankIDs(t *testing.T) {
+	got := forceRequirementSet([]string{"req.force.1", "", "req.force.2"})
+	if !got["req.force.1"] || !got["req.force.2"] {
+		t.Fatalf("force set = %v, want both non-blank ids", got)
+	}
+	if got[""] {
+		t.Fatalf("force set should ignore blank ids: %v", got)
+	}
+}
+
+func TestRemoveForceRedispatchCompletionsReopensDAGSweep(t *testing.T) {
+	completed := map[string]bool{
+		"req.force.1": true,
+		"req.keep.1":  true,
+	}
+	removeForceRedispatchCompletions(completed, forceRequirementSet([]string{"req.force.1"}))
+
+	if completed["req.force.1"] {
+		t.Fatalf("forced req still marked complete: %v", completed)
+	}
+	if !completed["req.keep.1"] {
+		t.Fatalf("unforced req should remain complete: %v", completed)
+	}
+}

--- a/workflow/payloads/types.go
+++ b/workflow/payloads/types.go
@@ -808,6 +808,10 @@ type ScenarioOrchestrationTrigger struct {
 	Stories    []workflow.Story `json:"stories,omitempty"`
 	TraceID    string           `json:"trace_id,omitempty"`
 	PlanBranch string           `json:"plan_branch,omitempty"` // GitHub plan-level branch (ADR-031)
+	// ForceRequirementIDs tells the orchestrator that these requirement
+	// executions were intentionally reopened by a recovery decision and must be
+	// recreated even if a stale req.* row still exists in EXECUTION_STATES.
+	ForceRequirementIDs []string `json:"force_requirement_ids,omitempty"`
 }
 
 // Schema implements message.Payload.


### PR DESCRIPTION
## Summary
- add progressive Story and Requirement deliverable gates for accepted scope.create obligations
- retry approved Stories with missing-file feedback before final branch assembly
- fix #226 scope_incomplete recovery redispatch by carrying affected req IDs into the orchestrator trigger, reopening them in DAG gating, and force-recreating stale req execution rows
- make execution reset/delete failures surface instead of reporting successful recovery while durable EXECUTION_STATES rows remain
- add review follow-up coverage for a sequential reopened req1 -> req2 redispatch where the dependent dispatch later runs without force
- document both slices in the contract-authoritative planning OpenSpec change

## Validation
- go test ./processor/requirement-executor
- go test ./processor/execution-manager ./processor/scenario-orchestrator ./processor/plan-manager
- go test ./processor/execution-manager ./processor/plan-manager
- go test ./...
- revive -config revive.toml -formatter friendly ./...
- git diff --check
- task e2e:mock -- execution-phase

## Notes
This PR intentionally has three commits: the deliverable closure gate base, the #226 redispatch recovery fix, and the review follow-up sequential redispatch regression.