### PR TITLE
[codex] fix execution prompt plan-state dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,6 @@ jobs:
 
       - name: go test
         run: go test ./...
+
+      - name: go integration tests
+        run: go test -race -tags integration -count=1 ./...

--- a/cmd/e2e/main_test.go
+++ b/cmd/e2e/main_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/c360studio/semspec/test/e2e/config"
+	"github.com/c360studio/semspec/tools/terminal"
 )
 
 // TestMockFixtureDirsMapToRegisteredScenarios guards the runnable-name ↔
@@ -61,5 +65,74 @@ func TestMockFixtureDirsMapToRegisteredScenarios(t *testing.T) {
 	}
 	if !sawDir {
 		t.Fatalf("no fixture directories found under %s", filepath.Clean(mockRoot))
+	}
+}
+
+func TestMockCoderSubmitWorkFixturesDeclareFileIntents(t *testing.T) {
+	const mockRoot = "../../test/e2e/fixtures/mock-responses"
+
+	type toolCall struct {
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}
+	type fixtureEnvelope struct {
+		ToolCalls     []toolCall `json:"tool_calls"`
+		FilesModified []string   `json:"files_modified"`
+		FileIntents   []any      `json:"file_intents"`
+	}
+
+	checked := 0
+	err := filepath.WalkDir(mockRoot, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasPrefix(d.Name(), "mock-coder") || filepath.Ext(d.Name()) != ".json" {
+			return nil
+		}
+
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		var fixture fixtureEnvelope
+		if err := json.Unmarshal(raw, &fixture); err != nil {
+			t.Errorf("%s: invalid JSON fixture: %v", p, err)
+			return nil
+		}
+
+		for _, call := range fixture.ToolCalls {
+			if call.Function.Name != "submit_work" {
+				continue
+			}
+			var args map[string]any
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &args); err != nil {
+				t.Errorf("%s: submit_work arguments are not valid JSON: %v", p, err)
+				continue
+			}
+			if _, ok := args["files_modified"]; !ok {
+				continue
+			}
+			if err := terminal.ValidateDeveloperDeliverable(args); err != nil {
+				t.Errorf("%s: coder submit_work fixture violates developer schema: %v", p, err)
+			}
+			checked++
+		}
+
+		if len(fixture.FilesModified) > 0 {
+			checked++
+			if len(fixture.FileIntents) != len(fixture.FilesModified) {
+				t.Errorf("%s: top-level coder fixture has %d files_modified entries but %d file_intents entries",
+					p, len(fixture.FilesModified), len(fixture.FileIntents))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk mock fixture root %s: %v", filepath.Clean(mockRoot), err)
+	}
+	if checked == 0 {
+		t.Fatalf("no mock coder submit_work or top-level files_modified fixtures found under %s", filepath.Clean(mockRoot))
 	}
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN go mod download
 COPY . .
 
 # Build the semspec binary (CGO enabled for tree-sitter)
-RUN CGO_ENABLED=1 GOOS=linux go build -o /semspec ./cmd/semspec
+RUN CGO_ENABLED=1 GOOS=linux go build -buildvcs=false -o /semspec ./cmd/semspec
 
 # Runtime stage
 FROM alpine:3.19

--- a/docker/Dockerfile.mock-llm
+++ b/docker/Dockerfile.mock-llm
@@ -13,7 +13,7 @@ RUN go mod download
 COPY . .
 
 # Build the mock-llm binary (no CGO needed — pure Go)
-RUN CGO_ENABLED=0 GOOS=linux go build -o /mock-llm ./cmd/mock-llm
+RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /mock-llm ./cmd/mock-llm
 
 # Runtime stage — minimal image
 FROM alpine:3.19

--- a/docker/sandbox.Dockerfile
+++ b/docker/sandbox.Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 go build -o /sandbox ./cmd/sandbox
+RUN CGO_ENABLED=0 go build -buildvcs=false -o /sandbox ./cmd/sandbox
 
 # Stage 2: Runtime image with the toolchains agents need to build and test code.
 FROM ubuntu:24.04

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -908,6 +908,7 @@ func (c *Component) handleDeveloperCompleteLocked(ctx context.Context, event *ag
 		c.logger.Warn("Failed to parse developer result", "slug", exec.Slug, "error", parseErr)
 	} else {
 		exec.FilesModified = result.FilesModified
+		exec.DeveloperFileIntents = result.FileIntents
 		exec.DeveloperOutput = result.Output
 		exec.DeveloperLLMRequestIDs = result.LLMRequestIDs
 	}
@@ -925,9 +926,9 @@ func (c *Component) handleDeveloperCompleteLocked(ctx context.Context, event *ag
 		}
 		switch {
 		case parseErr != nil:
-			feedback = "Your previous attempt ended without calling submit_work. You must call submit_work with a summary and a non-empty files_modified array before stopping. If you asked a question and did not get an answer, make reasonable assumptions from the plan and scenarios and continue — do not stop the loop waiting for an answer." + scopeHint
+			feedback = "Your previous attempt ended without a valid submit_work call. You must call submit_work with a summary, a non-empty files_modified array, and one file_intents entry for every files_modified path before stopping. If you asked a question and did not get an answer, make reasonable assumptions from the plan and scenarios and continue — do not stop the loop waiting for an answer." + scopeHint
 		default:
-			feedback = "Your previous submit_work had an empty files_modified array. You must write at least one file before calling submit_work. Create the implementation and test files called for by the scenarios, then submit again with the list of files you created or modified." + scopeHint
+			feedback = "Your previous submit_work had an empty files_modified array. You must write at least one file before calling submit_work. Create the implementation and test files called for by the scenarios, then submit again with the list of files you created or modified and one file_intents entry for each path." + scopeHint
 		}
 		c.routeFixableRejection(ctx, exec, feedback)
 		return
@@ -1550,6 +1551,7 @@ func (c *Component) startDeveloperRetryLocked(ctx context.Context, exec *taskExe
 	exec.TDDCycle++
 	exec.FilesModified = nil
 	exec.DeveloperOutput = nil
+	exec.DeveloperFileIntents = nil
 	exec.DeveloperLLMRequestIDs = nil
 	exec.ValidationPassed = false
 	exec.ValidationResults = nil
@@ -2049,6 +2051,7 @@ func (c *Component) runStructuralValidation(ctx context.Context, exec *taskExecu
 		ExecutionID:     uuid.New().String(),
 		Slug:            exec.Slug,
 		FilesModified:   exec.FilesModified,
+		FileIntents:     append([]payloads.FileIntent(nil), exec.DeveloperFileIntents...),
 		WorktreePath:    exec.WorktreePath,
 		TaskID:          exec.TaskID,
 		DeveloperLoopID: exec.DeveloperLoopID,

--- a/processor/execution-manager/component.go
+++ b/processor/execution-manager/component.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	sscache "github.com/c360studio/semstreams/pkg/cache"
+	"github.com/c360studio/semstreams/pkg/retry"
 
 	"github.com/c360studio/semspec/internal/trajectory"
 	"github.com/c360studio/semspec/model"
@@ -74,6 +75,8 @@ const (
 	stageDevelop = "develop" // developer writes tests then implements code (full TDD cycle)
 	stageReview  = "review"  // LLM code review with verdict + feedback
 
+	planStatesBucketName = "PLAN_STATES"
+
 	// Phase values written to entity triples.
 	phaseDeveloping       = "developing"
 	phaseValidating       = "validating"
@@ -96,6 +99,13 @@ type worktreeManager interface {
 	MergeWorktree(ctx context.Context, taskID string, opts ...sandbox.MergeOption) (*sandbox.MergeResult, error)
 	ListWorktreeFiles(ctx context.Context, taskID string) ([]sandbox.FileEntry, error)
 	GitStatus(ctx context.Context, taskID string) (string, error)
+}
+
+// planKeyValue is the narrow read surface execution-manager needs from
+// PLAN_STATES. Keeping the cached type small makes startup-race tests honest
+// without faking the entire JetStream KeyValue API.
+type planKeyValue interface {
+	Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error)
 }
 
 // newWorktreeManager returns a worktreeManager backed by the sandbox client,
@@ -132,11 +142,15 @@ type Component struct {
 	// store is the 3-layer execution store (cache + KV + triples).
 	store *executionStore
 
-	// planBucket is a best-effort read-only handle to PLAN_STATES so the
-	// TaskContext builder can surface plan-level fields (currently just the
-	// architect's TestSurface) to the developer prompt. nil when the bucket
-	// is unavailable at startup — callers treat that as "no test_surface".
-	planBucket jetstream.KeyValue
+	// planBucket is the required read-only handle to PLAN_STATES. Execution
+	// prompts depend on plan-level fields (contract constraints, test surface,
+	// harness profiles, upstream resolutions), so Start waits for plan-manager
+	// to create the bucket instead of allowing prompt assembly to run without it.
+	planBucket   planKeyValue
+	planBucketMu sync.Mutex
+	// planBucketOpener is an optional test hook. Production leaves it nil and
+	// waitForPlanBucket uses the component's NATS client.
+	planBucketOpener func(context.Context) (planKeyValue, error)
 
 	// activeExecs is a typed TTL cache mapping entityID → *taskExecution.
 	// Holds runtime pipeline state (mutexes, timers) for in-flight executions.
@@ -288,8 +302,11 @@ func (c *Component) Start(ctx context.Context) error {
 		return fmt.Errorf("create task routing cache: %w", err)
 	}
 
-	// Initialize EXECUTION_STATES bucket and store.
-	c.initExecutionStore(ctx)
+	// Initialize EXECUTION_STATES bucket/store and bind required PLAN_STATES
+	// dependency for prompt context.
+	if err := c.initExecutionStore(ctx); err != nil {
+		return err
+	}
 
 	// Reconcile: recover in-flight executions from graph state.
 	// Also populates the execution store from KV or graph.
@@ -397,11 +414,16 @@ func (c *Component) Stop(timeout time.Duration) error {
 // initAgentGraph connects to the ENTITY_STATES KV bucket and loads error
 // categories. When the bucket is unavailable, agent selection is disabled
 // and the orchestrator falls back to using the model from the trigger payload.
-// initExecutionStore creates the EXECUTION_STATES KV bucket and initializes
-// the 3-layer execution store. If bucket creation fails, the store operates
-// in cache+graph-only mode (graceful degradation).
-func (c *Component) initExecutionStore(ctx context.Context) {
+// initExecutionStore creates the EXECUTION_STATES KV bucket, initializes the
+// 3-layer execution store, and waits for the PLAN_STATES dependency used by
+// execution prompt assembly. EXECUTION_STATES KV can degrade to cache+graph
+// mode, but PLAN_STATES is load-bearing: without it developer/reviewer prompts
+// lose the authoritative plan contract.
+func (c *Component) initExecutionStore(ctx context.Context) error {
 	var kvStore *natsclient.KVStore
+	if c.natsClient == nil {
+		return errors.New("nats client unavailable")
+	}
 
 	bucket, err := c.natsClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
 		Bucket:  c.config.ExecutionStateBucket,
@@ -417,41 +439,78 @@ func (c *Component) initExecutionStore(ctx context.Context) {
 
 	store, err := newExecutionStore(ctx, kvStore, c.tripleWriter, c.logger)
 	if err != nil {
-		c.logger.Error("Failed to create execution store", "error", err)
-		return
+		return fmt.Errorf("create execution store: %w", err)
 	}
 	c.store = store
 
-	// Best-effort read handle to PLAN_STATES for plan-level lookups during
-	// TaskContext population (test_surface injection). Failure is non-fatal.
-	if js, err := c.natsClient.JetStream(); err == nil {
-		if pb, err := js.KeyValue(ctx, "PLAN_STATES"); err == nil {
-			c.planBucket = pb
-		} else {
-			c.logger.Warn("PLAN_STATES bucket unavailable — test_surface injection disabled",
-				"error", err)
-		}
+	pb, err := c.waitForPlanBucket(ctx)
+	if err != nil {
+		return fmt.Errorf("wait for %s bucket: %w", planStatesBucketName, err)
 	}
+	c.cachePlanBucket(pb)
+	c.logger.Info("PLAN_STATES bucket ready for execution prompt context", "bucket", planStatesBucketName)
+	return nil
+}
+
+func (c *Component) waitForPlanBucket(ctx context.Context) (planKeyValue, error) {
+	if c.planBucketOpener != nil {
+		return retry.DoWithResult(ctx, retry.Config{
+			MaxAttempts:  30,
+			InitialDelay: 200 * time.Millisecond,
+			MaxDelay:     2 * time.Second,
+			Multiplier:   1.5,
+		}, func() (planKeyValue, error) {
+			return c.planBucketOpener(ctx)
+		})
+	}
+	if c.natsClient == nil {
+		return nil, errors.New("nats client unavailable")
+	}
+	js, err := c.natsClient.JetStream()
+	if err != nil {
+		return nil, err
+	}
+	return workflow.WaitForKVBucket(ctx, js, planStatesBucketName)
+}
+
+func (c *Component) currentPlanBucket() planKeyValue {
+	c.planBucketMu.Lock()
+	defer c.planBucketMu.Unlock()
+	return c.planBucket
+}
+
+func (c *Component) cachePlanBucket(bucket planKeyValue) bool {
+	if bucket == nil {
+		return false
+	}
+	c.planBucketMu.Lock()
+	defer c.planBucketMu.Unlock()
+	firstBind := c.planBucket == nil
+	c.planBucket = bucket
+	return firstBind
 }
 
 // readPlan loads the plan from PLAN_STATES once so a single dispatch can derive
 // all of its architecture-backed prompt context (test_surface, harness
 // profiles, upstream resolutions) from one fetch + unmarshal instead of one
-// per field. Returns nil when the bucket, key, or value is unavailable;
-// callers treat nil as "no plan context" and proceed.
-func (c *Component) readPlan(ctx context.Context, slug string) *workflow.Plan {
-	if c.planBucket == nil || slug == "" {
-		return nil
+// per field.
+func (c *Component) readPlan(ctx context.Context, slug string) (*workflow.Plan, error) {
+	if slug == "" {
+		return nil, errors.New("plan slug is empty")
 	}
-	entry, err := c.planBucket.Get(ctx, slug)
+	bucket := c.currentPlanBucket()
+	if bucket == nil {
+		return nil, fmt.Errorf("%s bucket unavailable", planStatesBucketName)
+	}
+	entry, err := bucket.Get(ctx, slug)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("get plan %q from %s: %w", slug, planStatesBucketName, err)
 	}
 	var plan workflow.Plan
 	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
-		return nil
+		return nil, fmt.Errorf("unmarshal plan %q from %s: %w", slug, planStatesBucketName, err)
 	}
-	return &plan
+	return &plan, nil
 }
 
 // planArchitecture nil-safely returns the plan's architecture document.
@@ -580,15 +639,11 @@ func cloneStringStringMap(in map[string]string) map[string]string {
 // missing, req missing, no hint set) — recovery hints are advisory,
 // not load-bearing. Best-effort.
 func (c *Component) lookupRecoveryHint(ctx context.Context, slug, requirementID string) string {
-	if c.planBucket == nil || slug == "" || requirementID == "" {
+	if slug == "" || requirementID == "" {
 		return ""
 	}
-	entry, err := c.planBucket.Get(ctx, slug)
-	if err != nil {
-		return ""
-	}
-	var plan workflow.Plan
-	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
+	plan, err := c.readPlan(ctx, slug)
+	if err != nil || plan == nil {
 		return ""
 	}
 	for _, req := range plan.Requirements {
@@ -1592,7 +1647,7 @@ func resolveProvider(modelStr string) prompt.Provider {
 // assembler elides schema prose).
 // The ctx parameter is used for graph reads (error trends, lessons); context.WithoutCancel
 // is applied so these reads survive caller cancellation without inheriting the deadline.
-func (c *Component) buildAssemblyContext(ctx context.Context, role prompt.Role, exec *taskExecution, modelName string) *prompt.AssemblyContext {
+func (c *Component) buildAssemblyContext(ctx context.Context, role prompt.Role, exec *taskExecution, modelName string) (*prompt.AssemblyContext, error) {
 	var (
 		maxTokens int
 		endpoint  *ssmodel.EndpointConfig
@@ -1626,7 +1681,10 @@ func (c *Component) buildAssemblyContext(ctx context.Context, role prompt.Role, 
 		// Fetch the plan once; derive every architecture-backed field from it
 		// rather than re-fetching PLAN_STATES per field (3 reads × 3 roles per
 		// TDD cycle pre-consolidation).
-		plan := c.readPlan(ctx, exec.Slug)
+		plan, err := c.readPlan(ctx, exec.Slug)
+		if err != nil {
+			return nil, fmt.Errorf("load plan %q for %s prompt: %w", exec.Slug, role, err)
+		}
 		asmCtx.ContractProjection = prompt.BuildContractProjection(plan, role)
 		asmCtx.TaskContext = &prompt.TaskContext{
 			PlanGoal:            exec.Title,
@@ -1641,11 +1699,9 @@ func (c *Component) buildAssemblyContext(ctx context.Context, role prompt.Role, 
 			FileScope:           append([]string(nil), exec.FileScope...),
 			Scenarios:           scenariosToSpecs(exec.Scenarios),
 			UpstreamResolutions: prompt.ProjectUpstreams(planArchitecture(plan)),
-		}
-		if plan != nil {
-			// #204: re-inject the plan's hard constraints into the dev/validator/
-			// reviewer prompt — decomposition otherwise never carries them here.
-			asmCtx.TaskContext.PlanConstraints = append([]string(nil), plan.Constraints...)
+			// #204: decomposition does not carry hard plan constraints into
+			// task execution, so re-inject them for dev/validator/reviewer.
+			PlanConstraints: append([]string(nil), plan.Constraints...),
 		}
 
 		// Populate ErrorTrends from role-scoped lesson counts. Use threshold 0
@@ -1697,7 +1753,7 @@ func (c *Component) buildAssemblyContext(ctx context.Context, role prompt.Role, 
 		}
 	}
 
-	return asmCtx
+	return asmCtx, nil
 }
 
 // availableToolNames returns the full list of tool names registered in the system.
@@ -1764,10 +1820,6 @@ func (c *Component) dispatchDeveloperLocked(ctx context.Context, exec *taskExecu
 		return
 	}
 
-	taskID := fmt.Sprintf("dev-%s-%s", exec.EntityID, uuid.New().String())
-	exec.DeveloperTaskID = taskID
-	c.taskRouting.Set(taskID, exec.EntityID)
-
 	// Resolve developer model via capability registry. config.Model is the
 	// component-level override knob; the canonical path is CapabilityCoding →
 	// registry. exec.Model (set upstream by req-executor when it dispatched
@@ -1781,7 +1833,16 @@ func (c *Component) dispatchDeveloperLocked(ctx context.Context, exec *taskExecu
 	// Assemble system prompt via fragment pipeline. Pass devModel so the
 	// assembler sees HasResponseFormat for the endpoint the dispatch will
 	// hit; ResponseFormat is attached on the TaskMessage below.
-	asmCtx := c.buildAssemblyContext(ctx, prompt.RoleDeveloper, exec, devModel)
+	asmCtx, err := c.buildAssemblyContext(ctx, prompt.RoleDeveloper, exec, devModel)
+	if err != nil {
+		c.logger.Error("Cannot dispatch developer without plan context",
+			"slug", exec.Slug,
+			"task_id", exec.TaskID,
+			"error", err,
+		)
+		c.markErrorLocked(ctx, exec, fmt.Sprintf("developer prompt plan context unavailable: %v", err))
+		return
+	}
 	assembled := c.assembler.Assemble(asmCtx)
 
 	userPrompt := exec.Prompt
@@ -1811,6 +1872,10 @@ func (c *Component) dispatchDeveloperLocked(ctx context.Context, exec *taskExecu
 	if c.modelRegistry != nil {
 		endpoint = c.modelRegistry.GetEndpoint(devModel)
 	}
+
+	taskID := fmt.Sprintf("dev-%s-%s", exec.EntityID, uuid.New().String())
+	exec.DeveloperTaskID = taskID
+	c.taskRouting.Set(taskID, exec.EntityID)
 
 	task := &agentic.TaskMessage{
 		TaskID: taskID,
@@ -2098,10 +2163,6 @@ func (c *Component) dispatchReviewerLocked(ctx context.Context, exec *taskExecut
 		return
 	}
 
-	taskID := fmt.Sprintf("rev-%s-%s", exec.EntityID, uuid.New().String())
-	exec.ReviewerTaskID = taskID
-	c.taskRouting.Set(taskID, exec.EntityID)
-
 	// Resolve the reviewer model up-front so buildAssemblyContext sees the
 	// endpoint the dispatch will actually hit (ResponseFormat support is
 	// per-endpoint and gates schema-prose elision in the assembled prompt).
@@ -2110,7 +2171,16 @@ func (c *Component) dispatchReviewerLocked(ctx context.Context, exec *taskExecut
 	reviewerModel := model.ResolveModel(c.modelRegistry, c.config.CodeReviewerModel, model.CapabilityReviewing)
 
 	// Assemble system prompt via fragment pipeline.
-	asmCtx := c.buildAssemblyContext(ctx, prompt.RoleReviewer, exec, reviewerModel)
+	asmCtx, err := c.buildAssemblyContext(ctx, prompt.RoleReviewer, exec, reviewerModel)
+	if err != nil {
+		c.logger.Error("Cannot dispatch code reviewer without plan context",
+			"slug", exec.Slug,
+			"task_id", exec.TaskID,
+			"error", err,
+		)
+		c.markErrorLocked(ctx, exec, fmt.Sprintf("reviewer prompt plan context unavailable: %v", err))
+		return
+	}
 	assembled := c.assembler.Assemble(asmCtx)
 
 	// User prompt carries task context (what to review), not implementation
@@ -2135,6 +2205,10 @@ func (c *Component) dispatchReviewerLocked(ctx context.Context, exec *taskExecut
 	if c.modelRegistry != nil {
 		reviewerEndpoint = c.modelRegistry.GetEndpoint(reviewerModel)
 	}
+
+	taskID := fmt.Sprintf("rev-%s-%s", exec.EntityID, uuid.New().String())
+	exec.ReviewerTaskID = taskID
+	c.taskRouting.Set(taskID, exec.EntityID)
 
 	task := &agentic.TaskMessage{
 		TaskID: taskID,
@@ -2468,14 +2542,14 @@ func (c *Component) publishTask(ctx context.Context, subject string, task *agent
 	baseMsg := message.NewBaseMessage(task.Schema(), task, componentName)
 	data, err := json.Marshal(baseMsg)
 	if err != nil {
-		c.logger.Debug("Failed to marshal task message", "error", err)
+		c.logger.Error("Failed to marshal task message", "error", err)
 		c.errors.Add(1)
 		return
 	}
 
 	if c.natsClient != nil {
 		if err := c.natsClient.PublishToStream(ctx, subject, data); err != nil {
-			c.logger.Debug("Failed to publish task", "subject", subject, "error", err)
+			c.logger.Error("Failed to publish task", "subject", subject, "error", err)
 			c.errors.Add(1)
 		}
 	}

--- a/processor/execution-manager/component_test.go
+++ b/processor/execution-manager/component_test.go
@@ -1168,7 +1168,7 @@ func TestHandleDeveloperComplete_EmptyFilesModified_RoutesToRetry(t *testing.T) 
 	event := &agentic.LoopCompletedEvent{
 		TaskID:       exec.DeveloperTaskID,
 		Outcome:      agentic.OutcomeSuccess,
-		Result:       `{"summary": "done", "files_modified": []}`,
+		Result:       `{"summary": "done", "files_modified": [], "file_intents": []}`,
 		WorkflowSlug: WorkflowSlugTaskExecution,
 		WorkflowStep: stageDevelop,
 	}
@@ -1213,7 +1213,7 @@ func TestHandleDeveloperComplete_HallucinatedClaim_RoutesToRetry(t *testing.T) {
 	event := &agentic.LoopCompletedEvent{
 		TaskID:       exec.DeveloperTaskID,
 		Outcome:      agentic.OutcomeSuccess,
-		Result:       `{"summary": "Implemented /health endpoint that returns HTTP 200", "files_modified": ["main.go"]}`,
+		Result:       `{"summary": "Implemented /health endpoint that returns HTTP 200", "files_modified": ["main.go"], "file_intents": [{"path": "main.go", "intent": "modified_existing", "rationale": "Claimed existing endpoint implementation was changed."}]}`,
 		WorkflowSlug: WorkflowSlugTaskExecution,
 		WorkflowStep: stageDevelop,
 	}
@@ -1283,7 +1283,7 @@ func TestHandleDeveloperComplete_LeakedToWorkspace_RoutesPathConfusion(t *testin
 	event := &agentic.LoopCompletedEvent{
 		TaskID:       exec.DeveloperTaskID,
 		Outcome:      agentic.OutcomeSuccess,
-		Result:       `{"summary": "Configured gradle build with test deps", "files_modified": ["build.gradle", "src/test/java/org/sensorhub/MeshtasticDriverBuildTest.java"]}`,
+		Result:       `{"summary": "Configured gradle build with test deps", "files_modified": ["build.gradle", "src/test/java/org/sensorhub/MeshtasticDriverBuildTest.java"], "file_intents": [{"path": "build.gradle", "intent": "modified_existing", "rationale": "Claimed existing build configuration was updated."}, {"path": "src/test/java/org/sensorhub/MeshtasticDriverBuildTest.java", "intent": "companion_test", "rationale": "Claimed companion test coverage was added."}]}`,
 		WorkflowSlug: WorkflowSlugTaskExecution,
 		WorkflowStep: stageDevelop,
 	}

--- a/processor/execution-manager/execution_state.go
+++ b/processor/execution-manager/execution_state.go
@@ -31,6 +31,7 @@ type taskExecution struct {
 	// Raw LLM outputs (large blobs, not worth persisting to KV).
 	DeveloperOutput        json.RawMessage
 	DeveloperLLMRequestIDs []string
+	DeveloperFileIntents   []payloads.FileIntent
 	ValidationResults      []payloads.CheckResult
 	ReviewerLLMRequestIDs  []string
 

--- a/processor/execution-manager/integration_test.go
+++ b/processor/execution-manager/integration_test.go
@@ -5,9 +5,11 @@ package executionmanager
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/test/integration/graphmock"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/natsclient"
@@ -36,7 +38,7 @@ func TestIntegration_StartStop(t *testing.T) {
 	defer cancel()
 
 	// Mock graph-ingest so reconcileFromGraph does not block on unanswered requests.
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	comp := newExecIntegrationComponent(t, tc)
 
@@ -66,6 +68,45 @@ func TestIntegration_StartStop(t *testing.T) {
 	}
 }
 
+func TestIntegration_StartRequiresPlanStatesBucket(t *testing.T) {
+	tc := natsclient.NewTestClient(t,
+		natsclient.WithStreams(
+			natsclient.TestStreamConfig{
+				Name:     "WORKFLOW",
+				Subjects: []string{"workflow.async.>"},
+			},
+			natsclient.TestStreamConfig{
+				Name:     "AGENT",
+				Subjects: []string{"agentic.loop_completed.v1", "agent.task.>", "dev.task.>"},
+			},
+		),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	cfg := DefaultConfig()
+	cfg.Model = "default"
+	rawCfg, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal default config: %v", err)
+	}
+	compI, err := NewComponent(rawCfg, component.Dependencies{NATSClient: tc.Client})
+	if err != nil {
+		t.Fatalf("NewComponent() error: %v", err)
+	}
+	comp := compI.(*Component)
+	comp.sandbox = &stubSandbox{}
+
+	err = comp.Start(ctx)
+	if err == nil {
+		t.Fatal("Start() error = nil, want missing PLAN_STATES dependency failure")
+	}
+	if !strings.Contains(err.Error(), planStatesBucketName) {
+		t.Fatalf("Start() error = %q, want %s context", err, planStatesBucketName)
+	}
+}
+
 // TestIntegration_KVPendingTaskCreatesExecution verifies the KV self-trigger path:
 // writing a TaskExecution with stage=pending to EXECUTION_STATES causes the
 // component to claim the task, register an active execution, publish entity
@@ -88,29 +129,9 @@ func TestIntegration_KVPendingTaskCreatesExecution(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	// Mock graph-ingest so WriteTriple calls do not time out.
-	startMockGraphIngest(t, tc.Client)
+	comp := startExecIntegrationComponent(t, tc, ctx)
 
-	comp := newExecIntegrationComponent(t, tc)
-
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
-
-	// Subscribe to agent.task.development before writing KV so no messages are missed.
-	developerTasks := make(chan []byte, 10)
 	nativeConn := tc.GetNativeConnection()
-	developerSub, err := nativeConn.Subscribe("agent.task.development", func(msg *nats.Msg) {
-		data := make([]byte, len(msg.Data))
-		copy(data, msg.Data)
-		developerTasks <- data
-	})
-	if err != nil {
-		t.Fatalf("Subscribe(agent.task.development) error = %v", err)
-	}
-	t.Cleanup(func() { _ = developerSub.Unsubscribe() })
-
 	// Subscribe to graph.mutation.triple.add to observe entity triple requests.
 	triples := make(chan []byte, 20)
 	tripleSub, err := nativeConn.Subscribe("graph.mutation.triple.add", func(msg *nats.Msg) {
@@ -122,6 +143,9 @@ func TestIntegration_KVPendingTaskCreatesExecution(t *testing.T) {
 		t.Fatalf("Subscribe(graph.mutation.triple.add) error = %v", err)
 	}
 	t.Cleanup(func() { _ = tripleSub.Unsubscribe() })
+	if err := nativeConn.Flush(); err != nil {
+		t.Fatalf("flush subscriptions: %v", err)
+	}
 
 	// Write a pending task to EXECUTION_STATES — the KV watcher picks it up.
 	writeKVPendingTask(t, tc, ctx, workflow.TaskExecution{
@@ -136,8 +160,8 @@ func TestIntegration_KVPendingTaskCreatesExecution(t *testing.T) {
 	})
 
 	// Verify: a developer task message appears on agent.task.development.
-	developerMsgs := collectMessagesFrom(ctx, t, developerTasks, 1, 15*time.Second)
-	if len(developerMsgs) == 0 {
+	developerMsg := fetchLastStreamMessageForSubject(t, tc, ctx, "AGENT", "agent.task.development", 15*time.Second)
+	if len(developerMsg) == 0 {
 		t.Fatal("expected at least one developer task message on agent.task.development")
 	}
 
@@ -174,15 +198,7 @@ func TestIntegration_DuplicateKVEntryIsIdempotent(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
-	// Mock graph-ingest so WriteTriple calls do not block.
-	startMockGraphIngest(t, tc.Client)
-
-	comp := newExecIntegrationComponent(t, tc)
-
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecIntegrationComponent(t, tc, ctx)
 
 	task := workflow.TaskExecution{
 		Slug:         "dup-plan",
@@ -219,8 +235,12 @@ func TestIntegration_DuplicateKVEntryIsIdempotent(t *testing.T) {
 // to the provided test NATS client using the default configuration.
 func newExecIntegrationComponent(t *testing.T, tc *natsclient.TestClient) *Component {
 	t.Helper()
+	ctx := context.Background()
+	ensurePlanStatesBucket(t, tc, ctx)
 
-	rawCfg, err := json.Marshal(DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.Model = "default"
+	rawCfg, err := json.Marshal(cfg)
 	if err != nil {
 		t.Fatalf("marshal default config: %v", err)
 	}
@@ -230,7 +250,63 @@ func newExecIntegrationComponent(t *testing.T, tc *natsclient.TestClient) *Compo
 	if err != nil {
 		t.Fatalf("NewComponent() error: %v", err)
 	}
-	return compI.(*Component)
+	comp := compI.(*Component)
+	comp.sandbox = &stubSandbox{}
+	return comp
+}
+
+func startExecIntegrationComponent(t *testing.T, tc *natsclient.TestClient, ctx context.Context) *Component {
+	t.Helper()
+	graphmock.Start(t, tc.Client)
+	comp := newExecIntegrationComponent(t, tc)
+	if err := comp.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	return comp
+}
+
+func startExecMutationIntegrationComponent(t *testing.T, tc *natsclient.TestClient, ctx context.Context) *Component {
+	t.Helper()
+	graphmock.Start(t, tc.Client)
+	comp := newExecIntegrationComponent(t, tc)
+	if err := comp.initExecutionStore(ctx); err != nil {
+		t.Fatalf("initExecutionStore() error = %v", err)
+	}
+	if err := comp.startExecMutationHandler(ctx); err != nil {
+		t.Fatalf("startExecMutationHandler() error = %v", err)
+	}
+	return comp
+}
+
+func ensurePlanStatesBucket(t *testing.T, tc *natsclient.TestClient, ctx context.Context) jetstream.KeyValue {
+	t.Helper()
+	js, err := tc.Client.JetStream()
+	if err != nil {
+		t.Fatalf("ensurePlanStatesBucket: JetStream(): %v", err)
+	}
+	bucket, err := js.CreateOrUpdateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: planStatesBucketName,
+	})
+	if err != nil {
+		t.Fatalf("ensurePlanStatesBucket: create/open %s: %v", planStatesBucketName, err)
+	}
+	return bucket
+}
+
+func writeKVPlan(t *testing.T, tc *natsclient.TestClient, ctx context.Context, plan workflow.Plan) {
+	t.Helper()
+	if plan.Slug == "" {
+		t.Fatal("writeKVPlan: plan slug is required")
+	}
+	bucket := ensurePlanStatesBucket(t, tc, ctx)
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("writeKVPlan: marshal plan: %v", err)
+	}
+	if _, err := bucket.Put(ctx, plan.Slug, data); err != nil {
+		t.Fatalf("writeKVPlan: put %q: %v", plan.Slug, err)
+	}
 }
 
 // writeKVPendingTask serialises a TaskExecution and writes it to the
@@ -238,6 +314,7 @@ func newExecIntegrationComponent(t *testing.T, tc *natsclient.TestClient) *Compo
 // in watchTaskPending will pick it up and initiate execution.
 func writeKVPendingTask(t *testing.T, tc *natsclient.TestClient, ctx context.Context, task workflow.TaskExecution) {
 	t.Helper()
+	writeKVPlan(t, tc, ctx, workflow.Plan{Slug: task.Slug})
 
 	js, err := tc.Client.JetStream()
 	if err != nil {
@@ -260,6 +337,46 @@ func writeKVPendingTask(t *testing.T, tc *natsclient.TestClient, ctx context.Con
 	if _, err := bucket.Put(ctx, key, data); err != nil {
 		t.Fatalf("writeKVPendingTask: put %q: %v", key, err)
 	}
+}
+
+func fetchLastStreamMessageForSubject(t *testing.T, tc *natsclient.TestClient, ctx context.Context, streamName, subject string, timeout time.Duration) []byte {
+	t.Helper()
+	js, err := tc.Client.JetStream()
+	if err != nil {
+		t.Fatalf("fetchLastStreamMessageForSubject: JetStream(): %v", err)
+	}
+	stream, err := js.Stream(ctx, streamName)
+	if err != nil {
+		t.Fatalf("fetchLastStreamMessageForSubject: get %s stream: %v", streamName, err)
+	}
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		msg, err := stream.GetLastMsgForSubject(ctx, subject)
+		if err == nil {
+			return append([]byte(nil), msg.Data...)
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			t.Logf("fetchLastStreamMessageForSubject: context done for %s/%s: %v", streamName, subject, ctx.Err())
+			return nil
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	if info, err := stream.Info(ctx); err == nil {
+		t.Logf("fetchLastStreamMessageForSubject: timeout waiting for %s/%s, last error: %v, stream_subjects=%v msgs=%d first_seq=%d last_seq=%d",
+			streamName, subject, lastErr, info.Config.Subjects, info.State.Msgs, info.State.FirstSeq, info.State.LastSeq)
+		if info.State.LastSeq > 0 {
+			if raw, err := stream.GetMsg(ctx, info.State.LastSeq); err == nil {
+				t.Logf("fetchLastStreamMessageForSubject: last stored subject=%s len=%d", raw.Subject, len(raw.Data))
+			}
+		}
+	} else {
+		t.Logf("fetchLastStreamMessageForSubject: timeout waiting for %s/%s, last error: %v, stream info error: %v", streamName, subject, lastErr, err)
+	}
+	return nil
 }
 
 // collectMessagesFrom reads from ch until n messages arrive or the deadline passes.

--- a/processor/execution-manager/loop_completions.go
+++ b/processor/execution-manager/loop_completions.go
@@ -358,7 +358,8 @@ func buildLoopFailureFeedback(event *agentic.LoopCompletedEvent) string {
 				"You MUST call submit_work to terminate the loop. If your "+
 				"code in the worktree is correct, call submit_work now "+
 				"with summary, files_modified listing what you changed, "+
-				"and any output. If you are stuck or uncertain, call "+
+				"file_intents classifying each changed path, and any output. "+
+				"If you are stuck or uncertain, call "+
 				"submit_work with a partial summary that explicitly "+
 				"describes the obstacle — do not keep refining.",
 			event.Iterations, budget,

--- a/processor/execution-manager/plan_context_test.go
+++ b/processor/execution-manager/plan_context_test.go
@@ -1,0 +1,174 @@
+package executionmanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semspec/prompt"
+	promptdomain "github.com/c360studio/semspec/prompt/domain"
+	"github.com/c360studio/semspec/workflow"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestWaitForPlanBucket_RetriesUntilAvailable(t *testing.T) {
+	component := &Component{}
+	bucket := fakePlanBucket{values: map[string][]byte{"plan-mavlink": []byte(`{"slug":"plan-mavlink"}`)}}
+	openCalls := 0
+	component.planBucketOpener = func(context.Context) (planKeyValue, error) {
+		openCalls++
+		if openCalls == 1 {
+			return nil, errors.New("nats: bucket not found")
+		}
+		return bucket, nil
+	}
+
+	got, err := component.waitForPlanBucket(context.Background())
+	if err != nil {
+		t.Fatalf("waitForPlanBucket() error = %v", err)
+	}
+	if got == nil {
+		t.Fatalf("waitForPlanBucket() returned nil bucket")
+	}
+	if openCalls != 2 {
+		t.Fatalf("plan bucket opener calls = %d, want 2", openCalls)
+	}
+}
+
+func TestBuildAssemblyContext_ReviewerRequiresPlan(t *testing.T) {
+	component := newPlanContextTestComponent()
+	exec := &taskExecution{
+		TaskExecution: &workflow.TaskExecution{
+			Slug:         "plan-mavlink",
+			Title:        "Review MAVSDK driver implementation",
+			WorktreePath: "/work/plan-mavlink",
+		},
+	}
+
+	_, err := component.buildAssemblyContext(context.Background(), prompt.RoleReviewer, exec, "gemini-pro")
+	if err == nil {
+		t.Fatalf("buildAssemblyContext() error = nil, want PLAN_STATES load failure")
+	}
+	if !strings.Contains(err.Error(), "PLAN_STATES") {
+		t.Fatalf("buildAssemblyContext() error = %q, want PLAN_STATES context", err)
+	}
+}
+
+func TestBuildAssemblyContext_ReviewerReceivesPlanConstraints(t *testing.T) {
+	const constraint = "Do not hand-roll MAVLink framing, do not stub MAVSDK/OSH classes"
+
+	plan := workflow.Plan{
+		Slug:        "plan-mavlink",
+		Constraints: []string{constraint},
+		Contract: &workflow.ContractPacket{
+			ID:          workflow.PlanContractID("contract-mavlink"),
+			Constraints: []string{constraint},
+		},
+	}
+	planBytes, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+
+	component := newPlanContextTestComponent()
+	bucket := fakePlanBucket{values: map[string][]byte{plan.Slug: planBytes}}
+	component.cachePlanBucket(bucket)
+
+	exec := &taskExecution{
+		TaskExecution: &workflow.TaskExecution{
+			Slug:         plan.Slug,
+			Title:        "Review MAVSDK driver implementation",
+			WorktreePath: "/work/plan-mavlink",
+		},
+	}
+	asmCtx, err := component.buildAssemblyContext(context.Background(), prompt.RoleReviewer, exec, "gemini-pro")
+	if err != nil {
+		t.Fatalf("buildAssemblyContext() error = %v", err)
+	}
+	if asmCtx.TaskContext == nil {
+		t.Fatalf("TaskContext missing")
+	}
+	if !containsString(asmCtx.TaskContext.PlanConstraints, constraint) {
+		t.Fatalf("reviewer TaskContext missing plan constraint: %#v", asmCtx.TaskContext.PlanConstraints)
+	}
+	if asmCtx.ContractProjection == nil || !containsString(asmCtx.ContractProjection.Constraints, constraint) {
+		t.Fatalf("reviewer ContractProjection missing constraints: %#v", asmCtx.ContractProjection)
+	}
+
+	out := component.assembler.Assemble(asmCtx)
+	if out.RenderError != nil {
+		t.Fatalf("assemble reviewer prompt: %v", out.RenderError)
+	}
+	combined := out.SystemMessage + "\n" + out.UserMessage
+	if !strings.Contains(combined, "AUTHORITATIVE CONTRACT PACKET") {
+		t.Fatalf("reviewer prompt missing authoritative contract packet\n--- prompt ---\n%s", combined)
+	}
+	if !strings.Contains(combined, "do not stub MAVSDK/OSH classes") {
+		t.Fatalf("reviewer prompt missing no-stubs constraint\n--- prompt ---\n%s", combined)
+	}
+}
+
+func newPlanContextTestComponent() *Component {
+	registry := prompt.NewRegistry()
+	registry.RegisterAll(promptdomain.Software()...)
+	return &Component{
+		assembler: prompt.NewAssembler(registry),
+	}
+}
+
+type fakePlanBucket struct {
+	values map[string][]byte
+}
+
+func (b fakePlanBucket) Get(_ context.Context, key string) (jetstream.KeyValueEntry, error) {
+	value, ok := b.values[key]
+	if !ok {
+		return nil, errors.New("key not found")
+	}
+	return fakePlanEntry{key: key, value: value}, nil
+}
+
+type fakePlanEntry struct {
+	key   string
+	value []byte
+}
+
+func (e fakePlanEntry) Bucket() string {
+	return planStatesBucketName
+}
+
+func (e fakePlanEntry) Key() string {
+	return e.key
+}
+
+func (e fakePlanEntry) Value() []byte {
+	return append([]byte(nil), e.value...)
+}
+
+func (e fakePlanEntry) Revision() uint64 {
+	return 1
+}
+
+func (e fakePlanEntry) Created() time.Time {
+	return time.Time{}
+}
+
+func (e fakePlanEntry) Delta() uint64 {
+	return 0
+}
+
+func (e fakePlanEntry) Operation() jetstream.KeyValueOp {
+	return jetstream.KeyValuePut
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/processor/execution-manager/reconcile_integration_test.go
+++ b/processor/execution-manager/reconcile_integration_test.go
@@ -4,18 +4,15 @@ package executionmanager
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/test/integration/graphmock"
 	wf "github.com/c360studio/semspec/vocabulary/workflow"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
-	sgraph "github.com/c360studio/semstreams/graph"
-	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 )
 
@@ -44,7 +41,7 @@ func TestIntegration_ReconcileFromGraph(t *testing.T) {
 	defer cancel()
 
 	// Start mock graph-ingest to handle triple writes and queries.
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	tw := &graphutil.TripleWriter{
 		NATSClient:    tc.Client,
@@ -135,7 +132,7 @@ func TestIntegration_ReconcileSkipsTerminal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	tw := &graphutil.TripleWriter{
 		NATSClient:    tc.Client,
@@ -186,7 +183,7 @@ func TestIntegration_TripleRoundTrip(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	tw := &graphutil.TripleWriter{
 		NATSClient:    tc.Client,
@@ -222,120 +219,4 @@ func TestIntegration_TripleRoundTrip(t *testing.T) {
 
 func testLogger() *slog.Logger {
 	return slog.Default()
-}
-
-// mockGraphIngest provides in-memory graph-ingest NATS responders for testing.
-// It handles graph.mutation.triple.add and graph.ingest.query.entity/prefix.
-type mockGraphIngest struct {
-	mu       sync.Mutex
-	entities map[string]*sgraph.EntityState // entityID → state
-}
-
-func startMockGraphIngest(t *testing.T, nc *natsclient.Client) *mockGraphIngest {
-	t.Helper()
-	m := &mockGraphIngest{entities: make(map[string]*sgraph.EntityState)}
-
-	// Handle triple writes.
-	nc.SubscribeForRequests(context.Background(), "graph.mutation.triple.add", func(_ context.Context, data []byte) ([]byte, error) {
-		var req sgraph.AddTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return json.Marshal(map[string]any{"success": false, "error": err.Error()})
-		}
-
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		entity, ok := m.entities[req.Triple.Subject]
-		if !ok {
-			entity = &sgraph.EntityState{
-				ID:        req.Triple.Subject,
-				UpdatedAt: time.Now(),
-			}
-			m.entities[req.Triple.Subject] = entity
-		}
-
-		// Upsert triple — replace existing predicate or append.
-		found := false
-		for i, t := range entity.Triples {
-			if t.Predicate == req.Triple.Predicate {
-				entity.Triples[i] = req.Triple
-				found = true
-				break
-			}
-		}
-		if !found {
-			entity.Triples = append(entity.Triples, req.Triple)
-		}
-		entity.Version++
-		entity.UpdatedAt = time.Now()
-
-		return json.Marshal(map[string]any{"success": true, "kv_revision": entity.Version})
-	})
-
-	// Handle entity queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.entity", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		entity, ok := m.entities[req.ID]
-		m.mu.Unlock()
-
-		if !ok {
-			return nil, fmt.Errorf("not found: %s", req.ID)
-		}
-		return json.Marshal(entity)
-	})
-
-	// Handle prefix queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.prefix", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			Prefix string `json:"prefix"`
-			Limit  int    `json:"limit"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		var matches []sgraph.EntityState
-		for id, entity := range m.entities {
-			if len(id) >= len(req.Prefix) && id[:len(req.Prefix)] == req.Prefix {
-				matches = append(matches, *entity)
-				if req.Limit > 0 && len(matches) >= req.Limit {
-					break
-				}
-			}
-		}
-		m.mu.Unlock()
-
-		return json.Marshal(map[string]any{"entities": matches})
-	})
-
-	// Flush ensures all subscriptions are registered on the server before any
-	// caller fires requests. Without this, there is a race between the async
-	// subscribe round-trip and the first WriteTriple call.
-	if conn := nc.GetConnection(); conn != nil {
-		_ = conn.Flush()
-	}
-
-	return m
-}
-
-// tripleValue is a convenience to convert message.Triple objects to string.
-func tripleValue(triples []message.Triple, predicate string) string {
-	for _, t := range triples {
-		if t.Predicate == predicate {
-			if s, ok := t.Object.(string); ok {
-				return s
-			}
-			data, _ := json.Marshal(t.Object)
-			return string(data)
-		}
-	}
-	return ""
 }

--- a/processor/execution-manager/store_integration_test.go
+++ b/processor/execution-manager/store_integration_test.go
@@ -35,11 +35,7 @@ func TestIntegration_ExecutionStoreCreated(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	comp := newExecIntegrationComponent(t, tc)
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecIntegrationComponent(t, tc, ctx)
 
 	if comp.store == nil {
 		t.Fatal("store is nil after Start()")
@@ -73,11 +69,7 @@ func TestIntegration_TaskCreateMutation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	comp := newExecIntegrationComponent(t, tc)
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecMutationIntegrationComponent(t, tc, ctx)
 
 	// Send task.create mutation via request/reply.
 	createReq := TaskCreateRequest{
@@ -120,8 +112,8 @@ func TestIntegration_TaskCreateMutation(t *testing.T) {
 	if exec.TaskID != "task-001" {
 		t.Errorf("TaskID = %q, want %q", exec.TaskID, "task-001")
 	}
-	if exec.Stage != "developing" {
-		t.Errorf("Stage = %q, want %q", exec.Stage, "developing")
+	if exec.Stage != "pending" {
+		t.Errorf("Stage = %q, want %q", exec.Stage, "pending")
 	}
 	if exec.MaxTDDCycles != 3 {
 		t.Errorf("MaxTDDCycles = %d, want %d", exec.MaxTDDCycles, 3)
@@ -152,11 +144,7 @@ func TestIntegration_TaskPhaseMutation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	comp := newExecIntegrationComponent(t, tc)
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecMutationIntegrationComponent(t, tc, ctx)
 
 	// Create task.
 	createReq, _ := json.Marshal(TaskCreateRequest{
@@ -223,11 +211,7 @@ func TestIntegration_ReqCreateMutation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	comp := newExecIntegrationComponent(t, tc)
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecMutationIntegrationComponent(t, tc, ctx)
 
 	createReq, _ := json.Marshal(ReqCreateRequest{
 		Slug:          "plan-b",
@@ -257,8 +241,8 @@ func TestIntegration_ReqCreateMutation(t *testing.T) {
 	if !ok {
 		t.Fatalf("store.getReq(%q) not found", expectedKey)
 	}
-	if exec.Stage != "decomposing" {
-		t.Errorf("Stage = %q, want %q", exec.Stage, "decomposing")
+	if exec.Stage != "pending" {
+		t.Errorf("Stage = %q, want %q", exec.Stage, "pending")
 	}
 	if exec.RequirementID != "req-001" {
 		t.Errorf("RequirementID = %q, want %q", exec.RequirementID, "req-001")
@@ -288,11 +272,7 @@ func TestIntegration_TaskCompleteTerminal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	comp := newExecIntegrationComponent(t, tc)
-	if err := comp.Start(ctx); err != nil {
-		t.Fatalf("Start() error = %v", err)
-	}
-	t.Cleanup(func() { _ = comp.Stop(5 * time.Second) })
+	comp := startExecMutationIntegrationComponent(t, tc, ctx)
 
 	// Create.
 	createReq, _ := json.Marshal(TaskCreateRequest{

--- a/processor/execution-manager/testhelpers_test.go
+++ b/processor/execution-manager/testhelpers_test.go
@@ -159,6 +159,7 @@ func newTestComponent(t *testing.T) *Component {
 		t.Fatalf("newTestComponent: NewComponent failed: %v", err)
 	}
 	c := disc.(*Component)
+	c.config.Model = "default"
 
 	// Initialize typed caches that are normally created in Start().
 	ctx := context.Background()
@@ -178,6 +179,7 @@ func newTestComponent(t *testing.T) *Component {
 		t.Fatalf("newTestComponent: create execution store: %v", err)
 	}
 	c.store = store
+	c.cachePlanBucket(defaultPlanBucket{})
 	return c
 }
 
@@ -225,6 +227,29 @@ func (e *mockKVEntry) Revision() uint64                { return 1 }
 func (e *mockKVEntry) Created() time.Time              { return time.Time{} }
 func (e *mockKVEntry) Delta() uint64                   { return 0 }
 func (e *mockKVEntry) Operation() jetstream.KeyValueOp { return e.op }
+
+// defaultPlanBucket gives state-machine unit tests a minimal PLAN_STATES row
+// for whichever slug they use. Tests that need to prove missing-plan behavior
+// construct Component directly instead of using newTestComponent.
+type defaultPlanBucket struct{}
+
+func (defaultPlanBucket) Get(_ context.Context, key string) (jetstream.KeyValueEntry, error) {
+	value, _ := json.Marshal(workflow.Plan{Slug: key})
+	return &mockPlanEntry{key: key, value: value}, nil
+}
+
+type mockPlanEntry struct {
+	key   string
+	value []byte
+}
+
+func (e *mockPlanEntry) Bucket() string                  { return planStatesBucketName }
+func (e *mockPlanEntry) Key() string                     { return e.key }
+func (e *mockPlanEntry) Value() []byte                   { return append([]byte(nil), e.value...) }
+func (e *mockPlanEntry) Revision() uint64                { return 1 }
+func (e *mockPlanEntry) Created() time.Time              { return time.Time{} }
+func (e *mockPlanEntry) Delta() uint64                   { return 0 }
+func (e *mockPlanEntry) Operation() jetstream.KeyValueOp { return jetstream.KeyValuePut }
 
 // makeKVEntry builds a mockKVEntry for handleTaskPending unit tests.
 func makeKVEntry(t *testing.T, key string, fields map[string]any) *mockKVEntry {

--- a/processor/plan-decision-handler/integration_test.go
+++ b/processor/plan-decision-handler/integration_test.go
@@ -42,7 +42,7 @@ func seedPlanToKV(t *testing.T, nc *natsclient.Client, plan *workflow.Plan) {
 	if err != nil {
 		t.Fatalf("seedPlanToKV: marshal plan: %v", err)
 	}
-	if err := kvStore.Put(ctx, plan.Slug, data); err != nil {
+	if _, err := kvStore.Put(ctx, plan.Slug, data); err != nil {
 		t.Fatalf("seedPlanToKV: put %q: %v", plan.Slug, err)
 	}
 }

--- a/processor/plan-manager/http.go
+++ b/processor/plan-manager/http.go
@@ -847,16 +847,13 @@ func (c *Component) handlePromotePlan(w http.ResponseWriter, r *http.Request, sl
 		}
 	}
 
-	// The plan is now approved. The coordinator's KV watcher sees the status
-	// change and drives the pipeline forward (requirement generation → scenario
-	// generation → review). No manual dispatch needed — the KV write IS the event.
-	//
-	// For round 2 (requirements+scenarios already exist), check if we need to
-	// advance to ready_for_execution.
+	// The plan is now approved. For round 2 (requirements+scenarios already
+	// exist), advancing to ready_for_execution must also dispatch execution
+	// when an execution publisher is available.
 	if len(plan.Requirements) > 0 && len(plan.Scenarios) > 0 {
 		if plan.Status != workflow.StatusReadyForExecution && plan.Status != workflow.StatusImplementing {
 			c.logger.Info("Round 2 human approval: plan ready for execution", "slug", slug)
-			if err := c.setPlanStatusCached(r.Context(), plan, workflow.StatusReadyForExecution); err != nil {
+			if err := c.transitionToReadyForExecution(r.Context(), plan); err != nil {
 				c.logger.Error("Failed to set plan ready for execution", "slug", slug, "error", err)
 				http.Error(w, "Failed to update plan status", http.StatusInternalServerError)
 				return
@@ -1359,8 +1356,9 @@ func (c *Component) handleRetryPlan(w http.ResponseWriter, r *http.Request, slug
 			return
 		}
 	} else {
-		// Transition back to ready_for_execution so the orchestrator picks it up.
-		if err := c.setPlanStatusCached(pubCtx, plan, workflow.StatusReadyForExecution); err != nil {
+		// Transition back to ready_for_execution and dispatch the selected
+		// requirements when an execution publisher is available.
+		if err := c.transitionToReadyForExecution(pubCtx, plan, retryReqIDs); err != nil {
 			c.logger.Error("Failed to set plan ready for execution", "slug", slug, "error", err)
 			writeJSONError(w, "Failed to update plan status: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/processor/plan-manager/http_promote_test.go
+++ b/processor/plan-manager/http_promote_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 func TestHandlePromotePlan_ReviewedToApproved(t *testing.T) {
@@ -46,6 +47,53 @@ func TestHandlePromotePlan_ReviewedToApproved(t *testing.T) {
 	}
 	if got.Plan.Status != workflow.StatusApproved {
 		t.Errorf("Plan.Status = %q, want %q", got.Plan.Status, workflow.StatusApproved)
+	}
+}
+
+func TestHandlePromotePlan_Round2ReentryAutoStartsExecution(t *testing.T) {
+	c := setupTestComponent(t)
+	slug := "promote-round2-reentry"
+
+	plan := setupTestPlan(t, c, slug)
+	plan.Approved = true
+	plan.Status = workflow.StatusScenariosReviewed
+	plan.Requirements = []workflow.Requirement{{ID: "requirement.1", Title: "Fix ownership gate"}}
+	plan.Stories = []workflow.Story{{ID: "story.1", RequirementIDs: []string{"requirement.1"}, Status: workflow.StoryStatusReady}}
+	plan.Scenarios = []workflow.Scenario{{ID: "scenario.1", RequirementID: "requirement.1", StoryID: "story.1"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		if got.PlanSlug != slug {
+			t.Fatalf("published slug = %q, want %q", got.PlanSlug, slug)
+		}
+		if len(got.Requirements) != 1 || got.Requirements[0].ID != "requirement.1" {
+			t.Fatalf("published requirements = %v, want requirement.1", got.Requirements)
+		}
+		if len(got.Scenarios) != 1 || got.Scenarios[0].ID != "scenario.1" {
+			t.Fatalf("published scenarios = %v, want scenario.1", got.Scenarios)
+		}
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/plan-manager/plans/"+slug+"/promote", nil)
+	w := httptest.NewRecorder()
+
+	c.handlePromotePlan(w, req, slug)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !published {
+		t.Fatal("expected round-2 promote to publish scenario orchestrator trigger")
+	}
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing after promote")
+	}
+	if got.EffectiveStatus() != workflow.StatusImplementing {
+		t.Fatalf("status = %s, want implementing", got.EffectiveStatus())
 	}
 }
 

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1300,23 +1300,28 @@ func (c *Component) handleReadyForExecutionMutation(ctx context.Context, data []
 	if !current.CanTransitionTo(workflow.StatusReadyForExecution) {
 		return MutationResponse{Success: false, Error: fmt.Sprintf("invalid transition: %s → ready_for_execution", current)}
 	}
-	plan.Status = workflow.StatusReadyForExecution
-
-	if err := ps.save(ctx, plan); err != nil {
-		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
+	if err := c.transitionToReadyForExecution(ctx, plan); err != nil {
+		return MutationResponse{Success: false, Error: fmt.Sprintf("ready for execution: %v", err)}
 	}
 
 	c.logger.Info("Plan ready for execution via mutation", "slug", req.Slug)
-	if c.shouldAutoStartExecution() {
-		if err := c.startExecutionFromReady(ctx, plan); err != nil {
-			return MutationResponse{Success: false, Error: fmt.Sprintf("start execution: %v", err)}
-		}
-	}
 	return MutationResponse{Success: true}
 }
 
 func (c *Component) shouldAutoStartExecution() bool {
 	return c.natsClient != nil || c.orchestratorTriggerPublisher != nil
+}
+
+func (c *Component) transitionToReadyForExecution(ctx context.Context, plan *workflow.Plan, forceRequirementIDs ...[]string) error {
+	if err := c.setPlanStatusCached(ctx, plan, workflow.StatusReadyForExecution); err != nil {
+		return err
+	}
+	if c.shouldAutoStartExecution() {
+		if err := c.startExecutionFromReady(ctx, plan, forceRequirementIDs...); err != nil {
+			return fmt.Errorf("start execution: %w", err)
+		}
+	}
+	return nil
 }
 
 func (c *Component) startExecutionFromReady(ctx context.Context, plan *workflow.Plan, forceRequirementIDs ...[]string) error {
@@ -2048,9 +2053,10 @@ func (c *Component) handleGitHubPRFeedbackMutation(ctx context.Context, data []b
 		return MutationResponse{Success: false, Error: "no requirement executions were reset — cannot re-execute"}
 	}
 
-	// Transition awaiting_review → ready_for_execution.
+	// Transition awaiting_review → ready_for_execution, then dispatch the
+	// affected requirements when an execution publisher is available.
 	durableCtx := context.WithoutCancel(ctx)
-	if err := c.setPlanStatusCached(durableCtx, plan, workflow.StatusReadyForExecution); err != nil {
+	if err := c.transitionToReadyForExecution(durableCtx, plan, affectedReqIDs); err != nil {
 		return MutationResponse{Success: false, Error: fmt.Sprintf("transition to ready_for_execution: %v", err)}
 	}
 

--- a/processor/plan-manager/pr_feedback_reentry_test.go
+++ b/processor/plan-manager/pr_feedback_reentry_test.go
@@ -1,0 +1,83 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+func TestHandleGitHubPRFeedbackMutation_AutoStartsAffectedRequirements(t *testing.T) {
+	ctx := context.Background()
+	c := setupTestComponent(t)
+	slug := "pr-feedback-reentry"
+	plan := &workflow.Plan{
+		ID:     workflow.PlanEntityID(slug),
+		Slug:   slug,
+		Title:  slug,
+		Status: workflow.StatusAwaitingReview,
+		GitHub: &workflow.GitHubMetadata{
+			Repository: "C360Studio/semspec",
+			PRNumber:   263,
+		},
+		Requirements: []workflow.Requirement{
+			{ID: "req.pr.1", Title: "Address review feedback", Status: workflow.RequirementStatusActive},
+			{ID: "req.pr.2", Title: "Unaffected deprecated work", Status: workflow.RequirementStatusDeprecated},
+		},
+		Scenarios: []workflow.Scenario{
+			{ID: "scen.pr.1", RequirementID: "req.pr.1"},
+			{ID: "scen.pr.2", RequirementID: "req.pr.2"},
+		},
+	}
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	c.execBucket = resetKVStub{keys: []string{"req." + slug + ".req.pr.1"}}
+	c.reqResetSender = func(context.Context, string) error {
+		return nil
+	}
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		if got.PlanSlug != slug {
+			t.Fatalf("published slug = %q, want %q", got.PlanSlug, slug)
+		}
+		if len(got.ForceRequirementIDs) != 1 || got.ForceRequirementIDs[0] != "req.pr.1" {
+			t.Fatalf("ForceRequirementIDs = %v, want req.pr.1", got.ForceRequirementIDs)
+		}
+		return nil
+	}
+
+	body, err := json.Marshal(payloads.GitHubPRFeedbackRequest{
+		Slug:     slug,
+		PRNumber: 263,
+		ReviewID: 9001,
+		Reviewer: "reviewer",
+		State:    "CHANGES_REQUESTED",
+		Body:     "Please adjust the first requirement.",
+	})
+	if err != nil {
+		t.Fatalf("marshal feedback: %v", err)
+	}
+
+	resp := c.handleGitHubPRFeedbackMutation(ctx, body)
+	if !resp.Success {
+		t.Fatalf("handleGitHubPRFeedbackMutation failed: %s", resp.Error)
+	}
+	if !published {
+		t.Fatal("expected PR feedback recovery to publish scenario orchestrator trigger")
+	}
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing after PR feedback")
+	}
+	if got.EffectiveStatus() != workflow.StatusImplementing {
+		t.Fatalf("status = %s, want implementing", got.EffectiveStatus())
+	}
+	if got.GitHub.PRRevision != 1 {
+		t.Fatalf("PRRevision = %d, want 1", got.GitHub.PRRevision)
+	}
+}

--- a/processor/plan-manager/retry_test.go
+++ b/processor/plan-manager/retry_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 // newRetryTestComponent builds a Component with a plan store but no NATS.
@@ -112,6 +113,48 @@ func TestHandleRetryPlan_RequirementsScopeShape(t *testing.T) {
 	})
 	if w.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+}
+
+func TestHandleRetryPlan_ReentryAutoStartsExecution(t *testing.T) {
+	c := newRetryTestComponent(t)
+	slug := "retry-reentry"
+	plan := seedPlan(t, c, slug, workflow.StatusRejected)
+	plan.Requirements = []workflow.Requirement{{ID: "req.retry.1", Title: "Retry failed requirement"}}
+	plan.Scenarios = []workflow.Scenario{{ID: "scen.retry.1", RequirementID: "req.retry.1"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		if got.PlanSlug != slug {
+			t.Fatalf("published slug = %q, want %q", got.PlanSlug, slug)
+		}
+		if len(got.Requirements) != 1 || got.Requirements[0].ID != "req.retry.1" {
+			t.Fatalf("published requirements = %v, want req.retry.1", got.Requirements)
+		}
+		if len(got.ForceRequirementIDs) != 1 || got.ForceRequirementIDs[0] != "req.retry.1" {
+			t.Fatalf("ForceRequirementIDs = %v, want req.retry.1", got.ForceRequirementIDs)
+		}
+		return nil
+	}
+
+	w := postRetry(t, c, slug, map[string]any{
+		"scope":           "requirements",
+		"requirement_ids": []string{"req.retry.1"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !published {
+		t.Fatal("expected retry re-entry to publish scenario orchestrator trigger")
+	}
+	got, ok := c.plans.get(slug)
+	if !ok {
+		t.Fatal("plan missing after retry")
+	}
+	if got.EffectiveStatus() != workflow.StatusImplementing {
+		t.Fatalf("status = %s, want implementing", got.EffectiveStatus())
 	}
 }
 

--- a/processor/plan-reviewer/deterministic_preflight_test.go
+++ b/processor/plan-reviewer/deterministic_preflight_test.go
@@ -39,6 +39,55 @@ func TestDeterministicPreflightReview_HardStructuralErrorShortCircuits(t *testin
 	}
 }
 
+func TestDeterministicPreflightReview_ContractDeliverableUncoveredShortCircuits(t *testing.T) {
+	plan := &workflow.Plan{
+		Slug: "preflight-uncovered-contract-file",
+		Scope: workflow.Scope{
+			Create: []string{"src/main/java/RequiredDriver.java", "src/main/java/Helper.java"},
+		},
+		Contract: &workflow.ContractPacket{
+			Scope: workflow.ContractScopeSnapshot{
+				Create: []string{"src/main/java/RequiredDriver.java", "src/main/java/Helper.java"},
+			},
+		},
+		Architecture: &workflow.ArchitectureDocument{
+			ComponentBoundaries: []workflow.ComponentDef{
+				{
+					Name:                "driver",
+					ImplementationFiles: []string{"src/main/java/RequiredDriver.java", "src/main/java/Helper.java"},
+					Capabilities:        []string{"driver"},
+				},
+			},
+		},
+		Requirements: []workflow.Requirement{{ID: "req.driver", CapabilityName: "driver", Title: "Driver"}},
+		Stories: []workflow.Story{{
+			ID:             "story.driver",
+			RequirementIDs: []string{"req.driver"},
+			ComponentName:  "driver",
+			Title:          "Build driver",
+			Status:         workflow.StoryStatusReady,
+			FilesOwned:     []string{"src/main/java/Helper.java"},
+			Tasks:          []workflow.Task{{ID: "task.driver.test", StoryID: "story.driver", Description: "Write failing test"}},
+		}},
+	}
+
+	result := deterministicPreflightReview(plan)
+
+	if result == nil {
+		t.Fatal("expected deterministic preflight to reject uncovered root contract deliverable")
+	}
+	finding := firstFinding(result.Findings, "story.contract_scope_uncovered")
+	if finding == nil {
+		t.Fatalf("expected story.contract_scope_uncovered finding, got %+v", result.Findings)
+	}
+	if finding.TargetValue != "src/main/java/RequiredDriver.java" {
+		t.Fatalf("TargetValue = %q, want src/main/java/RequiredDriver.java", finding.TargetValue)
+	}
+	if result.Verdict != "needs_changes" {
+		t.Fatalf("verdict = %q, want needs_changes", result.Verdict)
+	}
+}
+
 func TestDeterministicPreflightReview_WarningOnlyDoesNotShortCircuit(t *testing.T) {
 	plan := &workflow.Plan{
 		Slug: "preflight-warning-only",

--- a/processor/project-manager/store_integration_test.go
+++ b/processor/project-manager/store_integration_test.go
@@ -5,124 +5,18 @@ package projectmanager
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/test/integration/graphmock"
 	"github.com/c360studio/semspec/vocabulary/semspec"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/graphutil"
-	sgraph "github.com/c360studio/semstreams/graph"
-	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 )
-
-// ---------------------------------------------------------------------------
-// Mock graph-ingest — handles triple writes and queries via Core NATS
-// ---------------------------------------------------------------------------
-
-type mockGraphIngest struct {
-	mu       sync.Mutex
-	entities map[string]*sgraph.EntityState
-}
-
-func startMockGraphIngest(t *testing.T, nc *natsclient.Client) *mockGraphIngest {
-	t.Helper()
-	m := &mockGraphIngest{entities: make(map[string]*sgraph.EntityState)}
-
-	nc.SubscribeForRequests(context.Background(), "graph.mutation.triple.add", func(_ context.Context, data []byte) ([]byte, error) {
-		var req sgraph.AddTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return json.Marshal(map[string]any{"success": false, "error": err.Error()})
-		}
-
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		entity, ok := m.entities[req.Triple.Subject]
-		if !ok {
-			entity = &sgraph.EntityState{
-				ID:        req.Triple.Subject,
-				UpdatedAt: time.Now(),
-			}
-			m.entities[req.Triple.Subject] = entity
-		}
-
-		found := false
-		for i, tr := range entity.Triples {
-			if tr.Predicate == req.Triple.Predicate {
-				entity.Triples[i] = req.Triple
-				found = true
-				break
-			}
-		}
-		if !found {
-			entity.Triples = append(entity.Triples, req.Triple)
-		}
-		entity.Version++
-		entity.UpdatedAt = time.Now()
-
-		return json.Marshal(map[string]any{"success": true, "kv_revision": entity.Version})
-	})
-
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.entity", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-		m.mu.Lock()
-		entity, ok := m.entities[req.ID]
-		m.mu.Unlock()
-		if !ok {
-			return nil, fmt.Errorf("not found: %s", req.ID)
-		}
-		return json.Marshal(entity)
-	})
-
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.prefix", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			Prefix string `json:"prefix"`
-			Limit  int    `json:"limit"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-		m.mu.Lock()
-		var matches []sgraph.EntityState
-		for id, entity := range m.entities {
-			if strings.HasPrefix(id, req.Prefix) {
-				matches = append(matches, *entity)
-				if req.Limit > 0 && len(matches) >= req.Limit {
-					break
-				}
-			}
-		}
-		m.mu.Unlock()
-		return json.Marshal(map[string]any{"entities": matches})
-	})
-
-	return m
-}
-
-func tripleValue(triples []message.Triple, predicate string) string {
-	for _, t := range triples {
-		if t.Predicate == predicate {
-			if s, ok := t.Object.(string); ok {
-				return s
-			}
-			data, _ := json.Marshal(t.Object)
-			return string(data)
-		}
-	}
-	return ""
-}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -135,7 +29,7 @@ func TestIntegration_SaveWritesTriples(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	mock := startMockGraphIngest(t, tc.Client)
+	mock := graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".semspec"), 0755); err != nil {
@@ -183,26 +77,24 @@ func TestIntegration_SaveWritesTriples(t *testing.T) {
 
 	// Verify triples were written to mock graph.
 	entityID := workflow.ProjectConfigEntityID("project")
-	mock.mu.Lock()
-	entity, ok := mock.entities[entityID]
-	mock.mu.Unlock()
+	entity, ok := mock.Entity(entityID)
 
 	if !ok {
 		t.Fatal("no entity written to graph")
 	}
 
-	if v := tripleValue(entity.Triples, semspec.ProjectConfigName); v != "test-project" {
+	if v := graphmock.TripleValue(entity.Triples, semspec.ProjectConfigName); v != "test-project" {
 		t.Errorf("triple name = %q, want test-project", v)
 	}
-	if v := tripleValue(entity.Triples, semspec.ProjectConfigType); v != "project" {
+	if v := graphmock.TripleValue(entity.Triples, semspec.ProjectConfigType); v != "project" {
 		t.Errorf("triple type = %q, want project", v)
 	}
-	if v := tripleValue(entity.Triples, semspec.ProjectConfigOrg); v != "testorg" {
+	if v := graphmock.TripleValue(entity.Triples, semspec.ProjectConfigOrg); v != "testorg" {
 		t.Errorf("triple org = %q, want testorg", v)
 	}
 
 	// Verify JSON blob triple is round-trippable.
-	jsonBlob := tripleValue(entity.Triples, semspec.ProjectConfigJSON)
+	jsonBlob := graphmock.TripleValue(entity.Triples, semspec.ProjectConfigJSON)
 	if jsonBlob == "" {
 		t.Fatal("no JSON blob triple written")
 	}
@@ -222,7 +114,7 @@ func TestIntegration_ReconcileGraphWins(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	mock := startMockGraphIngest(t, tc.Client)
+	mock := graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	semspecDir := filepath.Join(repoRoot, ".semspec")
@@ -268,9 +160,7 @@ func TestIntegration_ReconcileGraphWins(t *testing.T) {
 	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigName, "new-name")
 
 	// Verify mock has the entity.
-	mock.mu.Lock()
-	_, exists := mock.entities[entityID]
-	mock.mu.Unlock()
+	_, exists := mock.Entity(entityID)
 	if !exists {
 		t.Fatal("setup: entity not in mock graph")
 	}
@@ -304,7 +194,7 @@ func TestIntegration_ReconcileFileWins(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	mock := startMockGraphIngest(t, tc.Client)
+	mock := graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	semspecDir := filepath.Join(repoRoot, ".semspec")
@@ -346,9 +236,7 @@ func TestIntegration_ReconcileFileWins(t *testing.T) {
 	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigUpdatedAt, oldTime.Format(time.RFC3339))
 	_ = tw.WriteTriple(ctx, entityID, semspec.ProjectConfigJSON, string(jsonBlob))
 
-	mock.mu.Lock()
-	_, exists := mock.entities[entityID]
-	mock.mu.Unlock()
+	_, exists := mock.Entity(entityID)
 	if !exists {
 		t.Fatal("setup: entity not in mock graph")
 	}
@@ -373,7 +261,7 @@ func TestIntegration_ReconcileNoGraph(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	_ = startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	semspecDir := filepath.Join(repoRoot, ".semspec")
@@ -407,7 +295,7 @@ func TestIntegration_StandardsSaveAndReconcile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	_ = startMockGraphIngest(t, tc.Client)
+	mock := graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".semspec"), 0755); err != nil {
@@ -440,8 +328,8 @@ func TestIntegration_StandardsSaveAndReconcile(t *testing.T) {
 	// Verify triples written.
 	entityID := workflow.ProjectConfigEntityID("standards")
 	jsonBlob := ""
-	if mock, ok := getMockEntity(t, tc.Client, ctx, entityID); ok {
-		jsonBlob = tripleValue(mock.Triples, semspec.ProjectConfigJSON)
+	if entity, ok := mock.Entity(entityID); ok {
+		jsonBlob = graphmock.TripleValue(entity.Triples, semspec.ProjectConfigJSON)
 	}
 	if jsonBlob == "" {
 		t.Fatal("no JSON blob triple for standards")
@@ -476,7 +364,7 @@ func TestIntegration_SaveApprovedConfig(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	mock := startMockGraphIngest(t, tc.Client)
+	mock := graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".semspec"), 0755); err != nil {
@@ -523,33 +411,16 @@ func TestIntegration_SaveApprovedConfig(t *testing.T) {
 	// Verify ApprovedAt triples were written for all three.
 	for _, configType := range []string{"project", "checklist", "standards"} {
 		entityID := workflow.ProjectConfigEntityID(configType)
-		mock.mu.Lock()
-		entity, ok := mock.entities[entityID]
-		mock.mu.Unlock()
+		entity, ok := mock.Entity(entityID)
 		if !ok {
 			t.Errorf("%s: entity not in graph", configType)
 			continue
 		}
-		approvedVal := tripleValue(entity.Triples, semspec.ProjectConfigApprovedAt)
+		approvedVal := graphmock.TripleValue(entity.Triples, semspec.ProjectConfigApprovedAt)
 		if approvedVal == "" {
 			t.Errorf("%s: expected approved_at triple, got empty", configType)
 		}
 	}
-}
-
-// getMockEntity queries the mock graph-ingest for an entity via NATS.
-func getMockEntity(t *testing.T, nc *natsclient.Client, ctx context.Context, entityID string) (*sgraph.EntityState, bool) {
-	t.Helper()
-	reqData, _ := json.Marshal(map[string]string{"id": entityID})
-	respData, err := nc.RequestWithRetry(ctx, "graph.ingest.query.entity", reqData, 5*time.Second, natsclient.DefaultRetryConfig())
-	if err != nil {
-		return nil, false
-	}
-	var entity sgraph.EntityState
-	if err := json.Unmarshal(respData, &entity); err != nil {
-		return nil, false
-	}
-	return &entity, true
 }
 
 // TestIntegration_ChecklistSaveAndReconcile verifies the full round-trip
@@ -559,7 +430,7 @@ func TestIntegration_ChecklistSaveAndReconcile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	_ = startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	repoRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".semspec"), 0755); err != nil {

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -137,6 +137,8 @@ func newSandboxClient(url string) sandboxClient {
 // NATS substrate. See reopenOwnedStoriesForRecoveryLocked.
 type storyStatusClaimerFunc func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool
 
+type planLoaderFunc func(ctx context.Context, slug string) (*workflow.Plan, error)
+
 // Component orchestrates per-requirement execution.
 type Component struct {
 	config        Config
@@ -154,6 +156,11 @@ type Component struct {
 	// workflow.ClaimStoryStatus; tests inject a fake that enforces
 	// CanTransitionTo so the full walk chain is exercisable without NATS.
 	storyStatusClaimer storyStatusClaimerFunc
+
+	// planLoader is a test seam for code paths that need a current PLAN_STATES
+	// snapshot while exercising story-status transitions without a live NATS KV.
+	// Production leaves it nil and falls through to loadPlanFromKV.
+	planLoader planLoaderFunc
 
 	// nodeResultsSender is the seam for the NodeResults reset/replace mutation
 	// fired by the recovery-resume and restructure/fixable retry paths. Defaults
@@ -1483,6 +1490,13 @@ func (c *Component) loadPlanFromKV(ctx context.Context, slug string) (*workflow.
 	return &plan, nil
 }
 
+func (c *Component) loadPlanForExecution(ctx context.Context, slug string) (*workflow.Plan, error) {
+	if c.planLoader != nil {
+		return c.planLoader(ctx, slug)
+	}
+	return c.loadPlanFromKV(ctx, slug)
+}
+
 // buildReviewPrompt constructs the prompt for requirement-level review.
 // Includes requirement context, scenarios grouped by tier with tier-aware
 // verification instructions (ADR-041 Move 6 — the load-bearing fix for
@@ -2207,6 +2221,14 @@ func (c *Component) startRestructureRetryLocked(ctx context.Context, exec *requi
 	exec.LastReviewFeedback = feedback
 	exec.terminated = false
 
+	if result := c.resetCurrentStoryForRestructureLocked(ctx, exec); !result.allReady() {
+		c.markFailedLocked(ctx, exec, fmt.Sprintf(
+			"restructure retry could not reset Story reservation (%d/%d stories ready)",
+			result.reopened, result.candidates,
+		))
+		return
+	}
+
 	// Delete the old branch to avoid polluted context.
 	if c.sandbox != nil && exec.RequirementBranch != "" {
 		if err := c.sandbox.DeleteBranch(ctx, exec.RequirementBranch); err != nil {
@@ -2260,6 +2282,80 @@ func (c *Component) startRestructureRetryLocked(ctx context.Context, exec *requi
 	)
 
 	c.dispatchSynthesizerLocked(ctx, exec)
+}
+
+// resetCurrentStoryForRestructureLocked walks the current Story back to Ready
+// before a restructure retry re-dispatches it. The requirement reviewer runs at
+// the current-Story gate, so the next synthesizer pass will try to reclaim
+// SortedStoryIDs[CurrentStoryIdx]. If the previous attempt left that Story in
+// Executing, the reservation mutation would otherwise reject Executing→Executing
+// and the retry would self-wedge as a false M:N contention.
+//
+// The walk uses the same legal state-machine hops as recovery resume
+// (Executing→Failed→Pending→Ready) instead of adding a shortcut mutation.
+// Missing plan state is treated as no candidates here; dispatchSynthesizerLocked
+// already fails loudly when PLAN_STATES is unavailable.
+//
+// Caller must hold exec.mu.
+func (c *Component) resetCurrentStoryForRestructureLocked(ctx context.Context, exec *requirementExecution) storyReopenResult {
+	if exec == nil || exec.CurrentStoryIdx < 0 || exec.CurrentStoryIdx >= len(exec.SortedStoryIDs) {
+		return storyReopenResult{}
+	}
+	storyID := exec.SortedStoryIDs[exec.CurrentStoryIdx]
+	if storyID == "" || c.storyStatusClaimer == nil {
+		return storyReopenResult{}
+	}
+
+	plan, err := c.loadPlanForExecution(ctx, exec.Slug)
+	if err != nil || plan == nil {
+		c.logger.Warn("restructure retry: could not load plan to reset current Story",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"story_id", storyID, "error", err)
+		return storyReopenResult{}
+	}
+
+	story, ok := findStoryByID(plan, storyID)
+	if !ok {
+		c.logger.Warn("restructure retry: current Story missing from plan",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"story_id", storyID)
+		return storyReopenResult{}
+	}
+	if story.Status != "" && !story.Status.IsValid() {
+		c.logger.Warn("restructure retry: current Story has invalid status",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"story_id", storyID, "status", story.Status)
+		return storyReopenResult{candidates: 1}
+	}
+	if owner := workflow.DeterministicStoryOwner(story); owner != "" && owner != exec.RequirementID {
+		c.logger.Warn("restructure retry: refusing to reset non-owned Story reservation",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"story_id", storyID, "owner_requirement_id", owner)
+		return storyReopenResult{candidates: 1}
+	}
+
+	reopened, candidates := reopenStoriesFromPlan(ctx, exec.Slug, plan, []string{storyID},
+		func(ctx context.Context, slug, storyID string, target workflow.StoryStatus) bool {
+			ok := c.storyStatusClaimer(ctx, slug, storyID, target)
+			if !ok {
+				c.logger.Warn("restructure retry: story status reset step rejected",
+					"slug", slug, "requirement_id", exec.RequirementID,
+					"story_id", storyID, "target", target)
+			}
+			return ok
+		})
+
+	result := storyReopenResult{candidates: candidates, reopened: reopened}
+	if result.allReady() {
+		c.logger.Info("restructure retry: current Story reset to ready",
+			"slug", exec.Slug, "requirement_id", exec.RequirementID,
+			"story_id", storyID)
+		return result
+	}
+	c.logger.Warn("restructure retry: current Story could not be reset to ready",
+		"slug", exec.Slug, "requirement_id", exec.RequirementID,
+		"story_id", storyID, "reopened", result.reopened, "candidates", result.candidates)
+	return result
 }
 
 // isNodeDirty returns true if a node should be re-executed on retry.

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -2293,8 +2293,16 @@ func (c *Component) startRestructureRetryLocked(ctx context.Context, exec *requi
 //
 // The walk uses the same legal state-machine hops as recovery resume
 // (Executing→Failed→Pending→Ready) instead of adding a shortcut mutation.
-// Missing plan state is treated as no candidates here; dispatchSynthesizerLocked
-// already fails loudly when PLAN_STATES is unavailable.
+//
+// A plan-load failure (e.g. a transient PLAN_STATES read returning nil) or a
+// current Story missing from the plan fails CLOSED here (candidates=1, reopened=0)
+// so the caller markFailedLocked-s BEFORE wiping NodeResults / deleting the branch.
+// Failing open would skip the reset, then dispatchSynthesizerLocked would re-claim
+// the still-Executing Story (Executing→Executing rejected) and self-wedge as a
+// false M:N contention — the exact #260 symptom this guard exists to prevent
+// (loadPlanFromKV swallows transient NATS errors as (nil,nil), so this is reachable
+// on a momentary KV blip, not only a persistent outage). A genuinely-absent current
+// Story (CurrentStoryIdx out of range / empty ID) has nothing to reset and fails open.
 //
 // Caller must hold exec.mu.
 func (c *Component) resetCurrentStoryForRestructureLocked(ctx context.Context, exec *requirementExecution) storyReopenResult {
@@ -2308,18 +2316,23 @@ func (c *Component) resetCurrentStoryForRestructureLocked(ctx context.Context, e
 
 	plan, err := c.loadPlanForExecution(ctx, exec.Slug)
 	if err != nil || plan == nil {
+		// Fail closed: a nil/errored plan load (incl. a transient PLAN_STATES
+		// blip surfaced as (nil,nil) by loadPlanFromKV) must not skip the reset
+		// and let the retry re-dispatch the still-Executing Story (#260).
 		c.logger.Warn("restructure retry: could not load plan to reset current Story",
 			"slug", exec.Slug, "requirement_id", exec.RequirementID,
 			"story_id", storyID, "error", err)
-		return storyReopenResult{}
+		return storyReopenResult{candidates: 1}
 	}
 
 	story, ok := findStoryByID(plan, storyID)
 	if !ok {
+		// Fail closed: the current Story must exist in the plan during execution;
+		// a missing one is an inconsistency, not a license to re-dispatch.
 		c.logger.Warn("restructure retry: current Story missing from plan",
 			"slug", exec.Slug, "requirement_id", exec.RequirementID,
 			"story_id", storyID)
-		return storyReopenResult{}
+		return storyReopenResult{candidates: 1}
 	}
 	if story.Status != "" && !story.Status.IsValid() {
 		c.logger.Warn("restructure retry: current Story has invalid status",

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -2858,6 +2858,7 @@ func TestScopeScenariosToCurrentStory_FallsBackToLegacyUnlinkedScenarios(t *test
 //   - exec.RetryCount is incremented
 //   - exec.DAG and exec.SortedNodeIDs are cleared (full DAG reset)
 //   - exec.CurrentNodeIdx is reset to -1
+//   - the current Story reservation is walked back to Ready before re-dispatch
 //   - exec.terminated remains false (the exec continues, not terminates)
 //   - exec.LastReviewFeedback carries the reviewer's feedback forward
 //
@@ -2966,6 +2967,102 @@ func TestHandleReviewerComplete_Restructure_DeletesAndRecreatesBranch(t *testing
 	// We assert requirementsCompleted stayed 0 (no spurious double-complete).
 	if c.requirementsCompleted.Load() != 0 {
 		t.Errorf("requirementsCompleted = %d, want 0 — restructure is not a completion", c.requirementsCompleted.Load())
+	}
+}
+
+// TestHandleReviewerComplete_Restructure_ResetsExecutingStoryToReady pins
+// issue #260: a restructure retry must reset the current Story's reservation
+// before re-dispatch. Without this, the retry tries to claim Executing again,
+// plan-manager rejects Executing→Executing, and the executor misreads its own
+// stale reservation as M:N contention.
+func TestHandleReviewerComplete_Restructure_ResetsExecutingStoryToReady(t *testing.T) {
+	c := newTestComponent(t)
+	stub := &stubSandbox{}
+	c.sandbox = stub
+
+	const (
+		slug       = "plan-restructure"
+		reqID      = "req-restructure"
+		storyID    = "story.plan-restructure.1.1"
+		branchName = "semspec/requirement-req-restructure"
+	)
+
+	fake := newFakeClaimer(map[string]workflow.StoryStatus{
+		storyID: workflow.StoryStatusExecuting,
+	})
+	c.storyStatusClaimer = fake.claim
+	c.planLoader = func(_ context.Context, gotSlug string) (*workflow.Plan, error) {
+		if gotSlug != slug {
+			t.Fatalf("planLoader slug = %q, want %q", gotSlug, slug)
+		}
+		return &workflow.Plan{
+			Slug: slug,
+			Stories: []workflow.Story{
+				{
+					ID:             storyID,
+					Status:         workflow.StoryStatusExecuting,
+					RequirementIDs: []string{reqID},
+				},
+			},
+		}, nil
+	}
+
+	exec := &requirementExecution{
+		EntityID:          workflow.EntityPrefix() + ".exec.req.run.plan-restructure-req-restructure",
+		Slug:              slug,
+		RequirementID:     reqID,
+		storeKey:          workflow.RequirementExecutionKey(slug, reqID),
+		RequirementBranch: branchName,
+		RetryCount:        0,
+		MaxRetries:        3,
+		SortedStoryIDs:    []string{storyID},
+		CurrentStoryIdx:   0,
+		CurrentNodeIdx:    1,
+		VisitedNodes:      map[string]bool{"node-0": true},
+		DAG:               &TaskDAG{},
+		SortedNodeIDs:     []string{"node-0", "node-1"},
+	}
+	c.activeExecs.Set(exec.EntityID, exec) //nolint:errcheck
+
+	event := &agentic.LoopCompletedEvent{
+		LoopID:       "loop-restructure-story-reset",
+		TaskID:       "task-restructure-story-reset",
+		WorkflowSlug: WorkflowSlugRequirementExecution,
+		WorkflowStep: stageRequirementReview,
+		Outcome:      agentic.OutcomeSuccess,
+		Result:       `{"verdict":"rejected","rejection_type":"restructure","feedback":"redo the Story shape"}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	if got := fake.statusOf(storyID); got != workflow.StoryStatusReady {
+		t.Fatalf("final story status = %q, want %q", got, workflow.StoryStatusReady)
+	}
+
+	fake.mu.Lock()
+	calls := append([]struct {
+		storyID string
+		target  workflow.StoryStatus
+	}(nil), fake.calls...)
+	fake.mu.Unlock()
+
+	wantCalls := []struct {
+		storyID string
+		target  workflow.StoryStatus
+	}{
+		{storyID, workflow.StoryStatusFailed},
+		{storyID, workflow.StoryStatusPending},
+		{storyID, workflow.StoryStatusReady},
+	}
+	if len(calls) != len(wantCalls) {
+		t.Fatalf("story status reset calls = %v, want %v", calls, wantCalls)
+	}
+	for i, want := range wantCalls {
+		if calls[i] != want {
+			t.Errorf("story status reset call[%d] = %v, want %v", i, calls[i], want)
+		}
 	}
 }
 

--- a/processor/requirement-executor/component_test.go
+++ b/processor/requirement-executor/component_test.go
@@ -3066,6 +3066,99 @@ func TestHandleReviewerComplete_Restructure_ResetsExecutingStoryToReady(t *testi
 	}
 }
 
+// TestHandleReviewerComplete_Restructure_FailsClosedOnPlanLoadError pins the
+// fail-closed half of issue #260. When the plan cannot be loaded during a
+// restructure retry — e.g. a transient PLAN_STATES read that loadPlanFromKV
+// surfaces as (nil, nil) — resetCurrentStoryForRestructureLocked must NOT skip
+// the reset and let the retry proceed. Proceeding would wipe NodeResults, delete
+// the branch, and re-dispatch the still-Executing Story (Executing→Executing is
+// rejected), reopening the exact wedge the #260 fix exists to prevent. Instead
+// the retry must fail closed (markFailed) BEFORE any destructive state change.
+//
+// Negative control: revert resetCurrentStoryForRestructureLocked's plan-load
+// branch to `return storyReopenResult{}` and this test fails — terminated stays
+// false, NodeResults is wiped, and DeleteBranch is called.
+func TestHandleReviewerComplete_Restructure_FailsClosedOnPlanLoadError(t *testing.T) {
+	c := newTestComponent(t)
+	stub := &stubSandbox{}
+	c.sandbox = stub
+
+	const (
+		slug       = "plan-restructure"
+		reqID      = "req-restructure"
+		storyID    = "story.plan-restructure.1.1"
+		branchName = "semspec/requirement-req-restructure"
+	)
+
+	fake := newFakeClaimer(map[string]workflow.StoryStatus{
+		storyID: workflow.StoryStatusExecuting,
+	})
+	c.storyStatusClaimer = fake.claim
+	// Transient KV blip: loadPlanFromKV swallows NATS errors as (nil, nil), so the
+	// production loader can return a nil plan with no error mid-execution.
+	c.planLoader = func(_ context.Context, _ string) (*workflow.Plan, error) {
+		return nil, nil
+	}
+
+	exec := &requirementExecution{
+		EntityID:          workflow.EntityPrefix() + ".exec.req.run.plan-restructure-req-restructure",
+		Slug:              slug,
+		RequirementID:     reqID,
+		storeKey:          workflow.RequirementExecutionKey(slug, reqID),
+		RequirementBranch: branchName,
+		RetryCount:        0,
+		MaxRetries:        3,
+		SortedStoryIDs:    []string{storyID},
+		CurrentStoryIdx:   0,
+		CurrentNodeIdx:    1,
+		VisitedNodes:      map[string]bool{"node-0": true},
+		DAG:               &TaskDAG{},
+		SortedNodeIDs:     []string{"node-0", "node-1"},
+		NodeResults:       []NodeResult{{NodeID: "node-0"}},
+	}
+	c.activeExecs.Set(exec.EntityID, exec) //nolint:errcheck
+
+	event := &agentic.LoopCompletedEvent{
+		LoopID:       "loop-restructure-fail-closed",
+		TaskID:       "task-restructure-fail-closed",
+		WorkflowSlug: WorkflowSlugRequirementExecution,
+		WorkflowStep: stageRequirementReview,
+		Outcome:      agentic.OutcomeSuccess,
+		Result:       `{"verdict":"rejected","rejection_type":"restructure","feedback":"redo the Story shape"}`,
+	}
+
+	exec.mu.Lock()
+	c.handleRequirementReviewerCompleteLocked(context.Background(), event, exec)
+	exec.mu.Unlock()
+
+	// Failed closed: the requirement is terminated rather than re-dispatched.
+	if !exec.terminated {
+		t.Fatalf("exec.terminated = false, want true — restructure must fail closed on plan-load failure")
+	}
+	// The reset never ran, so the story-status claimer was never invoked and the
+	// Story is left exactly as it was (still Executing, not walked to Ready).
+	fake.mu.Lock()
+	gotCalls := len(fake.calls)
+	fake.mu.Unlock()
+	if gotCalls != 0 {
+		t.Errorf("story status claim calls = %d, want 0 — reset must not run on plan-load failure", gotCalls)
+	}
+	if got := fake.statusOf(storyID); got != workflow.StoryStatusExecuting {
+		t.Errorf("story status = %q, want %q — story must be left untouched", got, workflow.StoryStatusExecuting)
+	}
+	// The destructive restructure steps must NOT have run: the fail-closed gate
+	// fires before NodeResults is wiped and before the branch is deleted.
+	if len(exec.NodeResults) != 1 {
+		t.Errorf("NodeResults len = %d, want 1 — must not be wiped before the fail-closed gate", len(exec.NodeResults))
+	}
+	stub.mu.Lock()
+	deleted := len(stub.deletedBranchNames)
+	stub.mu.Unlock()
+	if deleted != 0 {
+		t.Errorf("DeleteBranch calls = %d, want 0 — branch must not be deleted on fail-closed restructure", deleted)
+	}
+}
+
 // TestHandleReviewerComplete_Restructure_PreservesBaseBranch is the regression
 // guard for #243: when the requirement has a DependsOn-derived BaseBranch, a
 // restructure rebuild recreates the branch from that base (via

--- a/processor/scenario-orchestrator/integration_test.go
+++ b/processor/scenario-orchestrator/integration_test.go
@@ -5,13 +5,11 @@ package scenarioorchestrator
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/test/integration/graphmock"
 	"github.com/c360studio/semstreams/component"
-	sgraph "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/natsclient"
 )
 
@@ -22,115 +20,6 @@ import (
 var workflowStreamSubjects = []string{
 	"scenario.orchestrate.*",
 	"workflow.trigger.requirement-execution-loop",
-}
-
-// ---------------------------------------------------------------------------
-// Mock graph-ingest — in-memory NATS responder for triple read/write.
-// ---------------------------------------------------------------------------
-
-// mockGraphIngest provides in-memory graph-ingest NATS responders for testing.
-// It handles graph.mutation.triple.add and graph.ingest.query.entity/prefix.
-type mockGraphIngest struct {
-	mu       sync.Mutex
-	entities map[string]*sgraph.EntityState // entityID → state
-}
-
-// startMockGraphIngest registers Core NATS request/reply handlers on the
-// graph-ingest subjects. The handlers store triples in memory and respond to
-// entity and prefix queries without requiring an external graph-ingest service.
-func startMockGraphIngest(t *testing.T, nc *natsclient.Client) *mockGraphIngest {
-	t.Helper()
-	m := &mockGraphIngest{entities: make(map[string]*sgraph.EntityState)}
-
-	// Handle triple writes.
-	nc.SubscribeForRequests(context.Background(), "graph.mutation.triple.add", func(_ context.Context, data []byte) ([]byte, error) {
-		var req sgraph.AddTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return json.Marshal(map[string]any{"success": false, "error": err.Error()})
-		}
-
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		entity, ok := m.entities[req.Triple.Subject]
-		if !ok {
-			entity = &sgraph.EntityState{
-				ID:        req.Triple.Subject,
-				UpdatedAt: time.Now(),
-			}
-			m.entities[req.Triple.Subject] = entity
-		}
-
-		// Upsert triple — replace existing predicate or append.
-		found := false
-		for i, t := range entity.Triples {
-			if t.Predicate == req.Triple.Predicate {
-				entity.Triples[i] = req.Triple
-				found = true
-				break
-			}
-		}
-		if !found {
-			entity.Triples = append(entity.Triples, req.Triple)
-		}
-		entity.Version++
-		entity.UpdatedAt = time.Now()
-
-		return json.Marshal(map[string]any{"success": true, "kv_revision": entity.Version})
-	})
-
-	// Handle entity queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.entity", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		entity, ok := m.entities[req.ID]
-		m.mu.Unlock()
-
-		if !ok {
-			return nil, fmt.Errorf("not found: %s", req.ID)
-		}
-		return json.Marshal(entity)
-	})
-
-	// Handle prefix queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.prefix", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			Prefix string `json:"prefix"`
-			Limit  int    `json:"limit"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		var matches []sgraph.EntityState
-		for id, entity := range m.entities {
-			if len(id) >= len(req.Prefix) && id[:len(req.Prefix)] == req.Prefix {
-				matches = append(matches, *entity)
-				if req.Limit > 0 && len(matches) >= req.Limit {
-					break
-				}
-			}
-		}
-		m.mu.Unlock()
-
-		return json.Marshal(map[string]any{"entities": matches})
-	})
-
-	// Flush ensures all subscriptions are registered on the server before any
-	// caller fires requests. Without this, there is a race between the async
-	// subscribe round-trip and the first WriteTriple call.
-	if conn := nc.GetConnection(); conn != nil {
-		_ = conn.Flush()
-	}
-
-	return m
 }
 
 // makeReqForPlan builds a Requirement with the correct PlanEntityID for a given slug.
@@ -147,7 +36,7 @@ func TestComponentStartStop(t *testing.T) {
 	defer cancel()
 
 	// Mock graph-ingest so startup reconciliation does not block on unanswered requests.
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 
 	comp := newIntegrationComponent(t, tc)
 

--- a/processor/structural-validator/executor.go
+++ b/processor/structural-validator/executor.go
@@ -140,7 +140,7 @@ func (e *Executor) Execute(ctx context.Context, trigger *payloads.ValidationRequ
 	// the 2026-06-13 mavlink-hard README assembly wedge upstream of merge
 	// (issues #175 / #177).
 	results = append(results,
-		e.runFileOwnershipContainment(ctx, workflow.NormalizeFilePaths(trigger.FilesOwned), workDir, runner)...)
+		e.runFileOwnershipContainment(ctx, workflow.NormalizeFilePaths(trigger.FilesOwned), trigger.FileIntents, workDir, runner)...)
 
 	// Advisory anti-mock governance check — only when test files are present.
 	if hasTestFiles(filesModified) {

--- a/processor/structural-validator/ownership_check.go
+++ b/processor/structural-validator/ownership_check.go
@@ -97,9 +97,10 @@ type ownershipVerdict struct {
 	// branch. Hard fail routed to DEV-RETRY: the developer must remove it.
 	RootScratch []string
 	// NamedSourceScratch are newly-created source/test files with high-signal
-	// throwaway basenames (Dummy.java, Scratch.java, FindClass.java) even when
-	// nested under a normal source tree. These are developer cleanup failures, not
-	// evidence that the architecture/story partition omitted a real deliverable.
+	// throwaway basenames (Dummy.java, dummy_test.go, scratch.spec.ts, temp.py)
+	// even when nested under a normal source tree. These are developer cleanup
+	// failures, not evidence that the architecture/story partition omitted a real
+	// deliverable.
 	NamedSourceScratch []string
 }
 
@@ -211,7 +212,8 @@ func isIgnorableBuildArtifact(p string) bool {
 // is never a deliverable, only dev scratch (e.g. a FindClass.java probe).
 var sourceFileExts = map[string]struct{}{
 	".java": {}, ".kt": {}, ".kts": {}, ".scala": {}, ".groovy": {},
-	".go": {}, ".py": {}, ".rb": {}, ".rs": {}, ".ts": {}, ".js": {},
+	".go": {}, ".py": {}, ".rb": {}, ".rs": {}, ".ts": {}, ".tsx": {},
+	".js": {}, ".jsx": {}, ".mjs": {}, ".cjs": {}, ".mts": {}, ".cts": {},
 	".c": {}, ".cc": {}, ".cpp": {}, ".cxx": {}, ".h": {}, ".hpp": {}, ".cs": {},
 }
 
@@ -225,13 +227,47 @@ func isNamedSourceScratch(p string) bool {
 	if !isSourceFile(p) {
 		return false
 	}
-	base := strings.TrimSuffix(path.Base(strings.ReplaceAll(p, "\\", "/")), path.Ext(p))
-	switch strings.ToLower(base) {
-	case "dummy", "dummytest", "scratch", "scratchtest", "findclass", "findclasstest":
+	base := path.Base(strings.ReplaceAll(p, "\\", "/"))
+	stem := strings.TrimSuffix(base, path.Ext(base))
+	lowerStem := strings.ToLower(stem)
+	if isScratchStem(lowerStem) {
+		return true
+	}
+
+	parts := strings.FieldsFunc(lowerStem, func(r rune) bool {
+		return r == '.' || r == '_' || r == '-'
+	})
+	if len(parts) > 1 && isScratchStem(parts[0]) && allScratchSuffixes(parts[1:]) {
+		return true
+	}
+
+	for _, suffix := range []string{"test", "tests", "spec", "specs"} {
+		if strings.HasSuffix(lowerStem, suffix) && isScratchStem(strings.TrimSuffix(lowerStem, suffix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isScratchStem(stem string) bool {
+	switch stem {
+	case "dummy", "scratch", "temp", "tmp", "probe", "findclass":
 		return true
 	default:
 		return false
 	}
+}
+
+func allScratchSuffixes(parts []string) bool {
+	for _, part := range parts {
+		switch part {
+		case "test", "tests", "spec", "specs":
+			continue
+		default:
+			return false
+		}
+	}
+	return len(parts) > 0
 }
 
 // firstSegment returns the top-level path component, or "" for a root-level file

--- a/processor/structural-validator/ownership_check.go
+++ b/processor/structural-validator/ownership_check.go
@@ -96,6 +96,11 @@ type ownershipVerdict struct {
 	// path stages everything (`git add -A`) and it would silently pollute the
 	// branch. Hard fail routed to DEV-RETRY: the developer must remove it.
 	RootScratch []string
+	// NamedSourceScratch are newly-created source/test files with high-signal
+	// throwaway basenames (Dummy.java, Scratch.java, FindClass.java) even when
+	// nested under a normal source tree. These are developer cleanup failures, not
+	// evidence that the architecture/story partition omitted a real deliverable.
+	NamedSourceScratch []string
 }
 
 // clean reports whether there are no hard-fail violations (scratch artefacts,
@@ -106,7 +111,8 @@ func (v ownershipVerdict) clean() bool {
 		len(v.ModifiedDocUnowned) == 0 &&
 		len(v.NewUnownedOutOfTerritory) == 0 &&
 		len(v.NewTopologyControlled) == 0 &&
-		len(v.RootScratch) == 0
+		len(v.RootScratch) == 0 &&
+		len(v.NamedSourceScratch) == 0
 }
 
 // parsePorcelain parses `git status --porcelain=v1` output into entries. It is
@@ -215,6 +221,19 @@ func isSourceFile(p string) bool {
 	return ok
 }
 
+func isNamedSourceScratch(p string) bool {
+	if !isSourceFile(p) {
+		return false
+	}
+	base := strings.TrimSuffix(path.Base(strings.ReplaceAll(p, "\\", "/")), path.Ext(p))
+	switch strings.ToLower(base) {
+	case "dummy", "dummytest", "scratch", "scratchtest", "findclass", "findclasstest":
+		return true
+	default:
+		return false
+	}
+}
+
 // firstSegment returns the top-level path component, or "" for a root-level file
 // with no directory (e.g. "FindClass.java" → "", "src/main/java/X.java" → "src").
 func firstSegment(p string) string {
@@ -294,12 +313,6 @@ func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) owners
 				// A NEW unowned doc is hygiene-only (an undeclared coverage
 				// matrix / scratch note); advisory, surfaced to the reviewer.
 				v.NewUnowned = append(v.NewUnowned, norm)
-			case len(territory) == 0 || withinTerritory(norm, territory):
-				// No declared territory (manual / E2E dispatch with no story
-				// context — the production caller skips the gate entirely in this
-				// case, so this only guards direct callers), or an in-package
-				// class split: advisory, matching pre-ADR-049 behavior.
-				v.NewUnowned = append(v.NewUnowned, norm)
 			case firstSegment(norm) == "" && isSourceFile(norm):
 				// A new SOURCE file at the worktree ROOT (no package directory) — a
 				// dev's throwaway probe (FindClass.java). Never a deliverable (source
@@ -309,6 +322,18 @@ func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) owners
 				// silently pollutes the branch. Hard fail routed to dev-retry so the
 				// developer removes it.
 				v.RootScratch = append(v.RootScratch, norm)
+			case isNamedSourceScratch(norm):
+				// High-signal throwaway source names are developer cleanup/stub
+				// failures even when created under src/main/java or src/test/java.
+				// Treating "Dummy.java" as a planning gap sends recovery to repair
+				// a plan that may be fine; the dev must remove the scratch instead.
+				v.NamedSourceScratch = append(v.NamedSourceScratch, norm)
+			case len(territory) == 0 || withinTerritory(norm, territory):
+				// No declared territory (manual / E2E dispatch with no story
+				// context — the production caller skips the gate entirely in this
+				// case, so this only guards direct callers), or an in-package
+				// class split: advisory, matching pre-ADR-049 behavior.
+				v.NewUnowned = append(v.NewUnowned, norm)
 			case firstSegment(norm) == "":
 				// A new NON-source file at the root (a stray note, an undeclared
 				// root config) — not a deliverable parallel stories converge on, and
@@ -410,7 +435,8 @@ func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []stri
 	// everything, so advisory scratch silently pollutes the branch).
 	containmentClean := len(verdict.JunkViolations) == 0 &&
 		len(verdict.ModifiedDocUnowned) == 0 &&
-		len(verdict.RootScratch) == 0
+		len(verdict.RootScratch) == 0 &&
+		len(verdict.NamedSourceScratch) == 0
 	containment := payloads.CheckResult{
 		Name:     checkName,
 		Passed:   containmentClean,
@@ -427,6 +453,9 @@ func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []stri
 		}
 		if len(verdict.RootScratch) > 0 {
 			fmt.Fprintf(&b, "Root-level source file(s) that are not deliverables must be removed before submit (a source file belongs in a package directory, not the worktree root — write throwaway probes to /tmp): %s. ", strings.Join(verdict.RootScratch, ", "))
+		}
+		if len(verdict.NamedSourceScratch) > 0 {
+			fmt.Fprintf(&b, "Throwaway source/test file(s) that are not deliverables must be removed before submit (write probes or placeholder classes to /tmp, not the worktree): %s. ", strings.Join(verdict.NamedSourceScratch, ", "))
 		}
 		if len(verdict.ModifiedDocUnowned) > 0 {
 			fmt.Fprintf(&b, "Modified shared documentation this story does not own: %s. A doc owned by no story (or by another story) is co-written by parallel stories and cannot be merged at assembly — only edit docs in your file scope; if a deliverable doc isn't yours, surface it as a planning gap. ", strings.Join(verdict.ModifiedDocUnowned, ", "))

--- a/processor/structural-validator/ownership_check.go
+++ b/processor/structural-validator/ownership_check.go
@@ -96,12 +96,18 @@ type ownershipVerdict struct {
 	// path stages everything (`git add -A`) and it would silently pollute the
 	// branch. Hard fail routed to DEV-RETRY: the developer must remove it.
 	RootScratch []string
-	// NamedSourceScratch are newly-created source/test files with high-signal
-	// throwaway basenames (Dummy.java, dummy_test.go, scratch.spec.ts, temp.py)
-	// even when nested under a normal source tree. These are developer cleanup
-	// failures, not evidence that the architecture/story partition omitted a real
+	// DeclaredScratch are worktree changes the developer explicitly classified
+	// as scratch_or_probe in submit_work. These are developer cleanup failures,
+	// not evidence that the architecture/story partition omitted a real
 	// deliverable.
-	NamedSourceScratch []string
+	DeclaredScratch []string
+	// UnclassifiedNewSource are newly-created source/test files missing a
+	// submit_work file_intents entry. Since semspec controls the tool schema,
+	// missing intent is a developer/tool-contract failure, not a planning gap.
+	UnclassifiedNewSource []string
+	// MismatchedFileIntent are new files whose declared intent contradicts git
+	// status, e.g. a new source file declared as modified_existing.
+	MismatchedFileIntent []string
 }
 
 // clean reports whether there are no hard-fail violations (scratch artefacts,
@@ -113,7 +119,9 @@ func (v ownershipVerdict) clean() bool {
 		len(v.NewUnownedOutOfTerritory) == 0 &&
 		len(v.NewTopologyControlled) == 0 &&
 		len(v.RootScratch) == 0 &&
-		len(v.NamedSourceScratch) == 0
+		len(v.DeclaredScratch) == 0 &&
+		len(v.UnclassifiedNewSource) == 0 &&
+		len(v.MismatchedFileIntent) == 0
 }
 
 // parsePorcelain parses `git status --porcelain=v1` output into entries. It is
@@ -223,53 +231,6 @@ func isSourceFile(p string) bool {
 	return ok
 }
 
-func isNamedSourceScratch(p string) bool {
-	if !isSourceFile(p) {
-		return false
-	}
-	base := path.Base(strings.ReplaceAll(p, "\\", "/"))
-	stem := strings.TrimSuffix(base, path.Ext(base))
-	lowerStem := strings.ToLower(stem)
-	if isScratchStem(lowerStem) {
-		return true
-	}
-
-	parts := strings.FieldsFunc(lowerStem, func(r rune) bool {
-		return r == '.' || r == '_' || r == '-'
-	})
-	if len(parts) > 1 && isScratchStem(parts[0]) && allScratchSuffixes(parts[1:]) {
-		return true
-	}
-
-	for _, suffix := range []string{"test", "tests", "spec", "specs"} {
-		if strings.HasSuffix(lowerStem, suffix) && isScratchStem(strings.TrimSuffix(lowerStem, suffix)) {
-			return true
-		}
-	}
-	return false
-}
-
-func isScratchStem(stem string) bool {
-	switch stem {
-	case "dummy", "scratch", "temp", "tmp", "probe", "findclass":
-		return true
-	default:
-		return false
-	}
-}
-
-func allScratchSuffixes(parts []string) bool {
-	for _, part := range parts {
-		switch part {
-		case "test", "tests", "spec", "specs":
-			continue
-		default:
-			return false
-		}
-	}
-	return len(parts) > 0
-}
-
 // firstSegment returns the top-level path component, or "" for a root-level file
 // with no directory (e.g. "FindClass.java" → "", "src/main/java/X.java" → "src").
 func firstSegment(p string) string {
@@ -308,10 +269,11 @@ func withinTerritory(norm string, territory map[string]struct{}) bool {
 
 // decideOwnership classifies a worktree change set against the owned file set.
 // Pure: no git, no IO. owned is the normalized set of Story.FilesOwned.
-func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) ownershipVerdict {
+func decideOwnership(changes []porcelainEntry, owned map[string]struct{}, intents []payloads.FileIntent) ownershipVerdict {
 	var v ownershipVerdict
 	owned = expandOwnedMapWithCompanionTests(owned)
 	territory := ownedTerritory(owned)
+	intentByPath := fileIntentByPath(intents)
 	for _, c := range changes {
 		norm := workflow.NormalizeFilePath(c.Path)
 		if norm == "" {
@@ -326,6 +288,21 @@ func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) owners
 		if pattern, ok := isJunkArtifact(norm); ok {
 			v.JunkViolations = append(v.JunkViolations, fmt.Sprintf("%s (%s)", norm, pattern))
 			continue
+		}
+		intent := strings.TrimSpace(intentByPath[norm])
+		if intent == payloads.FileIntentScratchOrProbe {
+			v.DeclaredScratch = append(v.DeclaredScratch, norm)
+			continue
+		}
+		if c.isNew() && isSourceFile(norm) {
+			switch intent {
+			case "":
+				v.UnclassifiedNewSource = append(v.UnclassifiedNewSource, norm)
+				continue
+			case payloads.FileIntentModifiedExisting:
+				v.MismatchedFileIntent = append(v.MismatchedFileIntent, fmt.Sprintf("%s declared %s but git status reports a new file", norm, intent))
+				continue
+			}
 		}
 		if _, isOwned := owned[norm]; isOwned {
 			continue
@@ -358,12 +335,6 @@ func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) owners
 				// silently pollutes the branch. Hard fail routed to dev-retry so the
 				// developer removes it.
 				v.RootScratch = append(v.RootScratch, norm)
-			case isNamedSourceScratch(norm):
-				// High-signal throwaway source names are developer cleanup/stub
-				// failures even when created under src/main/java or src/test/java.
-				// Treating "Dummy.java" as a planning gap sends recovery to repair
-				// a plan that may be fine; the dev must remove the scratch instead.
-				v.NamedSourceScratch = append(v.NamedSourceScratch, norm)
 			case len(territory) == 0 || withinTerritory(norm, territory):
 				// No declared territory (manual / E2E dispatch with no story
 				// context — the production caller skips the gate entirely in this
@@ -393,6 +364,18 @@ func decideOwnership(changes []porcelainEntry, owned map[string]struct{}) owners
 	return v
 }
 
+func fileIntentByPath(intents []payloads.FileIntent) map[string]string {
+	out := make(map[string]string, len(intents))
+	for _, intent := range intents {
+		path := workflow.NormalizeFilePath(intent.Path)
+		if path == "" {
+			continue
+		}
+		out[path] = strings.TrimSpace(intent.Intent)
+	}
+	return out
+}
+
 func expandOwnedMapWithCompanionTests(owned map[string]struct{}) map[string]struct{} {
 	if len(owned) == 0 {
 		return owned
@@ -416,7 +399,7 @@ func expandOwnedMapWithCompanionTests(owned map[string]struct{}) map[string]stru
 // validation / E2E / any dispatch without story context). A git failure is
 // surfaced as a non-blocking advisory rather than a hard fail — the gate must
 // not wedge a run on a plumbing hiccup.
-func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []string, workDir string, runner CommandRunner) []payloads.CheckResult {
+func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []string, intents []payloads.FileIntent, workDir string, runner CommandRunner) []payloads.CheckResult {
 	const checkName = payloads.CheckFileOwnershipContainment
 
 	// No story ownership context (manual validation / E2E / any dispatch
@@ -460,19 +443,22 @@ func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []stri
 		}}
 	}
 
-	verdict := decideOwnership(parsePorcelain(stdout), ownedSet)
+	verdict := decideOwnership(parsePorcelain(stdout), ownedSet, intents)
 
 	var results []payloads.CheckResult
 
-	// Required gate 1 (#175/#177): scratch artefacts, a non-owner co-writing a
-	// shared doc, or root-level source scratch — the shapes a developer CAN fix
-	// by retrying (remove the scratch / stop editing the shared doc). Routed to
-	// dev-retry, NOT recovery, and never left advisory (the commit path stages
-	// everything, so advisory scratch silently pollutes the branch).
+	// Required gate 1 (#175/#177): scratch artefacts, declared scratch/probes,
+	// a non-owner co-writing a shared doc, or root-level source scratch — the
+	// shapes a developer CAN fix by retrying (remove the scratch / stop editing
+	// the shared doc). Routed to dev-retry, NOT recovery, and never left
+	// advisory (the commit path stages everything, so advisory scratch silently
+	// pollutes the branch).
 	containmentClean := len(verdict.JunkViolations) == 0 &&
 		len(verdict.ModifiedDocUnowned) == 0 &&
 		len(verdict.RootScratch) == 0 &&
-		len(verdict.NamedSourceScratch) == 0
+		len(verdict.DeclaredScratch) == 0 &&
+		len(verdict.UnclassifiedNewSource) == 0 &&
+		len(verdict.MismatchedFileIntent) == 0
 	containment := payloads.CheckResult{
 		Name:     checkName,
 		Passed:   containmentClean,
@@ -490,8 +476,14 @@ func (e *Executor) runFileOwnershipContainment(ctx context.Context, owned []stri
 		if len(verdict.RootScratch) > 0 {
 			fmt.Fprintf(&b, "Root-level source file(s) that are not deliverables must be removed before submit (a source file belongs in a package directory, not the worktree root — write throwaway probes to /tmp): %s. ", strings.Join(verdict.RootScratch, ", "))
 		}
-		if len(verdict.NamedSourceScratch) > 0 {
-			fmt.Fprintf(&b, "Throwaway source/test file(s) that are not deliverables must be removed before submit (write probes or placeholder classes to /tmp, not the worktree): %s. ", strings.Join(verdict.NamedSourceScratch, ", "))
+		if len(verdict.DeclaredScratch) > 0 {
+			fmt.Fprintf(&b, "File(s) declared as scratch_or_probe must be removed before submit (write probes, notes, or placeholder classes to /tmp, not the worktree): %s. ", strings.Join(verdict.DeclaredScratch, ", "))
+		}
+		if len(verdict.UnclassifiedNewSource) > 0 {
+			fmt.Fprintf(&b, "New source/test file(s) are missing submit_work file_intents entries; classify each actual new source/test path as owned_deliverable, companion_test, planning_gap_required_file, or scratch_or_probe before submitting: %s. ", strings.Join(verdict.UnclassifiedNewSource, ", "))
+		}
+		if len(verdict.MismatchedFileIntent) > 0 {
+			fmt.Fprintf(&b, "submit_work file_intents contradict git status: %s. ", strings.Join(verdict.MismatchedFileIntent, "; "))
 		}
 		if len(verdict.ModifiedDocUnowned) > 0 {
 			fmt.Fprintf(&b, "Modified shared documentation this story does not own: %s. A doc owned by no story (or by another story) is co-written by parallel stories and cannot be merged at assembly — only edit docs in your file scope; if a deliverable doc isn't yours, surface it as a planning gap. ", strings.Join(verdict.ModifiedDocUnowned, ", "))

--- a/processor/structural-validator/ownership_check_test.go
+++ b/processor/structural-validator/ownership_check_test.go
@@ -103,6 +103,33 @@ func TestIsIgnorableBuildArtifact(t *testing.T) {
 	}
 }
 
+func TestIsNamedSourceScratch(t *testing.T) {
+	cases := map[string]bool{
+		"src/main/java/Dummy.java":                         true,
+		"src/test/java/org/acme/DummyTest.java":            true,
+		"pkg/dummy_test.go":                                true,
+		"pkg/scratch_test.go":                              true,
+		"web/src/dummy.test.ts":                            true,
+		"web/src/scratch.spec.tsx":                         true,
+		"scripts/temp.py":                                  true,
+		"cmd/probe.go":                                     true,
+		"src/FindClass.kt":                                 true,
+		"src/test/java/org/acme/RealDriverTest.java":       false,
+		"pkg/probe_driver.go":                              false,
+		"web/src/telemetryProbe.ts":                        false,
+		"web/src/useScratchpad.ts":                         false,
+		"README.md":                                        false,
+		"fixtures/dummy.json":                              false,
+		"src/main/java/org/acme/DummyImplementation.java":  false,
+		"src/main/java/org/acme/ScratchpadController.java": false,
+	}
+	for p, want := range cases {
+		if got := isNamedSourceScratch(p); got != want {
+			t.Errorf("isNamedSourceScratch(%q) = %v, want %v", p, got, want)
+		}
+	}
+}
+
 func TestFirstSegment(t *testing.T) {
 	cases := map[string]string{
 		"FindClass.java":     "", // root-level (no dir) → scratch, not a deliverable
@@ -189,6 +216,30 @@ func TestDecideOwnership(t *testing.T) {
 			porcelain:        "?? src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java",
 			owned:            ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
 			wantNamedScratch: []string{"src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java"},
+		},
+		{
+			name:             "Go dummy_test.go is dev-cleanup scratch, NOT a planning gap",
+			porcelain:        "?? pkg/driver/dummy_test.go",
+			owned:            ownedSetOf("internal/driver/driver.go"),
+			wantNamedScratch: []string{"pkg/driver/dummy_test.go"},
+		},
+		{
+			name:             "TypeScript scratch.spec.tsx is dev-cleanup scratch, NOT a planning gap",
+			porcelain:        "?? web/src/scratch.spec.tsx",
+			owned:            ownedSetOf("web/src/Driver.tsx"),
+			wantNamedScratch: []string{"web/src/scratch.spec.tsx"},
+		},
+		{
+			name:             "Python temp.py is dev-cleanup scratch, NOT a planning gap",
+			porcelain:        "?? scripts/temp.py",
+			owned:            ownedSetOf("src/driver/main.py"),
+			wantNamedScratch: []string{"scripts/temp.py"},
+		},
+		{
+			name:                  "legitimate source whose name contains probe still remains a planning gap",
+			porcelain:             "?? src/main/java/org/acme/probe/TelemetryProbe.java",
+			owned:                 ownedSetOf("src/main/java/org/acme/driver/Driver.java"),
+			wantNewOutOfTerritory: []string{"src/main/java/org/acme/probe/TelemetryProbe.java"},
 		},
 		{
 			name:                  "new unowned TEST outside territory is an ownership gap (hard fail)",

--- a/processor/structural-validator/ownership_check_test.go
+++ b/processor/structural-validator/ownership_check_test.go
@@ -130,6 +130,7 @@ func TestDecideOwnership(t *testing.T) {
 		wantNewOutOfTerritory []string // hard-fail: new source/test outside territory
 		wantNewTopology       []string // hard-fail: new topology-controlled project/build file
 		wantRootScratch       []string // hard-fail (dev-retry): root-level source scratch
+		wantNamedScratch      []string // hard-fail (dev-retry): obvious nested source scratch
 	}{
 		{
 			name:              "modified non-owned DOC (README wedge) hard-fails",
@@ -176,6 +177,18 @@ func TestDecideOwnership(t *testing.T) {
 			porcelain:             "?? src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java",
 			owned:                 ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
 			wantNewOutOfTerritory: []string{"src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java"},
+		},
+		{
+			name:             "nested Dummy.java is dev-cleanup scratch, NOT a planning gap",
+			porcelain:        "?? src/main/java/Dummy.java",
+			owned:            ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			wantNamedScratch: []string{"src/main/java/Dummy.java"},
+		},
+		{
+			name:             "in-territory DummyTest.java is still dev-cleanup scratch",
+			porcelain:        "?? src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java",
+			owned:            ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			wantNamedScratch: []string{"src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java"},
 		},
 		{
 			name:                  "new unowned TEST outside territory is an ownership gap (hard fail)",
@@ -333,6 +346,9 @@ func TestDecideOwnership(t *testing.T) {
 			}
 			if !equalSets(v.RootScratch, tc.wantRootScratch) {
 				t.Errorf("rootScratch = %v, want %v", sortedCopy(v.RootScratch), sortedCopy(tc.wantRootScratch))
+			}
+			if !equalSets(v.NamedSourceScratch, tc.wantNamedScratch) {
+				t.Errorf("namedSourceScratch = %v, want %v", sortedCopy(v.NamedSourceScratch), sortedCopy(tc.wantNamedScratch))
 			}
 		})
 	}
@@ -500,6 +516,24 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 		}
 		if !strings.Contains(gap.Stderr, "other/pkg/New.java") {
 			t.Errorf("expected offending path named in planning-gap, got %q", gap.Stderr)
+		}
+	})
+
+	t.Run("nested Dummy.java emits dev-cleanup containment failure, not planning-gap recovery", func(t *testing.T) {
+		runner := &fakeRunner{stdout: "?? src/main/java/Dummy.java\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
+		if c.Passed || !c.Required {
+			t.Fatalf("expected required containment failure for Dummy.java scratch, got %+v", c)
+		}
+		if !strings.Contains(c.Stderr, "Dummy.java") || !strings.Contains(c.Stderr, "Throwaway source/test") {
+			t.Errorf("expected Dummy.java dev-cleanup message, got %q", c.Stderr)
+		}
+		for _, r := range results {
+			if r.Name == payloads.CheckFileOwnershipPlanningGap {
+				t.Fatalf("Dummy.java scratch must not emit planning-gap recovery row: %+v", r)
+			}
 		}
 	})
 

--- a/processor/structural-validator/ownership_check_test.go
+++ b/processor/structural-validator/ownership_check_test.go
@@ -28,6 +28,14 @@ func ownedSetOf(paths ...string) map[string]struct{} {
 	return m
 }
 
+func intentsOf(intent string, paths ...string) []payloads.FileIntent {
+	out := make([]payloads.FileIntent, 0, len(paths))
+	for _, p := range workflow.NormalizeFilePaths(paths) {
+		out = append(out, payloads.FileIntent{Path: p, Intent: intent, Rationale: "test fixture"})
+	}
+	return out
+}
+
 func TestParsePorcelain(t *testing.T) {
 	in := " M src/A.java\n" +
 		"?? patch.diff\n" +
@@ -103,33 +111,6 @@ func TestIsIgnorableBuildArtifact(t *testing.T) {
 	}
 }
 
-func TestIsNamedSourceScratch(t *testing.T) {
-	cases := map[string]bool{
-		"src/main/java/Dummy.java":                         true,
-		"src/test/java/org/acme/DummyTest.java":            true,
-		"pkg/dummy_test.go":                                true,
-		"pkg/scratch_test.go":                              true,
-		"web/src/dummy.test.ts":                            true,
-		"web/src/scratch.spec.tsx":                         true,
-		"scripts/temp.py":                                  true,
-		"cmd/probe.go":                                     true,
-		"src/FindClass.kt":                                 true,
-		"src/test/java/org/acme/RealDriverTest.java":       false,
-		"pkg/probe_driver.go":                              false,
-		"web/src/telemetryProbe.ts":                        false,
-		"web/src/useScratchpad.ts":                         false,
-		"README.md":                                        false,
-		"fixtures/dummy.json":                              false,
-		"src/main/java/org/acme/DummyImplementation.java":  false,
-		"src/main/java/org/acme/ScratchpadController.java": false,
-	}
-	for p, want := range cases {
-		if got := isNamedSourceScratch(p); got != want {
-			t.Errorf("isNamedSourceScratch(%q) = %v, want %v", p, got, want)
-		}
-	}
-}
-
 func TestFirstSegment(t *testing.T) {
 	cases := map[string]string{
 		"FindClass.java":     "", // root-level (no dir) → scratch, not a deliverable
@@ -150,6 +131,7 @@ func TestDecideOwnership(t *testing.T) {
 		name                  string
 		porcelain             string
 		owned                 map[string]struct{}
+		intents               []payloads.FileIntent
 		wantJunk              []string // matched by path prefix (pattern suffix ignored)
 		wantModDocUnowned     []string // hard-fail: non-owner co-writing a shared doc
 		wantModUnowned        []string // advisory: non-owner editing non-doc
@@ -157,7 +139,9 @@ func TestDecideOwnership(t *testing.T) {
 		wantNewOutOfTerritory []string // hard-fail: new source/test outside territory
 		wantNewTopology       []string // hard-fail: new topology-controlled project/build file
 		wantRootScratch       []string // hard-fail (dev-retry): root-level source scratch
-		wantNamedScratch      []string // hard-fail (dev-retry): obvious nested source scratch
+		wantDeclaredScratch   []string // hard-fail (dev-retry): worktree path declared scratch_or_probe
+		wantUnclassified      []string // hard-fail (dev-retry): new source/test missing intent
+		wantIntentMismatch    []string // hard-fail (dev-retry): intent contradicts git status
 	}{
 		{
 			name:              "modified non-owned DOC (README wedge) hard-fails",
@@ -183,68 +167,92 @@ func TestDecideOwnership(t *testing.T) {
 			owned:     ownedSetOf("src/A.java"),
 		},
 		{
-			name:      "new owned source file is clean",
+			name:      "new owned source file with declared deliverable intent is clean",
 			porcelain: "A  src/A.java",
 			owned:     ownedSetOf("src/A.java"),
+			intents:   intentsOf(payloads.FileIntentOwnedDeliverable, "src/A.java"),
 		},
 		{
 			name:           "new unowned source (class split) in same dir is advisory",
 			porcelain:      "?? src/FooHelper.java",
 			owned:          ownedSetOf("src/Foo.java"),
+			intents:        intentsOf(payloads.FileIntentOwnedDeliverable, "src/FooHelper.java"),
 			wantNewUnowned: []string{"src/FooHelper.java"},
 		},
 		{
 			name:           "new unowned source in an OWNED subdirectory is advisory (in territory)",
 			porcelain:      "?? src/main/java/com/x/internal/Helper.java",
 			owned:          ownedSetOf("src/main/java/com/x/Driver.java"),
+			intents:        intentsOf(payloads.FileIntentOwnedDeliverable, "src/main/java/com/x/internal/Helper.java"),
 			wantNewUnowned: []string{"src/main/java/com/x/internal/Helper.java"},
 		},
 		{
 			name:                  "new unowned source OUTSIDE territory is an ownership gap (hard fail)",
 			porcelain:             "?? src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java",
 			owned:                 ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:               intentsOf(payloads.FileIntentPlanningGapRequiredFile, "src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java"),
 			wantNewOutOfTerritory: []string{"src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java"},
 		},
 		{
-			name:             "nested Dummy.java is dev-cleanup scratch, NOT a planning gap",
+			name:                "nested Dummy.java declared scratch_or_probe is dev-cleanup, NOT a planning gap",
+			porcelain:           "?? src/main/java/Dummy.java",
+			owned:               ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "src/main/java/Dummy.java"),
+			wantDeclaredScratch: []string{"src/main/java/Dummy.java"},
+		},
+		{
+			name:                "in-territory DummyTest.java declared scratch_or_probe is still dev-cleanup",
+			porcelain:           "?? src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java",
+			owned:               ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java"),
+			wantDeclaredScratch: []string{"src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java"},
+		},
+		{
+			name:                "Go dummy_test.go declared scratch_or_probe is dev-cleanup, NOT a planning gap",
+			porcelain:           "?? pkg/driver/dummy_test.go",
+			owned:               ownedSetOf("internal/driver/driver.go"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "pkg/driver/dummy_test.go"),
+			wantDeclaredScratch: []string{"pkg/driver/dummy_test.go"},
+		},
+		{
+			name:                "TypeScript scratch.spec.tsx declared scratch_or_probe is dev-cleanup, NOT a planning gap",
+			porcelain:           "?? web/src/scratch.spec.tsx",
+			owned:               ownedSetOf("web/src/Driver.tsx"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "web/src/scratch.spec.tsx"),
+			wantDeclaredScratch: []string{"web/src/scratch.spec.tsx"},
+		},
+		{
+			name:                "Python temp.py declared scratch_or_probe is dev-cleanup, NOT a planning gap",
+			porcelain:           "?? scripts/temp.py",
+			owned:               ownedSetOf("src/driver/main.py"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "scripts/temp.py"),
+			wantDeclaredScratch: []string{"scripts/temp.py"},
+		},
+		{
+			name:             "new source without file_intents is dev-retry, NOT a planning gap",
 			porcelain:        "?? src/main/java/Dummy.java",
 			owned:            ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
-			wantNamedScratch: []string{"src/main/java/Dummy.java"},
+			wantUnclassified: []string{"src/main/java/Dummy.java"},
 		},
 		{
-			name:             "in-territory DummyTest.java is still dev-cleanup scratch",
-			porcelain:        "?? src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java",
-			owned:            ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
-			wantNamedScratch: []string{"src/test/java/org/sensorhub/driver/mavsdk/DummyTest.java"},
-		},
-		{
-			name:             "Go dummy_test.go is dev-cleanup scratch, NOT a planning gap",
-			porcelain:        "?? pkg/driver/dummy_test.go",
-			owned:            ownedSetOf("internal/driver/driver.go"),
-			wantNamedScratch: []string{"pkg/driver/dummy_test.go"},
-		},
-		{
-			name:             "TypeScript scratch.spec.tsx is dev-cleanup scratch, NOT a planning gap",
-			porcelain:        "?? web/src/scratch.spec.tsx",
-			owned:            ownedSetOf("web/src/Driver.tsx"),
-			wantNamedScratch: []string{"web/src/scratch.spec.tsx"},
-		},
-		{
-			name:             "Python temp.py is dev-cleanup scratch, NOT a planning gap",
-			porcelain:        "?? scripts/temp.py",
-			owned:            ownedSetOf("src/driver/main.py"),
-			wantNamedScratch: []string{"scripts/temp.py"},
+			name:               "new source declared modified_existing is dev-retry, NOT a planning gap",
+			porcelain:          "?? src/main/java/Dummy.java",
+			owned:              ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:            intentsOf(payloads.FileIntentModifiedExisting, "src/main/java/Dummy.java"),
+			wantIntentMismatch: []string{"src/main/java/Dummy.java declared modified_existing but git status reports a new file"},
 		},
 		{
 			name:                  "legitimate source whose name contains probe still remains a planning gap",
 			porcelain:             "?? src/main/java/org/acme/probe/TelemetryProbe.java",
 			owned:                 ownedSetOf("src/main/java/org/acme/driver/Driver.java"),
+			intents:               intentsOf(payloads.FileIntentPlanningGapRequiredFile, "src/main/java/org/acme/probe/TelemetryProbe.java"),
 			wantNewOutOfTerritory: []string{"src/main/java/org/acme/probe/TelemetryProbe.java"},
 		},
 		{
 			name:                  "new unowned TEST outside territory is an ownership gap (hard fail)",
 			porcelain:             "?? src/test/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriverTest.java",
 			owned:                 ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:               intentsOf(payloads.FileIntentCompanionTest, "src/test/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriverTest.java"),
 			wantNewOutOfTerritory: []string{"src/test/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriverTest.java"},
 		},
 		{
@@ -255,9 +263,10 @@ func TestDecideOwnership(t *testing.T) {
 			// the ADR-049 ownership gap).
 		},
 		{
-			name:            "root-level source scratch (FindClass.java) is dev-cleanup, NOT a planning gap and NOT advisory",
+			name:            "root-level source cannot be a deliverable, NOT a planning gap and NOT advisory",
 			porcelain:       "?? FindClass.java",
 			owned:           ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:         intentsOf(payloads.FileIntentOwnedDeliverable, "FindClass.java"),
 			wantRootScratch: []string{"FindClass.java"},
 		},
 		{
@@ -265,6 +274,13 @@ func TestDecideOwnership(t *testing.T) {
 			porcelain:      "?? NOTES.txt",
 			owned:          ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
 			wantNewUnowned: []string{"NOTES.txt"},
+		},
+		{
+			name:                "root-level NON-source declared scratch_or_probe is dev-cleanup",
+			porcelain:           "?? NOTES.txt",
+			owned:               ownedSetOf("src/main/java/org/sensorhub/driver/mavsdk/MavSdkCSDriver.java"),
+			intents:             intentsOf(payloads.FileIntentScratchOrProbe, "NOTES.txt"),
+			wantDeclaredScratch: []string{"NOTES.txt"},
 		},
 		{
 			name:            "new root settings.gradle is topology planning gap",
@@ -287,6 +303,7 @@ func TestDecideOwnership(t *testing.T) {
 			name:      "new Java companion test for owned main class is clean",
 			porcelain: "?? src/test/java/org/sensorhub/impl/sensor/mavsdk/UnmannedSystemTest.java",
 			owned:     ownedSetOf("src/main/java/org/sensorhub/impl/sensor/mavsdk/UnmannedSystem.java"),
+			intents:   intentsOf(payloads.FileIntentCompanionTest, "src/test/java/org/sensorhub/impl/sensor/mavsdk/UnmannedSystemTest.java"),
 		},
 		{
 			name:           "new unowned DOC outside territory stays advisory (hygiene only)",
@@ -295,9 +312,10 @@ func TestDecideOwnership(t *testing.T) {
 			wantNewUnowned: []string{"docs/TRADEOFFS.md"},
 		},
 		{
-			name:           "empty owned set leaves a new source advisory (no story context)",
+			name:           "empty owned set with declared deliverable leaves a new source advisory (no story context)",
 			porcelain:      "?? src/New.java",
 			owned:          ownedSetOf(), // no declared territory → cannot be 'outside' it
+			intents:        intentsOf(payloads.FileIntentOwnedDeliverable, "src/New.java"),
 			wantNewUnowned: []string{"src/New.java"},
 		},
 		{
@@ -307,7 +325,8 @@ func TestDecideOwnership(t *testing.T) {
 			// their implementation_files → it is in this story's FilesOwned → the
 			// node gate treats it as owned (clean), and DeriveStoryScheduling
 			// serializes the sharing stories. No ownership gap.
-			owned: ownedSetOf("src/driver/mavsdk/MavsdkDriver.java", "src/driver/mavsdk/Telemetry.java"),
+			owned:   ownedSetOf("src/driver/mavsdk/MavsdkDriver.java", "src/driver/mavsdk/Telemetry.java"),
+			intents: intentsOf(payloads.FileIntentOwnedDeliverable, "src/driver/mavsdk/MavsdkDriver.java"),
 		},
 		{
 			name:      "patch.diff committed is junk",
@@ -370,7 +389,7 @@ func TestDecideOwnership(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			v := decideOwnership(parsePorcelain(tc.porcelain), tc.owned)
+			v := decideOwnership(parsePorcelain(tc.porcelain), tc.owned, tc.intents)
 
 			// Junk findings carry a "(pattern)" suffix; compare on the path prefix.
 			gotJunkPaths := make([]string, len(v.JunkViolations))
@@ -398,8 +417,14 @@ func TestDecideOwnership(t *testing.T) {
 			if !equalSets(v.RootScratch, tc.wantRootScratch) {
 				t.Errorf("rootScratch = %v, want %v", sortedCopy(v.RootScratch), sortedCopy(tc.wantRootScratch))
 			}
-			if !equalSets(v.NamedSourceScratch, tc.wantNamedScratch) {
-				t.Errorf("namedSourceScratch = %v, want %v", sortedCopy(v.NamedSourceScratch), sortedCopy(tc.wantNamedScratch))
+			if !equalSets(v.DeclaredScratch, tc.wantDeclaredScratch) {
+				t.Errorf("declaredScratch = %v, want %v", sortedCopy(v.DeclaredScratch), sortedCopy(tc.wantDeclaredScratch))
+			}
+			if !equalSets(v.UnclassifiedNewSource, tc.wantUnclassified) {
+				t.Errorf("unclassifiedNewSource = %v, want %v", sortedCopy(v.UnclassifiedNewSource), sortedCopy(tc.wantUnclassified))
+			}
+			if !equalSets(v.MismatchedFileIntent, tc.wantIntentMismatch) {
+				t.Errorf("mismatchedFileIntent = %v, want %v", sortedCopy(v.MismatchedFileIntent), sortedCopy(tc.wantIntentMismatch))
 			}
 		})
 	}
@@ -444,7 +469,10 @@ func TestDecideOwnership_NewUnownedSourceFile_FailsContainment(t *testing.T) {
 			"?? src/test/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriverTest.java\n",
 	)
 
-	v := decideOwnership(changes, owned)
+	v := decideOwnership(changes, owned, intentsOf(payloads.FileIntentPlanningGapRequiredFile,
+		"src/main/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriver.java",
+		"src/test/java/org/sensorhub/impl/sensor/mavsdk/MavsdkDriverTest.java",
+	))
 
 	if v.clean() {
 		t.Fatalf("decideOwnership treated newly-created unowned SOURCE/TEST files as advisory "+
@@ -486,7 +514,7 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 
 	t.Run("empty owned skips gate (no check row)", func(t *testing.T) {
 		runner := &fakeRunner{stdout: " M README.md"}
-		results := e.runFileOwnershipContainment(context.Background(), nil, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), nil, nil, "/wt", runner)
 		if len(results) != 0 {
 			t.Fatalf("expected no check rows when owned is empty, got %+v", results)
 		}
@@ -498,7 +526,7 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("modified-unowned DOC hard fails the required gate", func(t *testing.T) {
 		runner := &fakeRunner{stdout: " M README.md\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
 		c := findResult(t, results, "file-ownership-containment")
 		if c.Passed || !c.Required {
 			t.Fatalf("expected required FAIL, got %+v", c)
@@ -511,7 +539,7 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("modified-unowned non-doc (build.gradle) is advisory, gate passes", func(t *testing.T) {
 		runner := &fakeRunner{stdout: " M build.gradle\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
 		c := findResult(t, results, "file-ownership-containment")
 		if !c.Passed {
 			t.Fatalf("build-file edit by a non-owner must NOT hard-fail (usually mergeable), got %+v", c)
@@ -525,7 +553,7 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("junk hard fails the required gate", func(t *testing.T) {
 		runner := &fakeRunner{stdout: "?? patch.diff\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
 		c := findResult(t, results, "file-ownership-containment")
 		if c.Passed {
 			t.Fatalf("expected required FAIL on patch.diff, got %+v", c)
@@ -538,7 +566,8 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("in-territory new-unowned is advisory, gate passes", func(t *testing.T) {
 		runner := &fakeRunner{stdout: "?? src/Helper.java\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		intents := intentsOf(payloads.FileIntentOwnedDeliverable, "src/Helper.java")
+		results := e.runFileOwnershipContainment(context.Background(), owned, intents, "/wt", runner)
 		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
 		if !c.Passed {
 			t.Fatalf("required gate should pass when only in-territory new-unowned present, got %+v", c)
@@ -555,7 +584,8 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("out-of-territory new source emits a planning-gap Required failure", func(t *testing.T) {
 		runner := &fakeRunner{stdout: "?? other/pkg/New.java\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		intents := intentsOf(payloads.FileIntentPlanningGapRequiredFile, "other/pkg/New.java")
+		results := e.runFileOwnershipContainment(context.Background(), owned, intents, "/wt", runner)
 		// The base containment row (junk/doc) still passes — the gap is its own row.
 		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
 		if !c.Passed {
@@ -570,15 +600,16 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 		}
 	})
 
-	t.Run("nested Dummy.java emits dev-cleanup containment failure, not planning-gap recovery", func(t *testing.T) {
+	t.Run("declared scratch_or_probe emits dev-cleanup containment failure, not planning-gap recovery", func(t *testing.T) {
 		runner := &fakeRunner{stdout: "?? src/main/java/Dummy.java\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		intents := intentsOf(payloads.FileIntentScratchOrProbe, "src/main/java/Dummy.java")
+		results := e.runFileOwnershipContainment(context.Background(), owned, intents, "/wt", runner)
 		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
 		if c.Passed || !c.Required {
 			t.Fatalf("expected required containment failure for Dummy.java scratch, got %+v", c)
 		}
-		if !strings.Contains(c.Stderr, "Dummy.java") || !strings.Contains(c.Stderr, "Throwaway source/test") {
+		if !strings.Contains(c.Stderr, "Dummy.java") || !strings.Contains(c.Stderr, "scratch_or_probe") {
 			t.Errorf("expected Dummy.java dev-cleanup message, got %q", c.Stderr)
 		}
 		for _, r := range results {
@@ -588,10 +619,28 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 		}
 	})
 
+	t.Run("unclassified new source emits dev-retry containment failure, not planning-gap recovery", func(t *testing.T) {
+		runner := &fakeRunner{stdout: "?? src/main/java/Dummy.java\n M src/A.java\n"}
+		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
+		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
+		if c.Passed || !c.Required {
+			t.Fatalf("expected required containment failure for missing file_intents, got %+v", c)
+		}
+		if !strings.Contains(c.Stderr, "file_intents") || !strings.Contains(c.Stderr, "src/main/java/Dummy.java") {
+			t.Errorf("expected file_intents guidance naming Dummy.java, got %q", c.Stderr)
+		}
+		for _, r := range results {
+			if r.Name == payloads.CheckFileOwnershipPlanningGap {
+				t.Fatalf("missing intent must not emit planning-gap recovery row: %+v", r)
+			}
+		}
+	})
+
 	t.Run("new topology-controlled file emits a planning-gap Required failure", func(t *testing.T) {
 		runner := &fakeRunner{stdout: "?? osh-core/settings.gradle\n M src/A.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
 		c := findResult(t, results, payloads.CheckFileOwnershipContainment)
 		if !c.Passed {
 			t.Fatalf("containment (junk/doc) should pass; the topology gap is a separate row, got %+v", c)
@@ -608,7 +657,8 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("all owned and clean passes with no advisory", func(t *testing.T) {
 		runner := &fakeRunner{stdout: " M src/A.java\nA  src/B.java\n"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java", "src/B.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		intents := intentsOf(payloads.FileIntentOwnedDeliverable, "src/B.java")
+		results := e.runFileOwnershipContainment(context.Background(), owned, intents, "/wt", runner)
 		if len(results) != 1 {
 			t.Fatalf("expected only the required result, got %+v", results)
 		}
@@ -620,7 +670,7 @@ func TestRunFileOwnershipContainment(t *testing.T) {
 	t.Run("git failure is advisory not a hard fail", func(t *testing.T) {
 		runner := &fakeRunner{exitCode: 128, stderr: "not a git repository"}
 		owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-		results := e.runFileOwnershipContainment(context.Background(), owned, "/wt", runner)
+		results := e.runFileOwnershipContainment(context.Background(), owned, nil, "/wt", runner)
 		if len(results) != 1 || !results[0].Passed || results[0].Required {
 			t.Fatalf("git failure must not hard-fail, got %+v", results)
 		}
@@ -693,7 +743,8 @@ func TestRunFileOwnershipContainment_RealGit(t *testing.T) {
 	write("src/Helper.java", "class Helper {}\n")
 
 	owned := workflow.NormalizeFilePaths([]string{"src/A.java"})
-	results := (&Executor{}).runFileOwnershipContainment(context.Background(), owned, dir, &localRunner{})
+	intents := intentsOf(payloads.FileIntentOwnedDeliverable, "src/Helper.java")
+	results := (&Executor{}).runFileOwnershipContainment(context.Background(), owned, intents, dir, &localRunner{})
 
 	c := findResult(t, results, "file-ownership-containment")
 	if c.Passed {

--- a/prompt/domain/software.go
+++ b/prompt/domain/software.go
@@ -242,6 +242,7 @@ These are not stylistic preferences. The compiler / interpreter / type checker e
 
 Honest reporting is mandatory:
 - files_modified in your submit_work call MUST list every file you actually created or changed in this worktree, and MUST NOT list files you only intended to write or wrote to /tmp.
+- file_intents in your submit_work call MUST contain exactly one entry for every files_modified path. Use intent="modified_existing" for edits to existing files, "owned_deliverable" for new in-scope implementation files, "companion_test" for tests that belong with an owned implementation file, "planning_gap_required_file" when the implementation genuinely requires a new source/test path outside your declared file scope, and "scratch_or_probe" only to admit a throwaway file that you must remove before submitting.
 - The system runs ` + "`git status`" + ` against the worktree the moment your loop ends, BEFORE the validator or reviewer runs. If files_modified is non-empty but git status is empty, your submit is rejected immediately as a claim/observation mismatch — no validator dispatch, no reviewer dispatch, just a rejection that consumes a TDD cycle. Caught 2026-05-03 on openrouter @easy /health where a developer ran ` + "`cat main.go`" + ` three times and submitted with files_modified=["main.go"] plus a confident multi-sentence summary about implementing a /health endpoint. Zero write commands had been issued. Reading a file is not modifying it. ` + "`cat`" + `, ` + "`ls`" + `, ` + "`grep`" + `, and ` + "`find`" + ` are read-only — they do not change the worktree.
 - The actual write commands look like: ` + "`cat > path << 'EOF' ... EOF`" + `, ` + "`tee path < input`" + `, ` + "`sed -i 's/old/new/' path`" + `, ` + "`printf '...' >> path`" + `, ` + "`mv src dst`" + `, ` + "`cp src dst`" + `. If your bash transcript for this task contains ONLY read commands and you call submit_work with non-empty files_modified, you have hallucinated the work and the system will catch it.
 - If you're unsure whether a write succeeded (heredoc syntax, redirect path, sandbox quoting), run bash('git status') BEFORE submit_work. Empty output means you have not written anything yet — go write it before submitting.
@@ -462,10 +463,14 @@ qa-reviewer judges coverage against this declared surface.`)
 
 {
   "summary": "Implemented /goodbye endpoint with tests",
-  "files_modified": ["api/app.py", "api/test_goodbye.py"]
+  "files_modified": ["api/app.py", "api/test_goodbye.py"],
+  "file_intents": [
+    {"path": "api/app.py", "intent": "modified_existing", "rationale": "Updated the existing API app to add the endpoint."},
+    {"path": "api/test_goodbye.py", "intent": "companion_test", "rationale": "Added tests for the endpoint behavior."}
+  ]
 }
 
-Required: summary (string), files_modified (array of file paths you created or changed).`,
+Required: summary (string), files_modified (array of file paths you created or changed), file_intents (array with one path/intent/rationale object per files_modified path).`,
 				`Respond ONLY via the submit_work tool call. No markdown, no preamble, no explanation.`,
 			),
 		},

--- a/prompt/domain/software_render_test.go
+++ b/prompt/domain/software_render_test.go
@@ -294,36 +294,40 @@ func TestAssemblerEndToEnd_RequirementGenerator(t *testing.T) {
 	}
 }
 
-// TestAssembler_PlanConstraintsReachDeveloper pins #204's re-injection: the
+// TestAssembler_PlanConstraintsReachExecutionRoles pins #204's re-injection: the
 // plan's hard constraints (extracted by the planner) must appear in the
 // developer/validator/reviewer prompt, which decomposition otherwise never
 // carries them to. Without this, a dev can satisfy thin scenarios while
 // violating a stated prohibition ("do not stub") it never saw.
-func TestAssembler_PlanConstraintsReachDeveloper(t *testing.T) {
+func TestAssembler_PlanConstraintsReachExecutionRoles(t *testing.T) {
 	r := prompt.NewRegistry()
 	r.RegisterAll(Software()...)
 	a := prompt.NewAssembler(r)
 
 	const constraint = "do not stub MAVSDK/OSH classes"
-	out := a.Assemble(&prompt.AssemblyContext{
-		Role:           prompt.RoleDeveloper,
-		Provider:       prompt.ProviderOpenAI,
-		AvailableTools: []string{"bash", "submit_work"},
-		TaskContext: &prompt.TaskContext{
-			PlanGoal:        "Implement the driver",
-			PlanConstraints: []string{constraint, "full Connected Systems API coverage"},
-			WorktreePath:    "/work/wt",
-		},
-	})
-	if out.RenderError != nil {
-		t.Fatalf("unexpected RenderError: %v", out.RenderError)
-	}
-	combined := out.SystemMessage + "\n" + out.UserMessage
-	if !strings.Contains(combined, "PLAN CONSTRAINTS") {
-		t.Errorf("developer prompt missing the PLAN CONSTRAINTS block — #204 re-injection regressed")
-	}
-	if !strings.Contains(combined, constraint) {
-		t.Errorf("developer prompt missing the verbatim constraint %q", constraint)
+	for _, role := range []prompt.Role{prompt.RoleDeveloper, prompt.RoleValidator, prompt.RoleReviewer} {
+		t.Run(string(role), func(t *testing.T) {
+			out := a.Assemble(&prompt.AssemblyContext{
+				Role:           role,
+				Provider:       prompt.ProviderOpenAI,
+				AvailableTools: []string{"bash", "submit_work"},
+				TaskContext: &prompt.TaskContext{
+					PlanGoal:        "Implement the driver",
+					PlanConstraints: []string{constraint, "full Connected Systems API coverage"},
+					WorktreePath:    "/work/wt",
+				},
+			})
+			if out.RenderError != nil {
+				t.Fatalf("unexpected RenderError: %v", out.RenderError)
+			}
+			combined := out.SystemMessage + "\n" + out.UserMessage
+			if !strings.Contains(combined, "PLAN CONSTRAINTS") {
+				t.Errorf("%s prompt missing the PLAN CONSTRAINTS block — #204 re-injection regressed", role)
+			}
+			if !strings.Contains(combined, constraint) {
+				t.Errorf("%s prompt missing the verbatim constraint %q", role, constraint)
+			}
+		})
 	}
 
 	// Belt-and-suspenders: no constraints → no constraints block (no empty header).

--- a/prompt/integration_test.go
+++ b/prompt/integration_test.go
@@ -30,7 +30,7 @@ func softwareFragments() []*Fragment {
 		{ID: "sw.developer.system-base", Category: CategorySystemBase, Roles: []Role{RoleDeveloper}, Content: "You are a developer implementing code changes."},
 		{ID: "sw.developer.tool-directive", Category: CategoryToolDirective, Roles: []Role{RoleDeveloper}, Content: "CRITICAL: You MUST use bash to create or modify files."},
 		{ID: "sw.developer.role-context", Category: CategoryRoleContext, Roles: []Role{RoleDeveloper}, Content: "Gather context before writing code. Follow SOPs."},
-		{ID: "sw.developer.output-format", Category: CategoryOutputFormat, Roles: []Role{RoleDeveloper}, Content: `Output JSON: {"result": "...", "files_modified": [...]}`},
+		{ID: "sw.developer.output-format", Category: CategoryOutputFormat, Roles: []Role{RoleDeveloper}, Content: `Output JSON: {"summary": "...", "files_modified": [...], "file_intents": [...]}`},
 		{ID: "sw.developer.retry-directive", Category: CategoryToolDirective, Priority: 1, Roles: []Role{RoleDeveloper},
 			Condition: func(ctx *AssemblyContext) bool { return ctx.TaskContext != nil && ctx.TaskContext.Feedback != "" },
 			ContentFunc: func(ctx *AssemblyContext) string {

--- a/test/e2e/fixtures/mock-responses/exec-ownership-gate/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/exec-ownership-gate/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Registered the feature through the shared core driver (src/core/driver.py).\", \"files_modified\": [\"src/core/driver.py\"]}"
+        "arguments": "{\"summary\":\"Registered the feature through the shared core driver (src/core/driver.py).\",\"files_modified\":[\"src/core/driver.py\"],\"file_intents\":[{\"path\":\"src/core/driver.py\",\"intent\":\"planning_gap_required_file\",\"rationale\":\"Shared core entry point is outside the story file scope and must surface as a planning gap.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.2.json
+++ b/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.2.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye GET endpoint returning JSON, with a unit test.\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye GET endpoint returning JSON, with a unit test.\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.4.json
+++ b/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.4.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Added POST input validation to /goodbye (400 on missing name) plus a covering test.\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Added POST input validation to /goodbye (400 on missing name) plus a covering test.\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/exec-requirement-retry/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests.\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests.\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.2.json
+++ b/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.2.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.3.json
+++ b/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.3.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.5.json
+++ b/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.5.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.6.json
+++ b/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.6.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/exec-smoke/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.2.json
+++ b/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.2.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Written failing unit tests for /goodbye endpoint in api/test_goodbye.py\", \"files_modified\": [\"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Written failing unit tests for /goodbye endpoint in api/test_goodbye.py\",\"files_modified\":[\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.4.json
+++ b/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.4.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint in api/app.py returning JSON farewell message\", \"files_modified\": [\"api/app.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint in api/app.py returning JSON farewell message\",\"files_modified\":[\"api/app.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.5.json
+++ b/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.5.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/execution-phase/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/plan-phase/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/plan-phase/mock-coder.json
@@ -1,5 +1,20 @@
 {
   "response": "I have successfully implemented the /goodbye endpoint in api/app.py. The endpoint follows the same pattern as the /hello endpoint, returning a JSON response with a goodbye message. I also added tests in api/test_app.py to verify the endpoint behavior.",
   "tool_calls": [],
-  "files_modified": ["api/app.py", "api/test_app.py"]
+  "files_modified": [
+    "api/app.py",
+    "api/test_app.py"
+  ],
+  "file_intents": [
+    {
+      "path": "api/app.py",
+      "intent": "modified_existing",
+      "rationale": "Existing endpoint implementation file changed by the task."
+    },
+    {
+      "path": "api/test_app.py",
+      "intent": "companion_test",
+      "rationale": "Companion test file covering the changed implementation."
+    }
+  ]
 }

--- a/test/e2e/fixtures/mock-responses/plan-smoke/mock-coder.3.json
+++ b/test/e2e/fixtures/mock-responses/plan-smoke/mock-coder.3.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests in api/test_goodbye.py and endpoint in api/app.py\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests in api/test_goodbye.py and endpoint in api/app.py\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/plan-smoke/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/plan-smoke/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Task completed successfully\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Task completed successfully\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/plan-smoke/mock-recovery-agent.json
+++ b/test/e2e/fixtures/mock-responses/plan-smoke/mock-recovery-agent.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"action\":\"refine_prompt\",\"diagnosis\":\"Developer loop stopped short of submitting files_modified. Refining the prompt to require the explicit file list in submit_work so the next TDD cycle terminates cleanly.\",\"refined_prompt\":\"On submit_work, always include files_modified with the actual files you wrote (e.g. api/app.py, api/test_goodbye.py). Empty arrays or missing fields will be rejected by the developer-terminal validator.\",\"recovery_succeeded\":true}"
+        "arguments": "{\"action\":\"refine_prompt\",\"diagnosis\":\"Developer loop stopped short of submitting files_modified/file_intents. Refining the prompt to require the explicit file list and per-path intent declarations in submit_work so the next TDD cycle terminates cleanly.\",\"refined_prompt\":\"On submit_work, always include files_modified with the actual files you wrote (e.g. api/app.py, api/test_goodbye.py) and file_intents with one path/intent/rationale object for each file. Empty arrays or missing fields will be rejected by the developer-terminal validator.\",\"recovery_succeeded\":true}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.3.json
+++ b/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.3.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+        "arguments": "{\"summary\":\"Added Sub function with passing unit test\",\"files_modified\":[\"pkg/math/sub.go\",\"pkg/math/sub_test.go\"],\"file_intents\":[{\"path\":\"pkg/math/sub.go\",\"intent\":\"owned_deliverable\",\"rationale\":\"New implementation file owned by the scenario.\"},{\"path\":\"pkg/math/sub_test.go\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.4.json
+++ b/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.4.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+        "arguments": "{\"summary\":\"Added Sub function with passing unit test\",\"files_modified\":[\"pkg/math/sub.go\",\"pkg/math/sub_test.go\"],\"file_intents\":[{\"path\":\"pkg/math/sub.go\",\"intent\":\"owned_deliverable\",\"rationale\":\"New implementation file owned by the scenario.\"},{\"path\":\"pkg/math/sub_test.go\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.5.json
+++ b/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.5.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+        "arguments": "{\"summary\":\"Added Sub function with passing unit test\",\"files_modified\":[\"pkg/math/sub.go\",\"pkg/math/sub_test.go\"],\"file_intents\":[{\"path\":\"pkg/math/sub.go\",\"intent\":\"owned_deliverable\",\"rationale\":\"New implementation file owned by the scenario.\"},{\"path\":\"pkg/math/sub_test.go\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/qa-unit/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Added Sub function with passing unit test\", \"files_modified\": [\"pkg/math/sub.go\", \"pkg/math/sub_test.go\"]}"
+        "arguments": "{\"summary\":\"Added Sub function with passing unit test\",\"files_modified\":[\"pkg/math/sub.go\",\"pkg/math/sub_test.go\"],\"file_intents\":[{\"path\":\"pkg/math/sub.go\",\"intent\":\"owned_deliverable\",\"rationale\":\"New implementation file owned by the scenario.\"},{\"path\":\"pkg/math/sub_test.go\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.10.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.10.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.12.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.12.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.14.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.14.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.16.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.16.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.18.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.18.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.2.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.2.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.20.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.20.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.22.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.22.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.4.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.4.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.6.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.6.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.8.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.8.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.json
+++ b/test/e2e/fixtures/mock-responses/stall-retry/mock-coder.json
@@ -6,7 +6,7 @@
       "type": "function",
       "function": {
         "name": "submit_work",
-        "arguments": "{\"summary\": \"Implemented /goodbye endpoint with tests\", \"files_modified\": [\"api/app.py\", \"api/test_goodbye.py\"]}"
+        "arguments": "{\"summary\":\"Implemented /goodbye endpoint with tests\",\"files_modified\":[\"api/app.py\",\"api/test_goodbye.py\"],\"file_intents\":[{\"path\":\"api/app.py\",\"intent\":\"modified_existing\",\"rationale\":\"Existing endpoint implementation file changed by the task.\"},{\"path\":\"api/test_goodbye.py\",\"intent\":\"companion_test\",\"rationale\":\"Companion test file covering the changed implementation.\"}]}"
       }
     }
   ],

--- a/test/integration/graphmock/graphmock.go
+++ b/test/integration/graphmock/graphmock.go
@@ -1,0 +1,363 @@
+//go:build integration
+
+package graphmock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	sgraph "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// Ingest is an in-memory graph-ingest responder for integration tests that
+// exercise components over real NATS without starting the full graph-ingest
+// processor.
+type Ingest struct {
+	mu       sync.Mutex
+	entities map[string]*sgraph.EntityState
+}
+
+// Start registers graph-ingest request/reply handlers on the supplied NATS
+// client. The fake mirrors the mutation subjects used by semstreams
+// graph-ingest: triple.add/triple.add_batch append facts, while
+// update_with_triples replaces by predicate group.
+func Start(t testing.TB, nc *natsclient.Client) *Ingest {
+	t.Helper()
+	m := &Ingest{entities: make(map[string]*sgraph.EntityState)}
+
+	m.subscribe(t, nc, "graph.mutation.entity.update_with_triples", m.handleUpdateWithTriples)
+	m.subscribe(t, nc, "graph.mutation.entity.create_with_triples", m.handleCreateWithTriples)
+	m.subscribe(t, nc, "graph.mutation.triple.add", m.handleTripleAdd)
+	m.subscribe(t, nc, "graph.mutation.triple.add_batch", m.handleTripleAddBatch)
+	m.subscribe(t, nc, "graph.mutation.triple.remove", m.handleTripleRemove)
+	m.subscribe(t, nc, "graph.ingest.query.entity", m.handleQueryEntity)
+	m.subscribe(t, nc, "graph.ingest.query.prefix", m.handleQueryPrefix)
+
+	if conn := nc.GetConnection(); conn != nil {
+		if err := conn.Flush(); err != nil {
+			t.Fatalf("flush graph mock subscriptions: %v", err)
+		}
+	}
+
+	return m
+}
+
+// Entity returns a cloned entity so callers can inspect triples without racing
+// concurrent NATS handlers.
+func (m *Ingest) Entity(id string) (*sgraph.EntityState, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entity, ok := m.entities[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneEntity(entity), true
+}
+
+// MustEntity returns a cloned entity or fails the test.
+func (m *Ingest) MustEntity(t testing.TB, id string) *sgraph.EntityState {
+	t.Helper()
+	entity, ok := m.Entity(id)
+	if !ok {
+		t.Fatalf("entity %q not in graph mock", id)
+	}
+	return entity
+}
+
+// TripleValue converts the first object for predicate to a string, matching
+// the convenience helpers that used to be duplicated by integration suites.
+func TripleValue(triples []message.Triple, predicate string) string {
+	for _, triple := range triples {
+		if triple.Predicate != predicate {
+			continue
+		}
+		if s, ok := triple.Object.(string); ok {
+			return s
+		}
+		data, _ := json.Marshal(triple.Object)
+		return string(data)
+	}
+	return ""
+}
+
+func (m *Ingest) subscribe(t testing.TB, nc *natsclient.Client, subject string, handler func(context.Context, []byte) ([]byte, error)) {
+	t.Helper()
+	if _, err := nc.SubscribeForRequests(context.Background(), subject, handler); err != nil {
+		t.Fatalf("subscribe graph mock %s: %v", subject, err)
+	}
+}
+
+func (m *Ingest) handleUpdateWithTriples(_ context.Context, data []byte) ([]byte, error) {
+	var req sgraph.UpdateEntityWithTriplesRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(updateWithTriplesResponse(false, err.Error(), sgraph.ErrorCodeInvalidRequest, nil, 0, 0))
+	}
+	if req.Entity == nil || req.Entity.ID == "" {
+		return json.Marshal(updateWithTriplesResponse(false, "entity id required", sgraph.ErrorCodeInvalidRequest, nil, 0, 0))
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entity, ok := m.entities[req.Entity.ID]
+	if !ok {
+		return json.Marshal(updateWithTriplesResponse(false, "entity not found", sgraph.ErrorCodeEntityNotFound, nil, 0, 0))
+	}
+
+	removed := removePredicatesFromEntity(entity, req.RemoveTriples)
+	mergeTriplesIntoEntity(entity, req.AddTriples)
+	entity.Version++
+	entity.UpdatedAt = time.Now()
+
+	return json.Marshal(updateWithTriplesResponse(true, "", "", entity, len(req.AddTriples), removed))
+}
+
+func (m *Ingest) handleCreateWithTriples(_ context.Context, data []byte) ([]byte, error) {
+	var req sgraph.CreateEntityWithTriplesRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(createWithTriplesResponse(false, err.Error(), sgraph.ErrorCodeInvalidRequest, nil, 0))
+	}
+	if req.Entity == nil || req.Entity.ID == "" {
+		return json.Marshal(createWithTriplesResponse(false, "entity id required", sgraph.ErrorCodeInvalidRequest, nil, 0))
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.entities[req.Entity.ID]; exists {
+		return json.Marshal(createWithTriplesResponse(false, "entity already exists", sgraph.ErrorCodeEntityExists, nil, 0))
+	}
+
+	entity := &sgraph.EntityState{
+		ID:          req.Entity.ID,
+		MessageType: req.Entity.MessageType,
+		Triples:     append([]message.Triple(nil), req.Triples...),
+		Version:     1,
+		UpdatedAt:   time.Now(),
+	}
+	m.entities[req.Entity.ID] = entity
+
+	return json.Marshal(createWithTriplesResponse(true, "", "", entity, len(req.Triples)))
+}
+
+func (m *Ingest) handleTripleAdd(_ context.Context, data []byte) ([]byte, error) {
+	var req sgraph.AddTripleRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(sgraph.AddTripleResponse{
+			MutationResponse: mutationResponse(false, err.Error(), sgraph.ErrorCodeInvalidRequest, 0),
+		})
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entity := m.entityForWrite(req.Triple.Subject)
+	entity.Triples = append(entity.Triples, req.Triple)
+	entity.Version++
+	entity.UpdatedAt = time.Now()
+
+	return json.Marshal(sgraph.AddTripleResponse{
+		MutationResponse: mutationResponse(true, "", "", uint64(entity.Version)),
+		Triple:           &req.Triple,
+	})
+}
+
+func (m *Ingest) handleTripleAddBatch(_ context.Context, data []byte) ([]byte, error) {
+	var req sgraph.AddTriplesBatchRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(sgraph.AddTriplesBatchResponse{
+			MutationResponse: mutationResponse(false, err.Error(), sgraph.ErrorCodeInvalidRequest, 0),
+		})
+	}
+	if len(req.Triples) == 0 {
+		return json.Marshal(sgraph.AddTriplesBatchResponse{
+			MutationResponse: mutationResponse(true, "", "", 0),
+			WrittenCount:     0,
+		})
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, triple := range req.Triples {
+		entity := m.entityForWrite(triple.Subject)
+		entity.Triples = append(entity.Triples, triple)
+		entity.Version++
+		entity.UpdatedAt = time.Now()
+	}
+
+	return json.Marshal(sgraph.AddTriplesBatchResponse{
+		MutationResponse: mutationResponse(true, "", "", 0),
+		WrittenCount:     len(req.Triples),
+	})
+}
+
+func (m *Ingest) handleTripleRemove(_ context.Context, data []byte) ([]byte, error) {
+	var req sgraph.RemoveTripleRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(sgraph.RemoveTripleResponse{
+			MutationResponse: mutationResponse(false, err.Error(), sgraph.ErrorCodeInvalidRequest, 0),
+		})
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entity, ok := m.entities[req.Subject]
+	if !ok {
+		return json.Marshal(sgraph.RemoveTripleResponse{
+			MutationResponse: mutationResponse(true, "", "", 0),
+			Removed:          false,
+		})
+	}
+	removed := removePredicatesFromEntity(entity, []string{req.Predicate})
+	if removed > 0 {
+		entity.Version++
+		entity.UpdatedAt = time.Now()
+	}
+
+	return json.Marshal(sgraph.RemoveTripleResponse{
+		MutationResponse: mutationResponse(true, "", "", uint64(entity.Version)),
+		Removed:          removed > 0,
+	})
+}
+
+func (m *Ingest) handleQueryEntity(_ context.Context, data []byte) ([]byte, error) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+
+	entity, ok := m.Entity(req.ID)
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", req.ID)
+	}
+	return json.Marshal(entity)
+}
+
+func (m *Ingest) handleQueryPrefix(_ context.Context, data []byte) ([]byte, error) {
+	var req struct {
+		Prefix string `json:"prefix"`
+		Limit  int    `json:"limit"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var matches []sgraph.EntityState
+	for id, entity := range m.entities {
+		if !strings.HasPrefix(id, req.Prefix) {
+			continue
+		}
+		matches = append(matches, *cloneEntity(entity))
+		if req.Limit > 0 && len(matches) >= req.Limit {
+			break
+		}
+	}
+
+	return json.Marshal(map[string]any{"entities": matches})
+}
+
+func (m *Ingest) entityForWrite(id string) *sgraph.EntityState {
+	entity, ok := m.entities[id]
+	if !ok {
+		entity = &sgraph.EntityState{
+			ID:        id,
+			UpdatedAt: time.Now(),
+		}
+		m.entities[id] = entity
+	}
+	return entity
+}
+
+func createWithTriplesResponse(success bool, errText, code string, entity *sgraph.EntityState, triplesAdded int) sgraph.CreateEntityWithTriplesResponse {
+	return sgraph.CreateEntityWithTriplesResponse{
+		MutationResponse: mutationResponse(success, errText, code, revision(entity)),
+		Entity:           cloneEntity(entity),
+		TriplesAdded:     triplesAdded,
+	}
+}
+
+func updateWithTriplesResponse(success bool, errText, code string, entity *sgraph.EntityState, triplesAdded, triplesRemoved int) sgraph.UpdateEntityWithTriplesResponse {
+	return sgraph.UpdateEntityWithTriplesResponse{
+		MutationResponse: mutationResponse(success, errText, code, revision(entity)),
+		Entity:           cloneEntity(entity),
+		TriplesAdded:     triplesAdded,
+		TriplesRemoved:   triplesRemoved,
+		Version:          int64(revision(entity)),
+	}
+}
+
+func mutationResponse(success bool, errText, code string, kvRevision uint64) sgraph.MutationResponse {
+	return sgraph.MutationResponse{
+		Success:    success,
+		Error:      errText,
+		ErrorCode:  code,
+		Timestamp:  time.Now().UnixNano(),
+		KVRevision: kvRevision,
+	}
+}
+
+func revision(entity *sgraph.EntityState) uint64 {
+	if entity == nil {
+		return 0
+	}
+	return uint64(entity.Version)
+}
+
+func removePredicatesFromEntity(entity *sgraph.EntityState, predicates []string) int {
+	if entity == nil || len(predicates) == 0 || len(entity.Triples) == 0 {
+		return 0
+	}
+	remove := make(map[string]struct{}, len(predicates))
+	for _, predicate := range predicates {
+		remove[predicate] = struct{}{}
+	}
+	kept := entity.Triples[:0]
+	removed := 0
+	for _, triple := range entity.Triples {
+		if _, ok := remove[triple.Predicate]; ok {
+			removed++
+			continue
+		}
+		kept = append(kept, triple)
+	}
+	entity.Triples = kept
+	return removed
+}
+
+func mergeTriplesIntoEntity(entity *sgraph.EntityState, triples []message.Triple) {
+	if entity == nil || len(triples) == 0 {
+		return
+	}
+	byPredicate := make(map[string][]message.Triple)
+	for _, triple := range triples {
+		byPredicate[triple.Predicate] = append(byPredicate[triple.Predicate], triple)
+	}
+	kept := entity.Triples[:0]
+	for _, triple := range entity.Triples {
+		if _, replacing := byPredicate[triple.Predicate]; replacing {
+			continue
+		}
+		kept = append(kept, triple)
+	}
+	entity.Triples = kept
+	for _, group := range byPredicate {
+		entity.Triples = append(entity.Triples, group...)
+	}
+}
+
+func cloneEntity(entity *sgraph.EntityState) *sgraph.EntityState {
+	if entity == nil {
+		return nil
+	}
+	clone := *entity
+	clone.Triples = append([]message.Triple(nil), entity.Triples...)
+	return &clone
+}

--- a/tools/terminal/executor_test.go
+++ b/tools/terminal/executor_test.go
@@ -17,6 +17,18 @@ func TestSubmitWork_StopsLoop(t *testing.T) {
 		Arguments: map[string]any{
 			"summary":        "Implemented auth middleware",
 			"files_modified": []any{"auth.go", "auth_test.go"},
+			"file_intents": []any{
+				map[string]any{
+					"path":      "auth.go",
+					"intent":    "modified_existing",
+					"rationale": "Updated the middleware implementation requested by the task.",
+				},
+				map[string]any{
+					"path":      "auth_test.go",
+					"intent":    "companion_test",
+					"rationale": "Added tests covering the middleware behavior.",
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/tools/terminal/schemas.go
+++ b/tools/terminal/schemas.go
@@ -838,8 +838,38 @@ func developerSchema() map[string]any {
 				"items":       map[string]any{"type": "string"},
 				"description": "List of files created or modified",
 			},
+			"file_intents": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"path": map[string]any{
+							"type":        "string",
+							"description": "Workspace-relative path from files_modified",
+						},
+						"intent": map[string]any{
+							"type": "string",
+							"enum": []string{
+								"modified_existing",
+								"owned_deliverable",
+								"companion_test",
+								"planning_gap_required_file",
+								"scratch_or_probe",
+							},
+							"description": "Declared purpose of this file. Use scratch_or_probe for throwaway/probe files; use planning_gap_required_file when implementation requires a new source/test file outside the declared story scope.",
+						},
+						"rationale": map[string]any{
+							"type":        "string",
+							"description": "Brief reason this file belongs in the selected intent bucket.",
+						},
+					},
+					"required":             []string{"path", "intent", "rationale"},
+					"additionalProperties": false,
+				},
+				"description": "One entry per files_modified path declaring whether the change is an existing-file edit, owned deliverable, companion test, planning-gap required file, or scratch/probe.",
+			},
 		},
-		"required":             []string{"summary", "files_modified"},
+		"required":             []string{"summary", "files_modified", "file_intents"},
 		"additionalProperties": false,
 	}
 }

--- a/tools/terminal/schemas_test.go
+++ b/tools/terminal/schemas_test.go
@@ -20,9 +20,9 @@ func TestSchemaForDeliverable_HasNamedProperties(t *testing.T) {
 		{"architecture", []string{"technology_choices", "component_boundaries", "data_flow", "decisions", "actors", "integrations", "upstream_resolutions", "test_surface"}},
 		{"review", []string{"verdict", "feedback"}},
 		{"recovery", []string{"action", "diagnosis", "recovery_succeeded", "contract_impact", "refined_prompt", "scope_changes"}},
-		{"developer", []string{"summary", "files_modified"}},
+		{"developer", []string{"summary", "files_modified", "file_intents"}},
 		{"lesson", []string{"summary", "detail", "injection_form", "root_cause_role"}},
-		{"", []string{"summary", "files_modified"}}, // default
+		{"", []string{"summary", "files_modified", "file_intents"}}, // default
 	}
 
 	for _, tt := range tests {

--- a/tools/terminal/validators.go
+++ b/tools/terminal/validators.go
@@ -3,7 +3,9 @@ package terminal
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
+	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semspec/workflow/phases"
 	"github.com/c360studio/semstreams/metric"
 	"github.com/prometheus/client_golang/prometheus"
@@ -126,7 +128,7 @@ func ExpectedFieldsHint(deliverableType string) string {
 	case "review":
 		return `Expected JSON: {"verdict": "approved", "feedback": "..."}`
 	default:
-		return `Expected JSON: {"summary": "...", "files_modified": ["file.go"]}`
+		return `Expected JSON: {"summary": "...", "files_modified": ["file.go"], "file_intents": [{"path": "file.go", "intent": "modified_existing", "rationale": "..."}]}`
 	}
 }
 
@@ -281,7 +283,8 @@ func ValidateReviewDeliverable(d map[string]any) error {
 }
 
 // ValidateDeveloperDeliverable validates a developer deliverable from submit_work.
-// Required: summary (non-empty) AND files_modified (non-empty array of non-empty strings).
+// Required: summary (non-empty), files_modified (non-empty array of non-empty strings),
+// and file_intents (one intent object per file).
 //
 // Small models occasionally call submit_work with an empty files_modified array,
 // claiming "done" without writing any code. That was silently accepted, sent to
@@ -303,16 +306,79 @@ func ValidateDeveloperDeliverable(d map[string]any) error {
 	if len(files) == 0 {
 		return fmt.Errorf("files_modified must not be empty — if you have nothing to submit, keep working; do not call submit_work until you have written at least one file")
 	}
+	fileSet := make(map[string]struct{}, len(files))
 	for i, f := range files {
 		path, ok := f.(string)
 		if !ok {
 			return fmt.Errorf("files_modified[%d] must be a string path, got %T", i, f)
 		}
+		path = strings.TrimSpace(path)
 		if path == "" {
 			return fmt.Errorf("files_modified[%d] must be a non-empty path", i)
 		}
+		if _, exists := fileSet[path]; exists {
+			return fmt.Errorf("files_modified[%d] duplicates path %q", i, path)
+		}
+		fileSet[path] = struct{}{}
+	}
+
+	intentsRaw, ok := d["file_intents"]
+	if !ok {
+		return fmt.Errorf("file_intents is required — provide one intent object per files_modified path")
+	}
+	intents, ok := intentsRaw.([]any)
+	if !ok {
+		return fmt.Errorf("file_intents must be an array of objects, got %T", intentsRaw)
+	}
+	if len(intents) != len(files) {
+		return fmt.Errorf("file_intents must contain exactly one entry for each files_modified path")
+	}
+	intentSet := make(map[string]struct{}, len(intents))
+	for i, raw := range intents {
+		obj, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("file_intents[%d] must be an object with path, intent, and rationale", i)
+		}
+		path, ok := obj["path"].(string)
+		if !ok || strings.TrimSpace(path) == "" {
+			return fmt.Errorf("file_intents[%d].path is required (non-empty string)", i)
+		}
+		path = strings.TrimSpace(path)
+		if _, exists := intentSet[path]; exists {
+			return fmt.Errorf("file_intents[%d] duplicates path %q", i, path)
+		}
+		if _, ok := fileSet[path]; !ok {
+			return fmt.Errorf("file_intents[%d].path %q must match a files_modified entry", i, path)
+		}
+		intent, ok := obj["intent"].(string)
+		if !ok || !validDeveloperFileIntent(intent) {
+			return fmt.Errorf("file_intents[%d].intent must be one of modified_existing, owned_deliverable, companion_test, planning_gap_required_file, scratch_or_probe", i)
+		}
+		rationale, ok := obj["rationale"].(string)
+		if !ok || strings.TrimSpace(rationale) == "" {
+			return fmt.Errorf("file_intents[%d].rationale is required (non-empty string)", i)
+		}
+		intentSet[path] = struct{}{}
+	}
+	for path := range fileSet {
+		if _, ok := intentSet[path]; !ok {
+			return fmt.Errorf("file_intents missing path %q from files_modified", path)
+		}
 	}
 	return nil
+}
+
+func validDeveloperFileIntent(intent string) bool {
+	switch intent {
+	case payloads.FileIntentModifiedExisting,
+		payloads.FileIntentOwnedDeliverable,
+		payloads.FileIntentCompanionTest,
+		payloads.FileIntentPlanningGapRequiredFile,
+		payloads.FileIntentScratchOrProbe:
+		return true
+	default:
+		return false
+	}
 }
 
 // ValidateArchitectDeliverable validates an architecture deliverable.

--- a/tools/terminal/validators.go
+++ b/tools/terminal/validators.go
@@ -322,6 +322,15 @@ func ValidateDeveloperDeliverable(d map[string]any) error {
 		fileSet[path] = struct{}{}
 	}
 
+	return validateDeveloperFileIntents(d, fileSet, len(files))
+}
+
+// validateDeveloperFileIntents validates the file_intents array: exactly one
+// well-formed intent object per files_modified path (matching path, a valid
+// intent enum, and a non-empty rationale). Extracted from
+// ValidateDeveloperDeliverable to keep each function within the revive
+// statement-length limit.
+func validateDeveloperFileIntents(d map[string]any, fileSet map[string]struct{}, fileCount int) error {
 	intentsRaw, ok := d["file_intents"]
 	if !ok {
 		return fmt.Errorf("file_intents is required — provide one intent object per files_modified path")
@@ -330,7 +339,7 @@ func ValidateDeveloperDeliverable(d map[string]any) error {
 	if !ok {
 		return fmt.Errorf("file_intents must be an array of objects, got %T", intentsRaw)
 	}
-	if len(intents) != len(files) {
+	if len(intents) != fileCount {
 		return fmt.Errorf("file_intents must contain exactly one entry for each files_modified path")
 	}
 	intentSet := make(map[string]struct{}, len(intents))

--- a/tools/terminal/validators_test.go
+++ b/tools/terminal/validators_test.go
@@ -16,12 +16,19 @@ func TestValidateDeveloperDeliverable(t *testing.T) {
 			input: map[string]any{
 				"summary":        "Implemented loan calculator with unit tests",
 				"files_modified": []any{"calculator/calc.go", "calculator/calc_test.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calculator/calc.go", "intent": "modified_existing", "rationale": "Updated existing calculator."},
+					map[string]any{"path": "calculator/calc_test.go", "intent": "companion_test", "rationale": "Added unit coverage."},
+				},
 			},
 		},
 		{
 			name: "missing summary",
 			input: map[string]any{
 				"files_modified": []any{"calc.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "modified_existing", "rationale": "Updated existing file."},
+				},
 			},
 			wantError: "summary is required",
 		},
@@ -30,6 +37,9 @@ func TestValidateDeveloperDeliverable(t *testing.T) {
 			input: map[string]any{
 				"summary":        "",
 				"files_modified": []any{"calc.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "modified_existing", "rationale": "Updated existing file."},
+				},
 			},
 			wantError: "summary is required",
 		},
@@ -45,6 +55,7 @@ func TestValidateDeveloperDeliverable(t *testing.T) {
 			input: map[string]any{
 				"summary":        "Agent stopped with nothing",
 				"files_modified": []any{},
+				"file_intents":   []any{},
 			},
 			wantError: "files_modified must not be empty",
 		},
@@ -69,8 +80,73 @@ func TestValidateDeveloperDeliverable(t *testing.T) {
 			input: map[string]any{
 				"summary":        "Did the thing",
 				"files_modified": []any{"calc.go", ""},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "modified_existing", "rationale": "Updated existing file."},
+					map[string]any{"path": "", "intent": "modified_existing", "rationale": "Invalid empty path."},
+				},
 			},
 			wantError: "must be a non-empty path",
+		},
+		{
+			name: "missing file_intents",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go"},
+			},
+			wantError: "file_intents is required",
+		},
+		{
+			name: "file_intents wrong type",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go"},
+				"file_intents":   "calc.go",
+			},
+			wantError: "file_intents must be an array",
+		},
+		{
+			name: "file_intents missing files_modified path",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go", "calc_test.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "modified_existing", "rationale": "Updated existing file."},
+				},
+			},
+			wantError: "exactly one entry",
+		},
+		{
+			name: "file_intents path not in files_modified",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go"},
+				"file_intents": []any{
+					map[string]any{"path": "other.go", "intent": "modified_existing", "rationale": "Updated existing file."},
+				},
+			},
+			wantError: "must match a files_modified entry",
+		},
+		{
+			name: "file_intents invalid enum",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "probably_test", "rationale": "Nope."},
+				},
+			},
+			wantError: "intent must be one of",
+		},
+		{
+			name: "file_intents missing rationale",
+			input: map[string]any{
+				"summary":        "Did the thing",
+				"files_modified": []any{"calc.go"},
+				"file_intents": []any{
+					map[string]any{"path": "calc.go", "intent": "modified_existing", "rationale": ""},
+				},
+			},
+			wantError: "rationale is required",
 		},
 	}
 
@@ -103,6 +179,7 @@ func TestDeveloperValidatorIsRegistered(t *testing.T) {
 	err := v(map[string]any{
 		"summary":        "nothing",
 		"files_modified": []any{},
+		"file_intents":   []any{},
 	})
 	if err == nil {
 		t.Error("registered developer validator must reject empty files_modified")

--- a/tools/terminal/wire_shape_test.go
+++ b/tools/terminal/wire_shape_test.go
@@ -116,11 +116,11 @@ func TestStrictModeWireShape(t *testing.T) {
 		if got, want := schema["additionalProperties"], false; got != want {
 			t.Errorf("schema.additionalProperties = %v, want false", got)
 		}
-		// Top-level required must include both developer fields (developer
+		// Top-level required must include all developer fields (developer
 		// schema is fully strict-mode-compliant since it always was).
 		req, ok := schema["required"].([]any)
-		if !ok || len(req) != 2 {
-			t.Errorf("schema.required = %v, want [summary, files_modified]", schema["required"])
+		if !ok || len(req) != 3 {
+			t.Errorf("schema.required = %v, want [summary, files_modified, file_intents]", schema["required"])
 		}
 	})
 

--- a/workflow/cascade/cascade_integration_test.go
+++ b/workflow/cascade/cascade_integration_test.go
@@ -15,13 +15,15 @@ var integrationScenarios = []workflow.Scenario{
 	{ID: "sc-3", RequirementID: "req-2"},
 }
 
+var integrationStories []workflow.Story
+
 func TestPlanDecision_AffectsOneRequirement(t *testing.T) {
 	proposal := &workflow.PlanDecision{
 		ID:             "cp-1",
 		AffectedReqIDs: []string{"req-1"}, // affects sc-1, sc-2
 	}
 
-	result, err := PlanDecision(proposal, integrationScenarios)
+	result, err := PlanDecision(proposal, integrationStories, integrationScenarios)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -40,7 +42,7 @@ func TestPlanDecision_AffectsAllRequirements(t *testing.T) {
 		AffectedReqIDs: []string{"req-1", "req-2"},
 	}
 
-	result, err := PlanDecision(proposal, integrationScenarios)
+	result, err := PlanDecision(proposal, integrationStories, integrationScenarios)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +58,7 @@ func TestPlanDecision_NoMatchingScenarios(t *testing.T) {
 		AffectedReqIDs: []string{"req-nonexistent"},
 	}
 
-	result, err := PlanDecision(proposal, integrationScenarios)
+	result, err := PlanDecision(proposal, integrationStories, integrationScenarios)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/workflow/payloads/results.go
+++ b/workflow/payloads/results.go
@@ -258,6 +258,7 @@ type DeveloperResult struct {
 	TaskID        string          `json:"developer_task_id,omitempty"`
 	Status        string          `json:"status"`
 	FilesModified []string        `json:"files_modified,omitempty"`
+	FileIntents   []FileIntent    `json:"file_intents,omitempty"`
 	Output        json.RawMessage `json:"output,omitempty"`
 	LLMRequestIDs []string        `json:"llm_request_ids,omitempty"`
 }

--- a/workflow/payloads/types.go
+++ b/workflow/payloads/types.go
@@ -394,6 +394,9 @@ var DeveloperRequestType = message.Type{
 	Version:  "v1",
 }
 
+// FileIntent* enumerate the developer-declared intent for each modified file,
+// reported in submit_work's file_intents array and validated by the terminal
+// developer-deliverable validator.
 const (
 	FileIntentModifiedExisting        = "modified_existing"
 	FileIntentOwnedDeliverable        = "owned_deliverable"

--- a/workflow/payloads/types.go
+++ b/workflow/payloads/types.go
@@ -394,12 +394,31 @@ var DeveloperRequestType = message.Type{
 	Version:  "v1",
 }
 
+const (
+	FileIntentModifiedExisting        = "modified_existing"
+	FileIntentOwnedDeliverable        = "owned_deliverable"
+	FileIntentCompanionTest           = "companion_test"
+	FileIntentPlanningGapRequiredFile = "planning_gap_required_file"
+	FileIntentScratchOrProbe          = "scratch_or_probe"
+)
+
+// FileIntent records the developer's declared purpose for a changed path.
+// Structural validation still derives the authoritative changed/new file set
+// from git status; this field carries intent so the validator does not infer
+// scratch vs deliverable vs planning gap from filenames.
+type FileIntent struct {
+	Path      string `json:"path"`
+	Intent    string `json:"intent"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
 // ValidationRequest is the typed payload sent to the structural-validator component.
 // Purpose-built for the structural-validator component.
 type ValidationRequest struct {
-	ExecutionID   string   `json:"execution_id,omitempty"`
-	Slug          string   `json:"slug"`
-	FilesModified []string `json:"files_modified"`
+	ExecutionID   string       `json:"execution_id,omitempty"`
+	Slug          string       `json:"slug"`
+	FilesModified []string     `json:"files_modified"`
+	FileIntents   []FileIntent `json:"file_intents,omitempty"`
 
 	// WorktreePath overrides the default repo path for this validation run.
 	// When set, checks execute against this directory instead of the

--- a/workflow/plan_kv_integration_test.go
+++ b/workflow/plan_kv_integration_test.go
@@ -4,112 +4,14 @@ package workflow
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log/slog"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/test/integration/graphmock"
 	"github.com/c360studio/semspec/workflow/graphutil"
-	sgraph "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/natsclient"
 )
-
-// mockGraphIngest provides in-memory graph-ingest NATS responders for testing.
-// It handles graph.mutation.triple.add and graph.ingest.query.entity/prefix.
-type mockGraphIngest struct {
-	mu       sync.Mutex
-	entities map[string]*sgraph.EntityState // entityID → state
-}
-
-// startMockGraphIngest registers Core NATS request/reply handlers on the
-// graph-ingest subjects. The handlers store triples in memory and respond to
-// entity and prefix queries without requiring an external graph-ingest service.
-func startMockGraphIngest(t *testing.T, nc *natsclient.Client) *mockGraphIngest {
-	t.Helper()
-	m := &mockGraphIngest{entities: make(map[string]*sgraph.EntityState)}
-
-	// Handle triple writes.
-	nc.SubscribeForRequests(context.Background(), "graph.mutation.triple.add", func(_ context.Context, data []byte) ([]byte, error) {
-		var req sgraph.AddTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return json.Marshal(map[string]any{"success": false, "error": err.Error()})
-		}
-
-		m.mu.Lock()
-		defer m.mu.Unlock()
-
-		entity, ok := m.entities[req.Triple.Subject]
-		if !ok {
-			entity = &sgraph.EntityState{
-				ID:        req.Triple.Subject,
-				UpdatedAt: time.Now(),
-			}
-			m.entities[req.Triple.Subject] = entity
-		}
-
-		// Append all triples — graph-ingest preserves multi-valued predicates.
-		entity.Triples = append(entity.Triples, req.Triple)
-		entity.Version++
-		entity.UpdatedAt = time.Now()
-
-		return json.Marshal(map[string]any{"success": true, "kv_revision": entity.Version})
-	})
-
-	// Handle entity queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.entity", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		entity, ok := m.entities[req.ID]
-		m.mu.Unlock()
-
-		if !ok {
-			return nil, fmt.Errorf("not found: %s", req.ID)
-		}
-		return json.Marshal(entity)
-	})
-
-	// Handle prefix queries.
-	nc.SubscribeForRequests(context.Background(), "graph.ingest.query.prefix", func(_ context.Context, data []byte) ([]byte, error) {
-		var req struct {
-			Prefix string `json:"prefix"`
-			Limit  int    `json:"limit"`
-		}
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-
-		m.mu.Lock()
-		var matches []sgraph.EntityState
-		for id, entity := range m.entities {
-			if len(id) >= len(req.Prefix) && id[:len(req.Prefix)] == req.Prefix {
-				matches = append(matches, *entity)
-				if req.Limit > 0 && len(matches) >= req.Limit {
-					break
-				}
-			}
-		}
-		m.mu.Unlock()
-
-		return json.Marshal(map[string]any{"entities": matches})
-	})
-
-	// Flush ensures all subscriptions are registered on the server before any
-	// caller fires requests. Without this, there is a race between the async
-	// subscribe round-trip and the first WriteTriple call.
-	if conn := nc.GetConnection(); conn != nil {
-		_ = conn.Flush()
-	}
-
-	return m
-}
 
 // newTestTripleWriter creates a TripleWriter backed by a real NATS for integration
 // tests. It also starts the in-memory graph-ingest mock so that TripleWriter
@@ -119,7 +21,7 @@ func newTestTripleWriter(t *testing.T) *graphutil.TripleWriter {
 	tc := natsclient.NewTestClient(t,
 		natsclient.WithKVBuckets("ENTITY_STATES"),
 	)
-	startMockGraphIngest(t, tc.Client)
+	graphmock.Start(t, tc.Client)
 	return &graphutil.TripleWriter{
 		NATSClient:    tc.Client,
 		Logger:        slog.Default(),


### PR DESCRIPTION
## Summary

- make `execution-manager` treat `PLAN_STATES` as a required startup dependency with bounded retry instead of best-effort/lazy prompt context
- fail closed before developer/reviewer dispatch when plan context cannot be loaded, so plan constraints such as no-stubs cannot silently drop
- reset the current story back to ready during requirement restructure retry to avoid the executing-story wedge
- centralize `ready_for_execution` re-entry so promote/retry/PR-feedback paths publish `scenario.orchestrate.<slug>` instead of idling at ready (#263)
- add real NATS KV integration coverage for the `PLAN_STATES` dependency and execution pending-task path
- repair and wire repo-level integration tests into CI
- replace duplicated graph-ingest integration fakes with a shared `test/integration/graphmock` helper

## Root Cause

The task-level execution path could start with `PLAN_STATES` unavailable, cache a nil/best-effort plan bucket, and continue assembling developer/reviewer prompts without plan-derived constraints. Unit prompt rendering tests only proved constraints rendered when already present; they did not prove execution-manager could load real plan state from NATS KV.

Separately, the integration suite had drifted out of CI. Running `go test -race -tags integration -count=1 ./...` exposed stale tests and duplicated graph mocks that no longer matched the current graph mutation API.

Issue #263 exposed another state-machine coverage gap: `ready_for_execution` had multiple entrypoints. The mutation path auto-started execution, but the HTTP round-2 promote path used after `story_reprepare` only saved the status and assumed another watcher would dispatch. Retry and PR-feedback recovery had the same re-entry side-effect gap. The fix makes those paths transition to `implementing` and publish the orchestrator trigger whenever an execution publisher is available.

## Validation

- `go test ./processor/plan-manager`
- `go test -tags=integration ./processor/plan-manager`
- `go test ./workflow ./processor/scenario-orchestrator ./processor/requirement-executor ./processor/plan-manager`
- `go test ./...`
- `go test -race -tags=integration -count=1 ./...`
- `go test -tags=integration ./test/integration/graphmock ./processor/scenario-orchestrator ./processor/project-manager ./workflow ./processor/execution-manager -count=1 -timeout 5m`
- `go test -tags=integration ./processor/execution-manager -count=1 -timeout 5m`
- `task e2e:mock -- exec-requirement-retry`
- `git diff --check`
