### PR TITLE
fix(requirement-executor): fail-closed recovery on transient network blips (#286)

### DIFF
--- a/model/registry.go
+++ b/model/registry.go
@@ -3,11 +3,9 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"sync"
-	"time"
 )
 
 // Registry manages model selection based on capabilities.
@@ -72,30 +70,19 @@ type EndpointConfig struct {
 	// to enforce serial inference.
 	MaxConcurrent int `json:"max_concurrent,omitempty"`
 
-	// RequestTimeout is the per-request HTTP timeout for this endpoint.
-	// Go duration string (e.g., "300s", "5m"). Empty or "0" means no
-	// per-endpoint timeout — the caller's context deadline governs duration.
-	// Use this as a safety cap for cloud endpoints; leave unset for slow
-	// local LLMs that may take hours per response.
+	// RequestTimeout is the per-request LLM timeout for this endpoint as a Go
+	// duration string (e.g., "300s", "5m"). Empty or "0" means the caller's
+	// context deadline governs duration.
+	//
+	// ENFORCEMENT lives in semstreams' agentic-model component, which applies
+	// the precedence req → endpoint.request_timeout → capability → default via
+	// model.ResolveCapabilityTimeout and wraps each model call in
+	// context.WithTimeout (see processor/agentic-model/component.go:resolveTimeout).
+	// This field is the config surface that flows there; semspec does NOT parse
+	// or apply it locally — a prior GetRequestTimeout() helper here was dead
+	// code (removed 2026-06-24) that duplicated, and risked diverging from,
+	// that enforcement.
 	RequestTimeout string `json:"request_timeout,omitempty"`
-}
-
-// GetRequestTimeout parses RequestTimeout as a Go duration.
-// Returns 0 if the field is empty, "0", or unparseable.
-func (e *EndpointConfig) GetRequestTimeout() time.Duration {
-	if e.RequestTimeout == "" || e.RequestTimeout == "0" {
-		return 0
-	}
-	d, err := time.ParseDuration(e.RequestTimeout)
-	if err != nil {
-		slog.Warn("Invalid request_timeout in endpoint config, ignoring",
-			"model", e.Model, "value", e.RequestTimeout, "error", err)
-		return 0
-	}
-	if d <= 0 {
-		return 0
-	}
-	return d
 }
 
 // DefaultsConfig holds default model settings.

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -499,4 +499,3 @@ func TestRegistryGetToolCapableEndpoints_NoneToolCapable(t *testing.T) {
 		t.Errorf("expected 0 tool-capable endpoints, got %d: %v", len(got), got)
 	}
 }
-

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestNewDefaultRegistry(t *testing.T) {
@@ -501,34 +500,3 @@ func TestRegistryGetToolCapableEndpoints_NoneToolCapable(t *testing.T) {
 	}
 }
 
-func TestEndpointConfig_GetRequestTimeout(t *testing.T) {
-	tests := []struct {
-		name  string
-		value string
-		want  time.Duration
-	}{
-		{"empty string", "", 0},
-		{"zero string", "0", 0},
-		{"zero duration", "0s", 0},
-		{"valid seconds", "300s", 300 * time.Second},
-		{"valid minutes", "5m", 5 * time.Minute},
-		{"valid mixed", "1m30s", 90 * time.Second},
-		{"negative", "-5m", 0},
-		{"invalid no unit", "300", 0},
-		{"invalid garbage", "notaduration", 0},
-		{"sub-second", "500ms", 500 * time.Millisecond},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ep := &EndpointConfig{
-				Model:          "test-model",
-				RequestTimeout: tt.value,
-			}
-			got := ep.GetRequestTimeout()
-			if got != tt.want {
-				t.Errorf("GetRequestTimeout(%q) = %v, want %v", tt.value, got, tt.want)
-			}
-		})
-	}
-}

--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -18,6 +18,7 @@ package requirementexecutor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -31,6 +32,16 @@ import (
 // req-executor process so events redeliver after a crash; consumer is
 // shared with restarts.
 const planDecisionAcceptedConsumer = "requirement-executor-plan-decision-accepted"
+
+// maxRecoveryInfraRetries bounds how many CONSECUTIVE awaiting-recovery
+// deadline expiries may be absorbed while the pending-PlanDecision check
+// cannot reach NATS/KV (infrastructure unreachable — e.g. a network blip or
+// power outage). Each such expiry extends the deadline by one recoveryTimeout
+// instead of terminal-failing, so a TRANSIENT outage no longer dead-ends a
+// plan (AutoRejectOnExhaustion). A SUSTAINED outage still terminates once the
+// cap is hit, bounding total grace at maxRecoveryInfraRetries × recoveryTimeout.
+// Reset to 0 on any successful read so only a continuous outage trips it.
+const maxRecoveryInfraRetries = 6
 
 // recoveryDeferEnabled reports whether the ADR-037 race-closure path is
 // active. Centralizing the gate keeps the call sites tidy and the
@@ -132,7 +143,57 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 	if !exec.awaitingRecovery {
 		return
 	}
-	if c.hasPendingRecoveryDecision(context.Background(), exec.Slug, exec.RequirementID) {
+
+	pending, readErr := c.hasPendingRecoveryDecision(context.Background(), exec.Slug, exec.RequirementID)
+
+	// Infrastructure unreachable (NATS/KV read failed): we cannot conclude
+	// that recovery gave up — the recovery agent's own LLM/NATS calls were
+	// equally cut off. Terminal-failing here turns a transient network blip
+	// into an irreversible AutoRejectOnExhaustion (caught 2026-06-23: a power
+	// outage mid-run dead-ended a plan). Extend instead, bounded by
+	// maxRecoveryInfraRetries so a permanent outage still terminates.
+	if readErr != nil {
+		exec.recoveryInfraRetries++
+		if exec.recoveryInfraRetries > maxRecoveryInfraRetries {
+			c.logger.Warn("Recovery deadline expired and infrastructure still unreachable after retry cap; terminal-failing",
+				"entity_id", exec.EntityID,
+				"slug", exec.Slug,
+				"requirement_id", exec.RequirementID,
+				"reason", exec.recoveryReason,
+				"timeout", timeout,
+				"infra_retries", exec.recoveryInfraRetries,
+				"max_infra_retries", maxRecoveryInfraRetries,
+				"read_error", readErr,
+			)
+			exec.awaitingRecovery = false
+			exec.recoveryTimer = nil
+			c.markFailedLocked(context.Background(), exec, exec.recoveryReason)
+			return
+		}
+		nextTimeout := c.recoveryTimeout()
+		timer := time.AfterFunc(nextTimeout, func() {
+			c.handleRecoveryTimeout(exec, nextTimeout)
+		})
+		exec.recoveryTimer = &timeoutHandle{stop: func() { timer.Stop() }}
+		c.logger.Warn("Recovery deadline expired but infrastructure is unreachable; extending awaiting-recovery instead of terminal-failing",
+			"entity_id", exec.EntityID,
+			"slug", exec.Slug,
+			"requirement_id", exec.RequirementID,
+			"reason", exec.recoveryReason,
+			"expired_timeout", timeout,
+			"next_timeout", nextTimeout,
+			"infra_retries", exec.recoveryInfraRetries,
+			"max_infra_retries", maxRecoveryInfraRetries,
+			"read_error", readErr,
+		)
+		return
+	}
+
+	// Read succeeded — infra is reachable, so reset the transient-outage
+	// counter. A subsequent outage starts the budget fresh.
+	exec.recoveryInfraRetries = 0
+
+	if pending {
 		nextTimeout := c.recoveryTimeout()
 		timer := time.AfterFunc(nextTimeout, func() {
 			c.handleRecoveryTimeout(exec, nextTimeout)
@@ -160,30 +221,48 @@ func (c *Component) handleRecoveryTimeout(exec *requirementExecution, timeout ti
 	c.markFailedLocked(context.Background(), exec, exec.recoveryReason)
 }
 
-func (c *Component) hasPendingRecoveryDecision(ctx context.Context, slug, requirementID string) bool {
+// hasPendingRecoveryDecision reports whether a recoverable PlanDecision is
+// still pending for this requirement. The second return value is a non-nil
+// readErr ONLY when the infrastructure could not be reached to make the
+// determination (NATS/KV unavailable) — a transient condition the caller
+// extends through rather than terminal-failing on. A clean (false, nil) means
+// the read succeeded and there is genuinely no pending decision (terminal-fail
+// is legitimate). A missing plan key (jetstream.ErrKeyNotFound) and an
+// unparseable plan are NOT infra failures — extending could not help — so they
+// return (false, nil).
+func (c *Component) hasPendingRecoveryDecision(ctx context.Context, slug, requirementID string) (bool, error) {
 	if c.pendingRecoveryDecisionChecker != nil {
 		return c.pendingRecoveryDecisionChecker(ctx, slug, requirementID)
 	}
 	if c.natsClient == nil {
-		return false
+		return false, nil
 	}
 	js, err := c.natsClient.JetStream()
 	if err != nil {
 		c.logger.Debug("Recovery timeout: JetStream unavailable while checking pending PlanDecisions",
 			"slug", slug, "requirement_id", requirementID, "error", err)
-		return false
+		return false, fmt.Errorf("jetstream unavailable: %w", err)
 	}
 	bucket, err := js.KeyValue(ctx, "PLAN_STATES")
 	if err != nil {
 		c.logger.Debug("Recovery timeout: PLAN_STATES unavailable while checking pending PlanDecisions",
 			"slug", slug, "requirement_id", requirementID, "error", err)
-		return false
+		return false, fmt.Errorf("PLAN_STATES unavailable: %w", err)
 	}
 	entry, err := bucket.Get(ctx, slug)
 	if err != nil {
-		c.logger.Debug("Recovery timeout: plan unavailable while checking pending PlanDecisions",
+		// A genuinely absent plan key is not a transient infra failure —
+		// extending the deadline could not bring it back. Only an
+		// unreachable-store error (anything other than key-not-found) is
+		// transient.
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			c.logger.Debug("Recovery timeout: plan key not found while checking pending PlanDecisions",
+				"slug", slug, "requirement_id", requirementID)
+			return false, nil
+		}
+		c.logger.Debug("Recovery timeout: plan store unreachable while checking pending PlanDecisions",
 			"slug", slug, "requirement_id", requirementID, "error", err)
-		return false
+		return false, fmt.Errorf("plan store unreachable: %w", err)
 	}
 	var plan struct {
 		PlanDecisions []workflow.PlanDecision `json:"plan_decisions"`
@@ -191,14 +270,14 @@ func (c *Component) hasPendingRecoveryDecision(ctx context.Context, slug, requir
 	if err := json.Unmarshal(entry.Value(), &plan); err != nil {
 		c.logger.Debug("Recovery timeout: plan JSON unmarshal failed while checking pending PlanDecisions",
 			"slug", slug, "requirement_id", requirementID, "error", err)
-		return false
+		return false, nil
 	}
 	for _, dec := range plan.PlanDecisions {
 		if isPendingRecoveryDecisionForRequirement(dec, requirementID) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func isPendingRecoveryDecisionForRequirement(dec workflow.PlanDecision, requirementID string) bool {

--- a/processor/requirement-executor/awaiting_recovery_test.go
+++ b/processor/requirement-executor/awaiting_recovery_test.go
@@ -3,6 +3,7 @@ package requirementexecutor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -166,8 +167,8 @@ func TestRecoveryTimeout_ExtendsWhenPlanDecisionStillPending(t *testing.T) {
 	exec.awaitingRecovery = true
 	exec.recoveryReason = "architecture recovery proposed"
 	c.activeExecs.Set(exec.EntityID, exec)
-	c.pendingRecoveryDecisionChecker = func(_ context.Context, slug, requirementID string) bool {
-		return slug == "plan-pending" && requirementID == "req-pending"
+	c.pendingRecoveryDecisionChecker = func(_ context.Context, slug, requirementID string) (bool, error) {
+		return slug == "plan-pending" && requirementID == "req-pending", nil
 	}
 
 	c.handleRecoveryTimeout(exec, 50*time.Millisecond)
@@ -187,6 +188,99 @@ func TestRecoveryTimeout_ExtendsWhenPlanDecisionStillPending(t *testing.T) {
 	exec.recoveryTimer = nil
 	if c.requirementsFailed.Load() != 0 {
 		t.Fatalf("requirementsFailed = %d, want 0", c.requirementsFailed.Load())
+	}
+}
+
+// Network-blip fail-closed: when the pending-decision check cannot reach
+// NATS/KV (infra unreachable), the deadline must EXTEND, not terminal-fail.
+// Regression for the 2026-06-23 power-outage dead-end: a transient outage
+// during the awaiting-recovery window must not trigger AutoRejectOnExhaustion.
+func TestRecoveryTimeout_ExtendsWhenInfraUnreachable(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-infra", "req-infra")
+	exec.awaitingRecovery = true
+	exec.recoveryReason = "tdd budget exhausted"
+	c.activeExecs.Set(exec.EntityID, exec)
+	c.pendingRecoveryDecisionChecker = func(_ context.Context, _, _ string) (bool, error) {
+		return false, errors.New("nats unreachable")
+	}
+
+	c.handleRecoveryTimeout(exec, 50*time.Millisecond)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if exec.terminated {
+		t.Fatal("exec must NOT terminal-fail when infra is unreachable — transient blip would dead-end the plan")
+	}
+	if !exec.awaitingRecovery {
+		t.Fatal("exec should remain awaiting recovery through a transient outage")
+	}
+	if exec.recoveryTimer == nil {
+		t.Fatal("recovery timer should be re-armed to retry after the outage")
+	}
+	if exec.recoveryInfraRetries != 1 {
+		t.Fatalf("recoveryInfraRetries = %d, want 1", exec.recoveryInfraRetries)
+	}
+	exec.recoveryTimer.stop()
+	exec.recoveryTimer = nil
+	if c.requirementsFailed.Load() != 0 {
+		t.Fatalf("requirementsFailed = %d, want 0", c.requirementsFailed.Load())
+	}
+}
+
+// Bounded grace: a SUSTAINED outage (infra unreachable for more than
+// maxRecoveryInfraRetries consecutive deadline expiries) must still terminate
+// so a permanent failure doesn't extend forever.
+func TestRecoveryTimeout_TerminalFailsAfterInfraRetryCap(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-infra-cap", "req-infra-cap")
+	exec.awaitingRecovery = true
+	exec.recoveryReason = "tdd budget exhausted"
+	// Already at the cap; the next infra-unreachable expiry must terminate.
+	exec.recoveryInfraRetries = maxRecoveryInfraRetries
+	c.activeExecs.Set(exec.EntityID, exec)
+	c.pendingRecoveryDecisionChecker = func(_ context.Context, _, _ string) (bool, error) {
+		return false, errors.New("nats still unreachable")
+	}
+
+	c.handleRecoveryTimeout(exec, 50*time.Millisecond)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if !exec.terminated {
+		t.Fatal("exec should terminal-fail once the infra-retry cap is exceeded")
+	}
+	if exec.awaitingRecovery {
+		t.Error("exec.awaitingRecovery should be cleared after cap-driven terminal-fail")
+	}
+	if c.requirementsFailed.Load() != 1 {
+		t.Errorf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
+	}
+}
+
+// A successful read showing no pending decision resets the transient-outage
+// counter AND terminal-fails (the legitimate "recovery genuinely gave up"
+// path) — ensuring a prior blip's retries don't linger.
+func TestRecoveryTimeout_ResetsInfraCounterOnSuccessfulRead(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 60*time.Second, 1)
+	exec := newAwaitingExec("plan-reset", "req-reset")
+	exec.awaitingRecovery = true
+	exec.recoveryReason = "tdd budget exhausted"
+	exec.recoveryInfraRetries = 3 // carried over from an earlier blip
+	c.activeExecs.Set(exec.EntityID, exec)
+	c.pendingRecoveryDecisionChecker = func(_ context.Context, _, _ string) (bool, error) {
+		return false, nil // read OK, genuinely nothing pending
+	}
+
+	c.handleRecoveryTimeout(exec, 50*time.Millisecond)
+
+	exec.mu.Lock()
+	defer exec.mu.Unlock()
+	if !exec.terminated {
+		t.Fatal("exec should terminal-fail on a clean read with no pending decision")
+	}
+	if c.requirementsFailed.Load() != 1 {
+		t.Errorf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
 	}
 }
 

--- a/processor/requirement-executor/component.go
+++ b/processor/requirement-executor/component.go
@@ -214,7 +214,10 @@ type Component struct {
 
 	// pendingRecoveryDecisionChecker is a test seam for the awaiting-recovery
 	// timeout path. Production uses PLAN_STATES via hasPendingRecoveryDecision.
-	pendingRecoveryDecisionChecker func(ctx context.Context, slug, requirementID string) bool
+	// Returns (pending, readErr): a non-nil readErr means infrastructure was
+	// unreachable (the check could not be made), which the timeout path treats
+	// as "extend, don't terminal-fail" rather than "no pending decision".
+	pendingRecoveryDecisionChecker func(ctx context.Context, slug, requirementID string) (bool, error)
 }
 
 // NewComponent creates a new requirement-executor from raw JSON config.

--- a/processor/requirement-executor/execution_state.go
+++ b/processor/requirement-executor/execution_state.go
@@ -202,6 +202,14 @@ type requirementExecution struct {
 	// restarts are out-of-band — they fire AFTER the normal retry budget is
 	// already exhausted.
 	recoveryRestarts int
+
+	// recoveryInfraRetries counts CONSECUTIVE awaiting-recovery deadline
+	// expiries where the pending-PlanDecision check could not reach NATS/KV
+	// (infrastructure unreachable — e.g. a network blip). The deadline timer
+	// extends instead of terminal-failing in that case, but is bounded by
+	// maxRecoveryInfraRetries so a PERMANENT outage still terminates. Reset to
+	// 0 on any successful read so only a sustained outage trips the cap.
+	recoveryInfraRetries int
 }
 
 // ScenarioVerdict carries a per-scenario pass/fail from the requirement reviewer.


### PR DESCRIPTION
## Why

A transient network/NATS outage during the awaiting-recovery window irreversibly **terminal-failed** the requirement and triggered `AutoRejectOnExhaustion` on the whole plan. Caught 2026-06-23: a **power outage** mid-run (mavlink-hard gemini, plan `90313fea273d`) dead-ended a 4-requirement plan — an infrastructure failure mishandled as a terminal *agent* failure.

```
WARN  Recovery deadline expired; terminal-failing  requirement.90313fea273d.1  timeout=10m0s
WARN  Auto-rejecting plan on requirement-failure convergence (AutoRejectOnExhaustion)  failed=4 total=4
```

## Root cause (fail-open)

`hasPendingRecoveryDecision` returned `false` on **every** NATS/KV read-error path, so during an outage — exactly when those reads fail — "couldn't check" was read as "no pending decision", and `handleRecoveryTimeout` terminal-failed. The recovery agent's own LLM/NATS calls were equally cut off, so it could not possibly have produced a PlanDecision; the wallclock timer fired anyway with no infra-health gate. Same fail-open class as #261 (`34b281a8`).

## Fix

- `hasPendingRecoveryDecision` → `(bool, error)`. Non-nil error = infra unreachable (transient). `jetstream.ErrKeyNotFound` and an unparseable plan are **not** infra failures → `(false, nil)`, preserving legitimate terminal-fail.
- `handleRecoveryTimeout` **extends** the deadline on an infra error instead of terminal-failing, bounded by `maxRecoveryInfraRetries` (6) consecutive infra-unreachable expiries so a **permanent** outage still terminates. Counter resets on any successful read so only a *sustained* outage trips it.
- Guard tests: `ExtendsWhenInfraUnreachable`, `TerminalFailsAfterInfraRetryCap`, `ResetsInfraCounterOnSuccessfulRead`.

### Drive-by dead-code removal (#287)

`model/registry.go:GetRequestTimeout()` had zero production callers — per-call LLM timeout enforcement lives entirely in semstreams' agentic-model (`resolveTimeout` → `context.WithTimeout`). Removed the helper; the `RequestTimeout` field doc now redirects to the real enforcement point so no divergent local parser is re-added.

## Testing

- `go build ./...` clean; `go vet` clean.
- `go test ./...` exit 0.
- `go test -race ./processor/requirement-executor/` clean.

Closes #286. Refs #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)