### PR TITLE
fix(recovery): full-auto auto-accepts a scoped architecture_revise (#211)

### DIFF
--- a/processor/plan-decision-handler/disposition_watchdog_test.go
+++ b/processor/plan-decision-handler/disposition_watchdog_test.go
@@ -38,10 +38,9 @@ const (
 	// autoAcceptable: a well-formed recovery proposal of this kind can be
 	// auto-accepted by shouldAutoAcceptRecovery (subject to per-kind caps).
 	autoAcceptable disposition = iota
-	// humanGatedOrTerminal: this kind is NEVER auto-accepted. It is either a
-	// terminal record (execution_exhausted, assembly_conflict) or contract-
-	// changing and requires an operator decision (architecture_revise). It must
-	// surface as a visible proposed/terminal state, never silently auto-resolve.
+	// humanGatedOrTerminal: this kind is NEVER auto-accepted. It is a terminal
+	// record (execution_exhausted, assembly_conflict) that must surface as a
+	// visible proposed/terminal state, never silently auto-resolve.
 	humanGatedOrTerminal
 )
 
@@ -54,10 +53,12 @@ var kindDisposition = map[workflow.PlanDecisionKind]struct {
 	want     disposition
 	proposer string
 }{
-	workflow.PlanDecisionKindRequirementChange:  {autoAcceptable, "recovery-agent"},
-	workflow.PlanDecisionKindStoryReprepare:     {autoAcceptable, "recovery-agent"},
-	workflow.PlanDecisionKindScopeIncomplete:    {autoAcceptable, "plan-manager"},
-	workflow.PlanDecisionKindArchitectureRevise: {humanGatedOrTerminal, ""},
+	workflow.PlanDecisionKindRequirementChange: {autoAcceptable, "recovery-agent"},
+	workflow.PlanDecisionKindStoryReprepare:    {autoAcceptable, "recovery-agent"},
+	workflow.PlanDecisionKindScopeIncomplete:   {autoAcceptable, "plan-manager"},
+	// #211: full-auto is full-auto — a scoped architecture_revise auto-accepts
+	// (bounded by MaxAutoArchitectureRevises), no human gate.
+	workflow.PlanDecisionKindArchitectureRevise: {autoAcceptable, "recovery-agent"},
 	workflow.PlanDecisionKindExecutionExhausted: {humanGatedOrTerminal, ""},
 	workflow.PlanDecisionKindAssemblyConflict:   {humanGatedOrTerminal, ""},
 }

--- a/processor/plan-decision-handler/recovery_autoaccept.go
+++ b/processor/plan-decision-handler/recovery_autoaccept.go
@@ -159,9 +159,12 @@ func (c *Component) watchRecoveryProposals(ctx context.Context) {
 //     step 4). The cascade dirty-marks Stories + scenarios; plan-manager
 //     drives stories_generated → preparing_stories so Sarah re-runs with
 //     the diagnosis as Story.RecoveryHint.
-//   - PlanDecisionKindArchitectureRevise — parsed for visibility but not
-//     auto-accepted unless a future policy explicitly permits contract-changing
-//     architecture recovery.
+//   - PlanDecisionKindArchitectureRevise — #211 policy: full-auto is full-auto.
+//     A scoped, recovery-agent-emitted architecture_revise auto-accepts so a
+//     post-QA topology defect self-heals without a human gate. It is inherently
+//     contract-changing, so it bypasses the contract-change guards that hold
+//     other kinds for review; runaway is bounded by the MaxAutoArchitectureRevises
+//     cap loop-guard in the watcher, not a human approval.
 //
 // Other kinds (execution_exhausted terminal records, qa-reviewer
 // proposals, human proposals) stay human-gated. AffectedReqIDs is the
@@ -240,6 +243,19 @@ func shouldAutoAcceptRecovery(dec *workflow.PlanDecision) bool {
 	if dec.ContractImpact == nil || !dec.ContractImpact.Kind.IsValid() {
 		return false
 	}
+
+	// #211 — full-auto is full-auto: a scoped, recovery-agent-emitted
+	// architecture_revise auto-accepts so a post-QA topology defect self-heals
+	// without a human gate. architecture_revise is inherently contract-changing
+	// (recoveryDecisionRequiresContractChange == true; ContractImpact Kind is
+	// forced to change), so it must bypass the contract-change guards below that
+	// hold other kinds for review. Runaway is bounded by MaxAutoArchitectureRevises
+	// in the watcher, not by an operator. An UNSCOPED architecture_revise already
+	// returned above (empty AffectedReqIDs) — auto-accept has nothing to target.
+	if dec.Kind == workflow.PlanDecisionKindArchitectureRevise {
+		return true
+	}
+
 	if recoveryDecisionRequiresContractChange(dec) {
 		return false
 	}

--- a/processor/plan-decision-handler/should_auto_accept_test.go
+++ b/processor/plan-decision-handler/should_auto_accept_test.go
@@ -82,7 +82,7 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 			comment: "pre-existing path unchanged",
 		},
 		{
-			name: "architecture_revise stays human-gated even if malformed as refine",
+			name: "architecture_revise (refine impact) auto-accepts in full-auto",
 			dec: &workflow.PlanDecision{
 				ProposedBy:     "recovery-agent",
 				Status:         workflow.PlanDecisionStatusProposed,
@@ -90,8 +90,8 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 				AffectedReqIDs: []string{"req.demo.1"},
 				ContractImpact: recoveryImpact(workflow.ContractImpactRefine),
 			},
-			wantOK:  false,
-			comment: "architecture recovery changes topology/contract and cannot self-downgrade",
+			wantOK:  true,
+			comment: "#211: full-auto auto-accepts a scoped, recovery-agent architecture_revise",
 		},
 		{
 			name: "narrow_scope requirement_change stays human-gated even if malformed as preserve",
@@ -108,7 +108,7 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 			comment: "scope-narrowing is contract-changing even though it maps to requirement_change",
 		},
 		{
-			name: "contract-changing recovery stays human-gated",
+			name: "architecture_revise (change impact) auto-accepts in full-auto",
 			dec: &workflow.PlanDecision{
 				ProposedBy:     "recovery-agent",
 				Status:         workflow.PlanDecisionStatusProposed,
@@ -116,8 +116,31 @@ func TestShouldAutoAcceptRecovery_WidenedForStoryReprepare(t *testing.T) {
 				AffectedReqIDs: []string{"req.demo.1"},
 				ContractImpact: recoveryImpact(workflow.ContractImpactChange),
 			},
+			wantOK:  true,
+			comment: "#211: architecture_revise is inherently contract-changing; full-auto accepts it (cap-bounded), no human gate",
+		},
+		{
+			name: "architecture_revise without scope stays gated (no target)",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "recovery-agent",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindArchitectureRevise,
+				ContractImpact: recoveryImpact(workflow.ContractImpactChange),
+			},
 			wantOK:  false,
-			comment: "auto-accept may not silently amend the root contract",
+			comment: "#211: cap-bounded auto-accept still needs AffectedReqIDs to target; an unscoped whole-phase revise is not auto-accepted",
+		},
+		{
+			name: "architecture_revise from a non-recovery-agent proposer stays gated",
+			dec: &workflow.PlanDecision{
+				ProposedBy:     "qa-reviewer",
+				Status:         workflow.PlanDecisionStatusProposed,
+				Kind:           workflow.PlanDecisionKindArchitectureRevise,
+				AffectedReqIDs: []string{"req.demo.1"},
+				ContractImpact: recoveryImpact(workflow.ContractImpactChange),
+			},
+			wantOK:  false,
+			comment: "the auto-accept filter is recovery-agent-only by design",
 		},
 		{
 			name: "missing contract impact stays human-gated",


### PR DESCRIPTION
## What

Resolves the #211 policy decision: **full-auto is full-auto — no human gate for `architecture_revise`.**

Previously `shouldAutoAcceptRecovery` hard-returned `false` for `architecture_revise` (it is inherently contract-changing — `ContractImpact.Kind == change`), so a post-QA topology defect ended a full-auto run as a **pending human-gated proposal**. The run could not self-heal toward composite integration without a manual `POST .../plan-decisions/<id>/accept` (the salvage path documented across the mavlink runs).

Now a **scoped** (`AffectedReqIDs` non-empty), **recovery-agent-emitted** `architecture_revise` auto-accepts. It bypasses the contract-change guards that hold other kinds for review.

## Safety retained (not a human gate)
- **Cap loop-guard** — the existing `MaxAutoArchitectureRevises` cap (default **1**) in the watcher still bounds runaway re-runs; past the cap a further proposal stays proposed. This is runaway-safety, configurable per deployment (the e2e hybrid config already runs it at 2), **not** a per-decision operator approval.
- **Scoping** — an unscoped whole-phase `architecture_revise` (`AffectedReqIDs` empty) still stays gated: auto-accept has nothing to target (this is the #238-class whole-layer-regen risk).
- **Proposer** — the filter remains recovery-agent-only.

## INV1 stays honest
The #221 disposition watchdog (`disposition_watchdog_test.go`) now declares `architecture_revise → autoAcceptable (recovery-agent)`, so the kind-disposition contract matches the filter — the watchdog **forces** the two to agree. `should_auto_accept_test` cases flipped to the new policy, plus added scoping + proposer guard cases.

## Negative-control proven
With the carve-out removed, three assertions fail with the exact intended messages — the watchdog (`architecture_revise is declared autoAcceptable but shouldAutoAcceptRecovery=false`) and both flipped policy cases (`want true`) — while the unscoped/non-recovery-agent guards stay green. Restored → green.

## Test plan
- `go test ./...` — **72 packages ok, 0 fail**.
- `go build ./...`, gofmt, go vet, revive (v1.5.1) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)