### PR TITLE
fix(requirement-executor): auto-clamp recovery deadline to recovery model's per-call cap (#287)

### DIFF
--- a/processor/requirement-executor/awaiting_recovery.go
+++ b/processor/requirement-executor/awaiting_recovery.go
@@ -22,8 +22,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/c360studio/semspec/model"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
+	ssmodel "github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -50,12 +52,59 @@ func (c *Component) recoveryDeferEnabled() bool {
 	return c.config.DeferTerminalOnRecovery
 }
 
-// recoveryTimeout returns the configured awaiting-recovery deadline.
+// recoveryDispatchSlack is the headroom added on top of the recovery agent's
+// per-call LLM cap when computing the minimum safe awaiting-recovery deadline.
+// The deadline must cover not just the diagnosis LLM call but also recovery
+// dispatch + the proposed-PlanDecision emit that flips
+// hasPendingRecoveryDecision to true (after which the deadline auto-extends).
+const recoveryDispatchSlack = 5 * time.Minute
+
+// recoveryTimeout returns the effective awaiting-recovery deadline. It is the
+// configured value, AUTO-CLAMPED up to recoveryCapFloor() so the deadline can
+// never be shorter than the recovery agent's own per-call LLM cap (#287
+// inversion): a 600s deadline against a gemini-pro recovery model whose
+// request_timeout is 900s would terminal-fail a requirement whose recovery
+// diagnosis was still in flight, dead-ending the whole plan. The clamp makes
+// that impossible regardless of how the deadline is configured.
 func (c *Component) recoveryTimeout() time.Duration {
+	base := time.Duration(c.config.RecoveryTimeoutSeconds) * time.Second
 	if c.config.RecoveryTimeoutSeconds <= 0 {
-		return 60 * time.Second
+		base = 60 * time.Second
 	}
-	return time.Duration(c.config.RecoveryTimeoutSeconds) * time.Second
+	if floor := c.recoveryCapFloor(); floor > base {
+		c.logger.Warn("Awaiting-recovery deadline is shorter than the recovery agent's per-call LLM cap; clamping up to avoid spuriously terminal-failing an in-flight recovery (#287)",
+			"configured", base,
+			"clamped_to", floor,
+		)
+		return floor
+	}
+	return base
+}
+
+// recoveryCapFloor returns the minimum safe awaiting-recovery deadline: the
+// largest per-call LLM timeout across the recovery capabilities this executor
+// can invoke (execution-wedge and coordinator recovery), plus dispatch/emit
+// slack. Returns 0 when there is no registry or no per-call cap is configured —
+// in that case the configured deadline governs unchanged.
+func (c *Component) recoveryCapFloor() time.Duration {
+	if c.modelRegistry == nil {
+		return 0
+	}
+	var maxCap time.Duration
+	for _, capName := range []model.Capability{
+		model.CapabilityExecutionWedgeRecovery,
+		model.CapabilityCoordinatorRecovery,
+	} {
+		// Precedence: endpoint.request_timeout → capability.timeout. A 0
+		// default means "no cap configured for this capability".
+		if d := ssmodel.ResolveCapabilityTimeout(c.modelRegistry, string(capName), 0, c.logger); d > maxCap {
+			maxCap = d
+		}
+	}
+	if maxCap <= 0 {
+		return 0
+	}
+	return maxCap + recoveryDispatchSlack
 }
 
 // maxRecoveryRestarts returns the configured upper bound on resume

--- a/processor/requirement-executor/awaiting_recovery_test.go
+++ b/processor/requirement-executor/awaiting_recovery_test.go
@@ -7,11 +7,40 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c360studio/semspec/model"
 	"github.com/c360studio/semspec/workflow"
 	"github.com/c360studio/semspec/workflow/payloads"
 	"github.com/c360studio/semstreams/component"
+	ssmodel "github.com/c360studio/semstreams/model"
 	sscache "github.com/c360studio/semstreams/pkg/cache"
 )
+
+// fakeRecoveryRegistry is a minimal ssmodel.RegistryReader that resolves a
+// fixed capability→endpoint map — just enough to drive recoveryCapFloor's
+// clamp without standing up a real registry.
+type fakeRecoveryRegistry struct {
+	caps      map[string]string                  // capability -> endpoint name
+	endpoints map[string]*ssmodel.EndpointConfig // endpoint name -> config
+}
+
+func (f *fakeRecoveryRegistry) Resolve(capability string) string { return f.caps[capability] }
+func (f *fakeRecoveryRegistry) GetEndpoint(name string) *ssmodel.EndpointConfig {
+	return f.endpoints[name]
+}
+func (f *fakeRecoveryRegistry) GetCapability(string) *ssmodel.CapabilityConfig { return nil }
+func (f *fakeRecoveryRegistry) GetFallbackChain(string) []string               { return nil }
+func (f *fakeRecoveryRegistry) GetMaxTokens(string) int                        { return 0 }
+func (f *fakeRecoveryRegistry) GetDefault() string                             { return "" }
+func (f *fakeRecoveryRegistry) ListCapabilities() []string                     { return nil }
+func (f *fakeRecoveryRegistry) ListEndpoints() []string                        { return nil }
+func (f *fakeRecoveryRegistry) ResolveSummarization() string                   { return "" }
+
+func geminiProRecoveryRegistry() *fakeRecoveryRegistry {
+	return &fakeRecoveryRegistry{
+		caps:      map[string]string{string(model.CapabilityExecutionWedgeRecovery): "gemini-pro"},
+		endpoints: map[string]*ssmodel.EndpointConfig{"gemini-pro": {RequestTimeout: "900s"}},
+	}
+}
 
 // newTestComponentWithRecoveryDefer mirrors newTestComponent but enables
 // the ADR-037 race-closure path so the deferToAwaitingRecoveryLocked
@@ -281,6 +310,41 @@ func TestRecoveryTimeout_ResetsInfraCounterOnSuccessfulRead(t *testing.T) {
 	}
 	if c.requirementsFailed.Load() != 1 {
 		t.Errorf("requirementsFailed = %d, want 1", c.requirementsFailed.Load())
+	}
+}
+
+// #287 inversion guard: a configured deadline shorter than the recovery
+// model's per-call LLM cap (gemini-pro 900s) must be auto-clamped UP, so a
+// slow-but-valid recovery diagnosis is never spuriously terminal-failed.
+func TestRecoveryTimeout_ClampsUpToRecoveryModelCap(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 600*time.Second, 1) // configured 10m — below the 900s cap
+	c.modelRegistry = geminiProRecoveryRegistry()
+
+	got := c.recoveryTimeout()
+	want := 900*time.Second + recoveryDispatchSlack // 15m cap + 5m slack = 20m
+	if got != want {
+		t.Errorf("recoveryTimeout() = %v, want clamped %v (deadline must exceed the recovery model's 900s per-call cap)", got, want)
+	}
+}
+
+// No clamp when the configured deadline already exceeds the floor.
+func TestRecoveryTimeout_NoClampWhenConfiguredExceedsFloor(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 1800*time.Second, 1) // 30m > floor 20m
+	c.modelRegistry = geminiProRecoveryRegistry()
+
+	if got := c.recoveryTimeout(); got != 1800*time.Second {
+		t.Errorf("recoveryTimeout() = %v, want configured 1800s (already above floor)", got)
+	}
+}
+
+// No registry → no floor → the configured deadline governs unchanged
+// (backward-compatible with deployments that don't wire a model registry).
+func TestRecoveryTimeout_NoRegistryUsesConfigured(t *testing.T) {
+	c := newTestComponentWithRecoveryDefer(t, 600*time.Second, 1)
+	c.modelRegistry = nil
+
+	if got := c.recoveryTimeout(); got != 600*time.Second {
+		t.Errorf("recoveryTimeout() = %v, want configured 600s when no registry", got)
 	}
 }
 

--- a/processor/requirement-executor/config.go
+++ b/processor/requirement-executor/config.go
@@ -61,11 +61,15 @@ type Config struct {
 	// production gemini @hard runs set this true alongside auto-accept.
 	DeferTerminalOnRecovery bool `json:"defer_terminal_on_recovery" schema:"type:boolean,description:Defer terminal markFailed when recovery is in flight (ADR-037 stage-2 race closure),category:advanced,default:false"`
 
-	// RecoveryTimeoutSeconds bounds the phaseAwaitingRecovery wait. Real-LLM
-	// recovery diagnosis on gemini-pro lands in 10-20s, so 60s gives a
-	// comfortable margin without blocking too long when recovery silently
-	// fails. Only used when DeferTerminalOnRecovery is true.
-	RecoveryTimeoutSeconds int `json:"recovery_timeout_seconds" schema:"type:int,description:Seconds to wait in phaseAwaitingRecovery before terminal-failing,category:advanced,default:60,min:5,max:600"`
+	// RecoveryTimeoutSeconds bounds the phaseAwaitingRecovery wait. Typical
+	// real-LLM recovery diagnosis lands in 10-20s, but a single diagnosis call
+	// is capped by the recovery model's request_timeout (gemini-pro: 900s), so
+	// the deadline MUST be at least that cap + dispatch/emit slack or a slow
+	// diagnosis terminal-fails an in-flight recovery (#287). recoveryTimeout()
+	// auto-clamps this up to recoveryCapFloor() so a too-small value here can't
+	// cause that; the max bound is sized to hold the clamped floor. Only used
+	// when DeferTerminalOnRecovery is true.
+	RecoveryTimeoutSeconds int `json:"recovery_timeout_seconds" schema:"type:int,description:Seconds to wait in phaseAwaitingRecovery before terminal-failing (auto-clamped up to the recovery model's per-call cap + slack),category:advanced,default:60,min:5,max:3600"`
 
 	// PlanDecisionAcceptedSubject is the JetStream subject on which
 	// plan-decision-handler publishes accepted-PlanDecision events. Must

--- a/schemas/requirement-executor.v1.json
+++ b/schemas/requirement-executor.v1.json
@@ -47,10 +47,10 @@
     },
     "recovery_timeout_seconds": {
       "type": "number",
-      "description": "Seconds to wait in phaseAwaitingRecovery before terminal-failing",
+      "description": "Seconds to wait in phaseAwaitingRecovery before terminal-failing (auto-clamped up to the recovery model's per-call cap + slack)",
       "default": 60,
       "minimum": 5,
-      "maximum": 600,
+      "maximum": 3600,
       "category": "advanced"
     },
     "require_commit_observation": {

--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -559,7 +559,7 @@ tasks:
       RECOVERY_TIMEOUT_SECONDS:
         sh: |
           case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
-            hard|mavlink-hard)  echo '600' ;;
+            hard|mavlink-hard)  echo '1200' ;;  # 20min — must exceed the recovery model's 900s per-call cap + dispatch slack (#287)
             mavlink-decode)     echo '300' ;;
             *)                  echo '60' ;;
           esac
@@ -759,7 +759,7 @@ tasks:
       RECOVERY_TIMEOUT_SECONDS:
         sh: |
           case "$(echo '{{.CLI_ARGS}}' | awk '{print $2}')" in
-            hard|mavlink-hard)  echo '600' ;;   # 10min — fits one recovery-agent dispatch
+            hard|mavlink-hard)  echo '1200' ;;  # 20min — must exceed the recovery model's 900s per-call cap + dispatch slack (#287); was 600 and could terminal-fail an in-flight recovery
             mavlink-decode)     echo '300' ;;
             *)                  echo '60' ;;
           esac


### PR DESCRIPTION
## Why

The awaiting-recovery deadline could be **shorter than the recovery agent's own per-call LLM timeout**, so a slow-but-valid recovery diagnosis gets terminal-failed mid-flight — dead-ending the whole plan via `AutoRejectOnExhaustion`. On mavlink-hard gemini the deadline was **600s** while `execution_wedge_recovery` resolves to **gemini-pro** whose `request_timeout` is **900s**. The `config.go` comment ("fits one recovery-agent dispatch") and `schema max:600` had sized the deadline to the *typical* 10-20s diagnosis, ignoring the 900s per-call **cap** (the tail).

This is the inversion spotted in #287 — confirmed real and on the hot path (TDD-exhaustion → `execution_wedge_recovery` → gemini-pro 900s > 600s deadline). It's a tail risk (common-case recovery emits in <600s, which is why prior runs survived), but a slow recovery would waste a whole paid run.

## Fix — runtime self-protection (can't be re-broken by config)

- `recoveryTimeout()` now auto-clamps the configured value **up** to `recoveryCapFloor()` = max per-call cap across the recovery capabilities this executor can invoke (`execution_wedge_recovery`, `coordinator_recovery`, via `ssmodel.ResolveCapabilityTimeout`) + `recoveryDispatchSlack` (5m). The deadline is therefore always ≥ the recovery model's single-call cap + dispatch/emit slack, **regardless of how it's configured**. `nil` registry / no cap → no-op (configured value governs), preserving existing behavior.
- `config.go`: `schema max:600 → max:3600` (600 was below the recovery model's own cap); corrected the misleading comment; regenerated `schemas/requirement-executor.v1.json`.
- `taskfiles/e2e.yml`: mavlink-hard `RECOVERY_TIMEOUT_SECONDS` `600 → 1200` so the configured value matches the clamp floor (no surprise clamp WARN per run).

## Testing

- `go build ./...` clean, `go vet` clean, `gofmt` clean.
- `go test ./...` exit 0; `go test -race ./processor/requirement-executor/` clean.
- Guard tests: `ClampsUpToRecoveryModelCap`, `NoClampWhenConfiguredExceedsFloor`, `NoRegistryUsesConfigured`.

## Other issue found (not in this PR)

`specs/openapi.v3.yaml` is **stale** — regenerating it adds `acceptance_criteria` (#267) and `pending_architecture_revision` fields that earlier merged PRs added to the code but never regenerated. Reverted from this PR to keep scope clean; worth a separate regen + a CI freshness gate (there is currently no generated-file drift check in CI).

Closes #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)