### PR TITLE
fix(plan-manager): auto-advance recovery-triggered R2 re-review past the human gate (#295)

### DIFF
--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1295,21 +1295,29 @@ func (c *Component) handleScenariosReviewedMutation(ctx context.Context, data []
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 	}
 
-	// #295: a scenarios review that re-runs because a recovery (story_reprepare /
-	// architecture_revise / scope_incomplete) re-planned the stories is NOT
-	// initial human gating — the plan already cleared the ready_for_execution
-	// gate before the recovery. Awaiting a human approval here wedges any
-	// unattended run (and an attended one that's already left the approval UI):
-	// the plan sits at scenarios_reviewed forever (caught on a mavlink-hard run
-	// where a story_reprepare re-review wedged ~37min until a manual /promote).
+	// #295: a scenarios review that re-runs because a SCOPED story_reprepare
+	// recovery re-prepared the stories is NOT initial human gating — the plan's
+	// requirements + architecture are unchanged and were already approved, and
+	// the plan already cleared the ready_for_execution gate before the recovery.
+	// Awaiting a human approval here wedges any unattended run (and an attended
+	// one that's already left the approval UI): the plan sits at
+	// scenarios_reviewed forever (caught on a mavlink-hard run where a
+	// story_reprepare re-review wedged ~37min until a manual /promote).
 	// Auto-advance instead so recovery RESUMES execution rather than re-imposing
-	// the gate. The first (initial) R2 has no accepted recovery decision, so its
-	// await-for-approval behavior is unchanged.
-	if planHasAcceptedRecoveryDecision(plan) {
+	// the gate.
+	//
+	// Deliberately scoped to story_reprepare ONLY. A whole-phase
+	// architecture_revise wipes + regenerates requirements/architecture/stories/
+	// scenarios — a materially different plan that an operator who set
+	// auto_approve=false would legitimately want to re-review — so it keeps the
+	// await-for-approval behavior. scope_incomplete never reaches this handler
+	// (it advances straight to ready_for_execution). The initial R2 has no
+	// accepted recovery decision at all, so it is unchanged.
+	if planHasAcceptedStoryReprepareDecision(plan) {
 		if err := c.transitionToReadyForExecution(ctx, plan); err != nil {
 			return MutationResponse{Success: false, Error: fmt.Sprintf("auto-advance recovery re-review: %v", err)}
 		}
-		c.logger.Info("Recovery re-review: auto-advanced scenarios_reviewed → ready_for_execution (#295)", "slug", req.Slug)
+		c.logger.Info("Recovery re-review (story_reprepare): auto-advanced scenarios_reviewed → ready_for_execution (#295)", "slug", req.Slug)
 		return MutationResponse{Success: true}
 	}
 
@@ -1317,22 +1325,21 @@ func (c *Component) handleScenariosReviewedMutation(ctx context.Context, data []
 	return MutationResponse{Success: true}
 }
 
-// planHasAcceptedRecoveryDecision reports whether the plan carries an ACCEPTED
-// recovery PlanDecision (story_reprepare / architecture_revise / scope_incomplete).
-// Only the recovery path emits those kinds, so their presence means the plan has
-// already been through a recovery cycle — and therefore already cleared the
-// ready_for_execution human gate before it. Used to distinguish a recovery-driven
-// re-review (auto-advance) from the initial R2 (await approval).
-func planHasAcceptedRecoveryDecision(plan *workflow.Plan) bool {
+// planHasAcceptedStoryReprepareDecision reports whether the plan carries an
+// ACCEPTED story_reprepare PlanDecision. This kind is emitted ONLY by
+// execution-phase recovery (recovery-agent, in response to a RecoveryRequested
+// raised from an execution failure) and is SCOPED — it re-prepares stories for
+// affected requirements without regenerating requirements or architecture. The
+// invariant "an accepted story_reprepare ⟹ the plan already reached execution
+// and cleared the human gate" is enforced by where the kind is emitted (recovery
+// only fires post-implementing), NOT locally here — a first-ever R2 can never
+// carry one. Used to distinguish a scoped recovery re-review (safe to
+// auto-advance past the human gate) from the initial R2 (await approval).
+func planHasAcceptedStoryReprepareDecision(plan *workflow.Plan) bool {
 	for i := range plan.PlanDecisions {
 		d := &plan.PlanDecisions[i]
-		if d.Status != workflow.PlanDecisionStatusAccepted {
-			continue
-		}
-		switch d.Kind {
-		case workflow.PlanDecisionKindStoryReprepare,
-			workflow.PlanDecisionKindArchitectureRevise,
-			workflow.PlanDecisionKindScopeIncomplete:
+		if d.Status == workflow.PlanDecisionStatusAccepted &&
+			d.Kind == workflow.PlanDecisionKindStoryReprepare {
 			return true
 		}
 	}

--- a/processor/plan-manager/mutations.go
+++ b/processor/plan-manager/mutations.go
@@ -1295,8 +1295,48 @@ func (c *Component) handleScenariosReviewedMutation(ctx context.Context, data []
 		return MutationResponse{Success: false, Error: fmt.Sprintf("save: %v", err)}
 	}
 
+	// #295: a scenarios review that re-runs because a recovery (story_reprepare /
+	// architecture_revise / scope_incomplete) re-planned the stories is NOT
+	// initial human gating — the plan already cleared the ready_for_execution
+	// gate before the recovery. Awaiting a human approval here wedges any
+	// unattended run (and an attended one that's already left the approval UI):
+	// the plan sits at scenarios_reviewed forever (caught on a mavlink-hard run
+	// where a story_reprepare re-review wedged ~37min until a manual /promote).
+	// Auto-advance instead so recovery RESUMES execution rather than re-imposing
+	// the gate. The first (initial) R2 has no accepted recovery decision, so its
+	// await-for-approval behavior is unchanged.
+	if planHasAcceptedRecoveryDecision(plan) {
+		if err := c.transitionToReadyForExecution(ctx, plan); err != nil {
+			return MutationResponse{Success: false, Error: fmt.Sprintf("auto-advance recovery re-review: %v", err)}
+		}
+		c.logger.Info("Recovery re-review: auto-advanced scenarios_reviewed → ready_for_execution (#295)", "slug", req.Slug)
+		return MutationResponse{Success: true}
+	}
+
 	c.logger.Info("Plan scenarios reviewed via mutation (awaiting human approval)", "slug", req.Slug)
 	return MutationResponse{Success: true}
+}
+
+// planHasAcceptedRecoveryDecision reports whether the plan carries an ACCEPTED
+// recovery PlanDecision (story_reprepare / architecture_revise / scope_incomplete).
+// Only the recovery path emits those kinds, so their presence means the plan has
+// already been through a recovery cycle — and therefore already cleared the
+// ready_for_execution human gate before it. Used to distinguish a recovery-driven
+// re-review (auto-advance) from the initial R2 (await approval).
+func planHasAcceptedRecoveryDecision(plan *workflow.Plan) bool {
+	for i := range plan.PlanDecisions {
+		d := &plan.PlanDecisions[i]
+		if d.Status != workflow.PlanDecisionStatusAccepted {
+			continue
+		}
+		switch d.Kind {
+		case workflow.PlanDecisionKindStoryReprepare,
+			workflow.PlanDecisionKindArchitectureRevise,
+			workflow.PlanDecisionKindScopeIncomplete:
+			return true
+		}
+	}
+	return false
 }
 
 // handleArchitectureReviewedMutation advances the plan from

--- a/processor/plan-manager/r2_recovery_rereview_test.go
+++ b/processor/plan-manager/r2_recovery_rereview_test.go
@@ -1,0 +1,107 @@
+package planmanager
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semspec/workflow"
+	"github.com/c360studio/semspec/workflow/payloads"
+)
+
+// TestPlanHasAcceptedRecoveryDecision locks the signal that distinguishes a
+// recovery-driven R2 re-review (auto-advance) from an initial R2 (await approval).
+func TestPlanHasAcceptedRecoveryDecision(t *testing.T) {
+	tests := []struct {
+		name      string
+		decisions []workflow.PlanDecision
+		want      bool
+	}{
+		{"none", nil, false},
+		{"accepted story_reprepare", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindStoryReprepare}}, true},
+		{"accepted architecture_revise", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindArchitectureRevise}}, true},
+		{"accepted scope_incomplete", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindScopeIncomplete}}, true},
+		{"proposed (not accepted) story_reprepare", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusProposed, Kind: workflow.PlanDecisionKindStoryReprepare}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := planHasAcceptedRecoveryDecision(&workflow.Plan{PlanDecisions: tt.decisions}); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleScenariosReviewedMutation_RecoveryReReviewAutoAdvances is the #295
+// regression: a story_reprepare recovery re-runs R2 → scenarios_reviewed, and
+// in auto_approve=false the plan must NOT wedge awaiting a human approval that a
+// recovery cycle should not re-require. It must auto-advance and re-dispatch
+// execution. Reproduces the mavlink-hard wedge with NO LLM.
+func TestHandleScenariosReviewedMutation_RecoveryReReviewAutoAdvances(t *testing.T) {
+	c := setupTestComponent(t)
+	slug := "scen-recovery-reentry"
+
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingScenarios
+	plan.Approved = true
+	plan.Requirements = []workflow.Requirement{{ID: "requirement.1", Title: "x"}}
+	plan.Stories = []workflow.Story{{ID: "story.1", RequirementIDs: []string{"requirement.1"}, Status: workflow.StoryStatusReady}}
+	plan.Scenarios = []workflow.Scenario{{ID: "scenario.1", RequirementID: "requirement.1", StoryID: "story.1"}}
+	plan.PlanDecisions = []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindStoryReprepare}}
+	_ = c.plans.save(context.Background(), plan)
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, got *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		if got.PlanSlug != slug {
+			t.Fatalf("published slug = %q, want %q", got.PlanSlug, slug)
+		}
+		return nil
+	}
+
+	data, _ := json.Marshal(map[string]string{"slug": slug, "summary": "re-reviewed"})
+	resp := c.handleScenariosReviewedMutation(context.Background(), data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+	if !published {
+		t.Fatal("recovery re-review must auto-dispatch execution, not wedge at scenarios_reviewed (#295)")
+	}
+	got, _ := c.plans.get(slug)
+	if got.Status == workflow.StatusScenariosReviewed {
+		t.Errorf("plan stuck at scenarios_reviewed; want advanced past it (ready_for_execution/implementing)")
+	}
+}
+
+// TestHandleScenariosReviewedMutation_InitialR2AwaitsApproval guards the
+// unchanged path: with NO recovery decision (the initial R2), auto_approve=false
+// must still await human approval and NOT auto-dispatch.
+func TestHandleScenariosReviewedMutation_InitialR2AwaitsApproval(t *testing.T) {
+	c := setupTestComponent(t)
+	slug := "scen-initial"
+
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingScenarios
+	plan.Requirements = []workflow.Requirement{{ID: "requirement.1", Title: "x"}}
+	plan.Scenarios = []workflow.Scenario{{ID: "scenario.1", RequirementID: "requirement.1"}}
+	_ = c.plans.save(context.Background(), plan)
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, _ *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		return nil
+	}
+
+	data, _ := json.Marshal(map[string]string{"slug": slug})
+	resp := c.handleScenariosReviewedMutation(context.Background(), data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+	if published {
+		t.Error("initial R2 (no recovery decision) must await approval, not auto-dispatch")
+	}
+	got, _ := c.plans.get(slug)
+	if got.Status != workflow.StatusScenariosReviewed {
+		t.Errorf("status = %q, want scenarios_reviewed (awaiting approval)", got.Status)
+	}
+}

--- a/processor/plan-manager/r2_recovery_rereview_test.go
+++ b/processor/plan-manager/r2_recovery_rereview_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/c360studio/semspec/workflow/payloads"
 )
 
-// TestPlanHasAcceptedRecoveryDecision locks the signal that distinguishes a
-// recovery-driven R2 re-review (auto-advance) from an initial R2 (await approval).
-func TestPlanHasAcceptedRecoveryDecision(t *testing.T) {
+// TestPlanHasAcceptedStoryReprepareDecision locks the signal that distinguishes a
+// SCOPED recovery re-review (auto-advance) from everything else. Only an accepted
+// story_reprepare qualifies — whole-phase architecture_revise must NOT (it keeps
+// the human gate), and a first-ever R2 has no decision.
+func TestPlanHasAcceptedStoryReprepareDecision(t *testing.T) {
 	tests := []struct {
 		name      string
 		decisions []workflow.PlanDecision
@@ -19,13 +21,13 @@ func TestPlanHasAcceptedRecoveryDecision(t *testing.T) {
 	}{
 		{"none", nil, false},
 		{"accepted story_reprepare", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindStoryReprepare}}, true},
-		{"accepted architecture_revise", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindArchitectureRevise}}, true},
-		{"accepted scope_incomplete", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindScopeIncomplete}}, true},
+		{"accepted architecture_revise (whole-phase — must NOT auto-advance)", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindArchitectureRevise}}, false},
+		{"accepted scope_incomplete (never reaches this handler)", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindScopeIncomplete}}, false},
 		{"proposed (not accepted) story_reprepare", []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusProposed, Kind: workflow.PlanDecisionKindStoryReprepare}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := planHasAcceptedRecoveryDecision(&workflow.Plan{PlanDecisions: tt.decisions}); got != tt.want {
+			if got := planHasAcceptedStoryReprepareDecision(&workflow.Plan{PlanDecisions: tt.decisions}); got != tt.want {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
@@ -99,6 +101,42 @@ func TestHandleScenariosReviewedMutation_InitialR2AwaitsApproval(t *testing.T) {
 	}
 	if published {
 		t.Error("initial R2 (no recovery decision) must await approval, not auto-dispatch")
+	}
+	got, _ := c.plans.get(slug)
+	if got.Status != workflow.StatusScenariosReviewed {
+		t.Errorf("status = %q, want scenarios_reviewed (awaiting approval)", got.Status)
+	}
+}
+
+// TestHandleScenariosReviewedMutation_WholePhaseArchReviseAwaits guards the
+// product-risk boundary (review of #295): a whole-phase architecture_revise
+// regenerates the entire plan, so under auto_approve=false it must NOT bypass the
+// human gate — it keeps awaiting approval even though it is a recovery.
+func TestHandleScenariosReviewedMutation_WholePhaseArchReviseAwaits(t *testing.T) {
+	c := setupTestComponent(t)
+	slug := "scen-arch-revise"
+
+	plan := setupTestPlan(t, c, slug)
+	plan.Status = workflow.StatusReviewingScenarios
+	plan.Approved = true
+	plan.Requirements = []workflow.Requirement{{ID: "requirement.1", Title: "x"}}
+	plan.Scenarios = []workflow.Scenario{{ID: "scenario.1", RequirementID: "requirement.1"}}
+	plan.PlanDecisions = []workflow.PlanDecision{{Status: workflow.PlanDecisionStatusAccepted, Kind: workflow.PlanDecisionKindArchitectureRevise}}
+	_ = c.plans.save(context.Background(), plan)
+
+	published := false
+	c.orchestratorTriggerPublisher = func(_ context.Context, _ *payloads.ScenarioOrchestrationTrigger) error {
+		published = true
+		return nil
+	}
+
+	data, _ := json.Marshal(map[string]string{"slug": slug})
+	resp := c.handleScenariosReviewedMutation(context.Background(), data)
+	if !resp.Success {
+		t.Fatalf("mutation failed: %s", resp.Error)
+	}
+	if published {
+		t.Error("whole-phase architecture_revise must NOT auto-dispatch — a regenerated plan keeps the human gate")
 	}
 	got, _ := c.plans.get(slug)
 	if got.Status != workflow.StatusScenariosReviewed {


### PR DESCRIPTION
## Why

A `story_reprepare` recovery re-plans the stories and re-runs the round-2 scenarios review. With `auto_approve=false`, `handleScenariosReviewedMutation` set the plan to `scenarios_reviewed` and **waited for a human `ready_for_execution` approval** — but a recovery re-review is **not initial gating**: the plan already cleared that gate before the recovery. In any unattended run (and an attended one that's left the approval UI), the plan **wedges at `scenarios_reviewed` forever**.

Caught live on a mavlink-hard run: a `story_reprepare` re-review wedged ~37 min until a manual `POST /plans/<slug>/promote` un-wedged it. **This is a deterministic state-machine transition — zero LLM needed to reproduce — yet it was found ~2 h into a paid run.** Now caught for free in `go test ./...`.

## Fix

`handleScenariosReviewedMutation` auto-advances to `ready_for_execution` (and re-dispatches execution, exactly as `/promote` does) when the plan carries an **accepted recovery PlanDecision** (`story_reprepare` / `architecture_revise` / `scope_incomplete` — only recovery emits those). The initial R2 has no such decision, so its await-for-approval behavior is **unchanged**.

## Tests (no LLM)

- `TestPlanHasAcceptedRecoveryDecision` — the pure signal helper (accepted recovery kind ⇒ true; proposed/none ⇒ false).
- `TestHandleScenariosReviewedMutation_RecoveryReReviewAutoAdvances` — the wedge reproduction: recovery re-review must auto-dispatch, not wedge.
- `TestHandleScenariosReviewedMutation_InitialR2AwaitsApproval` — guard that the initial R2 still awaits approval.

`go test ./...` exit 0, `-race`, gofmt, vet clean.

## Scope note

This is the cleaner of the two wedges from that run. The sibling **#294** (post-recovery req re-dispatch idempotent-skip — recovery abandons execs, leaving reqs `active`, so re-dispatch hits "already exists" → `ready_count=0` idle) is a harder cross-component force-recreate change in the requirement-executor; it's a separate follow-up.

Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)