### PR TITLE
fix(recovery): carry Story IDs on escalation + pin node-results reset producers (#81, #82)

### DIFF
--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -1349,6 +1349,18 @@ func (c *Component) markEscalatedLocked(ctx context.Context, exec *taskExecution
 		trajectory.LogSummary(ctx, c.logger, c.natsClient, exec.DeveloperLoopID, "tdd-escalated", 0)
 	}
 
+	// Resolve the parent requirement's Story IDs so the recovery-agent can
+	// target a story_reprepare (it copies these into PlanDecision.AffectedStoryIDs
+	// for the cascade). The task exec does not carry them — they live on the
+	// requirement execution — so load it from EXECUTION_STATES by reqID. Without
+	// this the wedge degrades to a scenarios-only requirement_change and the
+	// Story shape is never re-prepared (#81). Best-effort: a cache/KV miss just
+	// leaves the field empty (the prior behaviour).
+	var affectedStoryIDs []string
+	if reqExec, ok := c.store.getReq(workflow.RequirementExecutionKey(exec.Slug, exec.RequirementID)); ok {
+		affectedStoryIDs = reqExec.SortedStoryIDs
+	}
+
 	c.emitRecoveryRequested(ctx, &payloads.RecoveryRequested{
 		RecoveryID:          uuid.New().String(),
 		Layer:               payloads.RecoveryLayerPhaseLocal,
@@ -1359,6 +1371,7 @@ func (c *Component) markEscalatedLocked(ctx context.Context, exec *taskExecution
 		EscalationReason:    reason,
 		LastFailureFeedback: exec.Feedback,
 		TraceID:             exec.TraceID,
+		AffectedStoryIDs:    affectedStoryIDs,
 	})
 
 	// Notify callers that the TDD pipeline escalated (treated as failure).

--- a/processor/execution-manager/recovery_publish_test.go
+++ b/processor/execution-manager/recovery_publish_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 )
 
@@ -74,5 +75,75 @@ func TestMarkEscalatedLocked_FiresRecoveryRequested(t *testing.T) {
 	}
 	if r.RecoveryID == "" {
 		t.Error("RecoveryID should be populated with a fresh UUID")
+	}
+}
+
+// TestMarkEscalatedLocked_CarriesAffectedStoryIDs pins #81: the task-level
+// escalation must resolve the parent requirement's Story IDs and carry them on
+// RecoveryRequested.AffectedStoryIDs, so the recovery-agent can propose a
+// story_reprepare (it copies these into PlanDecision.AffectedStoryIDs). The task
+// exec does not hold them — they live on the requirement execution — so the
+// handler loads it from the store by reqID. Without this the wedge silently
+// degrades to a scenarios-only requirement_change.
+func TestMarkEscalatedLocked_CarriesAffectedStoryIDs(t *testing.T) {
+	c := newTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	exec := newTestExec("affected-stories-slug", "task-as")
+	exec.RequirementID = "req-as-1"
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	// Seed the parent requirement execution carrying the Story IDs.
+	reqKey := workflow.RequirementExecutionKey("affected-stories-slug", "req-as-1")
+	if err := c.store.saveReq(testCtx(t), reqKey, &workflow.RequirementExecution{
+		Slug:           "affected-stories-slug",
+		RequirementID:  "req-as-1",
+		SortedStoryIDs: []string{"story.as.1", "story.as.2"},
+	}); err != nil {
+		t.Fatalf("seed req exec: %v", err)
+	}
+
+	exec.mu.Lock()
+	c.markEscalatedLocked(testCtx(t), exec, "tdd budget exhausted")
+	exec.mu.Unlock()
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("want 1 RecoveryRequested, got %d", len(got))
+	}
+	want := []string{"story.as.1", "story.as.2"}
+	if len(got[0].AffectedStoryIDs) != len(want) {
+		t.Fatalf("AffectedStoryIDs = %v, want %v (#81)", got[0].AffectedStoryIDs, want)
+	}
+	for i, id := range want {
+		if got[0].AffectedStoryIDs[i] != id {
+			t.Errorf("AffectedStoryIDs[%d] = %q, want %q", i, got[0].AffectedStoryIDs[i], id)
+		}
+	}
+}
+
+// TestMarkEscalatedLocked_NoParentReqExecLeavesAffectedStoryIDsEmpty confirms the
+// resolution is best-effort: a missing parent requirement execution leaves the
+// field empty rather than failing the escalation (the prior behaviour).
+func TestMarkEscalatedLocked_NoParentReqExecLeavesAffectedStoryIDsEmpty(t *testing.T) {
+	c := newTestComponent(t)
+	publisher, fetch := captureRecoveryPublisher()
+	c.recoveryPublisher = publisher
+
+	exec := newTestExec("no-parent-slug", "task-np")
+	exec.RequirementID = "req-np-1"
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	exec.mu.Lock()
+	c.markEscalatedLocked(testCtx(t), exec, "tdd budget exhausted")
+	exec.mu.Unlock()
+
+	got := fetch()
+	if len(got) != 1 {
+		t.Fatalf("want 1 RecoveryRequested, got %d", len(got))
+	}
+	if len(got[0].AffectedStoryIDs) != 0 {
+		t.Errorf("AffectedStoryIDs = %v, want empty when no parent req exec is stored", got[0].AffectedStoryIDs)
 	}
 }

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -155,6 +155,13 @@ type Component struct {
 	// CanTransitionTo so the full walk chain is exercisable without NATS.
 	storyStatusClaimer storyStatusClaimerFunc
 
+	// nodeResultsSender is the seam for the NodeResults reset/replace mutation
+	// fired by the recovery-resume and restructure/fixable retry paths. Defaults
+	// to sendReqReplaceNodeResults (nil natsClient short-circuits); tests install
+	// a capturing stub so the PRODUCER call sites can be pinned — a refactor that
+	// drops the call would otherwise pass every handler-side test (#82).
+	nodeResultsSender func(ctx context.Context, key string, results []workflow.NodeResult) error
+
 	// Story-gate (Murat) review knowledge — symmetric with the per-task
 	// reviewer in execution-manager so the requirement-level gate sees the
 	// same project standards + team lessons rather than judging in isolation.
@@ -247,6 +254,9 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 			return workflow.ClaimStoryStatus(ctx, nc, slug, storyID, target, logger)
 		},
 	}
+	// Default the node-results seam to the real NATS round-trip; tests override
+	// it to capture the producer call sites (#82).
+	c.nodeResultsSender = c.sendReqReplaceNodeResults
 	c.initReviewKnowledge()
 
 	for _, p := range cfg.Ports.Inputs {
@@ -2141,7 +2151,7 @@ func (c *Component) startFixableRetryLocked(ctx context.Context, exec *requireme
 	// Mirror the NodeResults trim to KV — it is append-only via
 	// handleReqNodeMutation, so without this stale current-Story entries
 	// reappear on the next restart via rebuildExecFromKV. Best-effort.
-	if err := c.sendReqReplaceNodeResults(ctx, exec.storeKey, workflowNodeResults(exec.NodeResults)); err != nil {
+	if err := c.nodeResultsSender(ctx, exec.storeKey, workflowNodeResults(exec.NodeResults)); err != nil {
 		c.logger.Warn("Failed to trim KV NodeResults on fixable retry",
 			"entity_id", exec.EntityID, "error", err)
 	}

--- a/processor/requirement-executor/exec_mutations.go
+++ b/processor/requirement-executor/exec_mutations.go
@@ -67,9 +67,10 @@ func (c *Component) sendReqReplaceNodeResults(ctx context.Context, key string, r
 }
 
 // sendReqResetNodeResults wipes the NodeResults slice on the existing
-// requirement execution KV entry.
+// requirement execution KV entry. Routes through the nodeResultsSender seam so
+// tests can pin the producer call sites (#82).
 func (c *Component) sendReqResetNodeResults(ctx context.Context, key string) error {
-	return c.sendReqReplaceNodeResults(ctx, key, nil)
+	return c.nodeResultsSender(ctx, key, nil)
 }
 
 // sendReqReset asks execution-manager to DELETE a requirement execution KV

--- a/processor/requirement-executor/node_results_seam_test.go
+++ b/processor/requirement-executor/node_results_seam_test.go
@@ -1,0 +1,95 @@
+package requirementexecutor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// These tests pin #82: the recovery-resume and restructure retry paths must
+// actually FIRE the node-results reset mutation. The handler side is already
+// tested; without a producer-side pin a refactor that drops the call (or moves
+// it past an early return) would silently resurrect stale NodeResults on the
+// next rebuild and pass every existing test. The nodeResultsSender seam lets us
+// observe the call without a live NATS round-trip.
+
+type capturedNodeResults struct {
+	key     string
+	results []workflow.NodeResult
+}
+
+func installCapturingNodeResultsSender(c *Component) *[]capturedNodeResults {
+	calls := &[]capturedNodeResults{}
+	c.nodeResultsSender = func(_ context.Context, key string, results []workflow.NodeResult) error {
+		*calls = append(*calls, capturedNodeResults{key: key, results: results})
+		return nil
+	}
+	return calls
+}
+
+func firedResetFor(calls []capturedNodeResults, key string) bool {
+	for _, c := range calls {
+		if c.key == key && len(c.results) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func TestResumeFromRecoveryLocked_FiresNodeResultsResetSeam(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	calls := installCapturingNodeResultsSender(c)
+	exec := newAwaitingExec("plan-nr", "req-nr")
+	c.activeExecs.Set(exec.EntityID, exec)
+
+	exec.mu.Lock()
+	_ = c.deferToAwaitingRecoveryLocked(context.Background(), exec, "reason")
+	c.resumeFromRecoveryLocked(context.Background(), exec)
+	exec.mu.Unlock()
+
+	if !firedResetFor(*calls, exec.storeKey) {
+		t.Errorf("resumeFromRecoveryLocked did not fire the node-results reset seam with empty results for %q; calls=%+v",
+			exec.storeKey, *calls)
+	}
+}
+
+func TestStartRestructureRetryLocked_FiresNodeResultsResetSeam(t *testing.T) {
+	c := newTestComponent(t)
+	c.sandbox = &stubSandbox{}
+	calls := installCapturingNodeResultsSender(c)
+
+	exec := &requirementExecution{
+		EntityID:          workflow.EntityPrefix() + ".exec.req.run.nr-restructure",
+		Slug:              "plan-nr",
+		RequirementID:     "req-restructure",
+		storeKey:          workflow.RequirementExecutionKey("plan-nr", "req-restructure"),
+		RequirementBranch: "semspec/requirement-req-restructure",
+		RetryCount:        0,
+		MaxRetries:        3,
+		CurrentNodeIdx:    1,
+		DAG:               &TaskDAG{},
+		SortedNodeIDs:     []string{"node-0", "node-1"},
+	}
+	c.activeExecs.Set(exec.EntityID, exec) //nolint:errcheck
+
+	event := &agentic.LoopCompletedEvent{
+		LoopID:       "loop-restructure-nr",
+		TaskID:       "task-restructure-nr",
+		WorkflowSlug: WorkflowSlugRequirementExecution,
+		WorkflowStep: stageRequirementReview,
+		Outcome:      agentic.OutcomeSuccess,
+		Result:       `{"verdict":"rejected","rejection_type":"restructure","feedback":"redo"}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	if !firedResetFor(*calls, exec.storeKey) {
+		t.Errorf("startRestructureRetryLocked did not fire the node-results reset seam with empty results for %q; calls=%+v",
+			exec.storeKey, *calls)
+	}
+}


### PR DESCRIPTION
The recovery-seam pair from the N-backlog.

## #81 — escalation drops the Story IDs
`markEscalatedLocked` emitted `RecoveryRequested` without `AffectedStoryIDs`, so the recovery-agent couldn't propose a `story_reprepare` (it copies these into `PlanDecision.AffectedStoryIDs` for the cascade) — the wedge degraded to a scenarios-only `requirement_change` and the Story shape was never re-prepared. The task exec doesn't carry the Story IDs (they live on the requirement execution), so the handler resolves them from `EXECUTION_STATES` by reqID. Best-effort: a miss leaves the field empty (prior behaviour).

## #82 — producer call sites unpinned
The recovery-resume and restructure/fixable retry paths fire a NodeResults reset/replace mutation, but only the **handler** side was tested. A refactor that dropped the **producer** call would silently resurrect stale NodeResults on the next rebuild and pass every test. The calls now route through a `nodeResultsSender` seam (mirrors the existing `storyStatusClaimer` pattern) so the producer sites are pinnable.

## Tests
- `markEscalatedLocked` carries the parent requirement's `SortedStoryIDs`; missing parent → empty (best-effort).
- `resumeFromRecoveryLocked` and `startRestructureRetryLocked` fire the node-results reset seam with empty results — **negative-control-verified to fail** when the producer call is removed.
- `go build` + `go vet` + `revive` clean; both packages' tests pass.

Closes #81, closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)