### PR TITLE
fix(ui): improve live run observability

### DIFF
--- a/ui/e2e/trajectory-entry-expand.spec.ts
+++ b/ui/e2e/trajectory-entry-expand.spec.ts
@@ -35,8 +35,8 @@ test.describe('@t0 trajectory-entry expansion', () => {
 
 		const expandBtn = page.getByTestId('entry-expand-btn');
 		await expect(expandBtn).toBeVisible();
-		await expect(expandBtn).toHaveAttribute('aria-expanded', 'false');
-		await expandBtn.click();
+		await expect(card).toHaveAttribute('aria-expanded', 'false');
+		await card.click();
 
 		const preview = page.getByTestId('entry-preview');
 		await expect(preview).toBeVisible();
@@ -46,8 +46,24 @@ test.describe('@t0 trajectory-entry expansion', () => {
 		await expect(preview).toContainText('Result');
 		await expect(preview).toContainText('PASS');
 
-		// aria-expanded reflects state so screen readers announce it.
-		await expect(expandBtn).toHaveAttribute('aria-expanded', 'true');
+		// aria-expanded reflects state on the card-level disclosure control.
+		await expect(card).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	test('entry can be expanded with keyboard when the card has focus', async ({ page }) => {
+		await page.goto('/e2e-test/trajectory-entry?scenario=tool-call');
+		await waitForHydration(page);
+
+		const card = page.getByTestId('trajectory-entry');
+		await card.focus();
+		await page.keyboard.press('Enter');
+
+		await expect(page.getByTestId('entry-preview')).toBeVisible();
+		await expect(card).toHaveAttribute('aria-expanded', 'true');
+
+		await page.keyboard.press('Space');
+		await expect(page.getByTestId('entry-preview')).toHaveCount(0);
+		await expect(card).toHaveAttribute('aria-expanded', 'false');
 	});
 
 	test('model-call entry reveals response text on expand (compact layout)', async ({ page }) => {

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -14,10 +14,17 @@ import { defineConfig, devices } from '@playwright/test';
  * Timeout configuration:
  * - Default: 90s global, 22.5s per expect
  * - Override with PLAYWRIGHT_TIMEOUT env var for slow environments
+ * - Web server default: 7m for cold Docker/model health gates
+ * - Override with PLAYWRIGHT_WEBSERVER_TIMEOUT env var when needed
  */
 
 const DEFAULT_TIMEOUT = 90000;
+const DEFAULT_WEB_SERVER_TIMEOUT = 420000;
 const timeout = parseInt(process.env.PLAYWRIGHT_TIMEOUT || String(DEFAULT_TIMEOUT), 10);
+const webServerTimeout = parseInt(
+	process.env.PLAYWRIGHT_WEBSERVER_TIMEOUT || String(DEFAULT_WEB_SERVER_TIMEOUT),
+	10
+);
 
 const useMockLLM = process.env.USE_MOCK_LLM === 'true';
 const dockerComposeCommand = useMockLLM
@@ -89,7 +96,7 @@ export default defineConfig({
 		command: dockerComposeCommand,
 		url: 'http://localhost:3000',
 		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
+		timeout: webServerTimeout,
 		stdout: 'pipe',
 		stderr: 'pipe',
 		env: mockEnv,

--- a/ui/src/lib/components/plan/LessonActivityDetail.svelte
+++ b/ui/src/lib/components/plan/LessonActivityDetail.svelte
@@ -10,6 +10,7 @@
 		lessonActivityModel,
 		type PersistedLessonSummary
 	} from '$lib/components/plan/observabilityModels';
+	import { compactPlanText, shouldCollapsePlanText } from '$lib/types/planDisplay';
 	import type { PlanWithStatus } from '$lib/types/plan';
 	import type { TrajectoryListItem } from '$lib/types/trajectory';
 
@@ -41,6 +42,14 @@
 		const date = new Date(value);
 		if (!Number.isFinite(date.getTime())) return '';
 		return `${date.toISOString().slice(11, 19)}Z`;
+	}
+
+	function lessonPreview(value: string): string {
+		return compactPlanText(value, 180);
+	}
+
+	function shouldShowRawLesson(lesson: PersistedLessonSummary): boolean {
+		return shouldCollapsePlanText(lesson.summary) || Boolean(lesson.detail);
 	}
 </script>
 
@@ -99,12 +108,24 @@
 				<div class="captured-row" data-positive={lesson.positive}>
 					<Icon name={lesson.positive ? 'lightbulb' : 'alert-circle'} size={14} />
 					<div class="captured-copy">
-						<span>{lesson.summary}</span>
-						<small>
+						<span class="lesson-summary">{lessonPreview(lesson.summary)}</span>
+						<small class="lesson-meta">
 							{lesson.relatedTaskTitle ?? lesson.source}
+							{#if lesson.role}
+								<span aria-hidden="true">·</span>
+								{formatToken(lesson.role)}
+							{/if}
 							<span aria-hidden="true">·</span>
 							{lesson.futureRunOnly ? 'future-run only' : `injected ${timeLabel(lesson.lastInjectedAt)}`}
 						</small>
+						{#if shouldShowRawLesson(lesson)}
+							<details class="lesson-raw">
+								<summary>Raw lesson details</summary>
+								<pre>{lesson.summary}{#if lesson.detail}
+
+{lesson.detail}{/if}</pre>
+							</details>
+						{/if}
 					</div>
 				</div>
 			{/each}
@@ -242,18 +263,48 @@
 		gap: 2px;
 	}
 
-	.captured-copy span {
+	.lesson-summary {
 		font-size: var(--font-size-sm);
 		line-height: var(--line-height-normal);
 		color: var(--color-text-primary);
+		overflow-wrap: anywhere;
 	}
 
-	.captured-copy small {
+	.lesson-meta {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 		gap: var(--space-1);
 		font-size: var(--font-size-xs);
 		color: var(--color-text-muted);
+	}
+
+	.lesson-raw {
+		margin-top: var(--space-1);
+		border: 1px solid var(--color-border-subtle, var(--color-border));
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-primary);
+	}
+
+	.lesson-raw summary {
+		padding: var(--space-1) var(--space-2);
+		cursor: pointer;
+		font-size: var(--font-size-xs);
+		color: var(--color-text-muted);
+	}
+
+	.lesson-raw pre {
+		max-height: 220px;
+		margin: 0;
+		padding: var(--space-2);
+		border-top: 1px solid var(--color-border-subtle, var(--color-border));
+		overflow: auto;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+		font-family: var(--font-family-mono);
+		font-size: var(--font-size-xs);
+		line-height: var(--line-height-relaxed);
+		color: var(--color-text-secondary);
 	}
 
 	.role-row {

--- a/ui/src/lib/components/plan/PlanDetail.svelte
+++ b/ui/src/lib/components/plan/PlanDetail.svelte
@@ -14,6 +14,7 @@
 	import { promotePlan } from '$lib/actions/plans';
 	import { feedStore } from '$lib/stores/feed.svelte';
 	import { LOCKED_STAGES } from '$lib/types/plan';
+	import { compactPlanText, planDisplayTitle, shouldCollapsePlanText } from '$lib/types/planDisplay';
 	import type { PlanWithStatus } from '$lib/types/plan';
 	import type { Phase } from '$lib/types/phase';
 	import type { Requirement } from '$lib/types/requirement';
@@ -35,6 +36,9 @@
 	let error = $state<string | null>(null);
 
 	const guidance = $derived(deriveGuidance(plan.approved, plan.stage, requirements.length));
+	const displayTitle = $derived(planDisplayTitle(plan));
+	const collapseGoal = $derived(shouldCollapsePlanText(plan.goal));
+	const collapseContext = $derived(shouldCollapsePlanText(plan.context));
 
 	const canEdit = $derived(!LOCKED_STAGES.includes(plan.stage));
 
@@ -86,13 +90,17 @@
 			approving = false;
 		}
 	}
+
+	function charsLabel(value: string | null | undefined): string {
+		return `${(value ?? '').length.toLocaleString()} chars`;
+	}
 </script>
 
 <div class="plan-detail">
 	<!-- Header -->
 	<header class="detail-header">
 		<div class="header-main">
-			<h2 class="detail-title">{plan.title || plan.slug}</h2>
+			<h2 class="detail-title">{displayTitle}</h2>
 			<StatusBadge status={plan.approved ? 'approved' : 'draft'} />
 		</div>
 		{#if canEdit && !isEditing}
@@ -158,7 +166,15 @@
 						<Icon name="target" size={14} />
 						Goal
 					</dt>
-					<dd class="section-content">{plan.goal}</dd>
+					{#if collapseGoal}
+						<dd class="section-content section-summary">{compactPlanText(plan.goal)}</dd>
+						<details class="source-details">
+							<summary>Raw goal / prompt <span>{charsLabel(plan.goal)}</span></summary>
+							<pre class="source-text">{plan.goal}</pre>
+						</details>
+					{:else}
+						<dd class="section-content">{plan.goal}</dd>
+					{/if}
 				</div>
 			{/if}
 
@@ -168,7 +184,15 @@
 						<Icon name="info" size={14} />
 						Context
 					</dt>
-					<dd class="section-content">{plan.context}</dd>
+					{#if collapseContext}
+						<dd class="section-content section-summary">{compactPlanText(plan.context)}</dd>
+						<details class="source-details">
+							<summary>Raw context <span>{charsLabel(plan.context)}</span></summary>
+							<pre class="source-text">{plan.context}</pre>
+						</details>
+					{:else}
+						<dd class="section-content">{plan.context}</dd>
+					{/if}
 				</div>
 			{/if}
 
@@ -343,6 +367,50 @@
 		line-height: var(--line-height-relaxed);
 		color: var(--color-text-primary);
 		white-space: pre-wrap;
+	}
+
+	.section-summary {
+		color: var(--color-text-secondary);
+	}
+
+	.source-details {
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-tertiary);
+		overflow: hidden;
+	}
+
+	.source-details summary {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-medium);
+		color: var(--color-text-secondary);
+	}
+
+	.source-details summary span {
+		font-size: var(--font-size-xs);
+		font-family: var(--font-family-mono);
+		color: var(--color-text-muted);
+	}
+
+	.source-text {
+		max-height: 280px;
+		margin: 0;
+		padding: var(--space-3);
+		border-top: 1px solid var(--color-border);
+		overflow: auto;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
+		font-family: var(--font-family-mono);
+		font-size: var(--font-size-xs);
+		line-height: var(--line-height-relaxed);
+		color: var(--color-text-secondary);
+		background: var(--color-bg-primary);
 	}
 
 	.section-textarea {

--- a/ui/src/lib/components/plan/PlanFreshnessIndicator.svelte
+++ b/ui/src/lib/components/plan/PlanFreshnessIndicator.svelte
@@ -2,6 +2,7 @@
 	import Icon from '$lib/components/shared/Icon.svelte';
 	import { planFreshnessIndicatorState } from '$lib/components/plan/observabilityModels';
 	import { feedStore } from '$lib/stores/feed.svelte';
+	import { questionsStore } from '$lib/stores/questions.svelte';
 	import type { PlanWithStatus } from '$lib/types/plan';
 
 	interface Props {
@@ -14,7 +15,12 @@
 		currentSlug: feedStore.currentSlug,
 		connected: feedStore.connected,
 		streamEverConnected: feedStore.streamEverConnected,
-		lastSuccessfulUpdateAt: feedStore.lastSuccessfulUpdateAt
+		lastSuccessfulUpdateAt: feedStore.lastSuccessfulUpdateAt,
+		questionsConnected: questionsStore.connected,
+		questionsEverConnected: questionsStore.streamEverConnected,
+		questionsLastSuccessfulUpdateAt: questionsStore.lastSuccessfulUpdateAt,
+		questionsError: questionsStore.streamError,
+		questionsLastErrorAt: questionsStore.lastErrorAt
 	}));
 
 	function formatTime(timestamp: string): string {

--- a/ui/src/lib/components/plan/observabilityModels.test.ts
+++ b/ui/src/lib/components/plan/observabilityModels.test.ts
@@ -415,6 +415,28 @@ describe('lesson activity observability model', () => {
 		expect(isLessonTrajectoryItem(trajectory({ workflow_slug: 'other', workflow_step: 'other', role: 'developer', task_id: 'lesson-pass' }))).toBe(true);
 		expect(isLessonTrajectoryItem(trajectory({ workflow_slug: 'semspec-task-execution', workflow_step: 'develop', role: 'developer', task_id: 'dev-1' }))).toBe(false);
 	});
+
+	it('carries persisted lesson role and detail for compact UI cards', () => {
+		const summaries = persistedLessonSummaries(
+			plan(),
+			[executionTask({ task_id: 'node-1', title: 'Fix coverage' })],
+			[],
+			[lesson({
+				ScenarioID: 'node-1',
+				Summary: 'Short summary',
+				Detail: 'Long evidence transcript',
+				Role: 'developer'
+			})]
+		);
+
+		expect(summaries).toHaveLength(1);
+		expect(summaries[0]).toMatchObject({
+			summary: 'Short summary',
+			detail: 'Long evidence transcript',
+			role: 'developer',
+			relatedTaskTitle: 'Fix coverage'
+		});
+	});
 });
 
 describe('freshness observability model', () => {
@@ -453,5 +475,25 @@ describe('freshness observability model', () => {
 		});
 
 		expect(state.shouldShow).toBe(false);
+	});
+
+	it('shows question stream failures even when plan feed is still connected', () => {
+		const state = planFreshnessIndicatorState(plan({ phase_summary: phaseSummary() }), {
+			currentSlug: 'demo',
+			connected: true,
+			streamEverConnected: true,
+			lastSuccessfulUpdateAt: '2026-06-16T12:11:00Z',
+			questionsConnected: false,
+			questionsEverConnected: true,
+			questionsLastSuccessfulUpdateAt: '2026-06-16T12:10:00Z',
+			questionsError: 'Questions stream connection error',
+			questionsLastErrorAt: '2026-06-16T12:12:00Z'
+		});
+
+		expect(state.shouldShow).toBe(true);
+		expect(state.disconnected).toBe(true);
+		expect(state.statusLabel).toBe('Question stream disconnected');
+		expect(state.reason).toBe('Questions stream connection error');
+		expect(state.source).toBe('question-manager');
 	});
 });

--- a/ui/src/lib/components/plan/observabilityModels.ts
+++ b/ui/src/lib/components/plan/observabilityModels.ts
@@ -109,7 +109,9 @@ export type ExecutionAttemptModel = {
 export type PersistedLessonSummary = {
 	id: string;
 	summary: string;
+	detail?: string;
 	source: string;
+	role?: string;
 	positive: boolean;
 	createdAt: string;
 	lastInjectedAt?: string | null;
@@ -162,6 +164,11 @@ export type FeedFreshnessSnapshot = {
 	connected: boolean;
 	streamEverConnected: boolean;
 	lastSuccessfulUpdateAt: string | null;
+	questionsConnected?: boolean;
+	questionsEverConnected?: boolean;
+	questionsLastSuccessfulUpdateAt?: string | null;
+	questionsError?: string | null;
+	questionsLastErrorAt?: string | null;
 };
 
 export type FreshnessIndicatorState = {
@@ -332,7 +339,9 @@ export function persistedLessonSummaries(
 		.map((lesson) => ({
 			id: lesson.ID,
 			summary: lesson.Summary,
+			detail: lesson.Detail,
 			source: lesson.Source,
+			role: lesson.Role,
 			positive: lesson.Positive,
 			createdAt: lesson.CreatedAt,
 			lastInjectedAt: lesson.LastInjectedAt,
@@ -434,9 +443,14 @@ export function planFreshnessIndicatorState(
 ): FreshnessIndicatorState {
 	const freshness = plan.phase_summary?.freshness ?? null;
 	const planScoped = feed.currentSlug === plan.slug;
-	const disconnected = planScoped && feed.streamEverConnected && !feed.connected;
+	const feedDisconnected = planScoped && feed.streamEverConnected && !feed.connected;
+	const questionsDisconnected = Boolean(feed.questionsEverConnected && !feed.questionsConnected);
+	const disconnected = feedDisconnected || questionsDisconnected;
 	const stale = Boolean(freshness?.stale);
 	const shouldShow = stale || disconnected;
+	const disconnectedReason = questionsDisconnected
+		? (feed.questionsError ?? 'Questions stream disconnected')
+		: undefined;
 	return {
 		shouldShow,
 		disconnected,
@@ -445,10 +459,15 @@ export function planFreshnessIndicatorState(
 			? 'Stale data and stream disconnected'
 			: stale
 				? 'Stale data'
-				: 'Stream disconnected',
-		lastUpdateAt: feed.lastSuccessfulUpdateAt ?? freshness?.generated_at ?? null,
-		reason: freshness?.reason,
-		source: freshness?.source
+				: questionsDisconnected
+					? 'Question stream disconnected'
+					: 'Stream disconnected',
+		lastUpdateAt: feed.lastSuccessfulUpdateAt ??
+			feed.questionsLastSuccessfulUpdateAt ??
+			freshness?.generated_at ??
+			null,
+		reason: disconnectedReason ?? freshness?.reason,
+		source: questionsDisconnected ? 'question-manager' : freshness?.source
 	};
 }
 

--- a/ui/src/lib/components/trajectory/TrajectoryEntryCard.svelte
+++ b/ui/src/lib/components/trajectory/TrajectoryEntryCard.svelte
@@ -66,8 +66,24 @@
 	}
 
 	function toggleExpanded() {
+		if (!hasPreview) return;
 		expanded = !expanded;
 	}
+
+	function handleCardClick(event: MouseEvent) {
+		if (!hasPreview) return;
+		const target = event.target as HTMLElement | null;
+		if (target?.closest('button, a, input, textarea, select')) return;
+		toggleExpanded();
+	}
+
+	function handleCardKeydown(event: KeyboardEvent) {
+		if (!hasPreview) return;
+		if (event.key !== 'Enter' && event.key !== ' ') return;
+		event.preventDefault();
+		toggleExpanded();
+	}
+
 </script>
 
 <div
@@ -78,6 +94,13 @@
 	class:tool-call={!isModelCall}
 	data-testid="trajectory-entry"
 	data-step-type={entry.step_type}
+	role="button"
+	tabindex={hasPreview ? 0 : -1}
+	aria-disabled={!hasPreview}
+	aria-expanded={expanded}
+	aria-label={`${expanded ? 'Collapse' : 'Expand'} trajectory entry ${displayName}`}
+	onclick={handleCardClick}
+	onkeydown={handleCardKeydown}
 >
 	<div class="card-header">
 		<div class="header-left">
@@ -107,15 +130,14 @@
 					 expansion is always allowed when there's something to show.
 					 Previously both were coupled, so the plan-page timeline
 					 couldn't reveal prompt/response/tool args (bug #7.10). -->
-				<button
+				<span
 					class="expand-btn"
-					onclick={toggleExpanded}
 					title={expanded ? 'Collapse' : 'Expand preview'}
 					data-testid="entry-expand-btn"
-					aria-expanded={expanded}
+					aria-hidden="true"
 				>
 					<Icon name={expanded ? 'chevron-up' : 'chevron-down'} size={14} />
-				</button>
+				</span>
 			{/if}
 		</div>
 	</div>
@@ -237,6 +259,19 @@
 		flex-direction: column;
 		gap: var(--space-2);
 		transition: border-color var(--transition-fast);
+	}
+
+	.entry-card[role='button']:not([aria-disabled='true']) {
+		cursor: pointer;
+	}
+
+	.entry-card[role='button']:not([aria-disabled='true']):hover {
+		border-color: var(--color-border-strong, var(--color-accent-muted));
+	}
+
+	.entry-card[role='button']:not([aria-disabled='true']):focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 
 	.entry-card.compact {

--- a/ui/src/lib/stores/activity.svelte.ts
+++ b/ui/src/lib/stores/activity.svelte.ts
@@ -6,6 +6,7 @@ import {
 } from '$lib/api/mock';
 import type { ActivityEvent } from '$lib/types';
 import { settingsStore } from '$lib/stores/settings.svelte';
+import { appendBounded } from './buffer';
 
 const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true';
 const RECONNECT_GRACE_MS = 15_000;
@@ -84,12 +85,14 @@ class ActivityStore {
 
 	private addEvent(event: ActivityEvent): void {
 		this.lastSuccessfulUpdateAt = new Date().toISOString();
-		this.recent = [...this.recent.slice(-(this.maxEvents - 1)), event];
+		this.recent = appendBounded(this.recent, event, this.maxEvents);
 
 		// Maintain loopLastSeen as a heartbeat timeline. Map must be replaced,
 		// not mutated, to trigger Svelte 5 reactivity — Maps aren't deeply reactive.
 		if (event.loop_id) {
-			if (event.type === 'loop_deleted') {
+			const state = event.data?.state;
+			const terminal = event.type === 'loop_deleted' || state === 'complete' || state === 'failed' || state === 'cancelled';
+			if (terminal) {
 				if (this.loopLastSeen.has(event.loop_id)) {
 					const next = new Map(this.loopLastSeen);
 					next.delete(event.loop_id);

--- a/ui/src/lib/stores/activity.test.ts
+++ b/ui/src/lib/stores/activity.test.ts
@@ -71,6 +71,19 @@ describe('ActivityStore — loopLastSeen', () => {
 		expect(activityStore.loopLastSeen.has('loop-c')).toBe(false);
 	});
 
+	it('evicts the entry on terminal loop state updates', () => {
+		tick({ type: 'loop_created', loop_id: 'loop-terminal' });
+		expect(activityStore.loopLastSeen.has('loop-terminal')).toBe(true);
+
+		tick({
+			type: 'loop_updated',
+			loop_id: 'loop-terminal',
+			data: { loop_id: 'loop-terminal', state: 'complete' }
+		} as Partial<ActivityEvent> & { type: string; loop_id?: string });
+
+		expect(activityStore.loopLastSeen.has('loop-terminal')).toBe(false);
+	});
+
 	it('tracks multiple loops independently', () => {
 		tick({ type: 'loop_created', loop_id: 'loop-d' });
 		tick({ type: 'loop_created', loop_id: 'loop-e' });

--- a/ui/src/lib/stores/buffer.test.ts
+++ b/ui/src/lib/stores/buffer.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { appendBounded, clampEventLimit } from './buffer';
+
+describe('bounded event buffers', () => {
+	it('clamps invalid persisted limits to a safe default', () => {
+		expect(clampEventLimit('not-a-number')).toBe(100);
+		expect(clampEventLimit(-5)).toBe(1);
+		expect(clampEventLimit(5000)).toBe(1000);
+	});
+
+	it('appends without throwing when the limit is invalid', () => {
+		expect(appendBounded([1, 2, 3], 4, Number.NaN)).toEqual([1, 2, 3, 4]);
+	});
+
+	it('keeps only the most recent events within the cap', () => {
+		expect(appendBounded([1, 2, 3], 4, 2)).toEqual([3, 4]);
+	});
+});

--- a/ui/src/lib/stores/buffer.ts
+++ b/ui/src/lib/stores/buffer.ts
@@ -1,0 +1,14 @@
+const DEFAULT_LIMIT = 100;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 1000;
+
+export function clampEventLimit(value: unknown, fallback = DEFAULT_LIMIT): number {
+	const numeric = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(numeric)) return fallback;
+	return Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, Math.trunc(numeric)));
+}
+
+export function appendBounded<T>(items: T[], item: T, limit: unknown): T[] {
+	const capped = clampEventLimit(limit);
+	return [...items.slice(-(capped - 1)), item];
+}

--- a/ui/src/lib/stores/feed.svelte.ts
+++ b/ui/src/lib/stores/feed.svelte.ts
@@ -9,6 +9,7 @@ import type {
 import type { Question } from '$lib/types';
 import { questionsStore } from './questions.svelte';
 import { settingsStore } from './settings.svelte';
+import { appendBounded } from './buffer';
 import {
 	annotateExecutionSummary,
 	classifyExecutionFeedKind,
@@ -373,7 +374,7 @@ class FeedStore {
 	}
 
 	private addEvent(event: FeedEvent): void {
-		this.events = [...this.events.slice(-(this.maxEvents - 1)), event];
+		this.events = appendBounded(this.events, event, this.maxEvents);
 	}
 
 	private markPlanConnected(): void {

--- a/ui/src/lib/stores/questions.svelte.ts
+++ b/ui/src/lib/stores/questions.svelte.ts
@@ -15,6 +15,10 @@ class QuestionsStore {
 	error = $state<string | null>(null);
 	lastRefresh = $state<Date | null>(null);
 	connected = $state(false);
+	streamEverConnected = $state(false);
+	lastSuccessfulUpdateAt = $state<string | null>(null);
+	lastErrorAt = $state<string | null>(null);
+	streamError = $state<string | null>(null);
 
 	private unsubscribe: (() => void) | null = null;
 
@@ -39,13 +43,19 @@ class QuestionsStore {
 				(error: Error) => {
 					console.error('Questions stream error:', error);
 					this.connected = false;
+					this.streamError = error.message || 'Questions stream connection error';
+					this.lastErrorAt = new Date().toISOString();
 					// Native EventSource auto-reconnect handles backoff.
 				}
 			);
 			this.connected = true;
+			this.streamEverConnected = true;
+			this.streamError = null;
 		} catch (err) {
 			console.error('Failed to connect to questions stream:', err);
 			this.connected = false;
+			this.streamError = err instanceof Error ? err.message : 'Failed to connect to questions stream';
+			this.lastErrorAt = new Date().toISOString();
 		}
 
 		// Initial fetch to populate state (non-blocking)
@@ -72,6 +82,9 @@ class QuestionsStore {
 		if (!this.connected) {
 			this.connected = true;
 		}
+		this.streamEverConnected = true;
+		this.streamError = null;
+		this.lastSuccessfulUpdateAt = new Date().toISOString();
 		switch (event.type) {
 			case 'question_created': {
 				const question = event.data as Question;
@@ -129,6 +142,8 @@ class QuestionsStore {
 		try {
 			this.all = await questionsApi.list({ status });
 			this.lastRefresh = new Date();
+			this.lastSuccessfulUpdateAt = this.lastRefresh.toISOString();
+			this.streamError = null;
 			// Inject pending questions into chat messages
 			for (const q of this.all.filter((q) => q.status === 'pending')) {
 				messagesStore.addQuestion(q);

--- a/ui/src/lib/stores/settings.svelte.ts
+++ b/ui/src/lib/stores/settings.svelte.ts
@@ -6,6 +6,7 @@
  */
 
 import { browser } from '$app/environment';
+import { clampEventLimit } from './buffer';
 
 const STORAGE_KEY = 'semspec-settings';
 
@@ -40,7 +41,7 @@ class SettingsStore {
 	}
 
 	get activityLimit(): number {
-		return this.settings.activityLimit;
+		return clampEventLimit(this.settings.activityLimit, DEFAULT_SETTINGS.activityLimit);
 	}
 
 	get reducedMotion(): boolean {
@@ -64,7 +65,7 @@ class SettingsStore {
 
 	// Activity limit management
 	setActivityLimit(limit: number): void {
-		this.settings.activityLimit = Math.max(10, Math.min(1000, limit));
+		this.settings.activityLimit = Math.max(10, clampEventLimit(limit, DEFAULT_SETTINGS.activityLimit));
 		this.saveToStorage();
 	}
 
@@ -93,7 +94,11 @@ class SettingsStore {
 			const stored = localStorage.getItem(STORAGE_KEY);
 			if (stored) {
 				const parsed = JSON.parse(stored) as Partial<Settings>;
-				this.settings = { ...DEFAULT_SETTINGS, ...parsed };
+				this.settings = {
+					...DEFAULT_SETTINGS,
+					...parsed,
+					activityLimit: Math.max(10, clampEventLimit(parsed.activityLimit, DEFAULT_SETTINGS.activityLimit))
+				};
 			}
 		} catch {
 			// Ignore parse errors, use defaults

--- a/ui/src/lib/types/planDisplay.test.ts
+++ b/ui/src/lib/types/planDisplay.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { PlanWithStatus } from './plan';
+import {
+	compactPlanText,
+	isRawPromptLike,
+	planDisplayTitle,
+	shouldCollapsePlanText
+} from './planDisplay';
+
+function plan(overrides: Partial<PlanWithStatus>): PlanWithStatus {
+	return {
+		id: 'plan.demo',
+		slug: 'abc123',
+		stage: 'drafting',
+		approved: false,
+		created_at: '2026-06-18T12:00:00Z',
+		active_loops: [],
+		...overrides
+	} as PlanWithStatus;
+}
+
+describe('plan display helpers', () => {
+	it('keeps short authored titles as the display title', () => {
+		expect(planDisplayTitle(plan({ title: 'MAVLink fallback support' }))).toBe(
+			'MAVLink fallback support'
+		);
+	});
+
+	it('does not promote raw prompts to the page title', () => {
+		const rawPrompt = `Starting from the existing OpenSensorHub MAVSDK addon, design and implement MAVLink support through the Connected Systems API.
+
+The implementation must provide full plugin coverage, tests, and documentation.`;
+
+		expect(isRawPromptLike(rawPrompt)).toBe(true);
+		expect(planDisplayTitle(plan({ title: rawPrompt, goal: rawPrompt }))).toBe('Plan abc123');
+		expect(shouldCollapsePlanText(rawPrompt)).toBe(true);
+	});
+
+	it('falls back to a concise goal when title is raw but goal is clean', () => {
+		expect(
+			planDisplayTitle(plan({
+				title: 'Implement this feature with a long operational instruction payload that should not become the title',
+				goal: 'Add MAVLink fallback support'
+			}))
+		).toBe('Add MAVLink fallback support');
+	});
+
+	it('compacts raw source text for summary rows', () => {
+		const compact = compactPlanText('a '.repeat(200), 24);
+		expect(compact.length).toBeLessThanOrEqual(24);
+		expect(compact.endsWith('...')).toBe(true);
+	});
+});

--- a/ui/src/lib/types/planDisplay.ts
+++ b/ui/src/lib/types/planDisplay.ts
@@ -1,0 +1,35 @@
+import type { PlanWithStatus } from './plan';
+
+const TITLE_LIMIT = 96;
+const SUMMARY_LIMIT = 220;
+
+export function isRawPromptLike(value: string | null | undefined): boolean {
+	const text = value?.trim() ?? '';
+	if (!text) return false;
+	if (text.length > TITLE_LIMIT) return true;
+	if (text.includes('\n')) return true;
+	if (/^#+\s/.test(text)) return true;
+	if (/\b(must|shall|implement|design)\b/i.test(text) && text.length > 72) return true;
+	return false;
+}
+
+export function planDisplayTitle(plan: PlanWithStatus | null | undefined): string {
+	if (!plan) return 'Plan';
+	const title = plan.title?.trim();
+	if (title && !isRawPromptLike(title)) return title;
+
+	const goal = plan.goal?.trim();
+	if (goal && !isRawPromptLike(goal)) return compactPlanText(goal, TITLE_LIMIT);
+
+	return plan.slug ? `Plan ${plan.slug}` : 'Plan';
+}
+
+export function compactPlanText(value: string | null | undefined, limit = SUMMARY_LIMIT): string {
+	const text = (value ?? '').replace(/\s+/g, ' ').trim();
+	if (text.length <= limit) return text;
+	return `${text.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
+export function shouldCollapsePlanText(value: string | null | undefined): boolean {
+	return isRawPromptLike(value) || (value?.length ?? 0) > SUMMARY_LIMIT;
+}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -24,9 +24,11 @@
 
 	let { data, children }: Props = $props();
 
-	const activeLoopCount = $derived(
+	const loadedActiveLoopCount = $derived(
 		(data.loops ?? []).filter((l) => ['pending', 'executing', 'paused'].includes(l.state)).length
 	);
+	const liveActiveLoopCount = $derived(activityStore.loopLastSeen.size);
+	const activeLoopCount = $derived(Math.max(loadedActiveLoopCount, liveActiveLoopCount));
 
 	const configWarning = $derived(
 		setupStore.step === 'scaffold' ||

--- a/ui/src/routes/plans/[slug]/+page.svelte
+++ b/ui/src/routes/plans/[slug]/+page.svelte
@@ -27,6 +27,7 @@
 	import { promotePlan, executePlan, retryFailed } from '$lib/actions/plans';
 	import RetrySelectedPicker from '$lib/components/plan/RetrySelectedPicker.svelte';
 	import { derivePlanPipeline, getStageLabel } from '$lib/types/plan';
+	import { planDisplayTitle } from '$lib/types/planDisplay';
 	import { activePhaseProgress } from '$lib/types/activePlanProgress';
 	import { selectFreshestPlan } from '$lib/types/planFreshness';
 	import { mergeLiveTrajectoryItems } from '$lib/types/trajectoryActivityProjection';
@@ -65,6 +66,7 @@
 		selectFreshestPlan(feedStore.currentPlan, data.plan, slug ?? '')
 	);
 	const pipeline = $derived(plan ? derivePlanPipeline(plan) : null);
+	const displayTitle = $derived(planDisplayTitle(plan));
 	const requirements = $derived(data.requirements);
 	const scenariosByReq = $derived(data.scenariosByReq);
 	const hasRequirements = $derived(requirements.length > 0);
@@ -482,7 +484,7 @@
 </script>
 
 <svelte:head>
-	<title>{plan?.title || plan?.slug || 'Plan'} - Semspec</title>
+	<title>{displayTitle} - Semspec</title>
 </svelte:head>
 
 <div class="plan-detail">
@@ -493,7 +495,7 @@
 		</a>
 		{#if plan}
 			<div class="header-info">
-				<h1 class="plan-title">{plan.title || plan.slug}</h1>
+				<h1 class="plan-title">{displayTitle}</h1>
 				<div class="plan-meta">
 					<ModeIndicator approved={plan.approved} />
 					<span class="plan-stage" data-stage={plan.stage} data-phase={plan.phase_summary?.phase ?? plan.stage}>


### PR DESCRIPTION
## Summary
- make trajectory entry cards expandable from the whole card and keyboard, while preserving the explicit chevron button
- harden activity/feed event buffering and surface question-stream disconnects in the plan freshness indicator
- use live SSE loop heartbeats as a fallback for the shell loop count so active work does not read as Loops 0
- demote raw prompts from page title/H1/doc chrome and compact huge Lesson Activity rows behind raw-detail expanders

## Verification
- npm run check
- npm run test
- npm run build
- npm run test:e2e -- trajectory-entry-expand.spec.ts
- git diff --check
- revive -config revive.toml -formatter friendly ./...

Fixes #231
Fixes #232
Fixes #233
Refs #217
Refs #218
Refs #219