### PR TITLE
fix(execution): restructure rebuild preserves the DependsOn base branch (#243)

### DIFF
--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -2203,10 +2203,15 @@ func (c *Component) startRestructureRetryLocked(ctx context.Context, exec *requi
 			c.logger.Warn("Failed to delete old requirement branch",
 				"branch", exec.RequirementBranch, "error", err)
 		}
-		// Create a fresh branch.
-		if err := c.sandbox.CreateBranch(ctx, exec.RequirementBranch, "HEAD"); err != nil {
+		// Recreate from the DependsOn-derived base, not "HEAD": a requirement
+		// that forks from a prerequisite branch must keep that base on a
+		// restructure rebuild, or it loses the prerequisite's work and its
+		// per-requirement isolation (#243). Mirrors resumeFromRecoveryLocked;
+		// selectReqBranchBase falls back to "HEAD" when no base is set.
+		recreateBase := selectReqBranchBase("", exec.BaseBranch)
+		if err := c.sandbox.CreateBranch(ctx, exec.RequirementBranch, recreateBase); err != nil {
 			c.logger.Warn("Failed to recreate requirement branch",
-				"branch", exec.RequirementBranch, "error", err)
+				"branch", exec.RequirementBranch, "base", recreateBase, "error", err)
 		}
 	}
 

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -2843,12 +2843,11 @@ func TestScopeScenariosToCurrentStory_FallsBackToLegacyUnlinkedScenarios(t *test
 // through the real handler path (handleRequirementReviewerCompleteLocked →
 // startRestructureRetryLocked) using the existing stubSandbox seam.
 //
-// NOTE on the rebuild base: production currently recreates from a hardcoded
-// "HEAD" regardless of exec.BaseBranch — a known bug (#243); the recovery-resume
-// path correctly uses selectReqBranchBase. The primary test below sets no
-// BaseBranch, so "HEAD" is the correct fallback there and we do NOT assert
-// "restructure always uses HEAD". The desired non-empty-base behavior is pinned
-// (skipped) by TestHandleReviewerComplete_Restructure_PreservesBaseBranch.
+// NOTE on the rebuild base: the rebuild recreates from the DependsOn-derived
+// base via selectReqBranchBase (mirroring resumeFromRecoveryLocked), falling
+// back to "HEAD" only when no BaseBranch is set (#243). The primary test below
+// sets no BaseBranch, so it asserts the "HEAD" fallback; the non-empty-base
+// behavior is pinned by TestHandleReviewerComplete_Restructure_PreservesBaseBranch.
 // ---------------------------------------------------------------------------
 
 // TestHandleReviewerComplete_Restructure_DeletesAndRecreatesBranch is the
@@ -2922,10 +2921,8 @@ func TestHandleReviewerComplete_Restructure_DeletesAndRecreatesBranch(t *testing
 		t.Errorf("CreateBranch calls = %v, want [%q] — fresh branch must be recreated",
 			createdBranches, branchName)
 	}
-	// This exec sets no BaseBranch, so "HEAD" is the correct fallback base. We do
-	// NOT assert "restructure always uses HEAD" — that would cement bug #243
-	// (restructure ignores a set BaseBranch). The desired behavior when a
-	// BaseBranch IS present is pinned by the skipped
+	// This exec sets no BaseBranch, so "HEAD" is the correct fallback base. The
+	// non-empty-base behavior (recreate from exec.BaseBranch) is pinned by
 	// TestHandleReviewerComplete_Restructure_PreservesBaseBranch below.
 	if len(createdBases) != 1 || createdBases[0] != "HEAD" {
 		t.Errorf("CreateBranch base = %v, want [\"HEAD\"] (the no-BaseBranch fallback)",
@@ -2972,17 +2969,12 @@ func TestHandleReviewerComplete_Restructure_DeletesAndRecreatesBranch(t *testing
 	}
 }
 
-// TestHandleReviewerComplete_Restructure_PreservesBaseBranch is the
-// desired-behavior characterization for bug #243: when the requirement has a
-// DependsOn-derived BaseBranch, a restructure rebuild must recreate the branch
-// from that base (via selectReqBranchBase), NOT from "HEAD" — otherwise the
-// prerequisite's work and per-requirement isolation are lost. The recovery
-// resume path (awaiting_recovery.go) already does this; startRestructureRetryLocked
-// hardcodes "HEAD" (component.go:2207). SKIPPED until #243 is fixed; unskip it
-// as the regression guard for that fix.
+// TestHandleReviewerComplete_Restructure_PreservesBaseBranch is the regression
+// guard for #243: when the requirement has a DependsOn-derived BaseBranch, a
+// restructure rebuild recreates the branch from that base (via
+// selectReqBranchBase), NOT from "HEAD" — otherwise the prerequisite's work and
+// per-requirement isolation are lost. Mirrors the recovery-resume path.
 func TestHandleReviewerComplete_Restructure_PreservesBaseBranch(t *testing.T) {
-	t.Skip("#243: startRestructureRetryLocked recreates from HEAD, dropping exec.BaseBranch; unskip when fixed")
-
 	c := newTestComponent(t)
 	stub := &stubSandbox{}
 	c.sandbox = stub


### PR DESCRIPTION
## What

`startRestructureRetryLocked` recreated the requirement branch from a hardcoded `"HEAD"` (`component.go:2207`), so a requirement that forks from a prerequisite branch lost that base — and the prerequisite's work and per-requirement isolation — on a restructure rebuild. The recovery-resume path (`resumeFromRecoveryLocked`) already resolves the base correctly.

## Fix

Recreate via `selectReqBranchBase("", exec.BaseBranch)` (mirrors the recovery-resume path), which returns `exec.BaseBranch` when set and falls back to `"HEAD"` otherwise — so the no-base case is unchanged.

Unskips `TestHandleReviewerComplete_Restructure_PreservesBaseBranch` (added as the skipped guard in #241); it now passes as the regression guard. The primary restructure test still asserts the `"HEAD"` fallback for an exec with no `BaseBranch`.

## Provenance

Surfaced by the e2e-flow deterministic-test audit (PR #241 "Other issues found"), filed as #243. Closes #243.

## Verification

`go build` + `go vet` + `revive` clean; `go test ./processor/requirement-executor` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)