### PR TITLE
fix(sandbox): persist per-ecosystem build caches across e2e runs (#291)

### DIFF
--- a/taskfiles/e2e.yml
+++ b/taskfiles/e2e.yml
@@ -31,9 +31,17 @@ tasks:
 
   ensure-model-caches:
     internal: true
-    desc: Ensure external Docker model cache volumes exist
+    desc: Ensure external Docker model + sandbox build-cache volumes exist
     cmds:
       - docker volume create semembed-cache >/dev/null
+      # Sandbox per-ecosystem build/dependency caches (#291). external so
+      # `down -v` keeps them warm across runs; idempotent create.
+      - docker volume create sandbox-cache-gomod >/dev/null
+      - docker volume create sandbox-cache-xdg >/dev/null
+      - docker volume create sandbox-cache-gradle >/dev/null
+      - docker volume create sandbox-cache-gradle-wrapper >/dev/null
+      - docker volume create sandbox-cache-m2 >/dev/null
+      - docker volume create sandbox-cache-npm >/dev/null
 
   check-ports:
     internal: true
@@ -113,11 +121,19 @@ tasks:
       - echo "[OK] Docker environment cleaned"
 
   clean-model-caches:
-    desc: Remove shared model cache volumes used by E2E graph services
+    desc: Remove shared model + sandbox build-cache volumes used by E2E (forces a cold next run)
     cmds:
-      - echo "[CLEAN-MODEL-CACHES] Removing shared model cache volumes..."
+      - echo "[CLEAN-MODEL-CACHES] Removing shared model + sandbox build-cache volumes..."
       - docker volume rm semembed-cache 2>/dev/null || true
-      - echo "[OK] Model caches removed"
+      - task: clean-sandbox-caches
+      - echo "[OK] Model + sandbox caches removed"
+
+  clean-sandbox-caches:
+    desc: Remove ONLY the sandbox build/dependency caches (#291) — forces a cold build next run for fidelity, without re-downloading the semembed model
+    cmds:
+      - echo "[CLEAN-SANDBOX-CACHES] Removing sandbox build-cache volumes (next run builds cold)..."
+      - docker volume rm sandbox-cache-gomod sandbox-cache-xdg sandbox-cache-gradle sandbox-cache-gradle-wrapper sandbox-cache-m2 sandbox-cache-npm 2>/dev/null || true
+      - echo "[OK] Sandbox caches removed"
 
   clean-workspace:
     internal: true

--- a/ui/docker-compose.e2e-llm.yml
+++ b/ui/docker-compose.e2e-llm.yml
@@ -49,6 +49,35 @@ services:
         limits:
           cpus: "1"
 
+  # Initialize ownership on the external build-cache volumes before the sandbox
+  # starts. Fresh Docker volumes are root-owned, but the sandbox runs as
+  # uid/gid 1000 (SANDBOX_UID/GID) — without this it cannot write its caches.
+  # The chown is non-recursive (just the mountpoint): this is safe ONLY because
+  # every writer into these trees runs as uid 1000 (the sandbox user; npm
+  # globals live in /usr, not ~/.npm), so files written later are already
+  # 1000-owned and never need re-chowning — which keeps startup instant even on
+  # a multi-GB warmed volume. (semembed-cache-init uses `chown -R` because its
+  # cache is small; do not copy that here.) Purely generic — no per-stack logic,
+  # so nothing gradle/Java-shaped is imposed on a non-Java run.
+  sandbox-cache-init:
+    image: alpine:3.19
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        for d in /v/gomod /v/xdg /v/gradle /v/gradle-wrapper /v/m2 /v/npm; do
+          mkdir -p "$$d" && chown 1000:1000 "$$d"
+        done
+    volumes:
+      - sandbox-cache-gomod:/v/gomod
+      - sandbox-cache-xdg:/v/xdg
+      - sandbox-cache-gradle:/v/gradle
+      - sandbox-cache-gradle-wrapper:/v/gradle-wrapper
+      - sandbox-cache-m2:/v/m2
+      - sandbox-cache-npm:/v/npm
+    restart: "no"
+
   sandbox:
     build:
       context: ..
@@ -85,11 +114,35 @@ services:
     depends_on:
       workspace-init:
         condition: service_completed_successfully
+      sandbox-cache-init:
+        condition: service_completed_successfully
     volumes:
       # Shared WORKSPACE_HOST_PATH — same bind mount semspec and semsource use.
       # Single host path = single workspace view, no risk of drift between
       # services (caught take-18 2026-05-13 with separate bind mounts).
       - ${WORKSPACE_HOST_PATH:-/tmp/semspec-ui-workspace}:/workspace
+      # Persistent per-ecosystem build/dependency caches. A fresh container
+      # otherwise re-downloads and recompiles everything from cold on the first
+      # build of every run — for the heavy osh/mavlink Java tree that cold build
+      # exceeds the sandbox /exec timeout and wedges the dev loop (#291). These
+      # are EXTERNAL volumes (survive `down -v`, like semembed-cache) so the
+      # warm cache carries across runs. Treatment is uniform across stacks — no
+      # ecosystem is privileged; each tool's standard cache dir is persisted, and
+      # a non-Java repo simply never writes to the gradle/m2 volumes.
+      #
+      # Deliberately the cache SUBDIRS, not whole ~/.gradle or ~/.m2: the sandbox
+      # writes ~/.gradle/init.d/10-osh-source-substitution.gradle at startup
+      # (auto-applied to every gradle build), so persisting all of ~/.gradle
+      # would leak that OSH-specific init script onto unrelated runs. Mounting
+      # only caches/ + wrapper/ keeps init.d (and gradle.properties / any
+      # ~/.m2/settings.xml) image-controlled and ephemeral. Ownership set by
+      # sandbox-cache-init.
+      - sandbox-cache-gomod:/go/pkg/mod
+      - sandbox-cache-xdg:/home/sandbox/.cache
+      - sandbox-cache-gradle:/home/sandbox/.gradle/caches
+      - sandbox-cache-gradle-wrapper:/home/sandbox/.gradle/wrapper
+      - sandbox-cache-m2:/home/sandbox/.m2/repository
+      - sandbox-cache-npm:/home/sandbox/.npm
     deploy:
       resources:
         limits:
@@ -142,3 +195,22 @@ services:
       --config /app/configs/${E2E_CONFIG:-semspec.json}
       --repo /workspace
       --log-level ${LOG_LEVEL:-info}
+
+# Per-ecosystem sandbox build/dependency caches. external:true so the normal
+# e2e `down -v` cleanup does NOT wipe them — the warm cache persists across runs
+# (created by taskfiles/e2e.yml ensure-model-caches; full reset via the deep
+# clean / `docker volume rm sandbox-cache-*`). To force a cold run for fidelity,
+# remove these volumes first.
+volumes:
+  sandbox-cache-gomod: # Go module cache (/go/pkg/mod)
+    external: true
+  sandbox-cache-xdg: # XDG cache: Go build cache + pip (~/.cache)
+    external: true
+  sandbox-cache-gradle: # Gradle deps + build cache (~/.gradle/caches)
+    external: true
+  sandbox-cache-gradle-wrapper: # Gradle wrapper distributions (~/.gradle/wrapper)
+    external: true
+  sandbox-cache-m2: # Maven local repository (~/.m2/repository)
+    external: true
+  sandbox-cache-npm: # npm cache (~/.npm)
+    external: true


### PR DESCRIPTION
## Why (#291)

A fresh sandbox container re-downloads + recompiles everything from **cold** on the first build of every run. For the heavy osh/mavlink Java tree that cold build exceeds the sandbox `/exec` timeout (default 30s, cap 5min) → SIGKILL mid-build → the dev agent never gets a clean build → the agentic loop blows its timeout → node wedges (#291). The image already warms the *steady state* (shared `GRADLE_USER_HOME`, `org.gradle.caching/daemon/parallel`), but that only pays off **after** a successful first build the agent may never reach because `~/.gradle` (and every other cache) is empty each run.

## What — Tier 1: make cold builds warm, domain-neutrally

Persist each ecosystem's dependency/build cache as **external** Docker volumes (survive `down -v`, mirroring the existing `semembed-cache`) so the warm cache carries across runs. **No stack is privileged** — each tool's standard cache dir is persisted uniformly, and a non-Java repo simply never writes to the gradle/m2 volumes:

| Stack | Cache dir (volume) |
|-------|--------------------|
| Go | `/go/pkg/mod`, `~/.cache/go-build` |
| Python | `~/.cache/pip` |
| Node | `~/.npm` |
| Gradle | `~/.gradle/caches`, `~/.gradle/wrapper` |
| Maven | `~/.m2/repository` |

A `sandbox-cache-init` service (alpine, mirroring `semembed-cache-init`) chowns the mountpoints to uid 1000 before the sandbox starts — non-recursive (safe because every cache writer runs as uid 1000), so it stays instant on a multi-GB warmed volume. `ensure-model-caches` creates the externals on every UI up path; `clean-sandbox-caches` forces a cold build for fidelity.

## Review (architect agent) — addressed

- **M1 (major, would have been introduced by this PR):** the sandbox writes `~/.gradle/init.d/10-osh-source-substitution.gradle`, auto-applied to *every* gradle build. Persisting all of `~/.gradle` would leak that OSH-specific init script across runs onto unrelated (Go/Node/non-OSH) repos — exactly the domain-bleed we're trying to avoid. **Fixed** by mounting the cache **subdirs** (`~/.gradle/caches` + `~/.gradle/wrapper`, `~/.m2/repository`) instead of the whole dirs (review m3), so `init.d` / `gradle.properties` / any `settings.xml` stay image-controlled + ephemeral. This also let the init service drop all gradle-specific logic → purely generic chown.
- **m1:** comment now states the non-recursive-chown invariant (safe ∵ all writers are uid 1000).
- **m4:** `clean-sandbox-caches` is a cold/fidelity opt-out distinct from the model-cache nuke.
- Reviewer confirmed: `down -v` survival, volume creation on all up paths, domain-neutrality, no credential leak, clean `config`.

## Validated

`docker compose config` clean (0 warnings); `sandbox-cache-init` run produces `1000:1000`-owned volumes; narrow mounts render correctly; gradle cache volume is empty (no stack-specific content).

## NOT yet validated (honest)

Per the project's own "green pipeline ≠ verified delivery" principle: the *mechanism* is validated, but **warm-cache reuse on a second run + the #291 wedge actually resolving** needs a real two-run repro. That happens on the next paid run — I'll confirm cache hits + wallclock drop then. This PR is "plausibly fixes #291," not yet "proven."

Refs #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)