### PR TITLE
test(scenario-orchestrator): pin idempotent-dispatch routing (#180); #175 already covered

### DIFF
--- a/processor/scenario-orchestrator/component.go
+++ b/processor/scenario-orchestrator/component.go
@@ -466,25 +466,30 @@ func (c *Component) dispatchRequirement(
 			"requirement_id", req.ID, "error", err)
 		return err
 	}
-	if err := c.triggerRequirementExecution(ctx, trigger.PlanSlug, trigger.TraceID, trigger.PlanBranch, base, req, scenarios, prereqs, force); err != nil {
-		// A "req execution already exists" rejection is a benign idempotency
-		// outcome, not a failure (issue #180): when plan-manager re-fires the
-		// orchestrator on a completion AND the DAG gate independently re-dispatches
-		// a now-ready requirement, both paths race to req.create and the executor's
-		// dedup correctly rejects the loser. The requirement got exactly one
-		// execution. Treat it as success — Debug-log and return nil — so the
-		// orchestrate cycle ACKs (no Error-level noise, and no NAK→redelivery churn
-		// that would re-run the whole cycle and re-log on every redelivery).
-		if isIdempotentReqRejection(err) {
-			c.logger.Debug("requirement already dispatched (idempotent re-fire), skipping",
-				"requirement_id", req.ID, "detail", err)
-			return nil
-		}
-		c.logger.Error("failed to trigger requirement execution",
-			"requirement_id", req.ID, "error", err)
-		return err
+	err = c.triggerRequirementExecution(ctx, trigger.PlanSlug, trigger.TraceID, trigger.PlanBranch, base, req, scenarios, prereqs, force)
+	return c.routeDispatchError(req.ID, err)
+}
+
+// routeDispatchError classifies a triggerRequirementExecution error (#180). A
+// benign "already exists" idempotency rejection — when plan-manager re-fires the
+// orchestrator on a completion AND the DAG gate independently re-dispatches a
+// now-ready requirement, both race to req.create and the executor's dedup rejects
+// the loser — is Debug-logged and SWALLOWED (return nil) so the orchestrate cycle
+// ACKs: no Error-level noise, and no NAK→redelivery churn that would re-run the
+// whole cycle and re-log on every redelivery. Any other error is Error-logged and
+// propagated; nil passes through.
+func (c *Component) routeDispatchError(reqID string, err error) error {
+	if err == nil {
+		return nil
 	}
-	return nil
+	if isIdempotentReqRejection(err) {
+		c.logger.Debug("requirement already dispatched (idempotent re-fire), skipping",
+			"requirement_id", reqID, "detail", err)
+		return nil
+	}
+	c.logger.Error("failed to trigger requirement execution",
+		"requirement_id", reqID, "error", err)
+	return err
 }
 
 // isIdempotentReqRejection reports whether a dispatch error is the benign

--- a/processor/scenario-orchestrator/component_test.go
+++ b/processor/scenario-orchestrator/component_test.go
@@ -1,9 +1,12 @@
 package scenarioorchestrator
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -796,4 +799,51 @@ func TestIsIdempotentReqRejection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRouteDispatchError pins the #180 ROUTING (the classifier above is tested
+// separately): a benign idempotency rejection must be swallowed (return nil) and
+// logged at DEBUG — not ERROR, which on a JetStream consumer turns into
+// NAK→redelivery churn that re-runs the whole orchestrate cycle. A genuine error
+// must propagate and log at ERROR.
+func TestRouteDispatchError(t *testing.T) {
+	newComp := func() (*Component, *bytes.Buffer) {
+		c := newTestComponent(t)
+		buf := &bytes.Buffer{}
+		c.logger = slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		return c, buf
+	}
+
+	t.Run("idempotent rejection swallowed and logged DEBUG not ERROR", func(t *testing.T) {
+		c, buf := newComp()
+		err := c.routeDispatchError("req.1", fmt.Errorf("req.create rejected: req execution already exists: k"))
+		if err != nil {
+			t.Errorf("idempotent rejection should return nil, got %v", err)
+		}
+		out := buf.String()
+		if strings.Contains(out, `"level":"ERROR"`) {
+			t.Errorf("idempotent rejection must NOT log ERROR (NAK/redelivery churn); got %s", out)
+		}
+		if !strings.Contains(out, `"level":"DEBUG"`) {
+			t.Errorf("idempotent rejection should log DEBUG; got %s", out)
+		}
+	})
+
+	t.Run("genuine error propagated and logged ERROR", func(t *testing.T) {
+		c, buf := newComp()
+		err := c.routeDispatchError("req.2", fmt.Errorf("req.create mutation failed: context deadline exceeded"))
+		if err == nil {
+			t.Fatal("genuine dispatch error should propagate, got nil")
+		}
+		if !strings.Contains(buf.String(), `"level":"ERROR"`) {
+			t.Errorf("genuine error should log ERROR; got %s", buf.String())
+		}
+	})
+
+	t.Run("nil passes through", func(t *testing.T) {
+		c, _ := newComp()
+		if err := c.routeDispatchError("req.3", nil); err != nil {
+			t.Errorf("nil error should return nil, got %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## #180 — idempotent-dispatch routing
`isIdempotentReqRejection` (the classifier) was already tested, but the **routing** that acts on it was not. Extracted the routing from `dispatchRequirement` into `routeDispatchError` and pinned it:
- benign `"already exists"` idempotency rejection (re-fire ↔ DAG-gate race) → **swallowed (nil) + DEBUG** — *not* ERROR, which on a JetStream consumer becomes NAK→redelivery churn that re-runs the whole orchestrate cycle and re-logs on every redelivery;
- genuine error → propagated + ERROR; nil → nil.

Behaviour is unchanged (pure extraction). The test uses a buffer logger to assert DEBUG-not-ERROR on idempotent and ERROR on genuine — guarding a future branch swap. Closes #180.

## #175 — already covered (recommend closing)
#175's acceptance (DeriveStoryScheduling serializes two stories that co-own a shared deliverable doc, rather than scheduling them in parallel) is **already met** by `TestDeriveStoryScheduling_SharedDeliverableDocSerializes` — two components both owning `README.md` produce `s2.DependsOn=[s1]`. (`Pass2_DifferentComponentSerialize` and `SameComponentSharedDocRejected` cover the adjacent cases.) No code is needed; recommend closing #175.

## Verification
`go build` + `revive` clean; `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)