### PR TITLE
fix(plan-manager): accumulate review findings across revision rounds (R-arch convergence)

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1635,6 +1635,109 @@ func formatReviewFindings(findingsJSON json.RawMessage, summary, verdict string)
 	return summary
 }
 
+// roundPhases maps a review round to the plan phase(s) whose findings that
+// round legitimately owns. mergeReviewFindings uses it to drop cross-phase
+// residue when carrying findings forward — a leaked prior-phase finding (e.g.
+// an R1 draft "plan" finding that the R1→approved advance fails to clear) must
+// not accumulate into a later phase and instruct a generator to remediate a
+// violation outside its authority. Returns nil for an unknown round (no
+// filter) — callers MUST pre-validate round ∈ [1,4] (handleRevisionMutation
+// guards this) so the unscoped-carry branch is never reached on the live path.
+func roundPhases(round int) map[string]struct{} {
+	switch round {
+	case 1: // draft review
+		return map[string]struct{}{"plan": {}}
+	case 2: // scenarios review (covers stories too)
+		return map[string]struct{}{"scenarios": {}, "stories": {}}
+	case 3: // architecture review
+		return map[string]struct{}{"architecture": {}}
+	case 4: // requirements review
+		return map[string]struct{}{"requirements": {}}
+	}
+	return nil
+}
+
+// mergeReviewFindings accumulates review findings ACROSS revision rounds within
+// a single review phase, so the regenerating agent (architect / req-gen) sees
+// the CUMULATIVE constraint set rather than only the latest round's. Without
+// this the generator oscillates — it fixes the newest finding and blindly
+// regresses an older one. That whack-a-mole is structural by design: the
+// deterministic preflight short-circuits the paid LLM reviewer (we do NOT want
+// to burn a semantic review when a cheap structural gate already failed), so
+// each round only ever surfaces ONE layer's findings (gen ADR-043 validator →
+// reviewer preflight → reviewer LLM). Carrying them forward is what lets the
+// architect satisfy every gate at once and converge within the revision cap
+// (caught: a mavlink-hard R-arch round exhausted 3/3 cycling scope-ownership →
+// component-placement → upstream-coordinate, never seeing them together).
+//
+// Carried findings already resolved are harmless: the architect revises its
+// PreviousArchitectureJSON, so a re-stated prior violation reads as "keep this
+// fixed," which is precisely what prevents the regression.
+//
+// Phase scoping is enforced HERE, not by relying on every advance path to clear
+// findings (the R1→approved path does not — verified). Only PRIOR findings
+// whose Phase belongs to this round (roundPhases) carry forward; current-round
+// findings (incoming) are always kept regardless of phase. So a bled cross-
+// phase finding is both excluded from the merge and overwritten off the plan.
+//
+// Dedup ignores the volatile LLM free-text (Evidence, Suggestion) so the same
+// logical finding re-emitted with drifted evidence collapses to one — otherwise
+// the cumulative list grows across rounds. On unparseable incoming it preserves
+// the existing accumulated set (does NOT honor the corrupt value).
+func mergeReviewFindings(existing, incoming json.RawMessage, round int) json.RawMessage {
+	var next []workflow.PlanReviewFinding
+	if err := json.Unmarshal(incoming, &next); err != nil {
+		return existing
+	}
+	var prior []workflow.PlanReviewFinding
+	_ = json.Unmarshal(existing, &prior) // nil / unparseable existing → no carry-forward
+
+	phases := roundPhases(round)
+	// Identity = the finding with the LLM-authored free-text zeroed
+	// (PlanReviewFinding is all-string, hence comparable). Evidence, Suggestion,
+	// AND Issue all render as their own directive lines, so a reviewer that
+	// rewords any of them round-to-round would otherwise grow the cumulative
+	// list with a logical duplicate. The structured discriminators that remain
+	// (SOPID, Phase, Severity, Status, Category, TargetID, Action, TargetField,
+	// TargetValue) identify the finding — including per-entity completeness
+	// findings via TargetID — so distinct findings are not over-merged.
+	keyOf := func(f workflow.PlanReviewFinding) workflow.PlanReviewFinding {
+		f.Evidence = ""
+		f.Suggestion = ""
+		f.Issue = ""
+		return f
+	}
+	seen := make(map[workflow.PlanReviewFinding]struct{}, len(prior)+len(next))
+	merged := make([]workflow.PlanReviewFinding, 0, len(prior)+len(next))
+	for _, f := range prior {
+		if phases != nil {
+			if _, ok := phases[f.Phase]; !ok {
+				continue // cross-phase residue — drop it
+			}
+		}
+		k := keyOf(f)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		merged = append(merged, f)
+	}
+	for _, f := range next { // current round: always kept
+		k := keyOf(f)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		merged = append(merged, f)
+	}
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return incoming
+	}
+	return out
+}
+
 // handleRevisionMutation processes a review rejection and either retries or escalates.
 // Round 1 (draft review): loops back to StatusCreated so the planner re-drafts.
 // Round 2 (scenarios review): loops back to StatusApproved, clearing Requirements/Scenarios
@@ -1678,12 +1781,17 @@ func (c *Component) handleRevisionMutation(ctx context.Context, data []byte) Mut
 			"revision round %d requires status %s, got %s", req.Round, expectedStatus, current)}
 	}
 
-	// Store review data and increment iteration.
+	// Store review data and increment iteration. Findings ACCUMULATE across
+	// rounds within this phase (mergeReviewFindings) so the regenerating agent
+	// sees the cumulative constraint set, not just the latest round's —
+	// otherwise it fixes the newest finding and regresses an older one. Cleared
+	// on phase advance by refreshApprovedReviewMetadata.
 	plan.ReviewIteration++
-	plan.ReviewFindings = req.Findings
+	merged := mergeReviewFindings(plan.ReviewFindings, req.Findings, req.Round)
+	plan.ReviewFindings = merged
 	plan.ReviewSummary = req.Summary
 	plan.ReviewVerdict = req.Verdict
-	plan.ReviewFormattedFindings = formatReviewFindings(req.Findings, req.Summary, req.Verdict)
+	plan.ReviewFormattedFindings = formatReviewFindings(merged, req.Summary, req.Verdict)
 
 	maxIterations := c.config.MaxReviewIterations
 	if maxIterations <= 0 {
@@ -1701,6 +1809,11 @@ func (c *Component) handleRevisionMutation(ctx context.Context, data []byte) Mut
 	case 1:
 		targetStatus = workflow.StatusCreated
 	case 2:
+		// Route on the LATEST round's findings (req.Findings), NOT the merged
+		// cumulative set: re-entry depth must reflect what THIS round flagged,
+		// and routing on the accumulated set could cascade a stale earlier-round
+		// finding all the way back to StatusCreated. Storage above is cumulative;
+		// routing here is intentionally freshest-only.
 		targetStatus = c.determineR2ReentryPoint(plan, req.Findings)
 	case 3:
 		// ADR-051 Slice 3: an architecture rejection re-runs the architect only.

--- a/processor/plan-manager/revision_finding_accumulation_test.go
+++ b/processor/plan-manager/revision_finding_accumulation_test.go
@@ -1,0 +1,152 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+)
+
+// TestMergeReviewFindings covers the pure accumulation helper: findings carry
+// forward across rounds (so the regenerating agent sees the cumulative
+// constraint set), cross-phase residue is dropped, evidence drift dedups, and an
+// unparseable incoming payload preserves the accumulated set.
+const roundArch = 3 // architecture review round
+
+func TestMergeReviewFindings(t *testing.T) {
+	mk := func(t *testing.T, fs ...workflow.PlanReviewFinding) json.RawMessage {
+		t.Helper()
+		b, err := json.Marshal(fs)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return b
+	}
+	a := workflow.PlanReviewFinding{Severity: "error", Status: "violation", Phase: "architecture", SOPID: "scoped_include_unowned", TargetField: "scope.include", TargetValue: "README.md"}
+	b := workflow.PlanReviewFinding{Severity: "error", Status: "violation", Phase: "architecture", SOPID: "component_placement", TargetID: "action-controlstreams"}
+
+	parse := func(t *testing.T, raw json.RawMessage) []workflow.PlanReviewFinding {
+		t.Helper()
+		var out []workflow.PlanReviewFinding
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("unmarshal merged: %v", err)
+		}
+		return out
+	}
+
+	t.Run("empty existing returns incoming", func(t *testing.T) {
+		got := parse(t, mergeReviewFindings(nil, mk(t, a), roundArch))
+		if len(got) != 1 || got[0] != a {
+			t.Fatalf("got %+v, want [a]", got)
+		}
+	})
+
+	t.Run("distinct rounds accumulate (union, order preserved)", func(t *testing.T) {
+		got := parse(t, mergeReviewFindings(mk(t, a), mk(t, b), roundArch))
+		if len(got) != 2 || got[0] != a || got[1] != b {
+			t.Fatalf("got %+v, want [a, b]", got)
+		}
+	})
+
+	t.Run("exact duplicate across rounds collapses", func(t *testing.T) {
+		got := parse(t, mergeReviewFindings(mk(t, a), mk(t, a, b), roundArch))
+		if len(got) != 2 || got[0] != a || got[1] != b {
+			t.Fatalf("got %+v, want [a, b] (a deduped)", got)
+		}
+	})
+
+	t.Run("free-text drift (evidence/suggestion/issue) dedups to one", func(t *testing.T) {
+		aDrift := a
+		aDrift.Evidence = "a different verbatim quote"
+		aDrift.Suggestion = "reworded suggestion"
+		aDrift.Issue = "the same violation, paraphrased"
+		got := parse(t, mergeReviewFindings(mk(t, a), mk(t, aDrift), roundArch))
+		if len(got) != 1 {
+			t.Fatalf("got %d findings, want 1 (drift on volatile free-text must not survive twice): %+v", len(got), got)
+		}
+	})
+
+	t.Run("cross-phase residue is dropped (the R1->R-req bleed)", func(t *testing.T) {
+		planFinding := workflow.PlanReviewFinding{Severity: "error", Status: "violation", Phase: "plan", SOPID: "goal_too_vague"}
+		// existing carries a leaked draft-phase finding; the current round is
+		// architecture (3). The bled plan finding must NOT accumulate.
+		got := parse(t, mergeReviewFindings(mk(t, planFinding), mk(t, a), roundArch))
+		if len(got) != 1 || got[0] != a {
+			t.Fatalf("got %+v, want only the architecture finding (plan residue dropped)", got)
+		}
+	})
+
+	t.Run("unparseable incoming preserves accumulated set", func(t *testing.T) {
+		bad := json.RawMessage(`{not-an-array`)
+		got := mergeReviewFindings(mk(t, a), bad, roundArch)
+		if string(got) != string(mk(t, a)) {
+			t.Fatalf("got %q, want the preserved existing set (not the corrupt payload)", string(got))
+		}
+	})
+}
+
+// TestHandleRevisionMutation_AccumulatesAcrossRounds is the regression for the
+// R-arch oscillation: two needs_changes rounds in the same review phase must
+// leave BOTH rounds' findings on the plan, so the architect revises against the
+// full constraint set instead of only the latest round's.
+func TestHandleRevisionMutation_AccumulatesAcrossRounds(t *testing.T) {
+	ctx := context.Background()
+	c := setupRevisionComponent(t, 5) // cap high so neither round escalates
+	plan := setupTestPlan(t, c, "arch-accum")
+	plan.Status = workflow.StatusReviewingArchitecture
+	plan.ReviewIteration = 0
+	if err := c.plans.save(ctx, plan); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	round1 := workflow.PlanReviewFinding{Severity: "error", Status: "violation", Phase: "architecture", SOPID: "scoped_include_unowned", TargetValue: "build.gradle"}
+	resp := c.handleRevisionMutation(ctx, marshalRevision(t, RevisionMutationRequest{
+		Slug: "arch-accum", Round: 3, Verdict: "needs_changes", Summary: "ownership",
+		Findings: makeFindings(t, []workflow.PlanReviewFinding{round1}),
+	}))
+	if !resp.Success {
+		t.Fatalf("round 1 revision failed: %s", resp.Error)
+	}
+
+	// Architect regenerates; the reviewer re-reviews → plan back in R-arch.
+	got, _ := c.plans.get("arch-accum")
+	got.Status = workflow.StatusReviewingArchitecture
+	if err := c.plans.save(ctx, got); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	round2 := workflow.PlanReviewFinding{Severity: "error", Status: "violation", Phase: "architecture", SOPID: "component_placement", TargetID: "action-controlstreams"}
+	resp = c.handleRevisionMutation(ctx, marshalRevision(t, RevisionMutationRequest{
+		Slug: "arch-accum", Round: 3, Verdict: "needs_changes", Summary: "placement",
+		Findings: makeFindings(t, []workflow.PlanReviewFinding{round2}),
+	}))
+	if !resp.Success {
+		t.Fatalf("round 2 revision failed: %s", resp.Error)
+	}
+
+	got, _ = c.plans.get("arch-accum")
+	var findings []workflow.PlanReviewFinding
+	if err := json.Unmarshal(got.ReviewFindings, &findings); err != nil {
+		t.Fatalf("unmarshal accumulated findings: %v", err)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("accumulated findings = %d, want 2 (round 1 + round 2)", len(findings))
+	}
+	haveR1, haveR2 := false, false
+	for _, f := range findings {
+		if f == round1 {
+			haveR1 = true
+		}
+		if f == round2 {
+			haveR2 = true
+		}
+	}
+	if !haveR1 || !haveR2 {
+		t.Fatalf("expected both rounds' findings; haveR1=%v haveR2=%v (%+v)", haveR1, haveR2, findings)
+	}
+	// The cumulative set must also reach the architect via the formatted text.
+	if got.ReviewFormattedFindings == "" {
+		t.Fatal("ReviewFormattedFindings empty — architect would see no feedback")
+	}
+}


### PR DESCRIPTION
## Why

The plan review runs the generating agent (architect / req-gen) through a serial gauntlet: generator ADR-043 validator → reviewer deterministic preflight → reviewer **paid LLM** review. The preflight **intentionally short-circuits the LLM** (we do not burn a semantic review when a cheap structural gate already failed — that ordering is correct and preserved). The cost: each revision round surfaces only **one gate's findings**, so the architect fixes the newest finding and blindly regresses an older one — structural↔semantic whack-a-mole that exhausts the 3/3 cap → plan rejected. Seen live on a mavlink-hard R-arch round (scope-ownership → component-placement → upstream-coordinate, cycling, never seen together).

## Fix

`handleRevisionMutation` now **accumulates** findings across rounds within a phase (`mergeReviewFindings`), so the regenerating agent sees the **cumulative constraint set**. Paired with the `PreviousArchitectureJSON` it already revises, it can satisfy every gate at once. **Zero extra LLM calls** — the short-circuit is untouched; it also cuts the redundant LLM re-runs that re-derive the same findings every time structural fails→passes.

## Correctness (from the go-reviewer review)

The reviewer caught a **blocker** my first cut introduced and I reworked to close it:

- **Phase-scoped at the merge** (`roundPhases`), not by relying on advance-clear paths. The R1→approved advance doesn't clear findings, so a naive merge would bleed a draft `phase:"plan"` finding into R-req and tell the requirement-generator to fix a draft violation it can't own. Only prior findings whose `Phase` belongs to the current round carry forward; incoming findings are always kept. Self-defending regardless of clear-path gaps.
- **Dedup ignores LLM free-text** (`Evidence`/`Suggestion`/`Issue` — each renders as a directive line and drifts round-to-round) so the cumulative list can't grow with logical dupes; structured discriminators + `TargetID` identify the finding.
- **Unparseable incoming preserves** the accumulated set (doesn't honor a corrupt value).
- **R2 re-entry still routes on the latest round's findings** (depth must reflect what *this* round flagged) — storage is cumulative, routing is freshest-only; documented.

Reviewer verdict after rework: blocker + major **closed**, nothing broken.

## Tests

`TestMergeReviewFindings` (accumulate, cross-phase-residue drop, free-text-drift dedup, parse-error preserve) + `TestHandleRevisionMutation_AccumulatesAcrossRounds` (two-round handler accumulation). `go build ./...`, `go test ./...`, `go test -race ./processor/plan-manager/`, gofmt, vet all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)