### PR TITLE
chore(deps): pin semsource to 377e063 ahead of breaking semstreams update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 3
 
   semsource:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy

--- a/docker/compose/e2e-epic.yml
+++ b/docker/compose/e2e-epic.yml
@@ -29,7 +29,7 @@ volumes:
 services:
   # External semsource: OpenSensorHub core (Java)
   semsource-osh:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     environment:
       - SEMSOURCE_LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
@@ -50,7 +50,7 @@ services:
 
   # External semsource: Meshtastic documentation
   semsource-meshtastic:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     environment:
       - SEMSOURCE_LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
@@ -66,7 +66,7 @@ services:
 
   # External semsource: OGC Connected Systems spec
   semsource-ogc:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     environment:
       - SEMSOURCE_LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:

--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -15,7 +15,7 @@ services:
       start_period: 5s
 
   semsource:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy

--- a/ui/docker-compose.e2e-epic.yml
+++ b/ui/docker-compose.e2e-epic.yml
@@ -73,7 +73,7 @@ services:
 
   # External semsource: Meshtastic (smallest — start first)
   semsource-meshtastic:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy
@@ -104,7 +104,7 @@ services:
 
   # External semsource: OGC Connected Systems spec (medium — second)
   semsource-ogc:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy
@@ -132,7 +132,7 @@ services:
 
   # External semsource: OpenSensorHub core (largest Java repo — start last)
   semsource-osh:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy
@@ -166,7 +166,7 @@ services:
   # for the same Java AST indexing memory; serializing keeps each
   # seed-burst inside the 4G limit OSH already set.
   semsource-mavsdk-java:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy
@@ -197,7 +197,7 @@ services:
   # sensorhub-driver-mavsdk this prompt extends from). Chained last so its
   # ~200MB clone + Java AST burst doesn't collide with anything else.
   semsource-osh-addons:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       nats:
         condition: service_healthy

--- a/ui/docker-compose.e2e-llm.yml
+++ b/ui/docker-compose.e2e-llm.yml
@@ -12,7 +12,7 @@
 
 services:
   semsource:
-    image: ghcr.io/c360studio/semsource:latest
+    image: ghcr.io/c360studio/semsource:377e063
     depends_on:
       workspace-init:
         condition: service_completed_successfully


### PR DESCRIPTION
Pin `semsource` to the known-good `377e063` tag across all compose stacks.

## Why
`semsource` is updating to the latest `semstreams`, which carries **breaking changes**. Every stack currently pulls `ghcr.io/c360studio/semsource:latest`, so a breaking publish would silently break local / e2e / prod stacks on the next image pull. Pinning to `377e063` holds a stable image until semspec is validated against the new semstreams.

## Changes
`:latest` → `:377e063`, 11 image references across 5 compose files (no other changes):
- `docker-compose.yml` (prod/dev)
- `docker/compose/e2e.yml`, `docker/compose/e2e-epic.yml`
- `ui/docker-compose.e2e-llm.yml`, `ui/docker-compose.e2e-epic.yml`

## Unpinning
Revert this commit (or bump the tag) once semspec is verified against the new semstreams/semsource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)