### PR TITLE
feat(ui): operator phase from authoritative stage set + INV6 contract test + invariant checklist (#221)

### DIFF
--- a/docs/e2e-flow.md
+++ b/docs/e2e-flow.md
@@ -679,6 +679,26 @@ The activity feed is still useful evidence, but it is not allowed to be the only
 current truth. Feed items that no longer match the current phase should be labeled as stale,
 orphaned, or historical rather than silently appearing as live execution.
 
+## State Machine Invariants
+
+Six invariants hold across the whole flow. They are the properties a paid e2e run should never be
+the first thing to discover — each is statically checkable, and each is pinned by a deterministic
+(no-LLM) test so a regression fails CI rather than a multi-hour run. This checklist is the contract
+between the state chart above and the test suite; when a transition is added, the matching invariant
+test is the gate, not a live run.
+
+| # | Invariant | Pinned by (deterministic test) |
+|---|-----------|--------------------------------|
+| **INV1** | No `PlanDecision` in `proposed` waits forever: every `PlanDecisionKind` either auto-accepts (within its per-plan cap) or is human-gated with a visible paused class — none lands in no-owner limbo. | `plan-decision-handler/disposition_watchdog_test.go` (`TestRecoveryDisposition_Watchdog`, `TestRecoveryDisposition_WatchdogExhaustive` — AST-parses every `PlanDecisionKind` const and cross-checks it has a disposition). |
+| **INV2** | Every `PlanDecisionKind` is valid, routed, and its cascade/accept path is exercised; the plan-state chokepoints reject illegal source stages. | `plan-manager/chokepoint_mutations_test.go` (`TestHandleClaimMutation_*`, `TestHandleGenerationFailedMutation`, `TestHandleReviewedMutation`, `TestHandleApprovedMutation`); `plan-decision-handler/architecture_revise_cap_test.go`. |
+| **INV3** | Every recoverable rejected/stalled state has a tested transition back into dispatch — no reset leaves an orphaned `task.<slug>.node-*` key and no requirement stays wedged after recovery (the redispatch-wedge class). | `plan-manager/reset_execution_taskkeys_test.go` (reset clears task-node keys); `scenario-orchestrator/force_redispatch_test.go` + `execution-manager/req_create_force_test.go` (force redispatch delete+recreate); `requirement-executor` restructure tests (`TestHandleReviewerComplete_Restructure_*`); `plan-manager/qa_verdict_test.go` (`reviewing_qa → rejected` fires recovery). |
+| **INV4** | Deferred-terminal timers do not punish intentional human-gated waits: a proposal that is policy-held does not get killed by the inactivity clock. | `plan-decision-handler/architecture_revise_cap_test.go` (cap → leave for human, not auto-accept); the INV1 disposition watchdog. |
+| **INV5** | Recovery diagnostics reach the next responsible agent — no dead-reject on a field that is present only in prose; the dedicated recovery schema is what the recovery agent emits, and Story IDs / node-result resets ride the escalation. | `tools/terminal/schemas_test.go` (recovery deliverable schema); `requirement-executor/awaiting_recovery_test.go`, `node_results_seam_test.go`, `req_completions_recovery_test.go`. |
+| **INV6** | The operator UI phase is derived from the authoritative state machine, not stale heuristics: every authoritative `stage` maps to an explicit operator label/phase (no raw snake-case fallthrough), and the derived pipeline advances monotonically with the backend stage. | `ui/src/lib/types/planStageContract.test.ts` (totality + monotonicity over every `PlanStage`); backend `phase_summary` derivation in `plan-manager`. |
+
+The authoritative source for INV6 is `phase_summary` on the plan API response (see *Operator And UI
+Observability* above); the UI never re-derives phase from raw loop rows.
+
 ## Retry And Recovery Taxonomy
 
 ```mermaid

--- a/ui/src/lib/types/plan.ts
+++ b/ui/src/lib/types/plan.ts
@@ -177,21 +177,34 @@ export function derivePlanPipeline(plan: PlanWithStatus): PlanPipeline {
 		planState = 'active';
 	}
 
-	// Determine requirements phase state (auto-cascade: approved → requirements → scenarios → ready)
+	// Determine requirements phase state (auto-cascade: approved → requirements →
+	// architecture → stories → scenarios → ready). The "requirements" pipeline
+	// phase covers the whole design cascade, so every intermediate generating/
+	// review stage reads as active rather than dipping back to none (#221 INV6:
+	// the derived phase must advance monotonically with the backend stage).
 	const reqsDoneStages: PlanStage[] = [
 		'scenarios_reviewed',
 		'ready_for_execution',
 		'tasks_approved',
 		'implementing',
 		'executing',
+		'ready_for_qa',
+		'reviewing_qa',
 		'reviewing_rollup',
 		'complete',
 		'complete_with_deferrals'
 	];
 	const reqsActiveStages: PlanStage[] = [
 		'approved',
+		'generating_requirements',
 		'requirements_generated',
+		'generating_architecture',
+		'architecture_generated',
+		'preparing_stories',
+		'stories_generated',
+		'generating_scenarios',
 		'scenarios_generated',
+		'reviewing_scenarios',
 		// Legacy stages
 		'phases_generated',
 		'phases_approved',
@@ -213,8 +226,11 @@ export function derivePlanPipeline(plan: PlanWithStatus): PlanPipeline {
 		executeState = 'complete';
 	} else if (stage === 'failed') {
 		executeState = 'failed';
-	} else if (stage === 'reviewing_rollup') {
-		executeState = 'active'; // rollup review is the final gate before complete
+	} else if (stage === 'reviewing_rollup' || stage === 'ready_for_qa' || stage === 'reviewing_qa') {
+		// QA gate + rollup review are execute-phase gates before complete; they
+		// must read as active, not none, or the operator pipeline regresses
+		// after implementation finishes (#221 INV6).
+		executeState = 'active';
 	} else if (isExecuting || stage === 'implementing' || stage === 'executing') {
 		executeState = 'active';
 	}
@@ -235,34 +251,61 @@ export const LOCKED_STAGES: readonly string[] = [
 ] as const;
 
 /**
- * Human-readable label for a plan stage.
+ * STAGE_LABELS maps every authoritative PlanStage to a human-readable operator
+ * label. Typed as Record<PlanStage, string>, so a stage added to the PlanStage
+ * union is a COMPILE error here until a label is supplied — the operator phase is
+ * derived from the authoritative state machine, never a raw snake_case
+ * fallthrough (#221 INV6). The contract test in planStageContract.test.ts pins
+ * the same property at runtime, plus pipeline monotonicity.
+ */
+export const STAGE_LABELS: Record<PlanStage, string> = {
+	created: 'Created',
+	draft: 'Draft',
+	exploring: 'Exploring',
+	explored: 'Explored',
+	drafting: 'Draft',
+	drafted: 'Drafted',
+	reviewing_draft: 'Reviewing Draft',
+	ready_for_approval: 'Ready for Approval',
+	reviewed: 'Reviewed',
+	needs_changes: 'Needs Changes',
+	planning: 'Planning',
+	approved: 'Approved',
+	rejected: 'Rejected',
+	generating_requirements: 'Generating Requirements',
+	requirements_generated: 'Requirements Generated',
+	generating_architecture: 'Generating Architecture',
+	architecture_generated: 'Architecture Generated',
+	preparing_stories: 'Preparing Stories',
+	stories_generated: 'Stories Generated',
+	generating_scenarios: 'Generating Scenarios',
+	scenarios_generated: 'Scenarios Generated',
+	reviewing_scenarios: 'Reviewing Scenarios',
+	scenarios_reviewed: 'Scenarios Reviewed',
+	awaiting_review: 'Awaiting Review',
+	changed: 'Change Accepted',
+	ready_for_execution: 'Ready to Execute',
+	phases_generated: 'Phases Generated',
+	phases_approved: 'Phases Approved',
+	tasks_generated: 'Tasks Generated',
+	tasks_approved: 'Ready to Execute',
+	tasks: 'Ready to Execute',
+	implementing: 'Executing',
+	executing: 'Executing',
+	ready_for_qa: 'Ready for QA',
+	reviewing_qa: 'Reviewing QA',
+	reviewing_rollup: 'Reviewing',
+	complete: 'Complete',
+	complete_with_deferrals: 'Complete — e2e deferred',
+	archived: 'Archived',
+	failed: 'Failed'
+};
+
+/**
+ * Human-readable label for a plan stage. STAGE_LABELS is exhaustive over
+ * PlanStage; the `?? stage` fallback only guards malformed/out-of-contract data
+ * arriving from the wire.
  */
 export function getStageLabel(stage: PlanStage): string {
-	const labels: Record<string, string> = {
-		draft: 'Draft',
-		drafting: 'Draft',
-		ready_for_approval: 'Ready for Approval',
-		reviewed: 'Reviewed',
-		needs_changes: 'Needs Changes',
-		planning: 'Planning',
-		approved: 'Approved',
-		rejected: 'Rejected',
-		requirements_generated: 'Requirements Generated',
-		scenarios_generated: 'Scenarios Generated',
-		scenarios_reviewed: 'Scenarios Reviewed',
-		ready_for_execution: 'Ready to Execute',
-		phases_generated: 'Phases Generated',
-		phases_approved: 'Phases Approved',
-		tasks_generated: 'Tasks Generated',
-		tasks_approved: 'Ready to Execute',
-		tasks: 'Ready to Execute',
-		implementing: 'Executing',
-		executing: 'Executing',
-		reviewing_rollup: 'Reviewing',
-		complete: 'Complete',
-		complete_with_deferrals: 'Complete — e2e deferred',
-		archived: 'Archived',
-		failed: 'Failed'
-	};
-	return labels[stage] ?? stage;
+	return STAGE_LABELS[stage] ?? stage;
 }

--- a/ui/src/lib/types/planStageContract.test.ts
+++ b/ui/src/lib/types/planStageContract.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+	derivePlanPipeline,
+	getStageLabel,
+	STAGE_LABELS,
+	type PlanStage,
+	type PlanWithStatus,
+	type PlanPhaseState,
+	type ActiveLoop
+} from './plan';
+
+/**
+ * #221 INV6 — the operator UI phase must be derived from the authoritative state
+ * machine, not stale heuristics. Two properties are pinned here:
+ *
+ *   1. Totality — every authoritative PlanStage maps to an explicit, human-
+ *      readable operator label (no raw snake_case fallthrough). STAGE_LABELS is
+ *      `Record<PlanStage, string>`, so a stage added to the union is already a
+ *      compile error under `npm run check`; this suite is the runtime mirror.
+ *   2. Monotonicity — as the backend stage advances along the happy-path spine,
+ *      none of the three derived pipeline phases (plan / requirements / execute)
+ *      regresses. The pre-fix derivation dipped requirements back to `none` on
+ *      every `generating_*` stage and left `ready_for_qa` / `reviewing_qa` with
+ *      `execute = none`; both read to an operator as "went backwards".
+ *
+ * ALL_PLAN_STAGES is the runtime enumeration of the union, kept authoritative by
+ * a compile-time exhaustiveness guard so it cannot silently drift.
+ */
+const ALL_PLAN_STAGES = [
+	'created',
+	'draft',
+	'exploring',
+	'explored',
+	'drafting',
+	'drafted',
+	'reviewing_draft',
+	'ready_for_approval',
+	'reviewed',
+	'needs_changes',
+	'planning',
+	'approved',
+	'rejected',
+	'generating_requirements',
+	'requirements_generated',
+	'generating_architecture',
+	'architecture_generated',
+	'preparing_stories',
+	'stories_generated',
+	'generating_scenarios',
+	'scenarios_generated',
+	'reviewing_scenarios',
+	'scenarios_reviewed',
+	'awaiting_review',
+	'changed',
+	'ready_for_execution',
+	'phases_generated',
+	'phases_approved',
+	'tasks_generated',
+	'tasks_approved',
+	'tasks',
+	'implementing',
+	'executing',
+	'ready_for_qa',
+	'reviewing_qa',
+	'reviewing_rollup',
+	'complete',
+	'complete_with_deferrals',
+	'archived',
+	'failed'
+] as const satisfies readonly PlanStage[];
+
+// Compile-time exhaustiveness: if a PlanStage is missing from ALL_PLAN_STAGES,
+// `_Missing` is a non-never union and this assignment fails `npm run check`.
+type _Missing = Exclude<PlanStage, (typeof ALL_PLAN_STAGES)[number]>;
+const _assertExhaustive: [_Missing] extends [never] ? true : { missingStages: _Missing } = true;
+void _assertExhaustive;
+
+function makePlan(
+	stage: PlanStage,
+	opts: { approved?: boolean; loops?: ActiveLoop[] } = {}
+): PlanWithStatus {
+	return {
+		id: 'plan-1',
+		slug: 'plan-1',
+		project_id: 'default',
+		title: 'Contract Plan',
+		created_at: '2026-01-01T00:00:00Z',
+		approved: opts.approved ?? false,
+		stage,
+		// Held constant so the test isolates the stage dimension.
+		goal: 'ship the thing',
+		context: 'brownfield baseline',
+		active_loops: opts.loops ?? []
+	};
+}
+
+describe('plan stage contract (#221 INV6)', () => {
+	it('every authoritative stage has an explicit human-readable label', () => {
+		for (const stage of ALL_PLAN_STAGES) {
+			const label = getStageLabel(stage);
+			expect(label, `label for ${stage}`).toBeTruthy();
+			// A raw fallthrough returns the stage string itself; an explicit label
+			// never equals its snake_case key and never contains an underscore.
+			expect(label, `${stage} fell through to the raw stage string`).not.toBe(stage);
+			expect(
+				label.includes('_'),
+				`label for ${stage} (${label}) looks like raw snake_case, not an operator label`
+			).toBe(false);
+		}
+	});
+
+	it('STAGE_LABELS is exactly the authoritative stage set (no missing, no extra)', () => {
+		expect(new Set(Object.keys(STAGE_LABELS))).toEqual(new Set(ALL_PLAN_STAGES));
+	});
+
+	// Canonical forward (happy-path) spine. Off-path holds (awaiting_review,
+	// changed), terminals (rejected, failed, archived), and legacy stages
+	// (phases_*, tasks_*, executing, tasks) are excluded — monotonicity is the
+	// property of the forward spine. `approved` flips true at the approval gate.
+	const HAPPY_PATH: PlanStage[] = [
+		'created',
+		'exploring',
+		'explored',
+		'drafting',
+		'drafted',
+		'reviewing_draft',
+		'ready_for_approval',
+		'reviewed',
+		'planning',
+		'approved',
+		'generating_requirements',
+		'requirements_generated',
+		'generating_architecture',
+		'architecture_generated',
+		'preparing_stories',
+		'stories_generated',
+		'generating_scenarios',
+		'scenarios_generated',
+		'reviewing_scenarios',
+		'scenarios_reviewed',
+		'ready_for_execution',
+		'implementing',
+		'ready_for_qa',
+		'reviewing_qa',
+		'reviewing_rollup',
+		'complete'
+	];
+	const APPROVED_FROM = HAPPY_PATH.indexOf('approved');
+
+	const rank: Record<PlanPhaseState, number> = { none: 0, active: 1, complete: 2, failed: 0 };
+
+	it('pipeline phases never regress along the happy-path spine', () => {
+		let prev = { plan: 0, requirements: 0, execute: 0 };
+		let prevStage = '(start)';
+		HAPPY_PATH.forEach((stage, i) => {
+			const pipeline = derivePlanPipeline(makePlan(stage, { approved: i >= APPROVED_FROM }));
+			const cur = {
+				plan: rank[pipeline.plan],
+				requirements: rank[pipeline.requirements],
+				execute: rank[pipeline.execute]
+			};
+			for (const phase of ['plan', 'requirements', 'execute'] as const) {
+				expect(
+					cur[phase],
+					`${phase} regressed ${prevStage} → ${stage} (${prev[phase]} → ${cur[phase]})`
+				).toBeGreaterThanOrEqual(prev[phase]);
+			}
+			prev = cur;
+			prevStage = stage;
+		});
+	});
+
+	it('the happy-path spine actually advances each phase to complete (not a vacuous floor)', () => {
+		const last = derivePlanPipeline(makePlan('complete', { approved: true }));
+		expect(last.plan).toBe<PlanPhaseState>('complete');
+		expect(last.requirements).toBe<PlanPhaseState>('complete');
+		expect(last.execute).toBe<PlanPhaseState>('complete');
+	});
+
+	it('an executing active loop drives the execute phase active (active-loop dimension)', () => {
+		const loops = [{ state: 'executing', current_task_id: 'task-1' } as ActiveLoop];
+		const pipeline = derivePlanPipeline(makePlan('ready_for_execution', { approved: true, loops }));
+		expect(pipeline.execute).toBe<PlanPhaseState>('active');
+	});
+});


### PR DESCRIPTION
## What

#221 **INV6** — the operator UI phase must be derived from the authoritative
state machine, not stale heuristics. This delivers the two pieces the audit
flagged as INV6's deliverable, plus the cross-cutting invariant checklist.

### 1. Frontend contract test (the deliverable) — `ui/src/lib/types/planStageContract.test.ts`
Pins two properties over **every** authoritative `PlanStage`:
- **Totality** — every stage maps to an explicit, human-readable operator label (no raw snake_case fallthrough). `ALL_PLAN_STAGES` is kept authoritative by a compile-time exhaustiveness guard (`Exclude<PlanStage, …>`), so a new backend stage can't silently drift past it.
- **Monotonicity** — along the happy-path spine, none of the three derived pipeline phases (plan / requirements / execute) regresses.
- Plus the active-loop dimension (an `executing` loop drives `execute = active`).

### 2. The red→green fixes the test surfaced (`ui/src/lib/types/plan.ts`)
- `getStageLabel` mapped only **24 of 40** authoritative stages; the other **16** (`created`, `exploring`, `explored`, `drafted`, `reviewing_draft`, `generating_*`, `architecture_generated`, `preparing_stories`, `stories_generated`, `reviewing_scenarios`, `awaiting_review`, `changed`, `ready_for_qa`, `reviewing_qa`) fell through to `?? stage` — the operator literally saw `generating_requirements`. Now an exhaustive `STAGE_LABELS: Record<PlanStage, string>` (a missing stage is a compile error under `npm run check`).
- `derivePlanPipeline` dipped `requirements` back to `none` on every `generating_*`/design stage and left `ready_for_qa`/`reviewing_qa` with `execute = none`, so the pipeline appeared to **go backwards** mid-run. The design cascade now reads `requirements = active`; the QA gate reads `execute = active`.

### 3. Invariant checklist into the doc — `docs/e2e-flow.md`
New **State Machine Invariants** section (INV1–INV6), each cross-referencing the deterministic test that pins it — turning the doc into the "every state tested" map the HARD GATE wants. Only tests verified present on `main` are cited.

## Negative-control proven (red→green)
With the fix reverted (one label + one pipeline stage removed), the three new assertions fail with the exact intended messages, e.g. `requirements regressed approved → generating_requirements (1 → 0)` and `generating_requirements fell through to the raw stage string`. Restored → all green.

## Test plan
- `npm test` (UI) — **271 passed** (19 files), incl. the 5 new contract assertions.
- `npm run check` (svelte-check / tsc) — 0 errors (the `Record<PlanStage,string>` + the test's exhaustiveness guard both type-check).
- No Go impact (touches only `docs/` + `ui/`).

## Notes / honest gaps
- The UI suite is **not wired into CI** (`.github/workflows/ci.yml` has no `ui/` step) — this test runs via `npm test` / `npm run check` locally. Wiring UI vitest into CI is the separate #217/#219 track, out of scope here.
- INV6's other half (the backend `phase_summary` authoritative source) is unchanged; this PR pins the UI side that consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)