### PR TITLE
fix(e2e): make exec-ownership-gate scenario tolerant of reactive auto-dispatch

### DIFF
--- a/test/e2e/scenarios/execution_trigger.go
+++ b/test/e2e/scenarios/execution_trigger.go
@@ -12,3 +12,23 @@ func executionAlreadyStarted(status, stage string) bool {
 		return false
 	}
 }
+
+// planExecutionTerminal reports whether the plan has reached a terminal state
+// that execution (not plan review) produced: failed/rejected via a dev-gate
+// escalation + AutoRejectOnExhaustion, an explicit escalation, or a
+// deferral-complete. Reactive-mode scenarios use this to recognise that
+// execution already ran (so a manual POST /execute would 400) without
+// conflating it with a pre-execution plan-review rejection — callers must have
+// already confirmed the plan passed approval before treating this as success.
+func planExecutionTerminal(status, stage string) bool {
+	switch status {
+	case "failed", "rejected", "escalated", "error", "complete_with_deferrals":
+		return true
+	}
+	switch stage {
+	case "failed", "rejected", "escalated", "error", "complete_with_deferrals":
+		return true
+	default:
+		return false
+	}
+}

--- a/test/e2e/scenarios/parallel_assembly.go
+++ b/test/e2e/scenarios/parallel_assembly.go
@@ -254,7 +254,7 @@ func (s *ParallelAssemblyScenario) stageWaitForPlanGoal(ctx context.Context, res
 
 func (s *ParallelAssemblyScenario) stageWaitForApproval(ctx context.Context, result *Result) error {
 	slug, _ := result.GetDetailString("plan_slug")
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
@@ -265,16 +265,30 @@ func (s *ParallelAssemblyScenario) stageWaitForApproval(ctx context.Context, res
 			if err != nil {
 				continue
 			}
-			if plan.Approved {
+			// Reactive mode (the mock e2e default) auto-dispatches execution the
+			// moment the plan is approved, and the ADR-049 ownership gate then
+			// fast-fails it to recovery + AutoRejectOnExhaustion — all within a
+			// second or two. So "approved" OR "already executing" both mean the
+			// plan passed review; we may never catch the bare approved tick.
+			if plan.Approved || executionAlreadyStarted(plan.Status, plan.Stage) {
 				result.SetDetail("plan_approved", true)
 				result.SetDetail("plan_stage", plan.Stage)
 				return nil
 			}
 			// The plan MUST pass R2 review to reach execution — a blocking
 			// finding here would mean the repaired/new rules wrongly rejected a
-			// conformant architecture (disjoint files, scope-aligned).
-			if plan.Stage == "escalated" || plan.Stage == "error" || plan.Status == "rejected" {
-				return fmt.Errorf("plan reached terminal state before approval: stage=%s status=%s", plan.Stage, plan.Status)
+			// conformant architecture (disjoint files, scope-aligned). But a
+			// post-execution rejection IS this scenario's success path: if the
+			// ownership gate has already fired, the plan was approved and reached
+			// the dev node, so treat it as approved rather than a review
+			// regression.
+			if plan.Stage == "escalated" || plan.Stage == "error" || plan.Status == "rejected" || plan.Status == "failed" {
+				if _, _, ok := s.observedOwnershipGap(ctx); ok {
+					result.SetDetail("plan_approved", true)
+					result.SetDetail("plan_stage", plan.Stage)
+					return nil
+				}
+				return fmt.Errorf("plan reached terminal state before approval with no ownership-gap evidence (likely a plan-review regression): stage=%s status=%s", plan.Stage, plan.Status)
 			}
 		}
 	}
@@ -282,14 +296,31 @@ func (s *ParallelAssemblyScenario) stageWaitForApproval(ctx context.Context, res
 
 func (s *ParallelAssemblyScenario) stageTriggerExecution(ctx context.Context, result *Result) error {
 	slug, _ := result.GetDetailString("plan_slug")
-	if plan, err := s.http.GetPlan(ctx, slug); err == nil && executionAlreadyStarted(plan.Status, plan.Stage) {
+	// Reactive mode auto-dispatches at ready_for_execution, so by now the plan
+	// may already be executing — or already terminated through the ADR-049 gate
+	// (escalated/rejected by AutoRejectOnExhaustion). A manual execute would then
+	// 400; reactive already did the work and stageWaitForOwnershipGap makes the
+	// real assertion. Only POST /execute when the plan is genuinely still parked
+	// awaiting a manual trigger.
+	if plan, err := s.http.GetPlan(ctx, slug); err == nil && plan != nil &&
+		(executionAlreadyStarted(plan.Status, plan.Stage) || planExecutionTerminal(plan.Status, plan.Stage)) {
 		result.SetDetail("execution_already_started", true)
 		result.SetDetail("execution_stage", plan.Stage)
+		result.SetDetail("execution_status", plan.Status)
 		return nil
 	}
 
 	resp, err := s.http.ExecutePlan(ctx, slug)
 	if err != nil {
+		// A late reactive dispatch can move the plan out of ready_for_execution
+		// between the GetPlan above and this call — re-check before failing.
+		if plan, gerr := s.http.GetPlan(ctx, slug); gerr == nil && plan != nil &&
+			(executionAlreadyStarted(plan.Status, plan.Stage) || planExecutionTerminal(plan.Status, plan.Stage)) {
+			result.SetDetail("execution_already_started", true)
+			result.SetDetail("execution_stage", plan.Stage)
+			result.SetDetail("execution_status", plan.Status)
+			return nil
+		}
 		return fmt.Errorf("execute plan: %w", err)
 	}
 	if resp.Error != "" {
@@ -309,11 +340,6 @@ func (s *ParallelAssemblyScenario) stageTriggerExecution(ctx context.Context, re
 func (s *ParallelAssemblyScenario) stageWaitForOwnershipGap(ctx context.Context, result *Result) error {
 	slug, _ := result.GetDetailString("plan_slug")
 
-	// Substrings that uniquely identify the ADR-049 move-3 escalation reason
-	// emitted by execution-manager (handleValidationFailedLocked) — see
-	// processor/execution-manager/component.go and ownership_check.go.
-	markers := []string{"planning gap (ADR-049 ownership)", "ADR-049 ownership", "declared file scope"}
-
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -321,31 +347,49 @@ func (s *ParallelAssemblyScenario) stageWaitForOwnershipGap(ctx context.Context,
 		case <-ctx.Done():
 			return fmt.Errorf("ownership/planning gap never observed in EXECUTION_STATES: %w", ctx.Err())
 		case <-ticker.C:
-			// A clean completion is a regression: move 3 should have blocked it.
+			// A clean completion is a regression: move 3 should have blocked the
+			// out-of-territory write before any complete state.
 			plan, err := s.http.GetPlan(ctx, slug)
-			if err == nil && plan.Status == "complete" {
-				return fmt.Errorf("plan reached 'complete' — the out-of-territory write was NOT caught at the dev node (ADR-049 move-3 regression)")
+			if err == nil && plan != nil && (plan.Status == "complete" || plan.Status == "complete_with_deferrals") {
+				return fmt.Errorf("plan reached %q — the out-of-territory write was NOT caught at the dev node (ADR-049 move-3 regression)", plan.Status)
 			}
 
-			kvResp, err := s.http.GetKVEntries(ctx, "EXECUTION_STATES")
-			if err != nil {
-				continue
-			}
-			for _, entry := range kvResp.Entries {
-				raw := string(entry.Value)
-				for _, m := range markers {
-					if strings.Contains(raw, m) {
-						result.SetDetail("ownership_gap_key", entry.Key)
-						result.SetDetail("ownership_gap_marker", m)
-						if plan != nil {
-							result.SetDetail("plan_status_at_gap", plan.Status)
-						}
-						return nil
-					}
+			if key, marker, ok := s.observedOwnershipGap(ctx); ok {
+				result.SetDetail("ownership_gap_key", key)
+				result.SetDetail("ownership_gap_marker", marker)
+				if plan != nil {
+					result.SetDetail("plan_status_at_gap", plan.Status)
 				}
+				return nil
 			}
 		}
 	}
+}
+
+// ownershipGapMarkers are substrings that uniquely identify the ADR-049 move-3
+// escalation reason emitted by execution-manager (handleValidationFailedLocked)
+// — see processor/execution-manager/component.go and ownership_check.go.
+var ownershipGapMarkers = []string{"planning gap (ADR-049 ownership)", "ADR-049 ownership", "declared file scope"}
+
+// observedOwnershipGap reports whether EXECUTION_STATES already carries the
+// ADR-049 move-3 planning-gap escalation for this run — proof the dev-review
+// ownership gate fired (this scenario's success signal). Returns the matching
+// KV key and marker for diagnostics. Best-effort: a KV fetch error reads as
+// "not yet observed" so the caller keeps polling.
+func (s *ParallelAssemblyScenario) observedOwnershipGap(ctx context.Context) (key, marker string, ok bool) {
+	kvResp, err := s.http.GetKVEntries(ctx, "EXECUTION_STATES")
+	if err != nil {
+		return "", "", false
+	}
+	for _, entry := range kvResp.Entries {
+		raw := string(entry.Value)
+		for _, m := range ownershipGapMarkers {
+			if strings.Contains(raw, m) {
+				return entry.Key, m, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 func (s *ParallelAssemblyScenario) stageVerifyMockStats(ctx context.Context, result *Result) error {


### PR DESCRIPTION
## What

The `exec-ownership-gate` mock scenario (ADR‑049 move‑3 ownership gate) was the lone failure in today's post-merge mock-ladder sweep (12/13). Root-caused from a diagnostic re-run with semspec logs: **the gate works perfectly — the scenario's step sequence didn't account for reactive mode.**

The mock e2e default is `reactive_mode=true`, so the orchestrator auto-dispatches execution the instant the plan is approved. The dev-node ownership gate then fast-fails the out-of-territory `src/core/driver.py` to recovery, and `AutoRejectOnExhaustion` rejects the plan — all within ~1–2 s. The scenario's `stageTriggerExecution` then manually POSTs `/execute` and gets `HTTP 400: Plan must be in ready_for_execution status to execute (current: rejected)`.

This is **not** a regression from today's merges: plan-review *approved* the plan (both rounds), the ADR‑049 gate fired correctly, and `AutoRejectOnExhaustion` (the rejecter) had zero changes in the audit window. Pre-existing scenario/harness assumption that broke under reactive + auto-reject.

## Fix (harness only — the gate is untouched)

- **`stageTriggerExecution`** — skip the manual `/execute` when the plan has already started executing (`executionAlreadyStarted`) **or** already terminated through the gate (new `planExecutionTerminal`: failed/rejected/escalated/error/complete_with_deferrals). Re-check on a 400 to absorb a dispatch that races between `GetPlan` and `ExecutePlan`.
- **`stageWaitForApproval`** — succeed on approved *or* execution-already-started; only fail a terminal state as a *plan-review* regression when there's **no** ownership-gap evidence in `EXECUTION_STATES` (a post-execution rejection is this scenario's success path). Poll tightened to 500 ms.
- Extracted **`observedOwnershipGap()`** + `ownershipGapMarkers`, shared by the approval and assertion stages; the assertion now also treats `complete_with_deferrals` as a regression alongside `complete`.

## Verified (non-vacuous)

`task e2e:mock -- exec-ownership-gate` → **PASS**, all 10 stages green, because the gate genuinely fired:
- `ownership_gap_marker = "planning gap (ADR-049 ownership)"`, `plan_status_at_gap = "rejected"`
- `mock-coder=2` — the dev loop ran and wrote the out-of-territory file (execution reached the dev node, not skipped)

`planExecutionTerminal` is referenced only by this scenario; `executionAlreadyStarted` is unchanged, so the other 12 mock scenarios are unaffected (ladder → **13/13**).

## Note
The deeper gap surfaced by this: **the mock ladder runs in no CI workflow** (`ci.yml` has no `e2e:mock`), which is why this sat undetected. Worth wiring up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)