### PR TITLE
ci(mock-ladder): activate the e2e gate — unify /workspace uid for Linux runners (closes #258)

### DIFF
--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -63,18 +63,30 @@ jobs:
         # satisfies the loader without supplying secrets.
         run: touch .env
 
+      - name: Match container uid/gid to the runner
+        # Run semspec + sandbox as the runner user so every /workspace write is
+        # host-owned and the host-side e2e runner can clean it between scenarios.
+        # SANDBOX_UID/GID feed the sandbox image build (proper passwd entry +
+        # owned HOME) and the semspec `user:` override; DOCKER_GID lets the
+        # non-root sandbox reach the DooD socket. See issue #258.
+        run: |
+          {
+            echo "SANDBOX_UID=$(id -u)"
+            echo "SANDBOX_GID=$(id -g)"
+            echo "DOCKER_GID=$(getent group docker | cut -d: -f3)"
+          } >> "$GITHUB_ENV"
+
       - name: Stack bring-up probe
-        # Validation aid (#258): bring the mock stack up once and confirm the
-        # sandbox stays healthy on this runner before the full ladder. The mock
-        # sandbox runs as root (e2e-mock.yml user:"0:0") so it can write the
-        # root-owned /workspace/.semspec tree semspec creates. Dumps sandbox logs
-        # if up --wait still fails. Self-contained teardown.
+        # Validation aid (#258): bring the mock stack up once and confirm both
+        # containers stay healthy on this runner before the full ladder. Dumps
+        # sandbox + semspec logs if up --wait still fails. Self-contained teardown.
         run: |
           set +e
           DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
           task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
           echo "=== ps ==="; $DC ps -a --format 'table {{.Service}}\t{{.Status}}'
           echo "=== sandbox logs ==="; $DC logs sandbox 2>&1 | tail -30
+          echo "=== semspec logs ==="; $DC logs semspec 2>&1 | tail -15
           task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
           exit 0
 

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -63,23 +63,20 @@ jobs:
         # satisfies the loader without supplying secrets.
         run: touch .env
 
-      - name: Match sandbox uid/gid + docker GID to the runner
-        # The sandbox bind-mounts /workspace (host-owned) and the host docker
-        # socket. On Mac Docker Desktop the uid mapping hides ownership, but on a
-        # Linux runner the sandbox image's baked uid (1000) differs from the
-        # runner user (1001) that owns /workspace, so the sandbox can't write it
-        # (mkdir worktrees -> permission denied) and git flags dubious ownership —
-        # the container exits 1 and up --wait fails the whole stack. Build the
-        # sandbox image AS the runner's uid/gid so it owns /workspace, and resolve
-        # the docker group GID so the DooD socket is accessible. NOTE: this is
-        # necessary but not yet sufficient — semspec still runs as root and
-        # creates /workspace/.semspec first; see issue #258.
+      - name: Stack bring-up probe
+        # Validation aid (#258): bring the mock stack up once and confirm the
+        # sandbox stays healthy on this runner before the full ladder. The mock
+        # sandbox runs as root (e2e-mock.yml user:"0:0") so it can write the
+        # root-owned /workspace/.semspec tree semspec creates. Dumps sandbox logs
+        # if up --wait still fails. Self-contained teardown.
         run: |
-          {
-            echo "SANDBOX_UID=$(id -u)"
-            echo "SANDBOX_GID=$(id -g)"
-            echo "DOCKER_GID=$(getent group docker | cut -d: -f3)"
-          } >> "$GITHUB_ENV"
+          set +e
+          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
+          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
+          echo "=== ps ==="; $DC ps -a --format 'table {{.Service}}\t{{.Status}}'
+          echo "=== sandbox logs ==="; $DC logs sandbox 2>&1 | tail -30
+          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
+          exit 0
 
       - name: Run mock ladder
         run: |

--- a/.github/workflows/mock-ladder.yml
+++ b/.github/workflows/mock-ladder.yml
@@ -7,21 +7,20 @@ name: Mock Ladder
 # (build -> up mock stack -> run -> teardown) for isolation. No paid tokens, no
 # model downloads — e2e-mock.yml stubs semembed/seminstruct to alpine no-ops.
 #
-# STATUS: PARKED (manual workflow_dispatch only) — see issue #258.
-# The gate workflow is correct and 13/13 locally, but the e2e stack does not yet
-# come up on a stock ubuntu-latest runner: semspec (root) and sandbox (non-root)
-# share the /workspace bind-mount, so the sandbox can't write the
-# root-owned /workspace/.semspec tree and exits 1, failing `up --wait`. Mac
-# Docker Desktop's uid mapping hides this; Linux exposes it. The steps below
-# already fix the gitignored-workspace, docker-socket GID, and git
-# dubious-ownership layers; the remaining piece is unifying the /workspace uid
-# across containers (issue #258). When that lands, switch the trigger back to:
-#   on:
-#     pull_request: { branches: [main] }
-#     push:         { branches: [main] }
-# and add "mock-ladder" to the branch-protection required checks for main.
+# Validated 13/13 on ubuntu-latest (#258). Getting the e2e stack to come up on a
+# stock Linux runner required unifying every /workspace writer on the runner uid
+# (semspec + sandbox run as the host user; see e2e-mock.yml + #258) — Mac Docker
+# Desktop's uid mapping hides the mismatch that Linux exposes.
+#
+# Runs in parallel with the fast lint-and-test gate (ci.yml), so it never blocks
+# quick feedback. To make it a required merge gate, add "mock-ladder" to the
+# branch-protection required checks for main.
 
 on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch: {}
 
 permissions:
@@ -75,20 +74,6 @@ jobs:
             echo "SANDBOX_GID=$(id -g)"
             echo "DOCKER_GID=$(getent group docker | cut -d: -f3)"
           } >> "$GITHUB_ENV"
-
-      - name: Stack bring-up probe
-        # Validation aid (#258): bring the mock stack up once and confirm both
-        # containers stay healthy on this runner before the full ladder. Dumps
-        # sandbox + semspec logs if up --wait still fails. Self-contained teardown.
-        run: |
-          set +e
-          DC="docker compose -p semspec-e2e -f docker/compose/e2e.yml -f docker/compose/e2e-mock.yml"
-          task e2e:up:mock -- plan-smoke; echo "up:mock rc=$?"
-          echo "=== ps ==="; $DC ps -a --format 'table {{.Service}}\t{{.Status}}'
-          echo "=== sandbox logs ==="; $DC logs sandbox 2>&1 | tail -30
-          echo "=== semspec logs ==="; $DC logs semspec 2>&1 | tail -15
-          task e2e:down:mock >/dev/null 2>&1; $DC down -v >/dev/null 2>&1
-          exit 0
 
       - name: Run mock ladder
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,15 @@ COPY --from=builder /build/configs /app/configs
 # Create workspace directory
 RUN mkdir -p /workspace
 
+# System-wide git identity + ownership trust so semspec can run as a non-root,
+# arbitrary uid (CI runs it as the host uid so /workspace files are host-owned
+# and cleanable by the host-side e2e runner; see issue #258). --system writes
+# /etc/gitconfig, read by every git invocation regardless of HOME, so git
+# operations work for a uid with no passwd entry or home dir.
+RUN git config --system user.email "semspec@semspec.dev" \
+    && git config --system user.name "Semspec" \
+    && git config --system --add safe.directory '*'
+
 # Set default environment
 ENV NATS_URL=nats://localhost:4222
 ENV SEMSPEC_REPO_PATH=/workspace

--- a/docker/compose/e2e-mock.yml
+++ b/docker/compose/e2e-mock.yml
@@ -86,3 +86,14 @@ services:
         condition: service_healthy
       mock-llm:
         condition: service_healthy
+
+  # Run the mock sandbox as root so it can write the /workspace/.semspec tree
+  # that semspec (also root) creates. On a Linux CI runner the host-owned
+  # /workspace plus the sandbox image's baked non-root uid otherwise collide:
+  # semspec (root) creates .semspec first, the non-root sandbox can't write
+  # inside it (mkdir worktrees -> permission denied), the container exits 1, and
+  # `up --wait` fails the whole stack. Mac Docker Desktop's uid mapping hides
+  # this; running root sidesteps it entirely. Scoped to this mock/CI overlay —
+  # real-LLM stacks keep the non-root sandbox boundary. See issue #258.
+  sandbox:
+    user: "0:0"

--- a/docker/compose/e2e-mock.yml
+++ b/docker/compose/e2e-mock.yml
@@ -64,8 +64,15 @@ services:
       start_period: 2s
 
   semspec:
+    # Run as the host uid (set by CI to the runner user; default 0/root locally
+    # — Mac Docker Desktop maps it transparently) so the /workspace files semspec
+    # writes are host-owned and the host-side e2e runner can clean them between
+    # scenarios. semspec only writes /workspace (+ /tmp); /etc/gitconfig (built
+    # in) gives it a HOME-independent git identity. See issue #258.
+    user: "${SANDBOX_UID:-0}:${SANDBOX_GID:-0}"
     command: ["--config", "/app/configs/e2e-mock.json", "--repo", "/workspace", "--log-level", "${LOG_LEVEL:-info}"]
     environment:
+      - HOME=/tmp
       - NATS_URL=nats://nats:4222
       - SEMSPEC_REPO_PATH=/workspace
       - SANDBOX_URL=http://sandbox:8090
@@ -87,13 +94,8 @@ services:
       mock-llm:
         condition: service_healthy
 
-  # Run the mock sandbox as root so it can write the /workspace/.semspec tree
-  # that semspec (also root) creates. On a Linux CI runner the host-owned
-  # /workspace plus the sandbox image's baked non-root uid otherwise collide:
-  # semspec (root) creates .semspec first, the non-root sandbox can't write
-  # inside it (mkdir worktrees -> permission denied), the container exits 1, and
-  # `up --wait` fails the whole stack. Mac Docker Desktop's uid mapping hides
-  # this; running root sidesteps it entirely. Scoped to this mock/CI overlay —
-  # real-LLM stacks keep the non-root sandbox boundary. See issue #258.
-  sandbox:
-    user: "0:0"
+  # The sandbox is built with SANDBOX_UID/SANDBOX_GID (CI sets them to the runner
+  # user; default 1000) so its `sandbox` user — with a real passwd entry and an
+  # owned HOME — matches semspec's uid. Every /workspace write across both
+  # containers is then host-owned and cleanable by the host-side e2e runner,
+  # closing the root-vs-runner ownership conflict on Linux runners. See #258.


### PR DESCRIPTION
## What

Finishes #258: the mock-LLM e2e ladder now comes up and runs **13/13 green on a stock `ubuntu-latest` runner**, so the workflow is **un-parked** (PR + push triggers active again). Validated end-to-end before this PR (run `27886420996`: `up:mock rc=0`, both containers healthy, all 13 scenarios PASS) — and this PR's own `mock-ladder` check re-validates the final, probe-less workflow exactly as it'll run in production.

## Root cause + fix

The e2e stack bind-mounts one `/workspace` into multiple containers that wrote it as **different uids** — invisible on Mac (Docker Desktop maps uids) but real on Linux. Two halves:

1. **Bring-up:** `semspec` (root) created `/workspace/.semspec` first; the non-root `sandbox` couldn't write inside it → exited 1 → `up --wait` failed.
2. **Inter-scenario cleanup:** once both ran (even as root), they planted root-owned files the host-side e2e runner (runner uid) couldn't `unlinkat` between scenarios.

**Fix — unify every `/workspace` writer on the runner uid:**
- `semspec` runs as the host uid (`user:` override + `HOME=/tmp` + a system-wide git identity in its Dockerfile — it only writes `/workspace`+`/tmp`).
- `sandbox` builds with its existing `SANDBOX_UID`/`SANDBOX_GID` args (proper passwd entry + owned HOME), running as the same uid.
- `DOCKER_GID` lets the non-root sandbox reach the DooD socket.
- Defaults stay `0`/`1000` so **local Mac runs are unchanged**. Scoped to the mock/CI overlay — real-LLM stacks keep the non-root sandbox boundary.

## Also includes (carried from the gate work)

- `clean-workspace` creates the gitignored workspace dir on a fresh checkout (fixes any clean clone, not just CI).
- Sandbox + semspec system-wide `safe.directory` / git identity (helps any uid-mismatch environment).
- The workflow: scenario discovery from fixture dirs, full lifecycle per scenario, PASS/FAIL summary + log artifact, no paid tokens / no model downloads.

## Provenance

Took ~11 CI runs to surface, each peeling one real Linux-only layer (gitignored workspace → docker-socket GID → git dubious-ownership → workspace write perms → semspec-root-vs-sandbox → inter-scenario cleanup). Every layer was a genuine Mac-only-passing portability bug; standing the gate up *was* the portability audit.

## Follow-up

After merge, add **`mock-ladder`** to the branch-protection required checks for `main` to make it a blocking gate (repo setting, not in YAML).

Closes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)