### PR TITLE
test(schema-parity): extend submit_work schema↔struct parity to exploration/requirements/scenarios/plan (#137)

### DIFF
--- a/processor/requirement-generator/requirement_schema_parity_test.go
+++ b/processor/requirement-generator/requirement_schema_parity_test.go
@@ -1,0 +1,102 @@
+package requirementgenerator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/terminal"
+)
+
+// TestRequirementSchemaStructParity guards the schema↔struct drift class
+// (#125/#126, #137) for the requirement-generator wire shape. The model's
+// submit_work payload for the "requirements" deliverable is parsed into the
+// UNEXPORTED requirementItem struct (parseRequirementsFromResult). A field that
+// exists in the submit_work schema but not the struct means the model emits a
+// value nothing unmarshals; a field in the struct but not the schema means the
+// model physically cannot emit a field a downstream validator may require — the
+// unwinnable loop this class pins.
+//
+// This test lives in the requirement-generator package (not tools/terminal,
+// where the architecture/exploration parity guards live) because requirementItem
+// is unexported. tools/terminal exposes SchemaForDeliverable so the canonical
+// wire schema is the single source of truth.
+func TestRequirementSchemaStructParity(t *testing.T) {
+	props := arrayItemProps(t, terminal.SchemaForDeliverable("requirements"), "requirements")
+	assertWireSchemaStructParity(t, "requirementItem", reflect.TypeOf(requirementItem{}), props)
+}
+
+// arrayItemProps navigates schema.properties[key].items.properties for an
+// array-of-object top-level field.
+func arrayItemProps(t *testing.T, schema map[string]any, key string) map[string]any {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no properties map")
+	}
+	field, ok := props[key].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing array property %q", key)
+	}
+	items, ok := field["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q has no items", key)
+	}
+	p, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q items has no properties", key)
+	}
+	return p
+}
+
+// assertWireSchemaStructParity fails when the struct's json field set and the
+// schema property set diverge (both directions). Mirrors the helper in
+// tools/terminal/schema_struct_parity_test.go; duplicated here because that
+// helper is an unexported test symbol and this struct is unexported in a
+// different package.
+func assertWireSchemaStructParity(t *testing.T, label string, structType reflect.Type, props map[string]any) {
+	t.Helper()
+	structFields := jsonFieldSet(structType)
+	schemaFields := make(map[string]bool, len(props))
+	for k := range props {
+		schemaFields[k] = true
+	}
+	for f := range structFields {
+		if !schemaFields[f] {
+			t.Errorf("%s: struct field %q (json) is MISSING from the submit_work schema — the model cannot emit it. Add it to the schema. (schema↔struct drift, #137.)", label, f)
+		}
+	}
+	for f := range schemaFields {
+		if !structFields[f] {
+			t.Errorf("%s: schema property %q has NO matching struct field — the model emits a value nothing unmarshals. Remove it from the schema or add the struct field.", label, f)
+		}
+	}
+}
+
+// jsonFieldSet returns the set of json field names for a struct, stripping
+// ",omitempty" and skipping json:"-". Anonymous embedded structs are flattened.
+func jsonFieldSet(t reflect.Type) map[string]bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			for k := range jsonFieldSet(f.Type) {
+				out[k] = true
+			}
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}

--- a/processor/scenario-generator/scenario_schema_parity_test.go
+++ b/processor/scenario-generator/scenario_schema_parity_test.go
@@ -1,0 +1,100 @@
+package scenariogenerator
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/terminal"
+)
+
+// TestScenarioSchemaStructParity guards the schema↔struct drift class
+// (#125/#126, #137) for the scenario-generator wire shape. The model's
+// submit_work payload for the "scenarios" deliverable is parsed into the
+// UNEXPORTED llmScenario struct before IDs are assigned. A field present in the
+// schema but not the struct means the model emits a value nothing unmarshals; a
+// field in the struct but not the schema means the model physically cannot emit
+// it (and ValidateScenarioTags would then reject an unwinnable loop — e.g. the
+// tags / harness_profile_ids ADR-041 fields the persona is required to emit).
+//
+// Lives in the scenario-generator package because llmScenario is unexported;
+// tools/terminal exposes SchemaForDeliverable as the single source of truth.
+func TestScenarioSchemaStructParity(t *testing.T) {
+	props := arrayItemProps(t, terminal.SchemaForDeliverable("scenarios"), "scenarios")
+	assertWireSchemaStructParity(t, "llmScenario", reflect.TypeOf(llmScenario{}), props)
+}
+
+// arrayItemProps navigates schema.properties[key].items.properties for an
+// array-of-object top-level field.
+func arrayItemProps(t *testing.T, schema map[string]any, key string) map[string]any {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("schema has no properties map")
+	}
+	field, ok := props[key].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing array property %q", key)
+	}
+	items, ok := field["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q has no items", key)
+	}
+	p, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q items has no properties", key)
+	}
+	return p
+}
+
+// assertWireSchemaStructParity fails when the struct's json field set and the
+// schema property set diverge (both directions). Mirrors the helper in
+// tools/terminal/schema_struct_parity_test.go; duplicated here because that
+// helper is an unexported test symbol and this struct is unexported in a
+// different package.
+func assertWireSchemaStructParity(t *testing.T, label string, structType reflect.Type, props map[string]any) {
+	t.Helper()
+	structFields := jsonFieldSet(structType)
+	schemaFields := make(map[string]bool, len(props))
+	for k := range props {
+		schemaFields[k] = true
+	}
+	for f := range structFields {
+		if !schemaFields[f] {
+			t.Errorf("%s: struct field %q (json) is MISSING from the submit_work schema — the model cannot emit it. Add it to the schema. (schema↔struct drift, #137.)", label, f)
+		}
+	}
+	for f := range schemaFields {
+		if !structFields[f] {
+			t.Errorf("%s: schema property %q has NO matching struct field — the model emits a value nothing unmarshals. Remove it from the schema or add the struct field.", label, f)
+		}
+	}
+}
+
+// jsonFieldSet returns the set of json field names for a struct, stripping
+// ",omitempty" and skipping json:"-". Anonymous embedded structs are flattened.
+func jsonFieldSet(t reflect.Type) map[string]bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			for k := range jsonFieldSet(f.Type) {
+				out[k] = true
+			}
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}

--- a/tools/terminal/schema_struct_parity_test.go
+++ b/tools/terminal/schema_struct_parity_test.go
@@ -58,6 +58,75 @@ func TestArchitectureSchemaStructParity(t *testing.T) {
 		reflect.TypeOf(workflow.APISurface{}), itemsProps(t, urProps, "apis"))
 }
 
+// TestExplorationSchemaStructParity extends the same schema↔struct drift guard
+// to the analyst sub-phase deliverable (ADR-040 Move 1). The exploration schema
+// is parsed straight into workflow.Exploration, so a field that exists in the
+// schema but not the struct (or vice versa) is the exact #125/#126 class of bug
+// for the capability wire shape. capabilities[] maps to workflow.Capability.
+func TestExplorationSchemaStructParity(t *testing.T) {
+	schema := schemaForDeliverable("exploration")
+	props := schemaProps(t, schema)
+
+	// Top level: capabilities + open_questions. Every field is analyst-authored;
+	// no system-owned exceptions.
+	assertSchemaStructParity(t, "Exploration",
+		reflect.TypeOf(workflow.Exploration{}), props)
+
+	// capabilities[].items — workflow.Capability. name/lifecycle/description/
+	// depends_on/surfaces are all model-emitted; no system-owned exceptions.
+	assertSchemaStructParity(t, "Capability",
+		reflect.TypeOf(workflow.Capability{}), itemsProps(t, props, "capabilities"))
+}
+
+// TestPlanSchemaStructParity guards the planner sub-phase deliverable. Unlike
+// the parse-into-one-struct deliverables above, workflow.Plan is the durable
+// entity and carries many SYSTEM-owned fields (id, status, review_*, github,
+// qa_*, …) that the model never emits. So the top level is a one-directional
+// SUBSET check — every planSchema property must map to a Plan json field (a
+// schema prop with no struct field is a value nothing unmarshals) — while the
+// reverse direction (struct fields absent from the schema) is intentionally not
+// asserted. The scope sub-object IS isomorphic to workflow.Scope, so it gets the
+// full bidirectional parity check.
+func TestPlanSchemaStructParity(t *testing.T) {
+	schema := schemaForDeliverable("plan")
+	props := schemaProps(t, schema)
+
+	assertSchemaPropsSubsetOfStruct(t, "Plan",
+		reflect.TypeOf(workflow.Plan{}), props)
+
+	assertSchemaStructParity(t, "Scope",
+		reflect.TypeOf(workflow.Scope{}), objectProps(t, props, "scope"))
+}
+
+// assertSchemaPropsSubsetOfStruct fails when a schema property has no matching
+// struct json field — the model emits a value nothing unmarshals. It does NOT
+// assert the reverse (struct fields absent from the schema), which is the right
+// shape for deliverables whose consuming struct is a durable entity with
+// system-owned fields the model never sets.
+func assertSchemaPropsSubsetOfStruct(t *testing.T, label string, structType reflect.Type, props map[string]any) {
+	t.Helper()
+	structFields := structJSONFields(structType)
+	for f := range props {
+		if !structFields[f] {
+			t.Errorf("%s: schema property %q has NO matching struct field — the model emits a value nothing unmarshals. Remove it from the schema or add the struct field.", label, f)
+		}
+	}
+}
+
+// objectProps navigates props[key].properties for an object (non-array) field.
+func objectProps(t *testing.T, props map[string]any, key string) map[string]any {
+	t.Helper()
+	field, ok := props[key].(map[string]any)
+	if !ok {
+		t.Fatalf("schema missing object property %q", key)
+	}
+	p, ok := field["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("schema property %q has no properties", key)
+	}
+	return p
+}
+
 // assertSchemaStructParity fails when the struct's JSON field set and the schema
 // property set diverge, modulo systemOwned (fields the system fills, not the
 // model). Both directions are checked: a struct field absent from the schema (the

--- a/tools/terminal/schemas.go
+++ b/tools/terminal/schemas.go
@@ -72,6 +72,17 @@ func ToolsForEndpoint(reg component.ToolRegistryReader, deliverableType string, 
 	return tools
 }
 
+// SchemaForDeliverable exposes the submit_work parameter schema for a
+// deliverable type to out-of-package schema↔struct parity tests. The
+// requirement-generator and scenario-generator parse the model's submit_work
+// payload into UNEXPORTED structs (requirementItem, llmScenario), so their
+// parity tests must run in those packages and need the canonical schema from
+// here. This is a read-only thin wrapper over schemaForDeliverable; production
+// dispatch code uses ToolsForDeliverable / ToolsForEndpoint, never this.
+func SchemaForDeliverable(deliverableType string) map[string]any {
+	return schemaForDeliverable(deliverableType)
+}
+
 // schemaForDeliverable returns a submit_work parameter schema with named
 // properties specific to the given deliverable type. Each role gets only
 // the fields it needs — no kitchen-sink union.


### PR DESCRIPTION
## What

Only the **architecture** deliverable had a submit_work schema↔struct parity
guard (`TestArchitectureSchemaStructParity`). This extends that guard — against
the recurring **#125/#126 drift class** (a field exists in the Go struct /
validator / prompt but NOT in the submit_work schema the model actually calls,
so the model physically cannot emit it and a downstream validator then rejects
an unwinnable loop) — to the other parse-into-struct deliverables.

Closes #137 (parity tiers; round-trip tier called out as the remaining honest gap below).

## Tiers delivered

| Deliverable | Parse target | Check | Where |
|---|---|---|---|
| `exploration` | `workflow.Exploration` + `workflow.Capability` | full bidirectional parity | `tools/terminal` |
| `plan` | `workflow.Plan` (top-level) + `workflow.Scope` | subset (top) + full parity (scope object) | `tools/terminal` |
| `requirements` | `requirementItem` *(unexported)* | full bidirectional parity | `requirement-generator` pkg |
| `scenarios` | `llmScenario` *(unexported)* | full bidirectional parity | `scenario-generator` pkg |

`requirementItem` / `llmScenario` are unexported, so their parity tests run in
the owning packages. `tools/terminal` now exports **`SchemaForDeliverable`** as
the single source of truth for the wire schema (thin read-only wrapper over the
existing `schemaForDeliverable`; production dispatch still uses
`ToolsForDeliverable`/`ToolsForEndpoint`).

`plan` uses a one-directional **subset** check (every schema prop must map to a
`Plan` json field) because `workflow.Plan` is a durable entity with many
system-owned fields the model never emits; its `scope` sub-object IS isomorphic
to `workflow.Scope` so it gets full parity.

## Negative-control proven

Each new code path was proven to **bite** by injecting a bogus schema property
and confirming the exact failure, then reverting:
- `TestExplorationSchemaStructParity` (reused helper, new wiring) ✅ fails
- `TestPlanSchemaStructParity` (new `assertSchemaPropsSubsetOfStruct`) ✅ fails
- `TestRequirementSchemaStructParity` (new owning-package helper + `arrayItemProps`) ✅ fails
- `scenarios` is a byte-identical copy of the requirements helper pointed at
  `"scenarios"`/`llmScenario`; it found real matching props (a mis-wire would
  `t.Fatal`), so the requirements bite proves that mechanism.

## Honest remaining gap

Deliverables with **no isomorphic parse struct** — `stories`, `review`,
`qa-review`, `lesson`, `recovery` — are not covered here. Their model output is
consumed positionally / by round-trip rather than parsed into one struct, so a
reflection-parity check doesn't apply; a round-trip fixture test is the right
shape and is the remaining tail of #137.

## Test plan
- `go test ./tools/terminal/ ./processor/requirement-generator/ ./processor/scenario-generator/` — green
- gofmt / go vet / revive (v1.5.1) — clean
- Negative-control: 3 injected bogus props → 3 targeted failures → reverted → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)