### PR TITLE
fix(execution): recover QA-recovery task completions

### DIFF
--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -171,6 +171,12 @@ type Component struct {
 	activeExecs   sscache.Cache[*requirementExecution]
 	activeExecsMu sync.Mutex // guards get-or-set for duplicate trigger detection
 
+	// taskCompletionReqExecLoader is a test seam for recovering a non-terminal
+	// requirement execution from EXECUTION_STATES when a task.> terminal update
+	// arrives but activeExecs has no matching owner. Production uses
+	// loadNonTerminalReqExecFromKV.
+	taskCompletionReqExecLoader func(ctx context.Context, slug, requirementID string) (*requirementExecution, error)
+
 	// Lifecycle
 	wg          sync.WaitGroup
 	replayGate  sync.WaitGroup // tracks watcher replay completion; resumption waits on this

--- a/processor/requirement-executor/recover_completed.go
+++ b/processor/requirement-executor/recover_completed.go
@@ -67,6 +67,47 @@ func (c *Component) loadTerminalReqExecFromKV(ctx context.Context, slug, require
 	return c.rebuildExecFromKV(key, &reqExec), nil
 }
 
+// loadNonTerminalReqExecFromKV fetches an in-flight requirement execution for
+// the given slug + requirement ID directly via the deterministic KV key. It is
+// used by the task-completion watcher as a durable fallback when activeExecs
+// has lost the owner for a terminal node completion, which can happen after a
+// QA-recovery reopens a completed requirement under the execution-manager's
+// hashed req.run entity ID.
+//
+// Returns nil + nil for missing or terminal entries. Returns nil + error only
+// for KV transport failure.
+func (c *Component) loadNonTerminalReqExecFromKV(ctx context.Context, slug, requirementID string) (*requirementExecution, error) {
+	if c.natsClient == nil {
+		return nil, nil
+	}
+
+	bucket, err := c.natsClient.GetKeyValueBucket(ctx, "EXECUTION_STATES")
+	if err != nil {
+		return nil, fmt.Errorf("get EXECUTION_STATES bucket: %w", err)
+	}
+	kvStore := c.natsClient.NewKVStore(bucket)
+
+	key := workflow.RequirementExecutionKey(slug, requirementID)
+	entry, err := kvStore.Get(ctx, key)
+	if err != nil {
+		if isKVNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get %s: %w", key, err)
+	}
+
+	var reqExec workflow.RequirementExecution
+	if err := json.Unmarshal(entry.Value, &reqExec); err != nil {
+		c.logger.Debug("Skipping corrupt EXECUTION_STATES entry during task-completion owner recovery",
+			"key", key, "error", err)
+		return nil, nil
+	}
+	if workflow.IsTerminalReqStage(reqExec.Stage) {
+		return nil, nil
+	}
+	return c.rebuildExecFromKV(key, &reqExec), nil
+}
+
 // loadCompletedReqExecFromKV fetches a completed requirement execution
 // from EXECUTION_STATES. ADR-044 M:N dedup uses this as the evidence
 // source when a non-owner requirement advances past a Story already

--- a/processor/requirement-executor/req_completions.go
+++ b/processor/requirement-executor/req_completions.go
@@ -174,15 +174,14 @@ func (c *Component) handleTaskStateChange(ctx context.Context, entry jetstream.K
 
 	exec := c.findExecByTaskID(taskExec.TaskID)
 	if exec == nil {
-		// A terminal task completion that matches no active execution's current
-		// node or reviewer task. Benign + common for nodes whose execution
-		// already completed and was cleaned from activeExecs — but it is ALSO
-		// the silent-drop shape that wedged the 2026-06-13 QA-recovery
-		// re-execution (a re-dispatched node completed, but routing back into
-		// the re-opened DAG found no owner, so the completion vanished and the
-		// requirement never advanced to re-QA — a permanent, invisible wedge).
-		// Log at DEBUG so the gate is visible on a debug run without flooding
-		// the normal path.
+		exec = c.recoverExecForTerminalTaskCompletion(ctx, taskExec)
+	}
+	if exec == nil {
+		// A terminal task completion that matches no active or persisted
+		// non-terminal execution's current node/reviewer task. Benign + common
+		// for nodes whose execution already completed and was cleaned from
+		// activeExecs. Recovery attempts above make the QA-recovery silent-drop
+		// shape fail closed instead of wedging the DAG.
 		c.logger.Debug("terminal task completion matched no active execution — dropping",
 			"task_id", taskExec.TaskID, "stage", taskExec.Stage)
 		return
@@ -258,6 +257,94 @@ func (c *Component) handleTaskStateChange(ctx context.Context, entry jetstream.K
 	}
 
 	c.handleNodeCompleteLocked(ctx, event, exec)
+}
+
+// recoverExecForTerminalTaskCompletion rehydrates an in-flight requirement
+// execution from EXECUTION_STATES when task.> completion routing misses the
+// activeExecs cache. This closes the QA-recovery wedge where a completed
+// requirement is reopened from its deterministic KV row, the first recovered
+// node finishes, and the terminal task update arrives before activeExecs has a
+// matching owner for the new hashed req.run entity.
+func (c *Component) recoverExecForTerminalTaskCompletion(ctx context.Context, taskExec workflow.TaskExecution) *requirementExecution {
+	if taskExec.Slug == "" || taskExec.RequirementID == "" {
+		return nil
+	}
+
+	loader := c.loadNonTerminalReqExecFromKV
+	if c.taskCompletionReqExecLoader != nil {
+		loader = c.taskCompletionReqExecLoader
+	}
+
+	exec, err := loader(ctx, taskExec.Slug, taskExec.RequirementID)
+	if err != nil {
+		c.logger.Warn("Failed to recover requirement execution for terminal task completion",
+			"slug", taskExec.Slug,
+			"requirement_id", taskExec.RequirementID,
+			"task_id", taskExec.TaskID,
+			"error", err)
+		return nil
+	}
+	if exec == nil {
+		return nil
+	}
+
+	exec.mu.Lock()
+	match := !exec.terminated && exec.CurrentNodeTaskID == taskExec.TaskID
+	currentTaskID := exec.CurrentNodeTaskID
+	exec.mu.Unlock()
+	if !match {
+		c.logger.Debug("recovered requirement execution does not own terminal task completion — dropping",
+			"slug", taskExec.Slug,
+			"requirement_id", taskExec.RequirementID,
+			"task_id", taskExec.TaskID,
+			"current_node_task_id", currentTaskID)
+		return nil
+	}
+
+	c.replaceActiveExecForRequirement(exec)
+	c.logger.Info("Recovered requirement execution owner for terminal task completion",
+		"entity_id", exec.EntityID,
+		"slug", exec.Slug,
+		"requirement_id", exec.RequirementID,
+		"task_id", taskExec.TaskID)
+	return exec
+}
+
+// replaceActiveExecForRequirement installs recovered as the active owner for
+// its slug + requirement and removes any stale cache rows for the same
+// requirement. The stale row can carry the first-pass entity ID while the
+// durable EXECUTION_STATES row carries execution-manager's hashed entity ID.
+func (c *Component) replaceActiveExecForRequirement(recovered *requirementExecution) {
+	if recovered == nil {
+		return
+	}
+
+	c.activeExecsMu.Lock()
+	defer c.activeExecsMu.Unlock()
+
+	for _, key := range c.activeExecs.Keys() {
+		exec, ok := c.activeExecs.Get(key)
+		if !ok || exec == nil || exec == recovered {
+			continue
+		}
+		exec.mu.Lock()
+		sameRequirement := exec.Slug == recovered.Slug && exec.RequirementID == recovered.RequirementID
+		if sameRequirement {
+			exec.terminated = true
+			if exec.timeoutTimer != nil {
+				exec.timeoutTimer.stop()
+			}
+			if exec.recoveryTimer != nil {
+				exec.recoveryTimer.stop()
+			}
+		}
+		exec.mu.Unlock()
+		if sameRequirement {
+			c.activeExecs.Delete(key) //nolint:errcheck // best-effort stale cache cleanup
+		}
+	}
+
+	c.activeExecs.Set(recovered.EntityID, recovered) //nolint:errcheck // best-effort recovery routing
 }
 
 // findExecByTaskID scans active executions for one whose dispatched task IDs

--- a/processor/requirement-executor/req_completions_recovery_test.go
+++ b/processor/requirement-executor/req_completions_recovery_test.go
@@ -1,0 +1,110 @@
+package requirementexecutor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type mockTaskCompletionKVEntry struct {
+	key   string
+	value []byte
+	op    jetstream.KeyValueOp
+}
+
+func (e *mockTaskCompletionKVEntry) Bucket() string                  { return "EXECUTION_STATES" }
+func (e *mockTaskCompletionKVEntry) Key() string                     { return e.key }
+func (e *mockTaskCompletionKVEntry) Value() []byte                   { return e.value }
+func (e *mockTaskCompletionKVEntry) Revision() uint64                { return 1 }
+func (e *mockTaskCompletionKVEntry) Created() time.Time              { return time.Time{} }
+func (e *mockTaskCompletionKVEntry) Delta() uint64                   { return 0 }
+func (e *mockTaskCompletionKVEntry) Operation() jetstream.KeyValueOp { return e.op }
+
+func TestHandleTaskStateChange_RehydratesReqExecAndAdvancesRecoveredQANode(t *testing.T) {
+	c := newTestComponent(t)
+
+	const (
+		slug          = "plan-qa-recovery"
+		requirementID = "req.plan.1"
+		node0TaskID   = "task-node-0"
+	)
+
+	dagRaw, err := json.Marshal(TaskDAG{Nodes: []TaskNode{
+		{ID: "node-0", Prompt: "fix the reviewed gap", Role: "developer", FileScope: []string{"src/a.go"}},
+		{ID: "node-1", Prompt: "cover the reviewed gap", Role: "developer", FileScope: []string{"src/a_test.go"}},
+	}})
+	if err != nil {
+		t.Fatalf("marshal dag: %v", err)
+	}
+
+	persisted := &workflow.RequirementExecution{
+		EntityID:          workflow.EntityPrefix() + ".exec.req.run.recovered",
+		Slug:              slug,
+		RequirementID:     requirementID,
+		Stage:             phaseExecuting,
+		CurrentNodeIdx:    0,
+		CurrentNodeTaskID: node0TaskID,
+		DAGRaw:            dagRaw,
+		SortedNodeIDs:     []string{"node-0", "node-1"},
+		SortedStoryIDs:    []string{"story.plan.1"},
+		CurrentStoryIdx:   0,
+		MaxRetries:        1,
+	}
+	recovered := c.rebuildExecFromKV(workflow.RequirementExecutionKey(slug, requirementID), persisted)
+
+	c.taskCompletionReqExecLoader = func(_ context.Context, gotSlug, gotRequirementID string) (*requirementExecution, error) {
+		if gotSlug != slug {
+			t.Fatalf("loader slug = %q, want %q", gotSlug, slug)
+		}
+		if gotRequirementID != requirementID {
+			t.Fatalf("loader requirement = %q, want %q", gotRequirementID, requirementID)
+		}
+		return recovered, nil
+	}
+
+	taskExec := workflow.TaskExecution{
+		Slug:          slug,
+		RequirementID: requirementID,
+		TaskID:        node0TaskID,
+		Stage:         "approved",
+		FilesModified: []string{"src/a.go"},
+		MergeCommit:   "abc123",
+		UpdatedAt:     time.Now(),
+	}
+	entryValue, err := json.Marshal(taskExec)
+	if err != nil {
+		t.Fatalf("marshal task execution: %v", err)
+	}
+
+	c.handleTaskStateChange(context.Background(), &mockTaskCompletionKVEntry{
+		key:   "task." + node0TaskID,
+		value: entryValue,
+		op:    jetstream.KeyValuePut,
+	})
+
+	if got := recovered.CurrentNodeIdx; got != 1 {
+		t.Fatalf("CurrentNodeIdx = %d, want 1 after recovered node completion", got)
+	}
+	if recovered.CurrentNodeTaskID == "" {
+		t.Fatal("CurrentNodeTaskID is empty; node 1 was not dispatched")
+	}
+	if recovered.CurrentNodeTaskID == node0TaskID {
+		t.Fatal("CurrentNodeTaskID still points at node 0; node 1 was not dispatched")
+	}
+	if !recovered.VisitedNodes["node-0"] {
+		t.Fatal("node-0 was not marked visited")
+	}
+	if len(recovered.NodeResults) != 1 {
+		t.Fatalf("NodeResults = %d, want 1", len(recovered.NodeResults))
+	}
+	if got := recovered.NodeResults[0].CommitSHA; got != "abc123" {
+		t.Fatalf("NodeResults[0].CommitSHA = %q, want abc123", got)
+	}
+	if _, ok := c.activeExecs.Get(recovered.EntityID); !ok {
+		t.Fatalf("recovered execution %q was not installed in activeExecs", recovered.EntityID)
+	}
+}


### PR DESCRIPTION
## Summary
- recover non-terminal requirement execution state from EXECUTION_STATES when a terminal task update has no activeExecs owner
- replace stale same-requirement cache rows before routing the completion into the recovered DAG
- add a regression proving a QA-recovery node-0 completion advances to node 1 instead of silently dropping

Fixes #229.

## Verification
- go test ./processor/requirement-executor
- go test ./...
- revive -config revive.toml -formatter friendly ./...
- task e2e:mock -- execution-phase
