### PR TITLE
fix(planning): plumb plan.Constraints to the requirement-generator (Root cause 1)

### DIFF
--- a/processor/requirement-generator/component.go
+++ b/processor/requirement-generator/component.go
@@ -454,6 +454,7 @@ func buildRequirementGeneratorPromptContext(trigger *payloads.RequirementGenerat
 		Title:                 trigger.Title,
 		Goal:                  trigger.Goal,
 		Context:               trigger.Context,
+		Constraints:           trigger.Constraints,
 		ReplaceRequirementIDs: trigger.ReplaceRequirementIDs,
 		RejectionReasons:      trigger.RejectionReasons,
 		PreviousError:         previousError,
@@ -835,6 +836,7 @@ func (c *Component) recoverDispatchFromKV(ctx context.Context, slug string) (*pe
 			Title:                plan.Title,
 			Goal:                 plan.Goal,
 			Context:              plan.Context,
+			Constraints:          plan.Constraints,
 			Scope:                &plan.Scope,
 			ExistingRequirements: plan.Requirements,
 			// ReplaceRequirementIDs left empty — full regen on restart is safe

--- a/processor/requirement-generator/plan_watcher.go
+++ b/processor/requirement-generator/plan_watcher.go
@@ -94,10 +94,11 @@ func (c *Component) watchPlanStates(ctx context.Context, js jetstream.JetStream)
 // trigger: only deprecated requirements are regenerated, active ones preserved.
 func (c *Component) generateFromKVTrigger(ctx context.Context, plan *workflow.Plan) {
 	trigger := &payloads.RequirementGeneratorRequest{
-		Slug:    plan.Slug,
-		Title:   plan.Title,
-		Goal:    plan.Goal,
-		Context: plan.Context,
+		Slug:        plan.Slug,
+		Title:       plan.Title,
+		Goal:        plan.Goal,
+		Context:     plan.Context,
+		Constraints: plan.Constraints,
 	}
 	if len(plan.Scope.Include) > 0 || len(plan.Scope.Create) > 0 || len(plan.Scope.Exclude) > 0 || len(plan.Scope.DoNotTouch) > 0 {
 		scope := plan.Scope

--- a/prompt/context_requirement_generator.go
+++ b/prompt/context_requirement_generator.go
@@ -11,6 +11,12 @@ type RequirementGeneratorContext struct {
 	Goal    string
 	Context string
 
+	// Constraints are the plan's hard must/must-not coverage obligations
+	// (plan.Constraints). The R-req/R2 reviewer judges requirement coverage
+	// against these, so the generator must see them to mandate complete
+	// coverage ("all typed plugins") rather than a partial "such as" list.
+	Constraints []string
+
 	// ScopeInclude lists files/directories the plan is allowed to modify.
 	ScopeInclude []string
 	// ScopeCreate lists files the plan intends to create.

--- a/prompt/domain/software_render.go
+++ b/prompt/domain/software_render.go
@@ -49,6 +49,14 @@ func renderRequirementGeneratorPrompt(rg *prompt.RequirementGeneratorContext) st
 	if len(rg.ScopeDoNotTouch) > 0 {
 		fmt.Fprintf(&sb, "**Do Not Touch**: %s\n\n", strings.Join(rg.ScopeDoNotTouch, ", "))
 	}
+	if len(rg.Constraints) > 0 {
+		sb.WriteString("## Mandatory Coverage Constraints\n\n")
+		sb.WriteString("These are HARD must/must-not obligations from the brief. The downstream review (R-req/R2) rejects a requirements set that does not satisfy every coverage mandate below, so your requirements MUST reflect them. When a constraint mandates COMPLETE coverage of a surface (e.g. \"full coverage for ALL plugins/methods/endpoints of X\"), the covering requirement must mandate the COMPLETE set by reference — write \"expose ALL typed plugins of <X>\" (intent-level, complete), NOT a partial illustrative list (\"such as actions, missions, camera\"), which the reviewer reads as under-coverage. You do NOT enumerate the upstream members yourself (you have no upstream access and that is the architect's/coverage-matrix's job) — you state the complete-coverage intent so nothing downstream narrows it.\n\n")
+		for _, c := range rg.Constraints {
+			fmt.Fprintf(&sb, "- %s\n", c)
+		}
+		sb.WriteString("\n")
+	}
 
 	// ADR-040 Move 2: when the analyst sub-phase ran, render the capability
 	// list so John produces 1 Requirement per Capability with capability_name

--- a/prompt/domain/software_render_test.go
+++ b/prompt/domain/software_render_test.go
@@ -182,6 +182,37 @@ func TestRenderRequirementGeneratorPrompt_FreshGeneration(t *testing.T) {
 	}
 }
 
+// TestRenderRequirementGeneratorPrompt_Constraints pins the constraint-plumbing
+// fix: plan.Constraints reaches the requirement-generator prompt as mandatory
+// coverage obligations, with the complete-coverage directive. Guards the
+// 2026-06-23 churn where R-req/R2 rejected Requirement 4 for a partial "such as"
+// plugin list — the generator never received the "full coverage" constraint, so
+// it was rejected for not covering text it couldn't see. Empty constraints emit
+// nothing (back-compat).
+func TestRenderRequirementGeneratorPrompt_Constraints(t *testing.T) {
+	got := renderRequirementGeneratorPrompt(&prompt.RequirementGeneratorContext{
+		Title:       "MAVSDK driver",
+		Goal:        "Expose MAVSDK plugins as CS API streams.",
+		Constraints: []string{"The implementation must provide full Connected Systems API coverage for all MAVSDK plugins."},
+	})
+	for _, want := range []string{
+		"## Mandatory Coverage Constraints",
+		"full Connected Systems API coverage for all MAVSDK plugins",
+		"expose ALL typed plugins", // the complete-coverage-by-reference directive
+		"NOT a partial illustrative list",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("constraints prompt missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+
+	// Back-compat: no constraints → no section.
+	none := renderRequirementGeneratorPrompt(&prompt.RequirementGeneratorContext{Title: "x", Goal: "y"})
+	if strings.Contains(none, "Mandatory Coverage Constraints") {
+		t.Errorf("empty constraints must not emit the section")
+	}
+}
+
 func TestRenderRequirementGeneratorPrompt_PartialRegen(t *testing.T) {
 	got := renderRequirementGeneratorPrompt(&prompt.RequirementGeneratorContext{
 		Title: "Add /goodbye endpoint",

--- a/workflow/payloads/graph_refactor.go
+++ b/workflow/payloads/graph_refactor.go
@@ -29,6 +29,14 @@ type RequirementGeneratorRequest struct {
 	Context string          `json:"context,omitempty"`
 	Scope   *workflow.Scope `json:"scope,omitempty"` // pointer so omitempty works on struct types
 
+	// Constraints are the plan's hard must/must-not coverage obligations
+	// (plan.Constraints, the #204 array lifted verbatim from the brief). The
+	// R-req/R2 reviewer criteria judge requirements against these, so the
+	// requirement-generator MUST receive them to satisfy coverage mandates —
+	// without this it was rejected for not covering text it never saw (the
+	// constraint-plumbing gap the planning-gate audit found).
+	Constraints []string `json:"constraints,omitempty"`
+
 	// ExistingRequirements carries approved requirements for partial regen context.
 	// The generator preserves these and only regenerates the IDs in ReplaceRequirementIDs.
 	ExistingRequirements []workflow.Requirement `json:"existing_requirements,omitempty"`


### PR DESCRIPTION
## Why (planning-gate audit, Root cause 1)

The R-req/R2 reviewer criteria judge requirements against the plan's coverage mandates in `plan.Constraints` — but **`Constraints` was never delivered to the requirement-generator** (no field on `RequirementGeneratorRequest`/`Context`/renderer). The reviewer saw *"full coverage for all MAVSDK plugins"*; the producer didn't. So the 2026-06-23 run rejected Requirement 4's partial *"such as actions, missions, camera"* list as under-coverage, the regen couldn't read the constraint, and it churned to the revision cap → rejected. **Verified plumbing gap, not an agent failure** (the requirement-generator is correctly forbidden from naming upstream specifics; it just needs to know the coverage *mandate*).

## What

- `Constraints` added to `RequirementGeneratorRequest`, populated from `plan.Constraints` at both dispatch sites (KV trigger + restart-recovery).
- `Constraints` added to `RequirementGeneratorContext`; request→context wired.
- Renderer emits a **"## Mandatory Coverage Constraints"** block instructing the generator to mandate **complete coverage by reference** (*"expose ALL typed plugins of X"*), not a partial illustrative list, and explicitly **not** to enumerate upstream members itself (it has no upstream access — that's the architect's/coverage-matrix's job).
- The complete-coverage intent flows downstream to scenarios **via the requirement description** (the scenario-generator consumes `RequirementDescription`), so this single insertion point covers both R-req and the R2 cascade — no separate scenario-gen plumb needed.
- Guard test `TestRenderRequirementGeneratorPrompt_Constraints` (renders + back-compat).

## Scope note

This closes the **mismatch (M)** half of Root cause 1 (producer couldn't see the constraint). The **upstream-enumeration (U)** half — whether R2 crit 1a still demands literal per-plugin scenario coverage that no planning agent can enumerate — is Root cause 3 (no deterministic upstream resolver), tracked separately. The re-run will show whether the requirement-level fix is sufficient or R2 crit 1a also needs an intent-coverage relaxation.

`go build ./...` clean · `go test ./...` 66/0 · vet + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)