### PR TITLE
docs(proposal): real-time churn detection + intervention

### DIFF
--- a/openspec/changes/realtime-churn-detection/design.md
+++ b/openspec/changes/realtime-churn-detection/design.md
@@ -1,0 +1,38 @@
+# Design — Real-time churn detection + intervention
+
+All file:line references verified against main `8aca8a5f` (2026-06-23).
+
+## Existing substrate (reuse)
+
+- **Detector framework** — `pkg/health/detector.go`: pure `Detector.Run(*Bundle) []Diagnosis` (no I/O/clock — deterministic for golden tests). `Severity` = info/warning/critical/undetermined. `Diagnosis{Shape, Severity, Evidence, Remediation, MemoryRef}`. `RunAll` aggregates.
+- **Live loop** — `cmd/semspec/watch_live.go`: `liveDetectors()` (~:302) wires 7 detectors, evaluated every tick; ALERT emission + dedupe (~:218-234, `seen[alertKey]`); `--bail-on <sev>` exits when tick max severity ≥ threshold; heartbeat prints `plans loops msgs active_loops ctx_util errors`.
+- **Closest existing detectors** (neither catches real churn):
+  - `RapidShallowToolCalls` — ≥6 tool-call responses in one loop with 0 `submit_work` (counts responses, not reads-vs-writes, no iteration #).
+  - `RepeatToolFailure` — same `(loop, tool, error-class)` failure ≥3× consecutively (only *failing* tool results; misses "succeeding calls, no worktree progress").
+
+## The churn signature lives in `agentic.Trajectory`
+
+- `agentic/trajectory.go`: `TrajectoryStep{StepType("model_call"|"tool_call"|"context_compaction"), ToolName, ToolArguments, ToolResult, ToolStatus("success"|"failed"), ErrorMessage, TokensIn/Out, ...}`; `Trajectory{LoopID, Steps[], Outcome}`.
+- This is enough to compute: read-vs-write tool ratio, repeated near-identical `ToolArguments`, repeated failing compiles on the same target — correlated with iteration position from `LoopEntity.Iterations`/`MaxIterations` (`agentic/state.go:52-53`).
+- **Gap 1 (plumbing):** trajectory *bodies* are NOT in the Bundle — `orchestrate.go` captures them to sibling tarball files; the Bundle carries only `TrajectoryRefs` (step *count* + outcome). A pure `Detector.Run(*Bundle)` cannot see steps today. Either thread trajectory bodies into the Bundle, or run the churn detector with direct trajectory access (outside the pure-detector contract).
+- **Gap 2 (semantics):** no tool is classified "read" vs "worktree write" anywhere — this change must define that mapping (e.g. `bash cat/grep/ls` + file-read = read; edit/write/apply-patch = write).
+
+## Recovery is post-mortem only — the actuation gap
+
+- Recovery fires **only after a loop terminates**, gated on `max_tdd_cycles` (=3, `execution-manager/config.go`) / agentic-loop `max_iterations` (=20). Publishers of `recovery.requested.<slug>`: execution-manager `markEscalatedLocked`, plan-manager `escalateRevision`/`fireQAVerdictRecovery`, requirement-executor retry-exhaustion — **every site is post-termination**. No mid-loop publisher exists.
+- The agentic-loop is event-driven; `HandleModelResponse` re-reads the loop entity each iteration (`handlers.go:~883`) — a natural between-iteration checkpoint.
+- **Interrupts:** only `agent.signal cancel` has real mid-flight effect (drains tool calls, `CancelLoop`). `pause` sets `PauseRequested` but it is **never read** (dead). `feedback`/`retry` signal types pass `Validate` but have **no handler** (dropped as "Unsupported signal type"). So mid-loop hint injection is **unwired** today.
+- **Hint pipe bug:** recovery's `refined_prompt` is parsed/validated but never propagated — `deriveDecision` returns `diagnosis` (not `refined_prompt`); only `diagnosis` reaches the dev via `applyRecoveryHint` → `Requirement.RecoveryHint` → "MANAGER RECOVERY GUIDANCE" block. A churn hint must land in `diagnosis` to be delivered (or fix the `refined_prompt` drop).
+
+## Build plan (incremental, lowest-risk first)
+
+1. **Define the churn signature** from real trajectory data (start with the 2026-06-23 architect trajectory `cad2673f-...` and any dev-loop trajectory). Pin thresholds (read:write ratio, repeat count, iteration floor) against real runs, not guesses.
+2. **Alert-only detector** in `pkg/health` (+ Gap 1 plumbing). Validates the signal with zero behavior risk; rides the existing ALERT/`--bail-on` path.
+3. **Intervention bridge** (only after the signal is trusted): cancel-and-recover (publish `agent.signal cancel`, then bridge cancellation → `recovery.requested` — `handleDeveloperCompleteLocked` currently routes `OutcomeCancelled` through cycle-consuming retry, so this bridge is new), or wire the dead `feedback` signal for true mid-loop injection. Fix the `refined_prompt` drop so hints land.
+4. **"Wrong gate" disposition.** Churn is often a false-reject symptom (2026-06-23: R-arch flagged companion tests the system auto-owns — a prompt↔system mismatch, not architect incapacity). When the churning agent has already structurally satisfied the gate, escalate the *gate* for review instead of looping the agent.
+
+## Open questions
+
+- Pure-detector purity vs. trajectory access: thread bodies into the Bundle (keeps detectors pure/testable) or special-case the churn detector with live trajectory fetch?
+- Cancel-and-recover vs. mid-loop feedback injection — which interrupt model? Cancel is wired but discards the worktree; feedback injection preserves it but is net-new and the loop's pause checkpoint is currently dead.
+- Detector authority: should the sidecar (an external observer) be allowed to actuate the system, or should the churn detector run *inside* a component (execution-manager) with the sidecar staying observe-only?

--- a/openspec/changes/realtime-churn-detection/proposal.md
+++ b/openspec/changes/realtime-churn-detection/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Recovery today is **post-mortem and limit-based**: the system only reacts to a wedged agent loop *after* a budget LIMIT is exhausted — `max_tdd_cycles` (default 3), the agentic-loop `max_iterations` (default 20), or a plan-review revision cap (3/3). By then the loop is dead, the worktree is discarded, and the paid tokens are spent. Two failure shapes seen live on `mavlink-hard` runs make the cost concrete:
+
+- **Dev contract thrash** — a developer reverse-engineering an upstream method contract through repeated edit→compile→fail cycles (the 2026-06-13 `ICommandStatus` loop burned ~3.5M tokens). Signature: many reads, ~0 worktree writes, repeated failing compiles on the same target.
+- **Architect gate oscillation** — an architect oscillating `generating_architecture ↔ reviewing_architecture` for 3 rounds against a reviewer finding, then dead-rejecting at the revision cap (2026-06-23 run).
+
+The right model is **real-time detection + intervention**, not post-mortem limits — and SemSpec **already has the substrate**: the `semspec watch --live --bail-on` sidecar runs a pure detector framework (`pkg/health`) against live system state every tick and emits `ALERT`/`BAIL` lines. It is **observe-only** today: it can warn and exit, but it cannot intervene in the running system. This change adds (a) a churn detector and (b) the missing observe→actuate path, so a churning loop is caught and helped *while it is still running* instead of after it burns its budget.
+
+A second, load-bearing lesson from the 2026-06-23 run: **churn is frequently a symptom of a wrong gate, not a stuck agent.** That run's architect "churn" was a *false-reject* — the R-arch reviewer flagged companion test files as unowned even though the system auto-owns them via companion-test expansion. So the intervention must be able to conclude "the gate may be wrong" (escalate the finding for human/meta review), not only "the agent is stuck, retry with a hint."
+
+## What Changes
+
+- Add a **churn detector** in `pkg/health` that reads developer/agent trajectory steps and flags the churn signature: high read-to-write ratio over N iterations, repeated near-identical tool calls, or repeated failing compiles on the same target — mid-loop, before budget exhaustion.
+- Plumb **trajectory bodies into the detector Bundle** (today only `TrajectoryRefs` step-counts are in-bundle; the per-step `ToolName`/`ToolArguments`/`ToolStatus` data a churn detector needs lives in sibling tarball files, invisible to a pure `Detector.Run(Bundle)`).
+- Add a **detector → intervention bridge**: on a confirmed churn diagnosis, trigger recovery *for a still-running loop* — either cancel-and-recover (the only clean interrupt today is the `agent.signal cancel`) or by wiring the currently-dead `feedback` signal for true mid-loop hint injection.
+- Fix the **hint-delivery pipe**: the recovery agent's structured `refined_prompt` is parsed but dropped — only `diagnosis` text reaches the dev via `Requirement.RecoveryHint`. A targeted churn hint (e.g. "read `/sources/<ns>` for class X's method contract before coding") must actually reach the next dispatch.
+- Add a **"wrong gate" disposition**: when the churn is an agent unable to satisfy a gate it has already structurally satisfied (false-reject), surface a finding for meta/human review rather than looping the agent against an unwinnable criterion.
+- Keep it **alert-only first**: ship the detector emitting diagnoses (no intervention) so the churn signature is validated against real trajectories before any actuation is wired.
+
+## Capabilities
+
+### New Capabilities
+
+- `realtime-churn-detection`: A live detector that recognizes a churning agent loop from its trajectory (reads-without-writes, repeated tool calls, repeated same-target compile failures) and emits a graded diagnosis while the loop is still running.
+- `churn-intervention`: A path from a churn diagnosis to a mid-loop intervention — cancel-and-recover or mid-loop hint injection — including delivery of a targeted, actionable hint to the next dispatch, and a "the gate may be wrong" escalation when the churn is a false-reject.
+
+### Modified Capabilities
+
+- `execution-observability`: the watch sidecar gains an actuation path (detection → intervention), not just ALERT/BAIL.
+
+## Impact
+
+- `pkg/health` (detector framework, Bundle, orchestrate trajectory capture), `cmd/semspec/watch_live.go` (`liveDetectors()`, ALERT/bail plumbing).
+- semstreams agentic-loop signal handling (`agent.signal.*`: the unwired `feedback`/`pause` signals), recovery-agent hint delivery (`refined_prompt` dropped), execution-manager cancel→recovery bridge.
+- No breaking API removals intended; alert-only phase is purely additive.


### PR DESCRIPTION
OpenSpec change capturing the real-time churn-detection idea (move from post-mortem/limit recovery to live detection+intervention on the existing semspec-watch detector framework). `proposal.md` + `design.md` with verified grounding and an alert-only-first build plan. Draft for iteration via `/opsx` — not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)