### PR TITLE
chore(specs): regenerate stale OpenAPI spec + add CI freshness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,23 @@ jobs:
             exit 1
           fi
 
+      - name: generated specs up to date
+        # specs/openapi.v3.yaml and schemas/*.v1.json are generated from Go
+        # source (cmd/openapi-generator). They drift silently when a struct or
+        # schema tag changes without regeneration — e.g. acceptance_criteria
+        # (#267) and recovery_timeout_seconds max (#287) both shipped before
+        # this gate existed. Regenerate and fail on any diff so the committed
+        # specs always match the code. Go-only by design: the TypeScript types
+        # under ui/ are generated from a sibling semstreams checkout (not the
+        # pinned module) and so are gated in the UI workspace, not here.
+        run: |
+          go run ./cmd/openapi-generator -o specs/openapi.v3.yaml -schemas ./schemas
+          if ! git diff --quiet specs/openapi.v3.yaml schemas/; then
+            echo "Generated specs are out of date — run 'task generate:openapi' and commit:"
+            git diff --stat specs/openapi.v3.yaml schemas/
+            exit 1
+          fi
+
       - name: revive
         # revive exit code is controlled by warningCode / errorCode in
         # revive.toml. warningCode=1 makes warnings fail the build.

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -2574,6 +2574,20 @@ components:
                                 type: object
                             type: array
                     type: object
+                pending_architecture_revision:
+                    nullable: true
+                    properties:
+                        proposal_id:
+                            type: string
+                        requirement_ids:
+                            items:
+                                type: string
+                            type: array
+                        story_ids:
+                            items:
+                                type: string
+                            type: array
+                    type: object
                 plan_decisions:
                     items:
                         properties:
@@ -2762,6 +2776,10 @@ components:
                 requirements:
                     items:
                         properties:
+                            acceptance_criteria:
+                                items:
+                                    type: string
+                                type: array
                             capability_name:
                                 type: string
                             created_at:
@@ -3490,6 +3508,20 @@ components:
                                 type: object
                             type: array
                     type: object
+                pending_architecture_revision:
+                    nullable: true
+                    properties:
+                        proposal_id:
+                            type: string
+                        requirement_ids:
+                            items:
+                                type: string
+                            type: array
+                        story_ids:
+                            items:
+                                type: string
+                            type: array
+                    type: object
                 phase_summary:
                     nullable: true
                     properties:
@@ -3810,6 +3842,10 @@ components:
                 requirements:
                     items:
                         properties:
+                            acceptance_criteria:
+                                items:
+                                    type: string
+                                type: array
                             capability_name:
                                 type: string
                             created_at:

--- a/ui/src/lib/types/api.generated.ts
+++ b/ui/src/lib/types/api.generated.ts
@@ -2900,6 +2900,11 @@ export interface components {
                     verdict?: string;
                 }[];
             } | null;
+            pending_architecture_revision?: {
+                proposal_id?: string;
+                requirement_ids?: string[];
+                story_ids?: string[];
+            } | null;
             plan_decisions?: {
                 affected_requirement_ids: string[];
                 affected_story_ids?: string[];
@@ -2976,6 +2981,7 @@ export interface components {
                 verdict: string;
             } | null;
             requirements?: {
+                acceptance_criteria?: string[];
                 capability_name?: string;
                 /** Format: date-time */
                 created_at: string;
@@ -3238,6 +3244,11 @@ export interface components {
                     verdict?: string;
                 }[];
             } | null;
+            pending_architecture_revision?: {
+                proposal_id?: string;
+                requirement_ids?: string[];
+                story_ids?: string[];
+            } | null;
             phase_summary?: {
                 active_loop_count: number;
                 detail?: string;
@@ -3366,6 +3377,7 @@ export interface components {
                 verdict: string;
             } | null;
             requirements?: {
+                acceptance_criteria?: string[];
                 capability_name?: string;
                 /** Format: date-time */
                 created_at: string;


### PR DESCRIPTION
## Why

`specs/openapi.v3.yaml` had drifted from the Go source: earlier merged PRs added fields (`acceptance_criteria` #267, `pending_architecture_revision`) but never regenerated the committed spec, and **nothing in CI caught it** (the Go CI runs no schema/types freshness check; the existing `generate:types:check` task was never wired in because it depends on a sibling semstreams checkout).

## What

- Regenerated `specs/openapi.v3.yaml` + the semspec TS types (`ui/src/lib/types/api.generated.ts`) so they match the code.
- **Added a Go-only CI gate** (`lint-and-test`): regenerates the spec + component schemas via `cmd/openapi-generator` and fails on any diff. Generation is deterministic (verified by regenerating twice → identical output). Verified the gate passes on this branch's committed state.

## Scope decisions

- **Go-only gate**: the UI TypeScript types are generated from a sibling `../semstreams` checkout (not the pinned Go module), so a TS gate would be fragile in CI — left to the UI workspace.
- **`semstreams.generated.ts` intentionally not touched**: the local sibling checkout is at **beta.115**, ahead of the pinned module **beta.107**, so regenerating it would pull in types (`loop_completed`, ADR-056 `enforce_owner_lease`) the backend doesn't run. That's a separate semstreams-bump concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)