### PR TITLE
ci: mock-ladder e2e gate (parked) + Linux portability fixes

### DIFF
--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -66,22 +66,6 @@ jobs:
         run: |
           echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
 
-      - name: Stack bring-up diagnostic
-        # One-shot: bring up the mock stack via the SAME deps the ladder uses
-        # (task e2e:up:mock runs ensure-model-caches etc.), then capture the
-        # sandbox failure reason if up --wait fails. Self-contained teardown.
-        run: |
-          set +e
-          echo "DOCKER_GID=${DOCKER_GID:-unset} runner uid=$(id -u) gid=$(id -g)"
-          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
-          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
-          echo "=== ps -a ==="; $DC ps -a
-          echo "=== sandbox compose logs ==="; $DC logs sandbox 2>&1 | tail -80
-          echo "=== sandbox inspect ==="; docker inspect semspec-e2e-sandbox-1 --format 'exit={{.State.ExitCode}} err={{.State.Error}} oom={{.State.OOMKilled}}' 2>&1
-          echo "=== semspec logs tail ==="; $DC logs semspec 2>&1 | tail -15
-          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
-          exit 0
-
       - name: Run mock ladder
         run: |
           set -uo pipefail

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -63,7 +63,8 @@ jobs:
         # Desktop (root:root socket); on Linux runners the socket is root:docker,
         # so resolve the runner's docker GID (the compose file flags this as the
         # one-env-var Linux override). Without it the sandbox exits 1 at startup.
-        run: echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
+        run: |
+          echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
 
       - name: Stack bring-up diagnostic
         # One-shot: confirm the mock stack reaches healthy on this runner and

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -56,6 +56,33 @@ jobs:
         # satisfies the loader without supplying secrets.
         run: touch .env
 
+      - name: Set DOCKER_GID for sandbox socket access
+        # The sandbox mounts the host docker socket (DooD) and runs as uid 1000,
+        # so it needs supplementary membership in the host's docker group to
+        # access the socket. The compose default DOCKER_GID=0 fits Mac Docker
+        # Desktop (root:root socket); on Linux runners the socket is root:docker,
+        # so resolve the runner's docker GID (the compose file flags this as the
+        # one-env-var Linux override). Without it the sandbox exits 1 at startup.
+        run: echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
+
+      - name: Stack bring-up diagnostic
+        # One-shot: confirm the mock stack reaches healthy on this runner and
+        # surface sandbox logs if it does not. Self-contained (own teardown); the
+        # ladder below re-runs the full lifecycle per scenario.
+        run: |
+          set +e
+          echo "DOCKER_GID=${DOCKER_GID:-unset}"
+          task e2e:build >/dev/null 2>&1
+          docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec sandbox >/dev/null 2>&1
+          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml build mock-llm >/dev/null 2>&1
+          mkdir -p test/e2e/workspace && ( cd test/e2e/workspace && [ -d .git ] || { git init -q && git config user.email e@t.l && git config user.name t && echo x > README.md && git add README.md && git commit -q -m init; } )
+          MOCK_SCENARIO=plan-smoke docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml up -d --wait
+          echo "up --wait rc=$?"
+          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml ps
+          echo "=== sandbox logs ==="; docker logs semspec-e2e-sandbox-1 2>&1 | tail -60
+          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml down -v >/dev/null 2>&1
+          exit 0
+
       - name: Run mock ladder
         run: |
           set -uo pipefail

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -67,23 +67,19 @@ jobs:
           echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
 
       - name: Stack bring-up diagnostic
-        # One-shot: confirm the mock stack reaches healthy on this runner and
-        # capture the sandbox failure reason if it does not. Self-contained (own
-        # teardown); the ladder below re-runs the full lifecycle per scenario.
+        # One-shot: bring up the mock stack via the SAME deps the ladder uses
+        # (task e2e:up:mock runs ensure-model-caches etc.), then capture the
+        # sandbox failure reason if up --wait fails. Self-contained teardown.
         run: |
           set +e
           echo "DOCKER_GID=${DOCKER_GID:-unset} runner uid=$(id -u) gid=$(id -g)"
-          task e2e:build >/dev/null 2>&1
-          docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec sandbox >/dev/null 2>&1
-          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml build mock-llm >/dev/null 2>&1
-          mkdir -p test/e2e/workspace && ( cd test/e2e/workspace && [ -d .git ] || { git init -q && git config user.email e@t.l && git config user.name t && echo x > README.md && git add README.md && git commit -q -m init; } )
-          echo "=== workspace ownership ==="; ls -lan test/e2e | grep workspace; ls -lan test/e2e/workspace | head
           DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
-          MOCK_SCENARIO=plan-smoke $DC up -d --wait; echo "up --wait rc=$?"
+          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
           echo "=== ps -a ==="; $DC ps -a
           echo "=== sandbox compose logs ==="; $DC logs sandbox 2>&1 | tail -80
           echo "=== sandbox inspect ==="; docker inspect semspec-e2e-sandbox-1 --format 'exit={{.State.ExitCode}} err={{.State.Error}} oom={{.State.OOMKilled}}' 2>&1
-          $DC down -v >/dev/null 2>&1
+          echo "=== semspec logs tail ==="; $DC logs semspec 2>&1 | tail -15
+          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
           exit 0
 
       - name: Run mock ladder

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -56,15 +56,21 @@ jobs:
         # satisfies the loader without supplying secrets.
         run: touch .env
 
-      - name: Set DOCKER_GID for sandbox socket access
-        # The sandbox mounts the host docker socket (DooD) and runs as uid 1000,
-        # so it needs supplementary membership in the host's docker group to
-        # access the socket. The compose default DOCKER_GID=0 fits Mac Docker
-        # Desktop (root:root socket); on Linux runners the socket is root:docker,
-        # so resolve the runner's docker GID (the compose file flags this as the
-        # one-env-var Linux override). Without it the sandbox exits 1 at startup.
+      - name: Match sandbox uid/gid + docker GID to the runner
+        # The sandbox bind-mounts /workspace (host-owned) and the host docker
+        # socket. On Mac Docker Desktop the uid mapping hides ownership, but on a
+        # Linux runner the sandbox image's baked uid (1000) differs from the
+        # runner user (1001) that owns /workspace, so the sandbox can't write it
+        # (mkdir worktrees -> permission denied) and git flags dubious ownership —
+        # the container exits 1 and up --wait fails the whole stack. Build the
+        # sandbox image AS the runner's uid/gid so it owns /workspace, and resolve
+        # the docker group GID so the DooD socket is accessible.
         run: |
-          echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
+          {
+            echo "SANDBOX_UID=$(id -u)"
+            echo "SANDBOX_GID=$(id -g)"
+            echo "DOCKER_GID=$(getent group docker | cut -d: -f3)"
+          } >> "$GITHUB_ENV"
 
       - name: Stack bring-up diagnostic
         # Temporary: bring the mock stack up via the ladder's own deps and confirm

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -7,15 +7,22 @@ name: Mock Ladder
 # (build -> up mock stack -> run -> teardown) for isolation. No paid tokens, no
 # model downloads — e2e-mock.yml stubs semembed/seminstruct to alpine no-ops.
 #
-# Runs in parallel with the fast lint-and-test gate (ci.yml), so it never blocks
-# quick feedback. To make it a required merge gate, add "mock-ladder" to the
-# branch-protection required checks for main.
+# STATUS: PARKED (manual workflow_dispatch only) — see issue #258.
+# The gate workflow is correct and 13/13 locally, but the e2e stack does not yet
+# come up on a stock ubuntu-latest runner: semspec (root) and sandbox (non-root)
+# share the /workspace bind-mount, so the sandbox can't write the
+# root-owned /workspace/.semspec tree and exits 1, failing `up --wait`. Mac
+# Docker Desktop's uid mapping hides this; Linux exposes it. The steps below
+# already fix the gitignored-workspace, docker-socket GID, and git
+# dubious-ownership layers; the remaining piece is unifying the /workspace uid
+# across containers (issue #258). When that lands, switch the trigger back to:
+#   on:
+#     pull_request: { branches: [main] }
+#     push:         { branches: [main] }
+# and add "mock-ladder" to the branch-protection required checks for main.
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -64,26 +71,15 @@ jobs:
         # (mkdir worktrees -> permission denied) and git flags dubious ownership —
         # the container exits 1 and up --wait fails the whole stack. Build the
         # sandbox image AS the runner's uid/gid so it owns /workspace, and resolve
-        # the docker group GID so the DooD socket is accessible.
+        # the docker group GID so the DooD socket is accessible. NOTE: this is
+        # necessary but not yet sufficient — semspec still runs as root and
+        # creates /workspace/.semspec first; see issue #258.
         run: |
           {
             echo "SANDBOX_UID=$(id -u)"
             echo "SANDBOX_GID=$(id -g)"
             echo "DOCKER_GID=$(getent group docker | cut -d: -f3)"
           } >> "$GITHUB_ENV"
-
-      - name: Stack bring-up diagnostic
-        # Temporary: bring the mock stack up via the ladder's own deps and confirm
-        # it reaches healthy on this runner (sandbox no longer exits on git
-        # dubious-ownership). Captures sandbox logs if up --wait still fails.
-        run: |
-          set +e
-          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
-          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
-          echo "=== ps ==="; $DC ps -a --format 'table {{.Service}}\t{{.Status}}'
-          echo "=== sandbox logs ==="; $DC logs sandbox 2>&1 | tail -40
-          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
-          exit 0
 
       - name: Run mock ladder
         run: |

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -1,0 +1,102 @@
+name: Mock Ladder
+
+# Deterministic, FREE (mock-LLM) end-to-end gate. Runs every scenario under
+# test/e2e/fixtures/mock-responses/ through the full stack with the mock LLM, so
+# a pipeline/recovery/ownership-gate regression fails CI instead of being
+# discovered by a paid LLM run. Each scenario is a full infra lifecycle
+# (build -> up mock stack -> run -> teardown) for isolation. No paid tokens, no
+# model downloads — e2e-mock.yml stubs semembed/seminstruct to alpine no-ops.
+#
+# Runs in parallel with the fast lint-and-test gate (ci.yml), so it never blocks
+# quick feedback. To make it a required merge gate, add "mock-ladder" to the
+# branch-protection required checks for main.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: read # pull ghcr.io/c360studio/semsource at stack bring-up
+
+concurrency:
+  group: mock-ladder-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mock-ladder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Provide empty .env
+        # The root Taskfile declares `dotenv: ['.env']`; .env is gitignored and
+        # absent in CI. The mock LLM needs no API keys, so an empty file
+        # satisfies the loader without supplying secrets.
+        run: touch .env
+
+      - name: Run mock ladder
+        run: |
+          set -uo pipefail
+          # Source of truth for the scenario set is the fixture directories, so a
+          # new mock scenario is gated automatically. Names are directory names
+          # (no spaces), so word-splitting the list is safe.
+          SCENARIOS="$(ls -1 test/e2e/fixtures/mock-responses/ | sort | tr '\n' ' ')"
+          echo "Scenarios: ${SCENARIOS}"
+          mkdir -p /tmp/ladder
+          fails=""
+          for s in ${SCENARIOS}; do
+            echo "::group::mock-ladder ${s}"
+            start=$(date +%s)
+            if task e2e:mock -- "${s}" > "/tmp/ladder/${s}.log" 2>&1; then
+              res="PASS"
+            else
+              res="FAIL"
+              fails="${fails} ${s}"
+            fi
+            echo "${res} ${s} ($(( $(date +%s) - start ))s)"
+            # On failure surface the tail inline; full logs are uploaded below.
+            if [ "${res}" = "FAIL" ]; then tail -100 "/tmp/ladder/${s}.log"; fi
+            echo "::endgroup::"
+          done
+          echo "=== mock ladder summary ==="
+          for s in ${SCENARIOS}; do
+            case " ${fails} " in
+              *" ${s} "*) echo "FAIL  ${s}" ;;
+              *)          echo "PASS  ${s}" ;;
+            esac
+          done
+          if [ -n "${fails# }" ]; then
+            echo "Mock ladder FAILED:${fails}"
+            exit 1
+          fi
+          echo "Mock ladder: all scenarios passed."
+
+      - name: Upload scenario logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mock-ladder-logs
+          path: /tmp/ladder/
+          retention-days: 7

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -66,6 +66,19 @@ jobs:
         run: |
           echo "DOCKER_GID=$(getent group docker | cut -d: -f3)" >> "$GITHUB_ENV"
 
+      - name: Stack bring-up diagnostic
+        # Temporary: bring the mock stack up via the ladder's own deps and confirm
+        # it reaches healthy on this runner (sandbox no longer exits on git
+        # dubious-ownership). Captures sandbox logs if up --wait still fails.
+        run: |
+          set +e
+          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
+          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
+          echo "=== ps ==="; $DC ps -a --format 'table {{.Service}}\t{{.Status}}'
+          echo "=== sandbox logs ==="; $DC logs sandbox 2>&1 | tail -40
+          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
+          exit 0
+
       - name: Run mock ladder
         run: |
           set -uo pipefail

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -68,20 +68,22 @@ jobs:
 
       - name: Stack bring-up diagnostic
         # One-shot: confirm the mock stack reaches healthy on this runner and
-        # surface sandbox logs if it does not. Self-contained (own teardown); the
-        # ladder below re-runs the full lifecycle per scenario.
+        # capture the sandbox failure reason if it does not. Self-contained (own
+        # teardown); the ladder below re-runs the full lifecycle per scenario.
         run: |
           set +e
-          echo "DOCKER_GID=${DOCKER_GID:-unset}"
+          echo "DOCKER_GID=${DOCKER_GID:-unset} runner uid=$(id -u) gid=$(id -g)"
           task e2e:build >/dev/null 2>&1
           docker compose -p semspec-e2e -f docker/compose/e2e.yml build semspec sandbox >/dev/null 2>&1
           docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml build mock-llm >/dev/null 2>&1
           mkdir -p test/e2e/workspace && ( cd test/e2e/workspace && [ -d .git ] || { git init -q && git config user.email e@t.l && git config user.name t && echo x > README.md && git add README.md && git commit -q -m init; } )
-          MOCK_SCENARIO=plan-smoke docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml up -d --wait
-          echo "up --wait rc=$?"
-          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml ps
-          echo "=== sandbox logs ==="; docker logs semspec-e2e-sandbox-1 2>&1 | tail -60
-          docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml down -v >/dev/null 2>&1
+          echo "=== workspace ownership ==="; ls -lan test/e2e | grep workspace; ls -lan test/e2e/workspace | head
+          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
+          MOCK_SCENARIO=plan-smoke $DC up -d --wait; echo "up --wait rc=$?"
+          echo "=== ps -a ==="; $DC ps -a
+          echo "=== sandbox compose logs ==="; $DC logs sandbox 2>&1 | tail -80
+          echo "=== sandbox inspect ==="; docker inspect semspec-e2e-sandbox-1 --format 'exit={{.State.ExitCode}} err={{.State.Error}} oom={{.State.OOMKilled}}' 2>&1
+          $DC down -v >/dev/null 2>&1
           exit 0
 
       - name: Run mock ladder

--- a/docker/sandbox-entrypoint.sh
+++ b/docker/sandbox-entrypoint.sh
@@ -15,6 +15,15 @@
 # misconfigured credential never blocks the sandbox from starting.
 set -e
 
+# The mounted /workspace is owned by the host user, whose uid can differ from the
+# sandbox uid (e.g. a CI runner at uid 1001 vs the sandbox image's uid 1000).
+# git's dubious-ownership guard then aborts the sandbox's "ensure valid HEAD"
+# commit with exit 128, so the container exits before serving /health and
+# `up --wait` fails the whole stack. The sandbox is a controlled execution
+# environment that owns whatever repo it operates on (workspace + per-node
+# worktrees), so trust them all. Non-fatal if git is unavailable.
+git config --global --add safe.directory '*' 2>/dev/null || true
+
 if [ -n "${GITHUB_TOKEN:-}" ]; then
 	HOME="${HOME:-/home/sandbox}"
 	(

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -104,6 +104,16 @@ COPY --from=builder /sandbox /usr/local/bin/sandbox
 COPY docker/sandbox-entrypoint.sh /usr/local/bin/sandbox-entrypoint.sh
 RUN chmod +x /usr/local/bin/sandbox-entrypoint.sh
 
+# Trust mounted repos regardless of host uid. /workspace is owned by the host
+# user, whose uid can differ from the sandbox uid (CI runner 1001 vs sandbox
+# 1000); without this, git's dubious-ownership guard aborts the sandbox's
+# "ensure valid HEAD" commit (exit 128), the container never serves /health, and
+# `up --wait` fails the whole stack. --system writes /etc/gitconfig as root, so
+# every git invocation reads it regardless of HOME — more robust than the
+# entrypoint's per-user --global (the sandbox binary may run git with a
+# different HOME).
+RUN git config --system --add safe.directory '*'
+
 USER sandbox
 # Explicit HOME so the entrypoint writes ~/.netrc + ~/.curlrc to the sandbox
 # user's home deterministically (Docker does not always derive HOME from USER).

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -124,6 +124,10 @@ tasks:
     desc: Clean E2E workspace
     silent: false
     cmds:
+      # The workspace dir is gitignored, so a fresh checkout (CI, new clone)
+      # lacks it. Create it as the current user BEFORE the docker mount below,
+      # otherwise the daemon auto-creates it root-owned and the git init fails.
+      - mkdir -p test/e2e/workspace
       - echo "[CLEAN-WORKSPACE] Cleaning test workspace..."
       - docker run --rm -v $(pwd)/test/e2e/workspace:/workspace alpine sh -c "rm -rf /workspace/* /workspace/.semspec 2>/dev/null; ls -la /workspace/" || true
       # Re-initialize a bare git repo so sandbox can start (requires a git repository).


### PR DESCRIPTION
## What

Wires up the mock-LLM e2e ladder as a CI workflow and lands the **Linux-portability fixes** discovered while standing it up. The gate is **parked** (manual `workflow_dispatch`) pending one remaining infra fix — see **#258** for the full diagnosis and path to a green, PR-triggered, required gate.

## Why parked

The ladder is correct and **13/13 locally**, but the full e2e stack doesn't yet come up on a stock `ubuntu-latest` runner: `semspec` (root) and `sandbox` (non-root) share the `/workspace` bind-mount, so the sandbox can't write the root-owned `/workspace/.semspec` tree and exits 1, failing `up --wait`. Mac Docker Desktop's uid mapping hides this; Linux exposes it. Rather than spam a red check on every PR, the trigger is `workflow_dispatch` only, with the path back to PR-triggered documented in the workflow header. **#258** tracks the remaining fix (unify the `/workspace` uid across containers).

## Portability fixes (correct regardless of CI — these are the wins)

- **`taskfiles/e2e.yml`** — `clean-workspace` creates the gitignored workspace dir on a fresh checkout (it `cd`'d into a dir that doesn't exist on a clean clone → failed every e2e run, not just CI).
- **`docker/sandbox.Dockerfile` + `docker/sandbox-entrypoint.sh`** — the sandbox trusts its workspace git repo (`safe.directory`, `--system`), so it starts under any host/container uid mismatch instead of aborting on git's dubious-ownership guard. Helps any non-Mac environment.

## The gate (parked, ready to flip on)

`.github/workflows/mock-ladder.yml`: discovers scenarios from the fixture dirs, runs each via `task e2e:mock` (full lifecycle per scenario, isolated), PASS/FAIL summary + log artifact, no paid tokens / no model downloads (mock stack stubs the model servers to alpine no-ops). Resolves the runner's `SANDBOX_UID`/`GID` + docker GID. To activate once #258 lands: switch the trigger back to `pull_request`/`push` and add `mock-ladder` to the required checks for `main`.

## Provenance

Found and proven by 9 CI runs on this branch, each peeling one real Linux-only layer (gitignored workspace → docker-socket GID → git dubious-ownership → workspace write perms → semspec-root-vs-sandbox). The companion scenario fix that takes the ladder to 13/13 merged as #256.

Refs #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)