### PR TITLE
fix(plan-manager): drop orphan scenarios on Story re-emission (#80)

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -423,6 +423,16 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 	}
 
 	plan.Stories = storiesToSave
+	// #80: a full Story replacement (e.g. Sarah re-emitting with different Story
+	// IDs on a story_reprepare) orphans scenarios pinned to the now-removed Story
+	// IDs — they bloat the plan KV blob and misreport plan.Scenarios counts. Drop
+	// scenarios whose StoryID is no longer present; preserve empty-StoryID (legacy
+	// / pre-per-Story) scenarios. The scoped architecture-revision branch above
+	// already curates scenarios and intentionally preserves unrelated ones, so it
+	// is skipped here.
+	if plan.PendingArchitectureRevision == nil {
+		plan.Scenarios = dropOrphanScenarios(plan.Scenarios, plan.Stories)
+	}
 	plan.Status = workflow.StatusStoriesGenerated
 
 	// ADR-043 follow-up — auto-derive plan.Scope.Create from the union of
@@ -448,6 +458,34 @@ func (c *Component) handleStoriesMutation(ctx context.Context, data []byte) Muta
 		"scope_create_count", len(plan.Scope.Create))
 
 	return MutationResponse{Success: true}
+}
+
+// dropOrphanScenarios removes scenarios whose StoryID is set but no longer
+// present in stories, preserving empty-StoryID (legacy / pre-per-Story)
+// scenarios. Guards #80: a Story re-emission with new IDs must not leave
+// scenarios pinned to dead Story IDs. Returns a fresh slice so it never aliases
+// the cached plan's backing array (cf. #223 cached-plan isolation).
+func dropOrphanScenarios(scenarios []workflow.Scenario, stories []workflow.Story) []workflow.Scenario {
+	if len(scenarios) == 0 {
+		return scenarios
+	}
+	valid := make(map[string]struct{}, len(stories))
+	for _, s := range stories {
+		if s.ID != "" {
+			valid[s.ID] = struct{}{}
+		}
+	}
+	kept := make([]workflow.Scenario, 0, len(scenarios))
+	for _, sc := range scenarios {
+		if sc.StoryID == "" {
+			kept = append(kept, sc) // legacy scenario predating the per-Story chain
+			continue
+		}
+		if _, ok := valid[sc.StoryID]; ok {
+			kept = append(kept, sc)
+		}
+	}
+	return kept
 }
 
 func mergeStoriesForScopedArchitectureRevision(plan *workflow.Plan, emitted []workflow.Story) ([]workflow.Story, []string, int, error) {

--- a/processor/plan-manager/orphan_scenario_test.go
+++ b/processor/plan-manager/orphan_scenario_test.go
@@ -1,0 +1,87 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestDropOrphanScenarios pins the pure filter behind #80: scenarios whose
+// StoryID is no longer in the Story set are dropped; empty-StoryID legacy
+// scenarios are always preserved.
+func TestDropOrphanScenarios(t *testing.T) {
+	stories := []workflow.Story{{ID: "C"}, {ID: "D"}}
+	scenarios := []workflow.Scenario{
+		{ID: "s1", StoryID: "A"}, // orphan — old story
+		{ID: "s2", StoryID: "C"}, // valid — current story
+		{ID: "s3", StoryID: ""},  // legacy — preserved
+		{ID: "s4", StoryID: "B"}, // orphan — old story
+	}
+	got := dropOrphanScenarios(scenarios, stories)
+
+	gotIDs := map[string]bool{}
+	for _, s := range got {
+		gotIDs[s.ID] = true
+	}
+	if len(got) != 2 || !gotIDs["s2"] || !gotIDs["s3"] {
+		t.Fatalf("dropOrphanScenarios kept %v, want [s2 (valid), s3 (legacy)]", gotIDs)
+	}
+	if gotIDs["s1"] || gotIDs["s4"] {
+		t.Errorf("orphan scenarios pinned to removed stories were not dropped: %v", gotIDs)
+	}
+
+	// Empty input is returned untouched.
+	if out := dropOrphanScenarios(nil, stories); len(out) != 0 {
+		t.Errorf("dropOrphanScenarios(nil) = %v, want empty", out)
+	}
+}
+
+// TestHandleStoriesMutation_DropsOrphanScenarios proves the filter is WIRED into
+// the full-replace path: when Sarah re-emits Stories with new IDs, scenarios
+// pinned to the old Story IDs are dropped while a legacy empty-StoryID scenario
+// survives (#80).
+func TestHandleStoriesMutation_DropsOrphanScenarios(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	plan := setupTestPlan(t, c, "orphan-scen")
+	plan.Status = workflow.StatusPreparingStories
+	// Prior Story shape A/B with scenarios, plus a legacy empty-StoryID scenario.
+	plan.Stories = []workflow.Story{{ID: "story.orphan-scen.old.A"}, {ID: "story.orphan-scen.old.B"}}
+	plan.Scenarios = []workflow.Scenario{
+		{ID: "scen.A", StoryID: "story.orphan-scen.old.A", RequirementID: "req.orphan-scen.1"},
+		{ID: "scen.B", StoryID: "story.orphan-scen.old.B", RequirementID: "req.orphan-scen.1"},
+		{ID: "scen.legacy", StoryID: "", RequirementID: "req.orphan-scen.1"},
+	}
+	_ = c.plans.save(ctx, plan)
+
+	// Sarah re-emits a fresh Story set with DIFFERENT IDs.
+	req := storiesMutationRequest{
+		Slug:       "orphan-scen",
+		Stories:    []workflow.Story{validStory("story.orphan-scen.1.1", "req.orphan-scen.1", "Implement core")},
+		StoryCount: 1,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if resp := c.handleStoriesMutation(ctx, data); !resp.Success {
+		t.Fatalf("handleStoriesMutation failed: %s", resp.Error)
+	}
+
+	got, ok := c.plans.get("orphan-scen")
+	if !ok {
+		t.Fatal("plan not found after mutation")
+	}
+	ids := map[string]bool{}
+	for _, s := range got.Scenarios {
+		ids[s.ID] = true
+	}
+	if ids["scen.A"] || ids["scen.B"] {
+		t.Errorf("orphan scenarios (old Story IDs) survived the Story replacement: %v", ids)
+	}
+	if !ids["scen.legacy"] {
+		t.Errorf("legacy empty-StoryID scenario was wrongly dropped: %v", ids)
+	}
+}


### PR DESCRIPTION
`handleStoriesMutation`'s full-replace path (`plan.Stories = req.Stories`) left `plan.Scenarios` untouched, so when Sarah re-emits Stories with different IDs (a `story_reprepare` cycle) scenarios pinned to the old Story IDs become orphans — bloating the plan KV blob and misreporting `plan.Scenarios` counts in observability, trace bundles, and sponsor packs.

## Fix
Filter at the replace site via `dropOrphanScenarios`, which drops scenarios whose `StoryID` is no longer present and **preserves empty-StoryID (legacy) scenarios**. The scoped architecture-revision branch already curates scenarios (and intentionally preserves unrelated ones), so it's skipped. Returns a fresh slice to avoid aliasing the cached plan's backing array (cf. #223).

## Tests
- `dropOrphanScenarios` pure filter (valid kept, orphans dropped, legacy preserved, empty input untouched).
- `handleStoriesMutation` integration: re-emitting with new Story IDs drops the old-Story-ID scenarios and keeps the legacy one.
- `go build` + `revive` clean; `go test ./processor/plan-manager` green.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)