### PR TITLE
test(schema): schema↔struct parity guards for all 11 deliverables + shared helper

### DIFF
--- a/processor/lesson-decomposer/schema_parity_test.go
+++ b/processor/lesson-decomposer/schema_parity_test.go
@@ -1,0 +1,36 @@
+package lessondecomposer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/schemaparity"
+	"github.com/c360studio/semspec/tools/terminal"
+)
+
+// TestLessonSchemaStructParity guards the lesson-decomposer (ADR-033 Phase 2b)
+// deliverable against schema↔struct drift. Output parses into the unexported
+// decomposerResult, with named evidence_steps/evidence_files item structs.
+func TestLessonSchemaStructParity(t *testing.T) {
+	props, err := schemaparity.Props(terminal.SchemaForDeliverable("lesson"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("decomposerResult", reflect.TypeOf(decomposerResult{}), props) {
+		t.Error(v)
+	}
+	stepItems, err := schemaparity.ItemsProps(props, "evidence_steps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("decomposerStepRef", reflect.TypeOf(decomposerStepRef{}), stepItems) {
+		t.Error(v)
+	}
+	fileItems, err := schemaparity.ItemsProps(props, "evidence_files")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("decomposerFileRef", reflect.TypeOf(decomposerFileRef{}), fileItems) {
+		t.Error(v)
+	}
+}

--- a/processor/qa-reviewer/schema_parity_test.go
+++ b/processor/qa-reviewer/schema_parity_test.go
@@ -1,0 +1,60 @@
+package qareviewer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/schemaparity"
+	"github.com/c360studio/semspec/tools/terminal"
+)
+
+// TestQAReviewSchemaStructParity guards the qa-reviewer (Murat) deliverable
+// against schema↔struct drift. Output parses into the unexported qaReviewOutput /
+// qaPlanDecision, which carry anonymous inline structs for `dimensions` and
+// `artifact_refs`; this descends into both so a drift at any level fails.
+func TestQAReviewSchemaStructParity(t *testing.T) {
+	props, err := schemaparity.Props(terminal.SchemaForDeliverable("qa-review"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	outT := reflect.TypeOf(qaReviewOutput{})
+	for _, v := range schemaparity.Bidirectional("qaReviewOutput", outT, props) {
+		t.Error(v)
+	}
+
+	// dimensions — anonymous inline struct on qaReviewOutput.
+	dimField, ok := outT.FieldByName("Dimensions")
+	if !ok {
+		t.Fatal("qaReviewOutput has no Dimensions field")
+	}
+	dimProps, err := schemaparity.ObjectProps(props, "dimensions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("qaReviewOutput.Dimensions", dimField.Type, dimProps) {
+		t.Error(v)
+	}
+
+	// plan_decisions[].items ↔ qaPlanDecision.
+	pdItems, err := schemaparity.ItemsProps(props, "plan_decisions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pdT := reflect.TypeOf(qaPlanDecision{})
+	for _, v := range schemaparity.Bidirectional("qaPlanDecision", pdT, pdItems) {
+		t.Error(v)
+	}
+
+	// artifact_refs[].items — anonymous inline struct on qaPlanDecision.
+	arField, ok := pdT.FieldByName("ArtifactRefs")
+	if !ok {
+		t.Fatal("qaPlanDecision has no ArtifactRefs field")
+	}
+	arItems, err := schemaparity.ItemsProps(pdItems, "artifact_refs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("qaPlanDecision.ArtifactRefs", arField.Type.Elem(), arItems) {
+		t.Error(v)
+	}
+}

--- a/processor/recovery-agent/schema_parity_test.go
+++ b/processor/recovery-agent/schema_parity_test.go
@@ -1,0 +1,34 @@
+package recoveryagent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/schemaparity"
+	"github.com/c360studio/semspec/tools/terminal"
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestRecoverySchemaStructParity guards the recovery-agent (ADR-037) deliverable
+// against schema↔struct drift. Output parses into the unexported
+// rawRecoveryResult. `feedback` is a DELIBERATE non-schema salvage field —
+// mid-tier models recurringly misfile the fix prose under "feedback" instead of
+// "refined_prompt", and the action-inference net adopts it rather than
+// terminal-failing a recoverable wedge — so it is allowlisted here.
+func TestRecoverySchemaStructParity(t *testing.T) {
+	props, err := schemaparity.Props(terminal.SchemaForDeliverable("recovery"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("rawRecoveryResult", reflect.TypeOf(rawRecoveryResult{}), props, "feedback") {
+		t.Error(v)
+	}
+	// contract_impact ↔ workflow.ContractImpact (the nested obligation summary).
+	ciProps, err := schemaparity.ObjectProps(props, "contract_impact")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("ContractImpact", reflect.TypeOf(workflow.ContractImpact{}), ciProps) {
+		t.Error(v)
+	}
+}

--- a/processor/story-preparer/schema_parity_test.go
+++ b/processor/story-preparer/schema_parity_test.go
@@ -1,0 +1,35 @@
+package storypreparer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semspec/tools/schemaparity"
+	"github.com/c360studio/semspec/tools/terminal"
+)
+
+// TestStoriesSchemaStructParity guards the story-preparer (Sarah) deliverable
+// against the schema↔struct drift class (#125/#126/#267). The model's
+// submit_work payload parses into the unexported positionalStoryInput /
+// positionalTaskInput DTOs, so the guard lives in this package — terminal
+// exposes only the canonical schema via SchemaForDeliverable.
+func TestStoriesSchemaStructParity(t *testing.T) {
+	props, err := schemaparity.Props(terminal.SchemaForDeliverable("stories"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	storyItems, err := schemaparity.ItemsProps(props, "stories")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("positionalStoryInput", reflect.TypeOf(positionalStoryInput{}), storyItems) {
+		t.Error(v)
+	}
+	taskItems, err := schemaparity.ItemsProps(storyItems, "tasks")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range schemaparity.Bidirectional("positionalTaskInput", reflect.TypeOf(positionalTaskInput{}), taskItems) {
+		t.Error(v)
+	}
+}

--- a/tools/schemaparity/schemaparity.go
+++ b/tools/schemaparity/schemaparity.go
@@ -1,0 +1,135 @@
+// Package schemaparity provides reflection-based helpers for asserting that a
+// submit_work JSON schema and the Go struct it unmarshals into carry the same
+// field set. It is the shared engine behind the per-deliverable parity guards
+// that catch the schema↔struct drift class (#125/#126/#267, and the review
+// action/target_field gap): a field in the struct but not the schema is a field
+// the model cannot emit on strict providers (and silently omits on advisory
+// ones); a field in the schema but not the struct is model output nothing reads.
+//
+// The functions are pure (no testing import) and return violation strings, so
+// they can be shared across the per-processor parity tests whose parse DTOs are
+// unexported and must be reflected on from inside their own package. Each caller
+// does `for _, v := range schemaparity.Bidirectional(...) { t.Error(v) }`.
+package schemaparity
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// JSONFields returns the json field-name set of a struct, stripping
+// ",omitempty", skipping json:"-", and flattening anonymous embedded structs.
+func JSONFields(t reflect.Type) map[string]bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			for k := range JSONFields(f.Type) {
+				out[k] = true
+			}
+			continue
+		}
+		tag := f.Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}
+
+// Bidirectional returns a violation for every field that exists on one side but
+// not the other, modulo systemOwned (fields the system fills post-parse, which
+// the model is not expected to emit and so are legitimately absent from the
+// schema). Use for deliverables whose parse target is a pure DTO of model output.
+func Bidirectional(label string, structType reflect.Type, props map[string]any, systemOwned ...string) []string {
+	owned := make(map[string]bool, len(systemOwned))
+	for _, f := range systemOwned {
+		owned[f] = true
+	}
+	structFields := JSONFields(structType)
+	schemaFields := make(map[string]bool, len(props))
+	for k := range props {
+		schemaFields[k] = true
+	}
+	var out []string
+	for f := range structFields {
+		if owned[f] || schemaFields[f] {
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s: struct field %q (json) is MISSING from the submit_work schema — the model cannot emit it. Add it to the schema, or to systemOwned if the system fills it.", label, f))
+	}
+	for f := range schemaFields {
+		if !structFields[f] {
+			out = append(out, fmt.Sprintf("%s: schema property %q has NO matching struct field — the model emits a value nothing unmarshals. Remove it from the schema or add the struct field.", label, f))
+		}
+	}
+	for f := range owned {
+		if schemaFields[f] {
+			out = append(out, fmt.Sprintf("%s: %q is in systemOwned but also present in the schema — remove it from the allowlist.", label, f))
+		}
+	}
+	return out
+}
+
+// SchemaSubsetOfStruct returns a violation for every schema property with no
+// matching struct field (model emits a value nothing unmarshals). It does NOT
+// assert the reverse — correct for durable-entity parse targets that carry
+// system-owned fields the model never sets.
+func SchemaSubsetOfStruct(label string, structType reflect.Type, props map[string]any) []string {
+	structFields := JSONFields(structType)
+	var out []string
+	for f := range props {
+		if !structFields[f] {
+			out = append(out, fmt.Sprintf("%s: schema property %q has NO matching struct field — the model emits a value nothing unmarshals. Remove it from the schema or add the struct field.", label, f))
+		}
+	}
+	return out
+}
+
+// Props returns schema["properties"] or an error if absent.
+func Props(schema map[string]any) (map[string]any, error) {
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema has no properties map")
+	}
+	return props, nil
+}
+
+// ItemsProps navigates props[key].items.properties for an array-of-object field.
+func ItemsProps(props map[string]any, key string) (map[string]any, error) {
+	field, ok := props[key].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema missing array property %q", key)
+	}
+	items, ok := field["items"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema property %q has no items", key)
+	}
+	p, ok := items["properties"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema property %q items has no properties", key)
+	}
+	return p, nil
+}
+
+// ObjectProps navigates props[key].properties for an object (non-array) field.
+func ObjectProps(props map[string]any, key string) (map[string]any, error) {
+	field, ok := props[key].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema missing object property %q", key)
+	}
+	p, ok := field["properties"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("schema property %q has no properties", key)
+	}
+	return p, nil
+}

--- a/tools/schemaparity/schemaparity_test.go
+++ b/tools/schemaparity/schemaparity_test.go
@@ -1,0 +1,75 @@
+package schemaparity
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type sampleStruct struct {
+	InSchema   string `json:"in_schema"`
+	OnlyStruct string `json:"only_struct"`
+	Owned      string `json:"owned"`
+	Ignored    string `json:"-"`
+}
+
+// schema props with: in_schema (matches), only_schema (no struct field).
+// owned is intentionally absent (it's a systemOwned struct field).
+func sampleProps() map[string]any {
+	return map[string]any{
+		"in_schema":   map[string]any{"type": "string"},
+		"only_schema": map[string]any{"type": "string"},
+	}
+}
+
+// TestBidirectional_CatchesBothDirections is the negative control proving the
+// guard is not vacuous: it must flag the struct-only field AND the schema-only
+// field, and must NOT flag the matched field or the allowlisted systemOwned one.
+func TestBidirectional_CatchesBothDirections(t *testing.T) {
+	got := Bidirectional("sample", reflect.TypeOf(sampleStruct{}), sampleProps(), "owned")
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "only_struct") {
+		t.Errorf("expected a violation for struct-only field only_struct; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "only_schema") {
+		t.Errorf("expected a violation for schema-only field only_schema; got:\n%s", joined)
+	}
+	if strings.Contains(joined, `"in_schema"`) {
+		t.Errorf("matched field in_schema should not be flagged; got:\n%s", joined)
+	}
+	if strings.Contains(joined, `field "owned"`) {
+		t.Errorf("systemOwned field owned should not be flagged; got:\n%s", joined)
+	}
+}
+
+// TestBidirectional_CleanWhenAligned proves no false positives when the struct
+// and schema agree (minus the allowlisted owned field).
+func TestBidirectional_CleanWhenAligned(t *testing.T) {
+	props := map[string]any{
+		"in_schema":   map[string]any{"type": "string"},
+		"only_struct": map[string]any{"type": "string"},
+	}
+	if got := Bidirectional("sample", reflect.TypeOf(sampleStruct{}), props, "owned"); len(got) != 0 {
+		t.Errorf("expected no violations, got: %v", got)
+	}
+}
+
+// TestStaleSystemOwned flags an allowlist entry that is actually present in the
+// schema (a stale exception that would mask real drift).
+func TestStaleSystemOwned(t *testing.T) {
+	props := map[string]any{
+		"in_schema":   map[string]any{"type": "string"},
+		"only_struct": map[string]any{"type": "string"},
+		"owned":       map[string]any{"type": "string"},
+	}
+	got := Bidirectional("sample", reflect.TypeOf(sampleStruct{}), props, "owned")
+	stale := false
+	for _, v := range got {
+		if strings.Contains(v, "remove it from the allowlist") {
+			stale = true
+		}
+	}
+	if !stale {
+		t.Errorf("expected a stale-allowlist violation for owned; got: %v", got)
+	}
+}

--- a/tools/terminal/schema_struct_parity_test.go
+++ b/tools/terminal/schema_struct_parity_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
 )
 
 // TestArchitectureSchemaStructParity is the guard against the recurring class of
@@ -76,6 +77,24 @@ func TestExplorationSchemaStructParity(t *testing.T) {
 	// depends_on/surfaces are all model-emitted; no system-owned exceptions.
 	assertSchemaStructParity(t, "Capability",
 		reflect.TypeOf(workflow.Capability{}), itemsProps(t, props, "capabilities"))
+}
+
+// TestDeveloperSchemaStructParity guards the developer deliverable. Like Plan,
+// payloads.DeveloperResult is a durable result type carrying system-owned fields
+// (request_id, slug, developer_task_id, status, output, llm_request_ids) the
+// model never emits — so the top level is a one-directional subset check. The
+// model-authored `summary` field had no struct home until #267-followup added
+// DeveloperResult.Summary; this test fails if it regresses to being dropped.
+func TestDeveloperSchemaStructParity(t *testing.T) {
+	schema := schemaForDeliverable("developer")
+	props := schemaProps(t, schema)
+
+	assertSchemaPropsSubsetOfStruct(t, "DeveloperResult",
+		reflect.TypeOf(payloads.DeveloperResult{}), props)
+
+	// file_intents[].items ↔ payloads.FileIntent — full parity (model-authored).
+	assertSchemaStructParity(t, "FileIntent",
+		reflect.TypeOf(payloads.FileIntent{}), itemsProps(t, props, "file_intents"))
 }
 
 // TestPlanSchemaStructParity guards the planner sub-phase deliverable. Unlike

--- a/workflow/payloads/results.go
+++ b/workflow/payloads/results.go
@@ -253,10 +253,14 @@ func registerValidationResult(reg *payloadregistry.Registry) error {
 
 // DeveloperResult is the output from the developer agent callback.
 type DeveloperResult struct {
-	RequestID     string          `json:"request_id,omitempty"`
-	Slug          string          `json:"slug"`
-	TaskID        string          `json:"developer_task_id,omitempty"`
-	Status        string          `json:"status"`
+	RequestID string `json:"request_id,omitempty"`
+	Slug      string `json:"slug"`
+	TaskID    string `json:"developer_task_id,omitempty"`
+	Status    string `json:"status"`
+	// Summary is the model-authored "summary of work completed" from the
+	// developer submit_work schema. Captured so the schema↔struct parity guard
+	// holds — the model emits it; without a struct home it was silently dropped.
+	Summary       string          `json:"summary,omitempty"`
 	FilesModified []string        `json:"files_modified,omitempty"`
 	FileIntents   []FileIntent    `json:"file_intents,omitempty"`
 	Output        json.RawMessage `json:"output,omitempty"`


### PR DESCRIPTION
## Why

The schema↔struct drift class keeps biting us (#125/#126, #267, and the review `action`/`target_field` gap): a field present in the Go struct but absent from the `submit_work` JSON schema (or vice versa) **fails silently** — on non-strict LLM providers (gemini/anthropic) the schema is advisory, so nothing errors at runtime; the only net is a per-deliverable parity unit test. Those existed for only **5 of 11** deliverables.

This closes the gap for **all 11**.

## What

- **New `tools/schemaparity` package** — pure (no `testing` import) reflection helpers shared by the per-processor parity tests whose parse DTOs are unexported. Ships **negative-control self-tests** that prove it flags drift in both directions and stays clean when aligned (so the guards aren't vacuous).
- **New parity tests** for the 5 previously-unguarded deliverables:
  - `stories` (story-preparer)
  - `recovery` (recovery-agent — the deliberate `feedback` salvage field is allowlisted)
  - `lesson` (lesson-decomposer)
  - `qa-review` (qa-reviewer — descends into the inline `dimensions`/`artifact_refs` structs)
  - `developer` (terminal)
- **`payloads.DeveloperResult` gains `Summary`** — the developer schema emits a "summary of work completed" that had no struct home and was silently dropped. Capturing it (additive, `omitempty`) makes the contract honest so the parity guard holds.

## Risk

**No runtime behavior change** — pure test additions plus one additive `omitempty` struct field that captures output the model already emits.

`go test ./...` 73 pkg ok / 0 fail; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)