### PR TITLE
fix(execution): compare-and-swap guard on the execution claim mutation (#157)

### DIFF
--- a/processor/execution-manager/claim_mutation_test.go
+++ b/processor/execution-manager/claim_mutation_test.go
@@ -1,0 +1,163 @@
+package executionmanager
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// These tests pin the claim compare-and-swap guard from #157:
+// handleExecClaimMutation must reject a claim whose entity is not at the
+// expected source stage, and two concurrent claims from the same source must
+// resolve to exactly one winner (no last-writer-wins double-dispatch).
+
+func claimData(t *testing.T, req ExecClaimRequest) []byte {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal ExecClaimRequest: %v", err)
+	}
+	return data
+}
+
+func seedTask(t *testing.T, c *Component, key, stage string) {
+	t.Helper()
+	if err := c.store.saveTask(context.Background(), key, &workflow.TaskExecution{Stage: stage}); err != nil {
+		t.Fatalf("seed task %s: %v", key, err)
+	}
+}
+
+func TestHandleExecClaimMutation_SourceStageGuard(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("correct source claims successfully", func(t *testing.T) {
+		c := newTestComponent(t)
+		const key = "task.demo.node-ok"
+		seedTask(t, c, key, "pending")
+
+		resp := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{
+			Key: key, Stage: "developing", ExpectedFromStage: "pending",
+		}))
+		if !resp.Success {
+			t.Fatalf("claim from correct source rejected: %s", resp.Error)
+		}
+		got, _ := c.store.getTask(key)
+		if got.Stage != "developing" {
+			t.Errorf("stage = %q, want developing", got.Stage)
+		}
+	})
+
+	t.Run("wrong source is rejected and leaves stage unchanged", func(t *testing.T) {
+		c := newTestComponent(t)
+		const key = "task.demo.node-wrong"
+		seedTask(t, c, key, "developing") // already past pending
+
+		resp := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{
+			Key: key, Stage: "reviewing", ExpectedFromStage: "pending",
+		}))
+		if resp.Success {
+			t.Fatal("claim from wrong source stage succeeded; want rejected (CAS precondition)")
+		}
+		got, _ := c.store.getTask(key)
+		if got.Stage != "developing" {
+			t.Errorf("stage = %q, want developing (unchanged after rejected claim)", got.Stage)
+		}
+	})
+
+	t.Run("legacy claim without ExpectedFromStage still works and rejects dup", func(t *testing.T) {
+		c := newTestComponent(t)
+		const key = "task.demo.node-legacy"
+		seedTask(t, c, key, "pending")
+
+		// No ExpectedFromStage → legacy path: advances on a different target.
+		resp := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{Key: key, Stage: "developing"}))
+		if !resp.Success {
+			t.Fatalf("legacy claim rejected: %s", resp.Error)
+		}
+		// Re-claiming the same (now current) target is rejected as a duplicate.
+		dup := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{Key: key, Stage: "developing"}))
+		if dup.Success {
+			t.Fatal("duplicate legacy claim succeeded; want rejected (already at stage)")
+		}
+	})
+}
+
+// TestHandleExecClaimMutation_ConcurrentSameSource is the acceptance test for
+// #157(b): N goroutines race to claim the same entity from the same source
+// stage; exactly one must win. Without the claimMu + CAS guard, multiple read
+// "pending" and all save "developing" (double-dispatch). The get-check-save race
+// is probabilistic per round, so we run many rounds and require EVERY round to
+// have exactly one winner — a missing mutex then fails deterministically in a
+// single run rather than flaking. (Verified: with the lock removed this fails.)
+func TestHandleExecClaimMutation_ConcurrentSameSource(t *testing.T) {
+	const (
+		rounds   = 50
+		claimers = 16
+	)
+	c := newTestComponent(t)
+	const key = "task.demo.node-race"
+
+	for round := 0; round < rounds; round++ {
+		seedTask(t, c, key, "pending") // reset to the source stage each round
+
+		var wins int64
+		var start, done sync.WaitGroup
+		start.Add(1)
+		for i := 0; i < claimers; i++ {
+			done.Add(1)
+			go func() {
+				defer done.Done()
+				start.Wait() // release together to maximize interleaving
+				resp := c.handleExecClaimMutation(context.Background(), claimData(t, ExecClaimRequest{
+					Key: key, Stage: "developing", ExpectedFromStage: "pending",
+				}))
+				if resp.Success {
+					atomic.AddInt64(&wins, 1)
+				}
+			}()
+		}
+		start.Done()
+		done.Wait()
+
+		if wins != 1 {
+			t.Fatalf("round %d: %d winners, want exactly 1 (double-dispatch guard)", round, wins)
+		}
+		if got, _ := c.store.getTask(key); got.Stage != "developing" {
+			t.Fatalf("round %d: final stage = %q, want developing", round, got.Stage)
+		}
+	}
+}
+
+// TestHandleExecClaimMutation_ReqSourceStageGuard covers the requirement-execution
+// branch of the same guard (the handler tries task then req).
+func TestHandleExecClaimMutation_ReqSourceStageGuard(t *testing.T) {
+	ctx := context.Background()
+	c := newTestComponent(t)
+	const key = "req.demo.feature"
+	if err := c.store.saveReq(ctx, key, &workflow.RequirementExecution{Stage: "pending"}); err != nil {
+		t.Fatalf("seed req: %v", err)
+	}
+
+	// Wrong source rejected.
+	bad := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{
+		Key: key, Stage: "decomposing", ExpectedFromStage: "executing",
+	}))
+	if bad.Success {
+		t.Fatal("req claim from wrong source succeeded; want rejected")
+	}
+	// Correct source succeeds.
+	ok := c.handleExecClaimMutation(ctx, claimData(t, ExecClaimRequest{
+		Key: key, Stage: "decomposing", ExpectedFromStage: "pending",
+	}))
+	if !ok.Success {
+		t.Fatalf("req claim from correct source rejected: %s", ok.Error)
+	}
+	got, _ := c.store.getReq(key)
+	if got.Stage != "decomposing" {
+		t.Errorf("req stage = %q, want decomposing", got.Stage)
+	}
+}

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -170,6 +170,11 @@ type Component struct {
 	running        bool
 	mu             sync.RWMutex
 	lifecycleMu    sync.Mutex
+	// claimMu serializes handleExecClaimMutation's get-check-save so a stage
+	// claim is atomic in-process: without it two interleaved claims can both
+	// read the same source stage and both save (last-writer-wins), double-
+	// dispatching a task/requirement (#157).
+	claimMu sync.Mutex
 
 	// Metrics
 	triggersProcessed   atomic.Int64

--- a/processor/execution-manager/mutations.go
+++ b/processor/execution-manager/mutations.go
@@ -187,6 +187,11 @@ type ReqNodeRequest struct {
 type ExecClaimRequest struct {
 	Key   string `json:"key"`   // KV key
 	Stage string `json:"stage"` // target in-progress stage
+	// ExpectedFromStage, when set, makes the claim a compare-and-swap on the
+	// stage: the handler rejects unless the entity is currently at this source
+	// stage. Empty preserves the legacy exact-duplicate-target check only
+	// (back-compat for callers that don't pin a source). See #157.
+	ExpectedFromStage string `json:"expected_from_stage,omitempty"`
 }
 
 // ExecMutationResponse is the reply to all execution mutation requests.
@@ -645,30 +650,59 @@ func (c *Component) handleExecClaimMutation(ctx context.Context, data []byte) Ex
 		return ExecMutationResponse{Success: false, Error: "key and phase required"}
 	}
 
+	// Serialize get-check-save so the claim is an atomic compare-and-swap on the
+	// stage (#157). Without this, two interleaved claims can both read the same
+	// source stage and both save (last-writer-wins), double-dispatching the
+	// entity. The lock is process-local; cross-process safety would need a KV
+	// ExpectedRevision CAS in saveTask/saveReq.
+	c.claimMu.Lock()
+	defer c.claimMu.Unlock()
+
 	// Try task first, then req
 	if exec, ok := c.store.getTask(req.Key); ok {
-		if exec.Stage == req.Stage {
-			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("already at stage %s", req.Stage)}
+		if resp, allowed := claimStageGuard(req, exec.Stage); !allowed {
+			return resp
 		}
 		exec.Stage = req.Stage
 		if err := c.store.saveTask(ctx, req.Key, exec); err != nil {
 			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 		}
-		c.logger.Info("Execution claimed via mutation", "key", req.Key, "phase", req.Stage)
+		c.logger.Info("Execution claimed via mutation", "key", req.Key, "phase", req.Stage, "from", req.ExpectedFromStage)
 		return ExecMutationResponse{Success: true}
 	}
 
 	if exec, ok := c.store.getReq(req.Key); ok {
-		if exec.Stage == req.Stage {
-			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("already at stage %s", req.Stage)}
+		if resp, allowed := claimStageGuard(req, exec.Stage); !allowed {
+			return resp
 		}
 		exec.Stage = req.Stage
 		if err := c.store.saveReq(ctx, req.Key, exec); err != nil {
 			return ExecMutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 		}
-		c.logger.Info("Execution claimed via mutation", "key", req.Key, "phase", req.Stage)
+		c.logger.Info("Execution claimed via mutation", "key", req.Key, "phase", req.Stage, "from", req.ExpectedFromStage)
 		return ExecMutationResponse{Success: true}
 	}
 
 	return ExecMutationResponse{Success: false, Error: fmt.Sprintf("execution not found: %s", req.Key)}
+}
+
+// claimStageGuard enforces the claim precondition against the entity's current
+// stage. When ExpectedFromStage is set it is a strict compare-and-swap source
+// check (reject unless the entity is at the expected source); otherwise it falls
+// back to the legacy "already at target" duplicate reject. Returns
+// (rejectResponse, false) on reject, (zero, true) on pass. See #157.
+func claimStageGuard(req ExecClaimRequest, current string) (ExecMutationResponse, bool) {
+	if req.ExpectedFromStage != "" && current != req.ExpectedFromStage {
+		return ExecMutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("claim rejected: expected source stage %q, found %q", req.ExpectedFromStage, current),
+		}, false
+	}
+	if current == req.Stage {
+		return ExecMutationResponse{
+			Success: false,
+			Error:   fmt.Sprintf("already at stage %s", req.Stage),
+		}, false
+	}
+	return ExecMutationResponse{}, true
 }

--- a/processor/execution-manager/task_watcher.go
+++ b/processor/execution-manager/task_watcher.go
@@ -68,8 +68,8 @@ func (c *Component) handleTaskPending(ctx context.Context, entry jetstream.KeyVa
 
 	key := entry.Key()
 
-	// Claim: pending → developing (atomic via mutation handler).
-	if !c.claimTaskExecution(ctx, key, phaseDeveloping) {
+	// Claim: pending → developing (atomic compare-and-swap via mutation handler).
+	if !c.claimTaskExecution(ctx, key, "pending", phaseDeveloping) {
 		return
 	}
 
@@ -201,9 +201,11 @@ func (c *Component) initTaskExecution(ctx context.Context, exec *taskExecution) 
 }
 
 // claimTaskExecution sends a claim mutation to this component's own mutation
-// handler. Returns true if the claim succeeded.
-func (c *Component) claimTaskExecution(ctx context.Context, key, stage string) bool {
-	data, err := json.Marshal(ExecClaimRequest{Key: key, Stage: stage})
+// handler. fromStage pins the expected source stage so the claim is a
+// compare-and-swap (#157); a concurrent or stale claim from a different stage is
+// rejected. Returns true if the claim succeeded.
+func (c *Component) claimTaskExecution(ctx context.Context, key, fromStage, toStage string) bool {
+	data, err := json.Marshal(ExecClaimRequest{Key: key, Stage: toStage, ExpectedFromStage: fromStage})
 	if err != nil {
 		return false
 	}

--- a/processor/requirement-executor/req_watcher.go
+++ b/processor/requirement-executor/req_watcher.go
@@ -82,8 +82,8 @@ func (c *Component) handleReqPending(ctx context.Context, entry jetstream.KeyVal
 
 	key := entry.Key()
 
-	// Claim: pending → decomposing (atomic via execution-manager mutation).
-	if !c.claimExecution(ctx, key, phaseDecomposing) {
+	// Claim: pending → decomposing (atomic compare-and-swap via execution-manager mutation).
+	if !c.claimExecution(ctx, key, "pending", phaseDecomposing) {
 		return
 	}
 
@@ -238,15 +238,18 @@ func (c *Component) initReqExecution(ctx context.Context, exec *requirementExecu
 	c.dispatchSynthesizerLocked(ctx, exec)
 }
 
-// claimExecution sends a claim mutation to execution-manager. Returns true if
-// the claim succeeded (this instance owns the entry).
-func (c *Component) claimExecution(ctx context.Context, key, stage string) bool {
+// claimExecution sends a claim mutation to execution-manager. fromStage pins the
+// expected source stage so the claim is a compare-and-swap (#157): a concurrent
+// or stale claim from a different stage is rejected. Returns true if the claim
+// succeeded (this instance owns the entry).
+func (c *Component) claimExecution(ctx context.Context, key, fromStage, toStage string) bool {
 	resp, err := c.sendMutation(ctx, mutExecClaim, map[string]any{
-		"key":   key,
-		"stage": stage,
+		"key":                 key,
+		"stage":               toStage,
+		"expected_from_stage": fromStage,
 	})
 	if err != nil {
-		c.logger.Debug("Claim execution failed", "key", key, "stage", stage, "error", err)
+		c.logger.Debug("Claim execution failed", "key", key, "from", fromStage, "stage", toStage, "error", err)
 		return false
 	}
 	return resp.Success


### PR DESCRIPTION
## What

`handleExecClaimMutation` was a get-copy-mutate-save with **no source-stage precondition** and **no atomicity** — its only guard rejected a claim whose target equaled the current stage. So:
- two interleaved claims could both read the same source stage and both save (last-writer-wins), **double-dispatching** a task/requirement; and
- a claim from an **unexpected source stage** was accepted (no CAS).

## Fix

- `ExecClaimRequest` gains `ExpectedFromStage`: when set, the handler rejects unless the entity is currently at that source stage (a stage compare-and-swap). Empty preserves the legacy exact-duplicate-target check (back-compat).
- A `claimMu` serializes the get-check-save so the claim is atomic in-process. (Cross-process safety would need a KV `ExpectedRevision` CAS in `saveTask`/`saveReq` — noted in the handler.)
- Both callers pin the source stage they already gate on: exec-manager `claimTaskExecution` (`pending → developing`) and requirement-executor `claimExecution` (`pending → decomposing`).

## Tests (`claim_mutation_test.go`)

- Wrong-source claim rejected (task **and** req branches); correct source succeeds.
- Legacy claim without `ExpectedFromStage` still works and rejects a duplicate.
- **50-round concurrent same-source race** asserting exactly one winner per round — **verified to fail deterministically when the mutex is removed** (round 2/10 → 2 winners), so it's a real regression guard, not a flaky one.
- `-race` clean.

## Verification

`go build` + `go vet` + `revive` clean; `go test ./...` = 72 packages, 0 failures (touched packages also run under `-race`).

Fixes #157. Found by the e2e-flow deterministic-test audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)