### PR TITLE
fix(recovery): guard malformed RecoveryID slice + typed-nil trajectory client (#31, #32)

### DIFF
--- a/internal/trajectory/trajectory.go
+++ b/internal/trajectory/trajectory.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 	"time"
 
@@ -90,6 +91,23 @@ type Requester interface {
 	Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
 }
 
+// isNilRequester reports whether client is unusable: nil at the interface level,
+// OR a typed-nil pointer/interface wrapped in the interface. A concrete
+// (*Client)(nil) passes a plain `client == nil` check (the interface holds a
+// type) but panics on first method call — every call site otherwise has to do
+// its own typed-nil dance (#32).
+func isNilRequester(client Requester) bool {
+	if client == nil {
+		return true
+	}
+	switch v := reflect.ValueOf(client); v.Kind() {
+	case reflect.Pointer, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
 // ErrNotFound is returned when the agentic-loop responder reports that no
 // trajectory exists for the requested loop ID. Callers should treat this as
 // terminal for that loop — retrying will not help.
@@ -104,7 +122,7 @@ var ErrNotFound = fmt.Errorf("trajectory not found")
 // error, so callers can distinguish "missing" from "transport failure" and
 // avoid retrying for ever.
 func Fetch(ctx context.Context, client Requester, loopID string, limit int) (*agentic.Trajectory, error) {
-	if client == nil {
+	if isNilRequester(client) {
 		return nil, fmt.Errorf("nats client required")
 	}
 	if loopID == "" {

--- a/internal/trajectory/trajectory_test.go
+++ b/internal/trajectory/trajectory_test.go
@@ -275,3 +275,25 @@ func TestLogSummary_NilLogger(t *testing.T) {
 		t.Errorf("expected no NATS request when logger nil, got subject %q", stub.gotSubject)
 	}
 }
+
+func TestFetch_TypedNilRequester(t *testing.T) {
+	// A typed-nil pointer satisfies the Requester interface but is unusable:
+	// `client == nil` is false (the interface holds a *stubRequester type), yet
+	// calling Request would dereference a nil pointer and panic. Fetch must
+	// reject it cleanly rather than relying on every call site to guard (#32).
+	var typedNil *stubRequester // nil pointer of a concrete Requester impl
+	_, err := Fetch(context.Background(), typedNil, "loop-x", 0)
+	if err == nil {
+		t.Fatal("Fetch with a typed-nil Requester returned nil error; want 'nats client required'")
+	}
+	if !strings.Contains(err.Error(), "nats client required") {
+		t.Errorf("error = %q, want it to mention 'nats client required'", err.Error())
+	}
+}
+
+func TestFetch_InterfaceNilRequester(t *testing.T) {
+	_, err := Fetch(context.Background(), nil, "loop-x", 0)
+	if err == nil || !strings.Contains(err.Error(), "nats client required") {
+		t.Fatalf("Fetch(nil) err = %v, want 'nats client required'", err)
+	}
+}

--- a/processor/recovery-agent/component.go
+++ b/processor/recovery-agent/component.go
@@ -799,7 +799,7 @@ func buildRecoveryPlanDecision(req *payloads.RecoveryRequested, loop *agentic.Lo
 		affectedReqs = []string{req.RequirementID}
 	}
 
-	decisionID := fmt.Sprintf("plan-decision.%s.recovery.%s", req.Slug, req.RecoveryID[:8])
+	decisionID := fmt.Sprintf("plan-decision.%s.recovery.%s", req.Slug, shortRecoveryID(req.RecoveryID))
 
 	// Story IDs are passed through unconditionally. They're only
 	// load-bearing when Kind=story_reprepare (cascade + applyRecoveryHint
@@ -833,6 +833,18 @@ func buildRecoveryPlanDecision(req *payloads.RecoveryRequested, loop *agentic.Lo
 		ContractImpact:   impact,
 		CreatedAt:        now,
 	}
+}
+
+// shortRecoveryID returns the first 8 chars of a recovery ID for the decision-ID
+// suffix, or the whole ID when it is shorter. Guards the slice against a
+// malformed (short) RecoveryID arriving on the recovery.requested.<slug>
+// boundary — payload Validate only checks non-empty, so a 1-7 char ID would
+// panic on a raw [:8] slice (#31).
+func shortRecoveryID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 func recoveryContractImpact(action payloads.RecoveryActionKind, diagnosis string, provided *workflow.ContractImpact, affectedIDs []string) *workflow.ContractImpact {

--- a/processor/recovery-agent/plan_decision_build_test.go
+++ b/processor/recovery-agent/plan_decision_build_test.go
@@ -1,12 +1,43 @@
 package recoveryagent
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 )
+
+// TestBuildRecoveryPlanDecision_ShortRecoveryIDNoPanic guards #31: the payload's
+// Validate only checks RecoveryID is non-empty, so a 1-7 char ID can arrive on
+// the recovery.requested.<slug> boundary. The decision-ID suffix used a raw
+// RecoveryID[:8] slice, which panics for a short ID. shortRecoveryID must
+// truncate safely and the build must produce a well-formed ID.
+func TestBuildRecoveryPlanDecision_ShortRecoveryIDNoPanic(t *testing.T) {
+	for _, id := range []string{"", "a", "abc", "1234567", "12345678", "123456789abc"} {
+		req := &payloads.RecoveryRequested{
+			RecoveryID:       id,
+			Slug:             "short-recovery",
+			Layer:            payloads.RecoveryLayerPhaseLocal,
+			EscalationReason: "test",
+			RequirementID:    "req-1",
+		}
+		dec := buildRecoveryPlanDecision(req, nil, payloads.RecoveryActionRefinePrompt, "diag", true, nil, time.Now())
+		if !strings.HasPrefix(dec.ID, "plan-decision.short-recovery.recovery.") {
+			t.Errorf("RecoveryID=%q: decision ID = %q, malformed", id, dec.ID)
+		}
+	}
+}
+
+func TestShortRecoveryID(t *testing.T) {
+	cases := map[string]string{"": "", "abc": "abc", "12345678": "12345678", "123456789": "12345678"}
+	for in, want := range cases {
+		if got := shortRecoveryID(in); got != want {
+			t.Errorf("shortRecoveryID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
 
 // TestBuildRecoveryPlanDecision_PrefersAffectedRequirementIDsOverSingleID is
 // the autonomy contract from the recovery-agent side: when plan-manager


### PR DESCRIPTION
Two small defensive guards found by the e2e-flow audit (the N-backlog).

## #31 — `RecoveryID[:8]` panic on a short ID
`buildRecoveryPlanDecision` built the decision-ID suffix from a raw `RecoveryID[:8]` slice, which panics when the ID is 1–7 chars. The payload's `Validate` only checks non-empty, so a short ID can arrive on the `recovery.requested.<slug>` boundary. New `shortRecoveryID` truncates safely.

## #32 — typed-nil `Requester` panics past the nil check
`trajectory.Fetch`'s `client == nil` only catches an interface-nil client; a typed-nil `(*Client)(nil)` wrapped in the `Requester` interface passes it and then panics on the first method call — forcing every call site to do its own typed-nil dance. New `isNilRequester` adds a reflective typed-nil guard.

## Tests
- short/empty `RecoveryID` build produces a well-formed decision ID (no panic) + `shortRecoveryID` table.
- `Fetch` rejects both interface-nil and typed-nil `Requester`s with the existing `"nats client required"` error.
- `go build` + `revive` clean; package tests pass.

Closes #31, closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)