### PR TITLE
fix(recovery): audit recovery submit schema

### DIFF
--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -516,7 +516,7 @@ func (c *Component) dispatchRecovery(ctx context.Context, req *payloads.Recovery
 		Role:         agentic.RoleGeneral,
 		Model:        modelName,
 		Prompt:       assembled.UserMessage,
-		Tools:        terminal.ToolsForEndpoint(c.toolRegistry, "review", endpoint, availableTools...),
+		Tools:        recoverySubmitTools(c.toolRegistry, endpoint, availableTools...),
 		ToolChoice:   prompt.ResolveToolChoice(prompt.RoleRecoveryAgent, availableTools),
 		WorkflowSlug: workflow.WorkflowSlugWedgeRecovery,
 		WorkflowStep: stepRecover,
@@ -1005,6 +1005,10 @@ func clip(s string, n int) string {
 // wire palette (submit_work + scratchpad — see prompt/tool_filter.go).
 func recoveryAvailableToolNames() []string {
 	return []string{"submit_work", "scratchpad"}
+}
+
+func recoverySubmitTools(reg component.ToolRegistryReader, endpoint *ssmodel.EndpointConfig, allowedTools ...string) []agentic.ToolDefinition {
+	return terminal.ToolsForEndpoint(reg, "recovery", endpoint, allowedTools...)
 }
 
 // resolveProvider maps a model string to a prompt.Provider. Mirrors the

--- a/processor/recovery-agent/result.go
+++ b/processor/recovery-agent/result.go
@@ -116,8 +116,19 @@ func parseRecoveryResult(raw string) (*parsedRecoveryResult, error) {
 			return nil, errResultMissingAction
 		}
 	}
-	if rr.Diagnosis == "" {
-		return nil, errResultMissingDiag
+	if strings.TrimSpace(rr.Diagnosis) == "" {
+		// #235: gemini-pro can emit review-shaped recovery output where the
+		// actual diagnosis lives under `feedback`. If we already salvage
+		// feedback as the action payload, salvage it as diagnosis too rather
+		// than dead-rejecting a recoverable QA-recovery.
+		switch {
+		case strings.TrimSpace(rr.Feedback) != "":
+			rr.Diagnosis = rr.Feedback
+		case strings.TrimSpace(rr.RefinedPrompt) != "":
+			rr.Diagnosis = rr.RefinedPrompt
+		default:
+			return nil, errResultMissingDiag
+		}
 	}
 
 	action := payloads.RecoveryActionKind(rr.Action)

--- a/processor/recovery-agent/result_test.go
+++ b/processor/recovery-agent/result_test.go
@@ -1,12 +1,15 @@
 package recoveryagent
 
 import (
+	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
+	"github.com/c360studio/semstreams/agentic"
 )
 
 func TestParseRecoveryResult(t *testing.T) {
@@ -156,6 +159,23 @@ func TestParseRecoveryResult(t *testing.T) {
 		}
 	})
 
+	t.Run("salvages diagnosis from feedback-only review-shaped result", func(t *testing.T) {
+		raw := `{"verdict":"rejected","summary":"Build failed before tests.","feedback":"The architecture mis-resolved org.sensorhub:sensorhub-core:2.0.1 as a source_build without a build-native acquisition path. Revise the architecture to provide a resolvable artifact or composite build contract.","findings":[],"rejection_type":"fixable","scenario_verdicts":[]}`
+		got, err := parseRecoveryResult(raw)
+		if err != nil {
+			t.Fatalf("expected #235 feedback-only recovery result to parse, got error: %v", err)
+		}
+		if got.Action != payloads.RecoveryActionRefinePrompt {
+			t.Errorf("Action: got %q, want refine_prompt inferred from feedback", got.Action)
+		}
+		if !strings.Contains(got.Diagnosis, "source_build") {
+			t.Errorf("diagnosis did not fall back to feedback: %q", got.Diagnosis)
+		}
+		if got.Diagnosis != got.RefinedPrompt {
+			t.Errorf("feedback fallback should populate diagnosis and refined_prompt; diagnosis=%q refined_prompt=%q", got.Diagnosis, got.RefinedPrompt)
+		}
+	})
+
 	// refined_prompt still wins when BOTH it and feedback are present (the
 	// schema-correct field takes precedence; feedback is only a fallback).
 	t.Run("prefers refined_prompt over feedback when both present", func(t *testing.T) {
@@ -219,6 +239,83 @@ func TestParseRecoveryResult(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRecoverySubmitWorkSchemaMatchesParserContract(t *testing.T) {
+	tools := recoverySubmitTools(&recoveryTestToolRegistry{
+		tools: []agentic.ToolDefinition{{
+			Name:        "submit_work",
+			Description: "Submit recovery decision",
+			Parameters:  map[string]any{"type": "object"},
+		}},
+	}, nil, "submit_work")
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1 submit_work", len(tools))
+	}
+	props := schemaProps(t, tools[0].Parameters)
+
+	structFields := jsonFields(reflect.TypeOf(rawRecoveryResult{}))
+	for field := range structFields {
+		if field == "feedback" {
+			if _, ok := props[field]; ok {
+				t.Fatalf("feedback is a parser fallback for non-schema review-shaped output; it must not be in the recovery submit_work schema")
+			}
+			continue
+		}
+		if _, ok := props[field]; !ok {
+			t.Errorf("rawRecoveryResult field %q missing from recovery submit_work schema", field)
+		}
+	}
+	for field := range props {
+		if !structFields[field] {
+			t.Errorf("recovery submit_work schema property %q has no rawRecoveryResult field", field)
+		}
+	}
+	for _, reviewOnly := range []string{"verdict", "findings", "rejection_type", "scenario_verdicts"} {
+		if _, ok := props[reviewOnly]; ok {
+			t.Errorf("recovery submit_work schema includes review-only field %q", reviewOnly)
+		}
+	}
+}
+
+type recoveryTestToolRegistry struct {
+	tools []agentic.ToolDefinition
+}
+
+func (r *recoveryTestToolRegistry) ListTools() []agentic.ToolDefinition {
+	return r.tools
+}
+
+func (r *recoveryTestToolRegistry) Execute(_ context.Context, _ agentic.ToolCall) (agentic.ToolResult, error) {
+	return agentic.ToolResult{}, nil
+}
+
+func schemaProps(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing properties")
+	}
+	return props
+}
+
+func jsonFields(typ reflect.Type) map[string]bool {
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	fields := map[string]bool{}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		tag := field.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name != "" {
+			fields[name] = true
+		}
+	}
+	return fields
 }
 
 // Note: the user-prompt content tests previously here (TestBuildUserPrompt*)

--- a/tools/terminal/schemas.go
+++ b/tools/terminal/schemas.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/component"
 	ssmodel "github.com/c360studio/semstreams/model"
@@ -99,6 +100,8 @@ func schemaForDeliverable(deliverableType string) map[string]any {
 		return architectureSchema()
 	case "review":
 		return reviewSchema()
+	case "recovery":
+		return recoverySchema()
 	case "qa-review":
 		return qaReviewSchema()
 	case "lesson":
@@ -723,6 +726,90 @@ func reviewSchema() map[string]any {
 			},
 		},
 		"required":             []string{"verdict", "feedback", "summary", "rejection_type", "findings", "scenario_verdicts"},
+		"additionalProperties": false,
+	}
+}
+
+func recoverySchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"action": map[string]any{
+				"type":        "string",
+				"description": "Recovery action to apply. Pick one closed-set value and write it first.",
+				"enum": []string{
+					string(payloads.RecoveryActionRefinePrompt),
+					string(payloads.RecoveryActionNarrowScope),
+					string(payloads.RecoveryActionSplitReq),
+					string(payloads.RecoveryActionStoryReprepare),
+					string(payloads.RecoveryActionArchitectureRevise),
+					string(payloads.RecoveryActionEscalateHuman),
+					string(payloads.RecoveryActionMarkUnrecoverable),
+				},
+			},
+			"diagnosis": map[string]any{
+				"type":        "string",
+				"description": "2-6 sentences explaining what the trajectory shows, why the prior agent wedged, and why the selected action fits.",
+			},
+			"recovery_succeeded": map[string]any{
+				"type":        "boolean",
+				"description": "true when the selected action plausibly fixes the wedge; false for escalate_human or mark_unrecoverable.",
+			},
+			"contract_impact": map[string]any{
+				"type":        "object",
+				"description": "How accepting this recovery affects the authoritative contract.",
+				"properties": map[string]any{
+					"kind": map[string]any{
+						"type":        "string",
+						"description": "preserve keeps the accepted contract; refine changes downstream shape while preserving obligations; change mutates obligations/topology/scope.",
+						"enum":        []string{"preserve", "refine", "change"},
+					},
+					"summary": map[string]any{
+						"type":        "string",
+						"description": "Concise contract-impact summary.",
+					},
+					"affected_ids": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Requirement, story, scenario, or capability IDs affected by the action. Emit [] when the impact is plan-wide or not ID-specific.",
+					},
+				},
+				"required":             []string{"kind", "summary", "affected_ids"},
+				"additionalProperties": false,
+			},
+			"refined_prompt": map[string]any{
+				"type":        []any{"string", "null"},
+				"description": "Complete replacement prompt for refine_prompt. Set null for every other action.",
+			},
+			"scope_changes": map[string]any{
+				"type":        "object",
+				"description": "Structured narrowing/splitting summary. For non narrow_scope/split_req actions, set summary to empty string and arrays to [].",
+				"properties": map[string]any{
+					"summary": map[string]any{
+						"type":        "string",
+						"description": "What scope is being narrowed or split, and why.",
+					},
+					"keep": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Files, concerns, or requirement slices that remain in scope. Emit [] when not applicable.",
+					},
+					"drop": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Files, concerns, or requirement slices to remove from the immediate retry. Emit [] when not applicable.",
+					},
+					"split_requirements": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Proposed smaller requirement titles or slices for split_req. Emit [] when not applicable.",
+					},
+				},
+				"required":             []string{"summary", "keep", "drop", "split_requirements"},
+				"additionalProperties": false,
+			},
+		},
+		"required":             []string{"action", "diagnosis", "recovery_succeeded", "contract_impact", "refined_prompt", "scope_changes"},
 		"additionalProperties": false,
 	}
 }

--- a/tools/terminal/schemas_test.go
+++ b/tools/terminal/schemas_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 func TestSchemaForDeliverable_HasNamedProperties(t *testing.T) {
@@ -18,6 +19,7 @@ func TestSchemaForDeliverable_HasNamedProperties(t *testing.T) {
 		{"scenarios", []string{"scenarios"}},
 		{"architecture", []string{"technology_choices", "component_boundaries", "data_flow", "decisions", "actors", "integrations", "upstream_resolutions", "test_surface"}},
 		{"review", []string{"verdict", "feedback"}},
+		{"recovery", []string{"action", "diagnosis", "recovery_succeeded", "contract_impact", "refined_prompt", "scope_changes"}},
 		{"developer", []string{"summary", "files_modified"}},
 		{"lesson", []string{"summary", "detail", "injection_form", "root_cause_role"}},
 		{"", []string{"summary", "files_modified"}}, // default
@@ -57,6 +59,44 @@ func TestSchemaForDeliverable_HasNamedProperties(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRecoverySchema_ActionEnumMatchesConstants(t *testing.T) {
+	schema := recoverySchema()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing properties")
+	}
+	action, ok := props["action"].(map[string]any)
+	if !ok {
+		t.Fatal("schema missing action")
+	}
+	enum, ok := action["enum"].([]string)
+	if !ok {
+		t.Fatalf("action.enum missing or not []string: %T", action["enum"])
+	}
+
+	want := map[string]bool{
+		string(payloads.RecoveryActionRefinePrompt):       false,
+		string(payloads.RecoveryActionNarrowScope):        false,
+		string(payloads.RecoveryActionSplitReq):           false,
+		string(payloads.RecoveryActionStoryReprepare):     false,
+		string(payloads.RecoveryActionArchitectureRevise): false,
+		string(payloads.RecoveryActionEscalateHuman):      false,
+		string(payloads.RecoveryActionMarkUnrecoverable):  false,
+	}
+	for _, value := range enum {
+		if _, known := want[value]; !known {
+			t.Errorf("action.enum has %q, not a RecoveryActionKind constant", value)
+			continue
+		}
+		want[value] = true
+	}
+	for value, seen := range want {
+		if !seen {
+			t.Errorf("action.enum missing %q — recovery schema drifted from RecoveryActionKind constants", value)
+		}
 	}
 }
 

--- a/tools/terminal/strict_mode_test.go
+++ b/tools/terminal/strict_mode_test.go
@@ -16,6 +16,7 @@ func allDeliverableSchemas() map[string]map[string]any {
 		"stories":      storiesSchema(),
 		"architecture": architectureSchema(),
 		"review":       reviewSchema(),
+		"recovery":     recoverySchema(),
 		"developer":    developerSchema(),
 		"lesson":       lessonSchema(),
 		"qa-review":    qaReviewSchema(),


### PR DESCRIPTION
## Summary
- route recovery-agent submit_work through an explicit recovery schema instead of the plan-review schema
- add recovery submit_work schema with closed action enum, contract impact, refined prompt, and structured scope changes
- salvage missing diagnosis from feedback/refined_prompt so feedback-only QA recovery results do not dead-reject
- add schema audits that pin recovery schema fields to rawRecoveryResult and keep review-only fields out

## Verification
- go test ./processor/recovery-agent ./tools/terminal
- go test ./...
- go build ./...
- revive -config revive.toml -formatter friendly ./...
- git diff --check

Fixes #235